### PR TITLE
Remove jupyterlab_requirements extension from DS notebook

### DIFF
--- a/base/ubi8-python-3.8/requirements.txt
+++ b/base/ubi8-python-3.8/requirements.txt
@@ -716,9 +716,9 @@ semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
     --hash=sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
     # via thoth-python
-sentry-sdk==1.10.0 \
-    --hash=sha256:1b965bcdbfe52321bb1307c7c93c74035afdbfceb5f585f01a963327c5befc4e \
-    --hash=sha256:8c648e96e0e2ec5e17ca75a28c442e2f523453fa7cf761ec093f4a656153490e
+sentry-sdk==1.10.1 \
+    --hash=sha256:06c0fa9ccfdc80d7e3b5d2021978d6eb9351fa49db9b5847cf4d1f2a473414ad \
+    --hash=sha256:105faf7bd7b7fa25653404619ee261527266b14103fe1389e0ce077bd23a9691
     # via thoth-common
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -788,9 +788,9 @@ urllib3==1.26.12 \
     #   requests
     #   sentry-sdk
     #   thamos
-virtualenv==20.16.5 \
-    --hash=sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da \
-    --hash=sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27
+virtualenv==20.16.6 \
+    --hash=sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108 \
+    --hash=sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e
     # via thamos
 websocket-client==1.4.1 \
     --hash=sha256:398909eb7e261f44b8f4bd474785b6ec5f5b499d4953342fe9755e01ef624090 \
@@ -865,9 +865,9 @@ yaspin==2.2.0 \
     --hash=sha256:a6948034483cb263a467bef5a564eb35458e950fcade2cd7ad1d7d4339db4711 \
     --hash=sha256:febdf35f3e0e45845dc2caa79a18780f9ec7a85a37a9a2c0389b314ba82d8912
     # via thamos
-zipp==3.9.0 \
-    --hash=sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb \
-    --hash=sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980
+zipp==3.10.0 \
+    --hash=sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1 \
+    --hash=sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8
     # via importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/jupyter/datascience/ubi8-python-3.8/requirements.in
+++ b/jupyter/datascience/ubi8-python-3.8/requirements.in
@@ -8,7 +8,6 @@ boto3==1.17.11
 scipy==1.6.2
 
 # JupyterLab extensions
-jupyterlab-requirements==0.16.2
 jupyter-resource-usage==0.6.1
 jupyterlab-s3-browser==0.10.1
 jupyterlab-widgets==3.0.3

--- a/jupyter/datascience/ubi8-python-3.8/requirements.txt
+++ b/jupyter/datascience/ubi8-python-3.8/requirements.txt
@@ -297,23 +297,19 @@ click==8.1.3 \
     --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
     # via
     #   invectio
-    #   jupyterlab-requirements
     #   pip-tools
     #   rich-click
     #   thamos
     #   thoth-analyzer
     #   thoth-python
-colorama==0.4.5 \
-    --hash=sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da \
-    --hash=sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via nbdime
 commonmark==0.9.1 \
     --hash=sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
     --hash=sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9
     # via rich
-csscompressor==0.9.5 \
-    --hash=sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05
-    # via jupyter-require
 cycler==0.11.0 \
     --hash=sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3 \
     --hash=sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f
@@ -323,8 +319,6 @@ daiquiri==3.2.1 \
     --hash=sha256:b797a7ac94219dc26ef8ebf04f1f507eefa83a7d174e9eb41acc33e3ebf16f38
     # via
     #   invectio
-    #   jupyter-nbutils
-    #   jupyter-require
     #   thamos
     #   thoth-common
 decorator==5.1.1 \
@@ -460,24 +454,14 @@ importlib-resources==5.10.0 \
 invectio==0.2.2 \
     --hash=sha256:cc1a2e69dd95ab98d90bc23fa6ad245d7f1a5f58b40cc9320c4d81786db01bdb \
     --hash=sha256:f20c8a35f1747eff5cc0a2d5222b0427f75d6096712e67ec2829f491bc5ed82e
-    # via
-    #   jupyterlab-requirements
-    #   thamos
+    # via thamos
 ipykernel==5.5.5 \
     --hash=sha256:29eee66548ee7c2edb7941de60c0ccf0a7a8dd957341db0a49c5e8e6a0fcb712 \
     --hash=sha256:e976751336b51082a89fc2099fb7f96ef20f535837c398df6eab1283c2070884
     # via
     #   -r -
-    #   ipynbname
     #   ipywidgets
-    #   jupyter-nbutils
-    #   jupyter-require
-    #   jupyterlab-requirements
     #   notebook
-ipynbname==2021.3.2 \
-    --hash=sha256:aaf6ab2fcbc68ab6c4c6ba924b57991a388ccc1c8fae782f2433340a40743dfe \
-    --hash=sha256:cf7bae999005dce012738d09610e69a47acd765797c0365c803f96c21ea2f32b
-    # via jupyterlab-requirements
 ipython==7.16.1 \
     --hash=sha256:2dbcc8c27ca7d3cfe4fcdff7f45b27f9a8d3edfa70ff8024a71c7a8eb5f09d64 \
     --hash=sha256:9f4fcb31d3b2c533333893b9172264e4821c1ac91839500f31bd43f2c59b3ccf
@@ -485,16 +469,11 @@ ipython==7.16.1 \
     #   -r -
     #   ipykernel
     #   ipywidgets
-    #   jupyter-latex-envs
-    #   jupyter-nbutils
-    #   jupyter-require
     #   jupyterlab
-    #   jupyterlab-requirements
 ipython-genutils==0.2.0 \
     --hash=sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8 \
     --hash=sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8
     # via
-    #   jupyter-contrib-nbextensions
     #   jupyter-server
     #   notebook
 ipywidgets==8.0.2 \
@@ -545,63 +524,28 @@ jupyter-bokeh==3.0.4 \
     --hash=sha256:4a2009c3d6938299df95c05e5b5b4c6df62d6e6ae9509c457ec070bc56b5621d \
     --hash=sha256:ba3b032f52a039d9e5ed8f6c50f3f9a00dcb97005871c24673a3b3a05465aef5
     # via -r -
-jupyter-client==7.4.3 \
-    --hash=sha256:4fa2514cdb54dd9fbdcf7d7e4c5c3c8a973028168a8b4fc097b6aef625be13b0 \
-    --hash=sha256:8845e3f5a339734b1ecc21d2100638aa1c7a145e356a31845f155cda5b624b1c
+jupyter-client==7.4.4 \
+    --hash=sha256:1c1d418ef32a45a1fae0b243e6f01cc9bf65fa8ddbd491a034b9ba6ac6502951 \
+    --hash=sha256:5616db609ac720422e6a4b893d6572b8d655ff41e058367f4459a0d2c0726832
     # via
     #   ipykernel
     #   jupyter-server
     #   nbclient
     #   notebook
-jupyter-contrib-core==0.4.0 \
-    --hash=sha256:5e77cdff5c73f5ff76b3713c459f928c0dff45eee53ee8c2fe3f26490f4d4270 \
-    --hash=sha256:ad995f5754188ab41ea5f94d69c9a1f96ba50543274d798d9001f937f730d326
-    # via
-    #   jupyter-contrib-nbextensions
-    #   jupyter-nbextensions-configurator
-jupyter-contrib-nbextensions==0.5.1 \
-    --hash=sha256:2c071f0aa208c569666f656bdc0f66906ca493cf9f06f46db6350db11030ff40 \
-    --hash=sha256:eecd28ecc2fc410226c0a3d4932ed2fac4860ccf8d9e9b1b29548835a35b22ab
-    # via jupyter-require
 jupyter-core==4.11.2 \
     --hash=sha256:3815e80ec5272c0c19aad087a0d2775df2852cfca8f5a17069e99c9350cecff8 \
     --hash=sha256:c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337
     # via
     #   jupyter-client
-    #   jupyter-contrib-core
-    #   jupyter-contrib-nbextensions
-    #   jupyter-latex-envs
-    #   jupyter-nbextensions-configurator
     #   jupyter-server
     #   jupyterlab
     #   nbconvert
     #   nbformat
     #   notebook
-jupyter-highlight-selected-word==0.2.0 \
-    --hash=sha256:9545dfa9cb057eebe3a5795604dcd3a5294ea18637e553f61a0b67c1b5903c58 \
-    --hash=sha256:9fa740424859a807950ca08d2bfd28a35154cd32dd6d50ac4e0950022adc0e7b
-    # via jupyter-contrib-nbextensions
-jupyter-latex-envs==1.4.6 \
-    --hash=sha256:070a31eb2dc488bba983915879a7c2939247bf5c3b669b398bdb36a9b5343872
-    # via jupyter-contrib-nbextensions
 jupyter-lsp==1.5.1 \
     --hash=sha256:28bb4c44f0c78b4fe55041b2209a8a1f33b1719f39e5e280d8c4d689dc44ca31 \
     --hash=sha256:751abd35413be99a4331f3597b09341adc755589ed32091ac2f686db3d61267e
     # via jupyterlab-lsp
-jupyter-nbextensions-configurator==0.5.0 \
-    --hash=sha256:0be87b9d828673f691120a026327e0ff4fa7f1602dc94b00b3b9e48d52391e84 \
-    --hash=sha256:bdc312c6baed70f6f35b464fa0bca850a266062c486af3e0ff601079e3238ceb
-    # via jupyter-contrib-nbextensions
-jupyter-nbutils==0.1.3 \
-    --hash=sha256:4630d4fc56c2c967e18d884895e8cc947dca698fe2f6ab1b021bdad2a8464243 \
-    --hash=sha256:dcd4e8ca9f53880f1d87e1a351ec9fc9d3b337553e90209b7fa16aa6bcb13390
-    # via jupyter-require
-jupyter-require==0.6.1 \
-    --hash=sha256:5473bbd3d0ca6e6bcc606281bcaaf7c57c51c2c2bf696c32d451066cb44c1301 \
-    --hash=sha256:c1aa042e2c17a2f45978abab74e96a7e0474f44dd138678cc177a0ee281dcc00
-    # via
-    #   jupyter-nbutils
-    #   jupyterlab-requirements
 jupyter-resource-usage==0.6.1 \
     --hash=sha256:29e7eaaaff9044d53b8e7e0ebcc4b414d5f8449a3c2529ebf5f55d92ff7eaec2 \
     --hash=sha256:8b766b9dded49e582cc38ebeb7f19af2eae50ccf77730afbe96f4a09def9874b
@@ -630,7 +574,6 @@ jupyterlab==3.2.4 \
     # via
     #   -r -
     #   jupyterlab-lsp
-    #   jupyterlab-requirements
     #   jupyterlab-s3-browser
 jupyterlab-git==0.30.1 \
     --hash=sha256:a596a293dc562f03ec1af48cb717b4f8a7f1c118a3e4cd13ea138e077674a638 \
@@ -644,10 +587,6 @@ jupyterlab-pygments==0.2.2 \
     --hash=sha256:2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f \
     --hash=sha256:7405d7fde60819d905a9fa8ce89e4cd830e318cdad22a0030f7a901da705585d
     # via nbconvert
-jupyterlab-requirements==0.16.2 \
-    --hash=sha256:0d241a252141dfd0b701c758afefcbb1778955ac2923de2c581300a634467d21 \
-    --hash=sha256:8f0b11838a18bd38df8e607777618fc1148e4ea1dc2bbf116d4196f62b4c6e28
-    # via -r -
 jupyterlab-s3-browser==0.10.1 \
     --hash=sha256:5a169bc35f52ddef8786043c93bebfe4255c4e6120aecbcdd9dfa51ed445d45b \
     --hash=sha256:676eb3bca4b45e1c2e6a3c7102084690ac722799b82aa0f7213eef5d98081e3a
@@ -816,9 +755,7 @@ lxml==4.9.1 \
     --hash=sha256:f9ced82717c7ec65a67667bb05865ffe38af0e835cdd78728f1209c8fffe0cad \
     --hash=sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8 \
     --hash=sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f
-    # via
-    #   jupyter-contrib-nbextensions
-    #   thoth-python
+    # via thoth-python
 markupsafe==2.1.1 \
     --hash=sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003 \
     --hash=sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88 \
@@ -973,8 +910,6 @@ nbconvert==7.2.2 \
     --hash=sha256:24acfaa466d2c9b7eb524800e4a45afbed862c5d058cfb30fc7aa24d448c95eb \
     --hash=sha256:fc7a3787c927cbd45a52e088e934fbbaab39afe61767522168a724b7483992be
     # via
-    #   jupyter-contrib-nbextensions
-    #   jupyter-latex-envs
     #   jupyter-server
     #   notebook
 nbdime==3.1.0 \
@@ -1004,10 +939,6 @@ notebook==6.4.1 \
     --hash=sha256:5d999285fd449898c4dfa0b7880dd881f317c653eb221e8d51d0b5400751ce35
     # via
     #   -r -
-    #   jupyter-contrib-core
-    #   jupyter-contrib-nbextensions
-    #   jupyter-latex-envs
-    #   jupyter-nbextensions-configurator
     #   jupyterlab-s3-browser
     #   nbclassic
 numpy==1.19.2 \
@@ -1363,9 +1294,6 @@ pyyaml==6.0 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via
     #   bokeh
-    #   jupyter-contrib-nbextensions
-    #   jupyter-nbextensions-configurator
-    #   jupyterlab-requirements
     #   kubernetes
     #   thamos
     #   thoth-common
@@ -1472,7 +1400,6 @@ rich==12.6.0 \
     --hash=sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e \
     --hash=sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0
     # via
-    #   jupyterlab-requirements
     #   rich-click
     #   thamos
 rich-click==1.5.2 \
@@ -1632,18 +1559,16 @@ termcolor==2.0.1 \
 termcolor-whl==1.1.2 \
     --hash=sha256:3e7eda7348bb90ddea2d7a2171df65ed4a37adf62574fbd5459198410fdba881
     # via yaspin
-terminado==0.16.0 \
-    --hash=sha256:3e995072a7178a104c41134548ce9b03e4e7f0a538e9c29df4f1fbc81c7cfc75 \
-    --hash=sha256:fac14374eb5498bdc157ed32e510b1f60d5c3c7981a9f5ba018bb9a64cec0c25
+terminado==0.17.0 \
+    --hash=sha256:520feaa3aeab8ad64a69ca779be54be9234edb2d0d6567e76c93c2c9a4e6e43f \
+    --hash=sha256:bf6fe52accd06d0661d7611cc73202121ec6ee51e46d8185d489ac074ca457c2
     # via
     #   jupyter-server
     #   notebook
 thamos==1.28.0 \
     --hash=sha256:a3d20abad114fe5f42fdb522b9ecade83429be5ae8552cb487815acb16685600 \
     --hash=sha256:fdce908d7e2a0e7bcc600e21c44614df91af2e8c905fd3651f8004734dd241d6
-    # via
-    #   -r -
-    #   jupyterlab-requirements
+    # via -r -
 thoth-analyzer==0.1.8 \
     --hash=sha256:3f830334a3ba725cacf64ccc756e42f0c7946fd8038da6565cb2de569ea5c9c1 \
     --hash=sha256:8a29ce615e5feddd301a8c6656132268bede23d4187a5cfb60f790f80cd04dc1
@@ -1654,16 +1579,13 @@ thoth-common==0.36.4 \
     --hash=sha256:64b2279721b334064ee8a6c33a1b884d27a95751d87d100c3360c2fb44507c6c \
     --hash=sha256:c59ff5eecc26c4c2ae0c5e0d478670c4542ca82aaedd55dc794c4a4787fb896b
     # via
-    #   jupyterlab-requirements
     #   thamos
     #   thoth-analyzer
     #   thoth-python
 thoth-python==0.16.11 \
     --hash=sha256:b0659e665fd8c634b45ebd2b3317d59132ccbd7451c42ac2a0704704deef6cb8 \
     --hash=sha256:e53dbb15b22bb5f4b1a80767476c96ffccddf043da2a90475bd312a64326c69e
-    # via
-    #   jupyterlab-requirements
-    #   thamos
+    # via thamos
 threadpoolctl==3.1.0 \
     --hash=sha256:8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b \
     --hash=sha256:a335baacfaa4400ae1f0d8e3a58d6674d2f8828e3716bb2802c44955ad391380
@@ -1698,9 +1620,6 @@ tornado==6.2 \
     #   bokeh
     #   ipykernel
     #   jupyter-client
-    #   jupyter-contrib-core
-    #   jupyter-contrib-nbextensions
-    #   jupyter-nbextensions-configurator
     #   jupyter-server
     #   jupyterlab
     #   nbdime
@@ -1714,11 +1633,7 @@ traitlets==5.5.0 \
     #   ipython
     #   ipywidgets
     #   jupyter-client
-    #   jupyter-contrib-core
-    #   jupyter-contrib-nbextensions
     #   jupyter-core
-    #   jupyter-latex-envs
-    #   jupyter-nbextensions-configurator
     #   jupyter-server
     #   nbclient
     #   nbconvert
@@ -1747,16 +1662,10 @@ urllib3==1.26.12 \
     #   requests
     #   sentry-sdk
     #   thamos
-virtualenv==20.16.5 \
-    --hash=sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da \
-    --hash=sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27
-    # via
-    #   jupyterlab-requirements
-    #   thamos
-voluptuous==0.13.1 \
-    --hash=sha256:4b838b185f5951f2d6e8752b68fcf18bd7a9c26ded8f143f92d6d28f3921a3e6 \
-    --hash=sha256:e8d31c20601d6773cb14d4c0f42aee29c6821bbd1018039aac7ac5605b489723
-    # via jupyterlab-requirements
+virtualenv==20.16.6 \
+    --hash=sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108 \
+    --hash=sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e
+    # via thamos
 wcwidth==0.2.5 \
     --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
     --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
@@ -1844,9 +1753,9 @@ yaspin==2.2.0 \
     --hash=sha256:a6948034483cb263a467bef5a564eb35458e950fcade2cd7ad1d7d4339db4711 \
     --hash=sha256:febdf35f3e0e45845dc2caa79a18780f9ec7a85a37a9a2c0389b314ba82d8912
     # via thamos
-zipp==3.9.0 \
-    --hash=sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb \
-    --hash=sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980
+zipp==3.10.0 \
+    --hash=sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1 \
+    --hash=sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8
     # via
     #   importlib-metadata
     #   importlib-resources
@@ -1863,7 +1772,6 @@ setuptools==65.5.0 \
     --hash=sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356
     # via
     #   ipython
-    #   jupyter-contrib-core
     #   kubernetes
     #   pip-tools
     #   thamos

--- a/jupyter/minimal/ubi8-python-3.8/requirements.txt
+++ b/jupyter/minimal/ubi8-python-3.8/requirements.txt
@@ -286,9 +286,9 @@ click==8.1.3 \
     #   thamos
     #   thoth-analyzer
     #   thoth-python
-colorama==0.4.5 \
-    --hash=sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da \
-    --hash=sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via nbdime
 commonmark==0.9.1 \
     --hash=sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
@@ -481,9 +481,9 @@ jsonschema==4.16.0 \
     #   jupyterlab-server
     #   nbformat
     #   thamos
-jupyter-client==7.4.3 \
-    --hash=sha256:4fa2514cdb54dd9fbdcf7d7e4c5c3c8a973028168a8b4fc097b6aef625be13b0 \
-    --hash=sha256:8845e3f5a339734b1ecc21d2100638aa1c7a145e356a31845f155cda5b624b1c
+jupyter-client==7.4.4 \
+    --hash=sha256:1c1d418ef32a45a1fae0b243e6f01cc9bf65fa8ddbd491a034b9ba6ac6502951 \
+    --hash=sha256:5616db609ac720422e6a4b893d6572b8d655ff41e058367f4459a0d2c0726832
     # via
     #   ipykernel
     #   jupyter-server
@@ -1127,9 +1127,9 @@ send2trash==1.8.0 \
     # via
     #   jupyter-server
     #   notebook
-sentry-sdk==1.10.0 \
-    --hash=sha256:1b965bcdbfe52321bb1307c7c93c74035afdbfceb5f585f01a963327c5befc4e \
-    --hash=sha256:8c648e96e0e2ec5e17ca75a28c442e2f523453fa7cf761ec093f4a656153490e
+sentry-sdk==1.10.1 \
+    --hash=sha256:06c0fa9ccfdc80d7e3b5d2021978d6eb9351fa49db9b5847cf4d1f2a473414ad \
+    --hash=sha256:105faf7bd7b7fa25653404619ee261527266b14103fe1389e0ce077bd23a9691
     # via thoth-common
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -1157,9 +1157,9 @@ termcolor==2.0.1 \
 termcolor-whl==1.1.2 \
     --hash=sha256:3e7eda7348bb90ddea2d7a2171df65ed4a37adf62574fbd5459198410fdba881
     # via yaspin
-terminado==0.16.0 \
-    --hash=sha256:3e995072a7178a104c41134548ce9b03e4e7f0a538e9c29df4f1fbc81c7cfc75 \
-    --hash=sha256:fac14374eb5498bdc157ed32e510b1f60d5c3c7981a9f5ba018bb9a64cec0c25
+terminado==0.17.0 \
+    --hash=sha256:520feaa3aeab8ad64a69ca779be54be9234edb2d0d6567e76c93c2c9a4e6e43f \
+    --hash=sha256:bf6fe52accd06d0661d7611cc73202121ec6ee51e46d8185d489ac074ca457c2
     # via
     #   jupyter-server
     #   notebook
@@ -1251,9 +1251,9 @@ urllib3==1.26.12 \
     #   requests
     #   sentry-sdk
     #   thamos
-virtualenv==20.16.5 \
-    --hash=sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da \
-    --hash=sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27
+virtualenv==20.16.6 \
+    --hash=sha256:186ca84254abcbde98180fd17092f9628c5fe742273c02724972a1d8a2035108 \
+    --hash=sha256:530b850b523c6449406dfba859d6345e48ef19b8439606c5d74d7d3c9e14d76e
     # via thamos
 wcwidth==0.2.5 \
     --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
@@ -1338,9 +1338,9 @@ yaspin==2.2.0 \
     --hash=sha256:a6948034483cb263a467bef5a564eb35458e950fcade2cd7ad1d7d4339db4711 \
     --hash=sha256:febdf35f3e0e45845dc2caa79a18780f9ec7a85a37a9a2c0389b314ba82d8912
     # via thamos
-zipp==3.9.0 \
-    --hash=sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb \
-    --hash=sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980
+zipp==3.10.0 \
+    --hash=sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1 \
+    --hash=sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8
     # via
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
Removed `jupyterlab_requirements` from requirements.in file 

## Description
This extension caused undisiered warnings of the direct usage of pip commands. [odh-manifests PR](https://github.com/red-hat-data-services/odh-manifests/pull/253)

## How Has This Been Tested?
```podman run --rm -it -p 8888:8888 quay.io/opendatahub/notebooks:jupyter-datascience-ubi8-python-3.8-pr-16```

![Screenshot from 2022-10-26 16-27-43](https://user-images.githubusercontent.com/42587738/198053810-66890bb5-39ed-4f17-8c54-1cb59a9a7354.png)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
