### PR TITLE
Add pip-tools installation into base notebook image

### DIFF
--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -12,6 +12,8 @@ LABEL name="odh-notebook-base-ubi8-python-3.8" \
 
 WORKDIR /opt/app-root/src
 
+RUN python -m pip install pip-tools==6.8.0
+
 # install the oc client
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \


### PR DESCRIPTION
Added pip-tools installation instructions into the base notebook image

## Description
Added `RUN python -m pip install pip-tools==6.8.0` into Dockerfile

## How Has This Been Tested?
1. Create a simple python script and call it `test.py`

``` python
import time
while(1):
    print('Hello from base image ubi8-py38')
    time.sleep(10)
```

3. Create a Dockerfile for the test image using the ubi8-python-3.8 as the build image 
```docker
FROM quay.io/opendatahub/notebooks:base-ubi8-python-3.8

# Add application sources with correct permissions for OpenShift
USER 0
COPY test.py .
RUN chown -R 1001:0 ./
USER 1001

# Run the test app
CMD ["python", "./test.py"]
```
5. Build and Run the new test image 
6. Run `podman exec -it ${CONTEINER_ID} /bin/bash` 
    - Run `pip-compile -h` to review the man page of the pip-compile

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
