### PR TITLE
Add weekly piplock refresher GitHub workflow for the new release branch [2023a] as well as to the old [2022d]

### DIFF
--- a/.github/workflows/piplock-renewal-2022d.yml
+++ b/.github/workflows/piplock-renewal-2022d.yml
@@ -1,0 +1,44 @@
+# This GitHub action is meant to be triggered weekly in order to update the pipfile.locks 
+
+name: Weekly Pipfile.locks renewal on [2022d] branch
+
+on:
+ # Triggers the workflow every Saturday at 9 am
+ schedule:
+   - cron: "0 9 * * 6"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+     
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      # Checkout the paricular branch
+      - name: Checkout code from the release branch
+        uses: actions/checkout@v3
+        with:
+          ref: 2022d
+
+      # Setup Python environment
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: |
+            3.8
+            3.9
+      - name: Install pipenv
+        run: pip install pipenv
+
+      # Runs the makefile recipe `refresh-pipfilelock-files` and push the chances back to the branch
+      - name: Run make refresh-pipfilelock-files and push the chances back to the branch
+        run: |
+          make refresh-pipfilelock-files
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git add .
+          git commit -m "Update the pipfile.lock via the weekly workflow action"
+          git push

--- a/.github/workflows/piplock-renewal-2023a.yml
+++ b/.github/workflows/piplock-renewal-2023a.yml
@@ -1,0 +1,44 @@
+# This GitHub action is meant to be triggered weekly in order to update the pipfile.locks 
+
+name: Weekly Pipfile.locks renewal on [2023a] branch
+
+on:
+ # Triggers the workflow every Saturday at 9 am
+ schedule:
+   - cron: "0 9 * * 6"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+     
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      # Checkout the paricular branch
+      - name: Checkout code from the release branch
+        uses: actions/checkout@v3
+        with:
+          ref: 2023a
+
+      # Setup Python environment
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: |
+            3.8
+            3.9
+      - name: Install pipenv
+        run: pip install pipenv
+
+      # Runs the makefile recipe `refresh-pipfilelock-files` and push the chances back to the branch
+      - name: Run make refresh-pipfilelock-files and push the chances back to the branch
+        run: |
+          make refresh-pipfilelock-files
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git add .
+          git commit -m "Update the pipfile.lock via the weekly workflow action"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Pull requests are the best way to propose changes to the notebooks repository:
     jupyter-${NOTEBOOK_NAME}-ubi8-python-3.8: jupyter-minimal-ubi8-python-3.8
 	$(call image,$@,jupyter/${NOTEBOOK_NAME}/ubi8-python-3.8,$<)
     ```
+- Add the paths of the new pipfiles under `refresh-pipfilelock-files`
 - Test the changes locally, by manually running the `$ make jupyter-${NOTEBOOK_NAME}-ubi8-python-3.8` from the terminal.
 
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ make ${NOTEBOOK_NAME}
 ```
 
 The image will be built and pushed to the
-[quay.io/opendatahub/notebooks](https://quay.io/opendatahub/notebooks)
+[quay.io/opendatahub/workbench-images](https://quay.io/opendatahub/workbench-images)
 repository.
 
-You can use a different registry by overwriting the `IMAGE_REGISTRY` variable:
+You can overwrite `IMAGE_REGISTRY` and `RELEASE` variables to use a different registry or release tag:
 
 ```shell
-make ${NOTEBOOK_NAME} -e IMAGE_REGISTRY=quay.io/${YOUR_USER}/notebooks
+make ${NOTEBOOK_NAME} -e IMAGE_REGISTRY=quay.io/${YOUR_USER}/workbench-images -e RELEASE=2023x
 ```
 
 ## Testing


### PR DESCRIPTION
This PR adds to the repository two GitHub workflows that are meant to refresh the piplockfiles weekly, for both versions of the images (N & N-1)

Fix: https://github.com/opendatahub-io/notebooks/issues/35 

For the old release `release-1.2` I have opened this issue: https://github.com/opendatahub-io/notebooks/issues/38

## Description
Apart from the workflows, fixed also the release tag on the image_tag, because the format should be 2023x (where x is a letter and not the quarter of the year)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
