### PR TITLE
Wait for the runtime pod readiness for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,9 @@ test-%: bin/kubectl
 # This validation is created from subset of https://github.com/elyra-ai/elyra/blob/9c417d2adc9d9f972de5f98fd37f6945e0357ab9/Makefile#L325
 .PHONY: validate-runtime-image
 validate-runtime-image: bin/kubectl
+	$(eval NOTEBOOK_NAME := $(subst .,-,$(subst cuda-,,$*)))
+	$(info # Running tests for $(NOTEBOOK_NAME) runtime...)
+	$(KUBECTL_BIN) wait --for=condition=ready pod runtime-pod --timeout=300s
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \
 	if [[ $$image == "" ]] ; then \
 		echo "Usage: make validate-runtime-image image=<container-image-name>" ; \


### PR DESCRIPTION
Wait for the runtime pod readiness for e2e tests

## Description

The e2e tests trigger runtime test, right after the pods is created.
This would make the test wait till pod is ready for connection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Execute following commands
```
make deploy8-runtimes-datascience-ubi8-python-3.8 \
            -e IMAGE_REGISTRY="${NOTEBOOK_IMAGE[0]}" -e NOTEBOOK_TAG="${NOTEBOOK_IMAGE[1]}"
make validate-runtime-image image=runtime-datascience-ubi8-python-3.8
make undeploy8-runtimes-datascience-ubi8-python-3.8
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
