### PR TITLE
Curl notebook API using --retry-connrefused

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ test-%: bin/kubectl
 	$(info # Running tests for $(NOTEBOOK_NAME) notebook...)
 	$(KUBECTL_BIN) wait --for=condition=ready pod -l app=$(NOTEBOOK_NAME) --timeout=60s
 	$(KUBECTL_BIN) port-forward svc/$(NOTEBOOK_NAME)-notebook 8888:8888 &
-	curl --retry-all-errors --retry 5 --retry-delay 5 -s \
-		http://localhost:8888/notebook/opendatahub/jovyan/api && echo
-	pkill -f "$(KUBECTL_BIN).*port-forward.*"
+	curl --retry 5 --retry-delay 5 --retry-connrefused \
+		http://localhost:8888/notebook/opendatahub/jovyan/api; EXIT_CODE=$$?; echo && \
+	pkill --full "^$(KUBECTL_BIN).*port-forward.*"; \
+	exit $${EXIT_CODE}


### PR DESCRIPTION
## Description
E2E tests are failing because the curl version in ubi8 images does not support `--retry-all-errors` flag, use `--retry-connrefused` instead.

```shell
$ curl --retry-all-errors --retry 5 --retry-delay 5 -s \
	http://localhost:8888/notebook/opendatahub/jovyan/api && echo
curl: option --retry-all-errors: is unknown 
```

## How Has This Been Tested?
By running `ci/prow/notebooks-e2e-tests` job.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

