### PR TITLE
Enable jupyterlab-s3-browser plugin on buildtime

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -16,6 +16,9 @@ COPY Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
+# Explicitly enable jupyterlab_s3_browser plugin
+RUN jupyter serverextension enable --py jupyterlab_s3_browser
+
 # Remove Elyra logo from JupyterLab because this is not a pure Elyra image \
 RUN sed -i 's/widget\.id === \x27jp-MainLogo\x27/widget\.id === \x27jp-MainLogo\x27 \&\& false/' /opt/app-root/share/jupyter/labextensions/@elyra/theme-extension/static/lib_index_js.*.js
 

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -16,6 +16,9 @@ COPY Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
+# Explicitly enable jupyterlab_s3_browser plugin
+RUN jupyter serverextension enable --py jupyterlab_s3_browser
+
 # Remove Elyra logo from JupyterLab because this is not a pure Elyra image \
 RUN sed -i 's/widget\.id === \x27jp-MainLogo\x27/widget\.id === \x27jp-MainLogo\x27 \&\& false/' /opt/app-root/share/jupyter/labextensions/@elyra/theme-extension/static/lib_index_js.*.js
 


### PR DESCRIPTION
Enable jupyterlab-s3-browser plugin on buildtime

## Description

As we had to downgrade `jupyterlab-s3-plugin` due to dependencies issue with latest `boto3` release,
the enabling of plugin was missed.
- with this pr, we are explicitly enabling the plugin on build time

Fixes: https://github.com/opendatahub-io/notebooks/issues/39

## How Has This Been Tested?

Yes, tested.
Run the notebook of this pr or `quay.io/harshad16/notebook:enable-s3`
once in the notebook, try out the plugin for results.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
