### PR TITLE
Set default env vars for ssl_sa_certs and sa_token path

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
+++ b/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
@@ -8,3 +8,7 @@ cp /opt/app-root/bin/utils/jupyter_elyra_config.py /opt/app-root/src/.jupyter/
 if [ "$(ls -A /opt/app-root/runtimes/)" ]; then
   cp -r /opt/app-root/runtimes/..data/*.json $(jupyter --data-dir)/metadata/runtimes/
 fi
+
+# Environment vars set for accessing ssl_sa_certs and sa_token
+export KF_PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
+++ b/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
@@ -8,3 +8,7 @@ cp /opt/app-root/bin/utils/jupyter_elyra_config.py /opt/app-root/src/.jupyter/
 if [ "$(ls -A /opt/app-root/runtimes/)" ]; then
   cp -r /opt/app-root/runtimes/..data/*.json $(jupyter --data-dir)/metadata/runtimes/
 fi
+
+# Environment vars set for accessing ssl_sa_certs and sa_token
+export KF_PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"


### PR DESCRIPTION
Set default env vars for ssl_sa_certs and sa_token path

## Description


This PR sets the path of SA token and ssl_sa_certs to env vars, as it would be easy for using the env vars directly.

## How Has This Been Tested?

The path can be checked in the image for availability.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
