### PR TITLE
Add appropriate instructions into base image's Dockerfile

### DIFF
--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -1,2 +1,20 @@
 FROM registry.access.redhat.com/ubi8/python-38:latest
 
+LABEL name="odh-notebook-base-ubi8-python-3.8" \
+      summary="Python 3.8 base image for ODH notebooks" \
+      description="Base Python 3.8 builder image based on UBI8 for ODH notebooks" \
+      io.k8s.display-name="Python 3.8 base image for ODH notebooks" \
+      io.k8s.description="Base Python 3.8 builder image based on UBI8 for ODH notebooks" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/ubi8-python-3.8" \
+      io.openshift.build.image="quay.io/opendatahub/notebooks:base-ubi8-python-3.8"
+
+WORKDIR /opt/app-root/src
+
+# install the oc client
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+        -o /tmp/openshift-client-linux.tar.gz && \
+    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
+    mv oc /opt/app-root/bin && \
+    rm -f /tmp/openshift-client-linux.tar.gz


### PR DESCRIPTION
Add appropriate instructions into the base image's Dockerfile

## Description
**Added the following into the base notebook image:**

- Labels
- OC Client (4.11.1)

**Changes on Makefile:**
- Changed variable name `$(IMAGE_CONTEXT)` to `$(IMAGE_DIR)` for better naming cohesion

## How Has This Been Tested?

1. Create a simple python script and call it `test.py`

``` python
import time
while(1):
    print('Hello from base image ubi8-py38')
    time.sleep(10)
```

3. Create a Dockerfile for the test image using the ubi8-python-3.8 as build image 
```docker
FROM quay.io/opendatahub/notebooks:base-ubi8-python-3.8-pr-2

# Add application sources with correct permissions for OpenShift
USER 0
COPY test.py .
RUN chown -R 1001:0 ./
USER 1001

# Run the test app
CMD ["python", "./test.py"]
```
5. Build and Run the new test image 
6. Run `podman inspect ${IMAGE_ID}` to review the labels and the details of the image
7. Run `podman exec -it ${CONTEINER_ID} /bin/bash` 
    - Run `oc version` to review the oc version

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
