### PR TITLE
Update the notebook with runtime ubi image

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "registry.access.redhat.com/ubi8/python-38@sha256:70c8859892d55466d11734431233ec0348cad66a3be6aa7777a7694569808c26"
+        "image_name": "registry.redhat.io/ubi8/python-38@sha256:ce9647e1967c8fbdc171a3ff99642fbaca344cd43010cd3ab9314cdcb8a74d98"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.9 (UBI9)",
-        "image_name": "registry.access.redhat.com/ubi9/python-39@sha256:ca20140a54051a5063b42a1a55fdca4261a07eca0aa470239b8a7b1fad51bee8"
+        "image_name": "registry.redhat.io/ubi9/python-39@sha256:02427ad2ce51fad244ad46cb877c5e2aa9e09e79728c02ad137f6bf36c81948f"
     },
     "schema_name": "runtime-image"
 }


### PR DESCRIPTION
Update the notebook with runtime ubi image

## Description

Using the image from [registry.redhat.io](https://catalog.redhat.com/software/containers/ubi9/python-39/61a61032bfd4a5234d59629e?push_date=1683641102000&container-tabs=gti&architecture=amd64&gti-tabs=red-hat-login) 
Fixes: https://github.com/opendatahub-io/notebooks/issues/88

## How Has This Been Tested?
```
$ podman run -it registry.redhat.io/ubi9/python-39@sha256:02427ad2ce51fad244ad46cb877c5e2aa9e09e79728c02ad137f6bf36c81948f


This is a S2I python-3.9 rhel base image:
There are multiple ways how to run the image, see documentation at:
https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md

To use it in Openshift, run:
oc new-app python:3.9~https://github.com/sclorg/s2i-python-container.git --context-dir=3.9/test/setup-test-app/

You can then run the resulting image via:
oc get pods
oc exec <pod> -- curl 127.0.0.1:8080

```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
