### PR TITLE
Allow overriding NOTEBOOK_TAG variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,9 @@ endif
 .PHONY: deploy
 deploy-%-ubi8-python-3.8: bin/kubectl
 	$(eval NOTEBOOK_DIR := $(subst -,/,$*)/ubi8-python-3.8/kustomize/base)
+ifndef NOTEBOOK_TAG
 	$(eval NOTEBOOK_TAG := $*-ubi8-python-3.8-$(IMAGE_TAG))
+endif
 	$(info # Deploying notebook from $(NOTEBOOK_DIR) directory...)
 	@sed -i 's,newName: .*,newName: $(IMAGE_REGISTRY),g' $(NOTEBOOK_DIR)/kustomization.yaml
 	@sed -i 's,newTag: .*,newTag: $(NOTEBOOK_TAG),g' $(NOTEBOOK_DIR)/kustomization.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the Openshift CI, the images have the following format:

```
registry.build02.ci.openshift.org/ci-op-88vkxw7s/pipeline@sha256:c67474628c4338e1ec7c51d68479fd149df4df3e5b90536c652abe7a3a633de8
```

This PRs allows us to pass the tag only when the variable is defined:

```
IFS=':' read -a NOTEBOOK_IMAGE <<< "${JUPYTER_MINIMAL_IMAGE}"
make deploy-jupyter-minimal-ubi8-python-3.8 \
    -e IMAGE_REGISTRY="${NOTEBOOK_IMAGE[0]}" -e NOTEBOOK_TAG="${NOTEBOOK_IMAGE[1]}"
```


## How Has This Been Tested?

Not setting NOTEBOOK_TAG:

```
$ make deploy-jupyter-minimal-ubi8-python-3.8 -e IMAGE_TAG="pr-9"
$ make test-jupyter-minimal-ubi8-python-3.8
{"version": "1.19.1"}
```

And setting NOTEBOOK_TAG:

```
$ make deploy-jupyter-minimal-ubi8-python-3.8 -e NOTEBOOK_TAG="jupyter-minimal-ubi8-python-3.8-pr-9"
$ make test-jupyter-minimal-ubi8-python-3.8
{"version": "1.19.1"}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
