### PR TITLE
Implement NOTEBOOK_ARGS in minimal notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,161 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+bin/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 These images were created to be used with Open Data Hub (ODH) with the ODH Notebook Controller as the launcher.
 
 ## Container Image Layering
- 
+
 ```mermaid
 graph TB
     subgraph Main Tree
@@ -49,4 +49,25 @@ You can use a different registry by overwriting the `IMAGE_REGISTRY` variable:
 
 ```shell
 make -e IMAGE_REGISRY=quay.io/YOUR_USER/notebooks jupyter-minimal-ubi8-python-3.8
+```
+
+## Testing
+
+Deploy the notebook images in your Kubernetes environment (replace
+**jupyter-minimal-ubi8-python-3.8** with the name of your notebook):
+
+```shell
+make deploy-jupyter-minimal-ubi8-python-3.8
+```
+
+Run the test suite against this notebook:
+
+```shell
+make test-jupyter-minimal-ubi8-python-3.8
+```
+
+Clean up the environment when the tests are finished:
+
+```shell
+make undeploy-jupyter-minimal-ubi8-python-3.8
 ```

--- a/jupyter/minimal/ubi8-python-3.8/Dockerfile
+++ b/jupyter/minimal/ubi8-python-3.8/Dockerfile
@@ -13,6 +13,7 @@ LABEL name="odh-notebook-jupyter-minimal-ubi8-python-3.8" \
 
 WORKDIR /opt/app-root/bin
 
+COPY utils utils/
 COPY requirements.txt start-notebook.sh ./
 
 RUN python -m pip install -r requirements.txt && \

--- a/jupyter/minimal/ubi8-python-3.8/kustomize/base/kustomization.yaml
+++ b/jupyter/minimal/ubi8-python-3.8/kustomize/base/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: jupyter-minimal-ubi8-python-3-8-
+commonLabels:
+  app: jupyter-minimal-ubi8-python-3-8
+resources:
+  - service.yaml
+  - statefulset.yaml
+images:
+  - name: quay.io/opendatahub/notebooks
+    newName: quay.io/opendatahub/notebooks
+    newTag: jupyter-minimal-ubi8-python-3.8

--- a/jupyter/minimal/ubi8-python-3.8/kustomize/base/service.yaml
+++ b/jupyter/minimal/ubi8-python-3.8/kustomize/base/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notebook
+  labels:
+    app: notebook
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8888
+      protocol: TCP
+      targetPort: notebook-port
+  selector:
+    app: notebook

--- a/jupyter/minimal/ubi8-python-3.8/kustomize/base/statefulset.yaml
+++ b/jupyter/minimal/ubi8-python-3.8/kustomize/base/statefulset.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: notebook
+  annotations:
+    opendatahub.io/username: jovyan
+  labels:
+    opendatahub.io/user: jovyan
+spec:
+  replicas: 1
+  selector: {}
+  serviceName: notebook
+  template:
+    metadata:
+      labels: {}
+    spec:
+      containers:
+        - name: notebook
+          image: quay.io/opendatahub/notebooks:jupyter-minimal-ubi8-python-3.8
+          imagePullPolicy: Always
+          workingDir: /opt/app-root/src
+          env:
+            - name: NOTEBOOK_ARGS
+              value: |-
+                --ServerApp.port=8888
+                --ServerApp.token=''
+                --ServerApp.password=''
+                --ServerApp.base_url=/notebook/opendatahub/jovyan
+                --ServerApp.quit_button=False
+                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
+          ports:
+            - name: notebook-port
+              protocol: TCP
+              containerPort: 8888
+          livenessProbe:
+            tcpSocket:
+              port: notebook-port
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /notebook/opendatahub/jovyan/api
+              port: notebook-port
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi

--- a/jupyter/minimal/ubi8-python-3.8/start-notebook.sh
+++ b/jupyter/minimal/ubi8-python-3.8/start-notebook.sh
@@ -1,3 +1,36 @@
 #!/usr/bin/env bash
 
-jupyter lab
+# Load bash libraries
+SCRIPT_DIR=$(dirname -- "$0")
+source ${SCRIPT_DIR}/utils/*.sh
+
+# Initialize notebooks arguments variable
+NOTEBOOK_PROGRAM_ARGS=""
+
+# Set default ServerApp.port value if NOTEBOOK_PORT variable is defined
+if [ -n "${NOTEBOOK_PORT}" ]; then
+    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.port=${NOTEBOOK_PORT} "
+fi
+
+# Set default ServerApp.base_url value if NOTEBOOK_BASE_URL variable is defined
+if [ -n "${NOTEBOOK_BASE_URL}" ]; then
+    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.base_url=${NOTEBOOK_BASE_URL} "
+fi
+
+# Set default ServerApp.root_dir value if NOTEBOOK_ROOT_DIR variable is defined
+if [ -n "${NOTEBOOK_ROOT_DIR}" ]; then
+    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.root_dir=${NOTEBOOK_ROOT_DIR} "
+else
+    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.root_dir=${HOME} "
+fi
+
+# Add additional arguments if NOTEBOOK_ARGS variable is defined
+if [ -n "${NOTEBOOK_ARGS}" ]; then
+    NOTEBOOK_PROGRAM_ARGS+=${NOTEBOOK_ARGS}
+fi
+
+# Start the JupyterLab notebook
+start_process jupyter lab ${NOTEBOOK_PROGRAM_ARGS} \
+    --ServerApp.ip=0.0.0.0 \
+    --ServerApp.allow_origin="*" \
+    --ServerApp.open_browser=False

--- a/jupyter/minimal/ubi8-python-3.8/utils/process.sh
+++ b/jupyter/minimal/ubi8-python-3.8/utils/process.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function start_process() {
+    trap stop_process TERM INT
+
+    echo "Running command: $@"
+    "$@" &
+
+    PID=$!
+    wait $PID
+    trap - TERM INT
+    wait $PID
+    STATUS=$?
+    exit $STATUS
+}
+
+function stop_process() {
+    kill -TERM $PID
+}


### PR DESCRIPTION
## Description
Extend the minimal notebook entrypoint to use NOTEBOOK_ARGS environment variables to pass additional ServerApp flags at startup.

## How Has This Been Tested?

Deploy the minimal notebook in your Kubernetes/OpenShift environment:

```shell
$ make deploy-jupyter-minimal-ubi8-python-3.8 -e IMAGE_TAG="pr-7"
# Deploying notebook in jupyter/minimal/ubi8-python-3.8/kustomize/base directory...
bin/kubectl apply -k jupyter/minimal/ubi8-python-3.8/kustomize/base
service/jupyter-minimal-ubi8-python-3-8-notebook created
statefulset.apps/jupyter-minimal-ubi8-python-3-8-notebook created
```

Run a minimal test to verify the API is exposed and running:

```shell
$ make test-jupyter-minimal-ubi8-python-3.8                                               
# Running tests for jupyter-minimal-ubi8-python-3-8 notebook...
bin/kubectl wait --for=condition=ready pod -l app=jupyter-minimal-ubi8-python-3-8 --timeout=60s
pod/jupyter-minimal-ubi8-python-3-8-notebook-0 condition met
bin/kubectl port-forward svc/jupyter-minimal-ubi8-python-3-8-notebook 8888:8888 &
curl --retry-all-errors --retry 5 --retry-delay 5 -s \
	http://localhost:8888/notebook/opendatahub/jovyan/api && echo
Forwarding from 127.0.0.1:8888 -> 8888
Forwarding from [::1]:8888 -> 8888
Handling connection for 8888
{"version": "1.19.1"}
pkill -f "bin/kubectl.*port-forward.*"
```

Clean up your environment:

```
$ make undeploy-jupyter-minimal-ubi8-python-3.8
# Undeploying notebook from jupyter/minimal/ubi8-python-3.8/kustomize/base directory...
bin/kubectl delete -k jupyter/minimal/ubi8-python-3.8/kustomize/base
service "jupyter-minimal-ubi8-python-3-8-notebook" deleted
statefulset.apps "jupyter-minimal-ubi8-python-3-8-notebook" deleted
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
