### PR TITLE
Provide runtimes image in workbench images 

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -27,8 +27,13 @@ RUN echo "Installing softwares and packages" && \
     sed -i 's/widget\.id === \x27jp-MainLogo\x27/widget\.id === \x27jp-MainLogo\x27 \&\& false/' /opt/app-root/share/jupyter/labextensions/@elyra/theme-extension/static/lib_index_js.*.js && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # Remove default Elyra runtime-images \
+    rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
     fix-permissions /opt/app-root -P
+
+# Copy Elyra runtime-images definitions and set the version
+COPY runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
 
 WORKDIR /opt/app-root/src

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "Datascience with Python 3.8 (UBI8)",
+    "metadata": {
+        "tags": [],
+        "display_name": "Datascience with Python 3.8 (UBI8)",
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-f93694f"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
+    "metadata": {
+        "tags": [],
+        "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-f93694f"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
+    "metadata": {
+        "tags": [],
+        "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-f93694f"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "Python 3.8 (UBI8)",
+    "metadata": {
+        "tags": [],
+        "display_name": "Python 3.8 (UBI8)",
+        "image_name": "registry.access.redhat.com/ubi8/python-38@sha256:70c8859892d55466d11734431233ec0348cad66a3be6aa7777a7694569808c26"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -27,8 +27,13 @@ RUN echo "Installing softwares and packages" && \
     sed -i 's/widget\.id === \x27jp-MainLogo\x27/widget\.id === \x27jp-MainLogo\x27 \&\& false/' /opt/app-root/share/jupyter/labextensions/@elyra/theme-extension/static/lib_index_js.*.js && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # Remove default Elyra runtime-images \
+    rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P
+
+# Copy Elyra runtime-images definitions and set the version
+COPY runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
 
 WORKDIR /opt/app-root/src

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "Datascience with Python 3.9 (UBI9)",
+    "metadata": {
+        "tags": [],
+        "display_name": "Datascience with Python 3.9 (UBI9)",
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.9-f93694f"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
+    "metadata": {
+        "tags": [],
+        "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9-f93694f"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
+    "metadata": {
+        "tags": [],
+        "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi9-python-3.9-f93694f"
+    },
+    "schema_name": "runtime-image"
+}

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -1,0 +1,9 @@
+{
+    "display_name": "Python 3.9 (UBI9)",
+    "metadata": {
+        "tags": [],
+        "display_name": "Python 3.9 (UBI9)",
+        "image_name": "registry.access.redhat.com/ubi9/python-39@sha256:ca20140a54051a5063b42a1a55fdca4261a07eca0aa470239b8a7b1fad51bee8"
+    },
+    "schema_name": "runtime-image"
+}


### PR DESCRIPTION
Include the runtime images inside the workbench images

## Description

Runtime images are directly used in elyra pipelines, so they are to be a part of the workbench images.
Reference: https://elyra.readthedocs.io/en/latest/user_guide/runtime-image-conf.html

Related-to: https://github.com/opendatahub-io/notebooks/issues/54
Depends-On: #63 https://github.com/openshift/release/pull/38165

## How Has This Been Tested?

Tested in local system builds.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
