### PR TITLE
Remove the default Pipeline runtime config

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
+++ b/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
@@ -1,38 +1,5 @@
 #!/bin/bash
 set -x
 
-replace_invalid_characters (){
-  python -c 'import sys;print(sys.argv[1].translate ({ord(c): "-" for c in "!@#$%^&*()[]{};:,/<>?\|`~=_+"}))' "$1"
-}
-
 # Set the elyra config on the right path
 cp /opt/app-root/bin/utils/jupyter_elyra_config.py /opt/app-root/src/.jupyter/
-
-# Assumptions are existing kubeflow installation is in the kubeflow namespace
-DEFAULT_RUNTIME_FILE=$(jupyter --data-dir)/metadata/runtimes/my_kfp.json
-
-if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/namespace" ]; then
-  SA_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-fi
-
-COS_BUCKET=$(replace_invalid_characters "$COS_BUCKET")
-export COS_BUCKET=${COS_BUCKET:-default}
-
-# If Kubeflow credentials are not supplied, use default Kubeflow installation credentials
-KF_DEPLOYMENT_NAMESPACE="${SA_NAMESPACE:=default}"
-AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:=minio}"
-AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:=minio123}"
-
-if [[ ! -f "$DEFAULT_RUNTIME_FILE" ]]; then
-  elyra-metadata install runtimes --schema_name=kfp \
-                                  --name=my_kfp \
-                                  --display_name=Default \
-                                  --auth_type=NO_AUTHENTICATION \
-                                  --api_endpoint=http://ml-pipeline."$KF_DEPLOYMENT_NAMESPACE".svc.cluster.local:3000/pipeline \
-                                  --cos_endpoint=http://minio-service."$KF_DEPLOYMENT_NAMESPACE".svc.cluster.local:9000 \
-                                  --cos_auth_type=USER_CREDENTIALS \
-                                  --cos_username="$AWS_ACCESS_KEY_ID" \
-                                  --cos_password="$AWS_SECRET_ACCESS_KEY" \
-                                  --cos_bucket="$COS_BUCKET" \
-                                  --engine=Tekton
-fi

--- a/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
+++ b/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
@@ -1,38 +1,5 @@
 #!/bin/bash
 set -x
 
-replace_invalid_characters (){
-  python -c 'import sys;print(sys.argv[1].translate ({ord(c): "-" for c in "!@#$%^&*()[]{};:,/<>?\|`~=_+"}))' "$1"
-}
-
 # Set the elyra config on the right path
 cp /opt/app-root/bin/utils/jupyter_elyra_config.py /opt/app-root/src/.jupyter/
-
-# Assumptions are existing kubeflow installation is in the kubeflow namespace
-DEFAULT_RUNTIME_FILE=$(jupyter --data-dir)/metadata/runtimes/my_kfp.json
-
-if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/namespace" ]; then
-  SA_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-fi
-
-COS_BUCKET=$(replace_invalid_characters "$COS_BUCKET")
-export COS_BUCKET=${COS_BUCKET:-default}
-
-# If Kubeflow credentials are not supplied, use default Kubeflow installation credentials
-KF_DEPLOYMENT_NAMESPACE="${SA_NAMESPACE:=default}"
-AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:=minio}"
-AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:=minio123}"
-
-if [[ ! -f "$DEFAULT_RUNTIME_FILE" ]]; then
-  elyra-metadata install runtimes --schema_name=kfp \
-                                  --name=my_kfp \
-                                  --display_name=Default \
-                                  --auth_type=NO_AUTHENTICATION \
-                                  --api_endpoint=http://ml-pipeline."$KF_DEPLOYMENT_NAMESPACE".svc.cluster.local:3000/pipeline \
-                                  --cos_endpoint=http://minio-service."$KF_DEPLOYMENT_NAMESPACE".svc.cluster.local:9000 \
-                                  --cos_auth_type=USER_CREDENTIALS \
-                                  --cos_username="$AWS_ACCESS_KEY_ID" \
-                                  --cos_password="$AWS_SECRET_ACCESS_KEY" \
-                                  --cos_bucket="$COS_BUCKET" \
-                                  --engine=Tekton
-fi


### PR DESCRIPTION
Remove the default Pipeline runtime config

## Description

As Opendatahub provides Data Science Pipelines, the default configuration of pipeline runtime to Kubeflow pipeline might confuse the users. 
Removing the default, it can be added by the user in runtime if they need it.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
