### PR TITLE
Add R Studio notebook based on CentOS with Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,23 +89,25 @@ graph TB
 
     subgraph Runtimes
         %% Nodes
-        runtimes-datascience-ubi8-python-3.9("CUDA Data Science Notebook<br/>(cuda-jupyter-datascience-ubi8-python-3.9)");
-        runtimes-pytorch-ubi8-python-3.9("PyTorch Notebook<br/>(jupyter-pytorch-ubi8-python-3.9)");
-        cuda-runtimes-tensorflow-ubi8-python-3.9("CUDA TensorFlow Notebook<br/>(cuda-jupyter-tensorflow-ubi8-python-3.9)");
+        runtimes-datascience-ubi9-python-3.9("CUDA Data Science Notebook<br/>(cuda-jupyter-datascience-ubi9-python-3.9)");
+        runtimes-pytorch-ubi9-python-3.9("PyTorch Notebook<br/>(jupyter-pytorch-ubi9-python-3.9)");
+        cuda-runtimes-tensorflow-ubi9-python-3.9("CUDA TensorFlow Notebook<br/>(cuda-jupyter-tensorflow-ubi9-python-3.9)");
 
         %% Edges
-        base-ubi8-python-3.9 --> runtimes-datascience-ubi8-python-3.9;
-        base-ubi8-python-3.9 --> runtimes-pytorch-ubi8-python-3.9;
-        cuda-ubi8-python-3.9 --> cuda-runtimes-tensorflow-ubi8-python-3.9;
+        base-ubi9-python-3.9 --> runtimes-datascience-ubi9-python-3.9;
+        base-ubi9-python-3.9 --> runtimes-pytorch-ubi9-python-3.9;
+        cuda-ubi9-python-3.9 --> cuda-runtimes-tensorflow-ubi9-python-3.9;
     end
 
-    subgraph Code Server/VS code
+    subgraph Other Notebooks
         %% Nodes
         c9s-python-3.9("CentOS Stream Base<br/>(c9s-python-3.9)");
         code-server-c9s-python-3.9("Code Server <br/>(code-server-c9s-python-3.9)");
+        r-studio-c9s-python-3.9("R Studio <br/>(r-studio-c9s-python-3.9)");
 
         %% Edges
         c9s-python-3.9 --> code-server-c9s-python-3.9;
+        c9s-python-3.9 --> r-studio-c9s-python-3.9;
     end
 
 ```
@@ -137,6 +139,7 @@ The following workbench images are available:
 - runtime-pytorch-ubi8-python-3.9
 - cuda-runtime-tensorflow-ubi8-python-3.9
 - code-server-c9s-python-3.9
+- r-studio-c9s-python-3.9;
 
 If you want to manually build a workbench image, you can use the following
 command:

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -1,0 +1,115 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+LABEL name="odh-notebook-rstudio-c9s-python-3.9" \
+      summary="R Studio image with python 3.9 based on CentOS Stream 9" \
+      description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.display-name="R Studio image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.description="R Studio image with python 3.9 based on CentOS Stream 9" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/c9s-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-c9s-python-3.9"
+
+USER 0
+
+ENV R_VERSION=4.3.0
+
+# Install R
+RUN yum install -y yum-utils && \
+    yum-config-manager --enable crb && \
+    yum install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    INSTALL_PKGS="R-core R-core-devel R-java R-Rcpp R-highlight \
+    R-littler R-littler-examples openssl-libs compat-openssl11" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /usr/lib64/R/etc/Rprofile.site && \
+    (umask 002;touch /usr/lib64/R/etc/Renviron.site) && \
+    yum -y clean all --enablerepo='*'
+
+# set R library to default (used in install.r from littler)
+ENV LIBLOC /usr/lib64/R/library
+
+# set User R Library path
+ENV R_LIBS_USER /opt/app-root/src/Rpackages/4.2
+
+WORKDIR /tmp/
+
+# Install RStudio
+RUN wget https://download2.rstudio.org/server/rhel8/x86_64/rstudio-server-rhel-2022.12.0-353-x86_64.rpm && \
+    yum install -y rstudio-server-rhel-2022.12.0-353-x86_64.rpm && \
+    rm rstudio-server-rhel-2022.12.0-353-x86_64.rpm && \
+    yum -y clean all  --enablerepo='*'
+
+# Specific RStudio config and fixes
+RUN chmod 1777 /var/run/rstudio-server && \
+    mkdir -p /usr/share/doc/R
+COPY rsession.conf /etc/rstudio/rsession.conf
+
+# Install NGINX to proxy RStudio and pass probes check 
+ENV NGINX_VERSION=1.22 \
+    NGINX_SHORT_VER=122 \
+    NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+# Modules does not exist
+RUN yum -y module enable nginx:$NGINX_VERSION && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
+    # spawn-fcgi is not in epel9
+    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/34/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-20.fc34.x86_64.rpm && \
+    yum -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY nginx/root/ /
+
+# Changing ownership and user rights to support following use-cases:
+# 1) running container on OpenShift, whose default security model
+#    is to run the container under random UID, but GID=0
+# 2) for working root-less container with UID=1001, which does not have
+#    to have GID=0
+# 3) for default use-case, that is running container directly on operating system,
+#    with default UID and GID (1001:0)
+# Supported combinations of UID:GID are thus following:
+# UID=1001 && GID=0
+# UID=<any>&& GID=0
+# UID=1001 && GID=<any>
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/api/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    chown -R 1001:0 ${NGINX_CONF_PATH} && \
+    chown -R 1001:0 ${NGINX_APP_ROOT}/etc && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod    ug+rw  ${NGINX_CONF_PATH} && \
+    chmod -R ug+rwX ${NGINX_APP_ROOT}/etc && \
+    chmod -R ug+rwX ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run && \
+    rpm-file-permissions
+
+# Configure nginx
+COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY nginx/api/ /opt/app-root/api/
+
+# Launcher
+WORKDIR /opt/app-root/bin
+
+COPY utils utils/
+COPY run-rstudio.sh setup_rstudio.py rsession.sh run-nginx.sh ./
+
+WORKDIR /opt/app-root/src
+
+USER 1001
+
+CMD /opt/app-root/bin/run-rstudio.sh

--- a/rstudio/c9s-python-3.9/kustomize/base/kustomization.yaml
+++ b/rstudio/c9s-python-3.9/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: rstudio-
+resources:
+  - pod.yaml
+images:
+  - name: rstudio-workbench
+    newName: quay.io/opendatahub/workbench-images
+    newTag: rstudio-c9s-python-3.9

--- a/rstudio/c9s-python-3.9/kustomize/base/pod.yaml
+++ b/rstudio/c9s-python-3.9/kustomize/base/pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  labels:                                
+    app: rstudio-image
+spec:
+  containers:                            
+  - name: rstudio
+    image: rstudio-workbench
+    command: [ "/bin/sh", "-c", "while true ; do date; sleep 5; done;" ] 
+    imagePullPolicy: Always
+    ports:
+      - containerPort: 8787
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 500m
+        memory: 500Mi

--- a/rstudio/c9s-python-3.9/nginx/api/kernels/access.cgi
+++ b/rstudio/c9s-python-3.9/nginx/api/kernels/access.cgi
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Status: 200"
+echo "Content-type: application/json"
+echo
+# Retrieve last line from custom logs
+LOG_TAIL=$(tail -n 1 /var/log/nginx/rstudio.access.log)
+# Extract last_activity field
+LAST_ACTIVITY=$(echo $LOG_TAIL | grep -Po 'last_activity":"\K.*?(?=")')
+if [[ $(date -d $LAST_ACTIVITY"+10 minutes" +%s) -lt $(date +%s) ]]; then
+    # No activity for the past 10mn, we consider VSCode idle and begin to send idle response
+    # As logs always write "busy", we first substitute with "idle" in the answer
+    sed s/busy/idle/ <<<"$LOG_TAIL"
+else
+    echo $LOG_TAIL
+fi

--- a/rstudio/c9s-python-3.9/nginx/api/probe.cgi
+++ b/rstudio/c9s-python-3.9/nginx/api/probe.cgi
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [[ $(ps -aux | grep server | grep rsession) ]]; then
+    echo "Status: 200"
+    echo "Content-type: text/html"
+    echo
+    echo  "<html><body>RServer is up!</body></html>"
+else
+    echo "Status: 404"
+    echo "Content-type: text/html"
+    echo ""
+    echo "<html><body>RServer is not running!</body></html>"
+fi

--- a/rstudio/c9s-python-3.9/nginx/httpconf/http.conf
+++ b/rstudio/c9s-python-3.9/nginx/httpconf/http.conf
@@ -1,0 +1,34 @@
+# Make WebSockets working
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+###
+# Custom logging for direct last_activity based culling, brace yourself!
+###
+
+# Exclude heartbeat from logging for culling purposes
+map $request $loggable {
+    ~\/rstudio\/events\/get_events  0;
+    default 1;
+}
+
+# iso8601 with millisecond precision transformer (mimicking Jupyter output)
+map $time_iso8601 $time_iso8601_p1 {
+    ~([^+]+) $1;
+}
+map $time_iso8601 $time_iso8601_p2 {
+    ~\+([0-9:]+)$ $1;
+}
+map $msec $millisec {
+    ~\.([0-9]+)$ $1;
+}
+
+log_format json escape=json '[{'
+    '"id":"rstudio",'
+    '"name":"rstudio",'
+    '"last_activity":"$time_iso8601_p1.$millisec+$time_iso8601_p2",'
+    '"execution_state":"busy",'
+    '"connections": 1'
+    '}]';

--- a/rstudio/c9s-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
+++ b/rstudio/c9s-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
@@ -1,0 +1,9 @@
+# Set current user in nss_wrapper
+PASSWD_DIR="/opt/app-root/etc"
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < ${PASSWD_DIR}/passwd.template > ${PASSWD_DIR}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${PASSWD_DIR}/passwd
+export NSS_WRAPPER_GROUP=/etc/group

--- a/rstudio/c9s-python-3.9/nginx/root/opt/app-root/etc/passwd.template
+++ b/rstudio/c9s-python-3.9/nginx/root/opt/app-root/etc/passwd.template
@@ -1,0 +1,15 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin
+apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin

--- a/rstudio/c9s-python-3.9/nginx/root/opt/app-root/etc/scl_enable
+++ b/rstudio/c9s-python-3.9/nginx/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-nginx$NGINX_SHORT_VER

--- a/rstudio/c9s-python-3.9/nginx/root/opt/app-root/nginxconf.sed
+++ b/rstudio/c9s-python-3.9/nginx/root/opt/app-root/nginxconf.sed
@@ -1,0 +1,18 @@
+# Change port
+/listen/s%80%8888 default_server%
+
+# One worker only
+/worker_processes/s%auto%1%
+
+s/^user *nginx;//
+s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
+s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
+s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d
+
+# Addition for RStudio
+/server_name/s%server_name  _%server_name  ${BASE_URL}%

--- a/rstudio/c9s-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
+++ b/rstudio/c9s-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template
+++ b/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template
@@ -1,0 +1,66 @@
+###############
+# Fix rstudio-server auth-sign-in redirect bug
+###############
+rewrite ^/auth-sign-in(.*) "$scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+###############
+
+###############
+# api calls from probes get to CGI processing
+###############
+location /api/ {
+  index probe.cgi;
+  fastcgi_index probe.cgi;
+  gzip off;
+  access_log  off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+
+location = /api/kernels {
+    return 302 $scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = / {
+    return 302 $scheme://$http_host/rstudio/;
+}
+
+location = /rstudio {
+    return 302 $scheme://$http_host/rstudio/;
+}
+
+location /rstudio/ {
+    rewrite ^/rstudio/(.*)$ /$1 break;
+    # Standard RStudio/NGINX configuration
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+
+    # Needed to make it work properly
+    proxy_set_header X-RStudio-Request $scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Root-Path /rstudio;
+    proxy_set_header Host $http_host;
+
+    access_log /var/log/nginx/rstudio.access.log json if=$loggable;
+}
+###############

--- a/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
@@ -1,0 +1,93 @@
+###############
+# Fix rstudio-server auth-sign-in redirect bug
+###############
+rewrite ^/auth-sign-in(.*) "$scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+###############
+
+###############
+# api calls from probes get to CGI processing
+###############
+location = ${NB_PREFIX}/api {
+    return 302 /api/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/ {
+    return 302 /api/;
+    access_log  off;
+}
+
+location /api/ {
+  index probe.cgi;
+  fastcgi_index probe.cgi;
+  gzip off;
+  access_log  off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = ${NB_PREFIX}/api/kernels {
+    return 302 $scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/kernels/ {
+    return 302 $scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# root and prefix get to RStudio endpoint
+###############
+location = ${NB_PREFIX} {
+    return 302 $scheme://$http_host/rstudio/;
+}
+
+location ${NB_PREFIX}/ {
+    return 302 $scheme://$http_host/rstudio/;
+}
+
+location = /rstudio {
+    return 302 $scheme://$http_host/rstudio/;
+}
+
+location = / {
+    return 302 $scheme://$http_host/rstudio/;
+}
+
+location /rstudio/ {
+    rewrite ^/rstudio/(.*)$ /$1 break;
+    # Standard RStudio/NGINX configuration
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+
+    # Needed to make it work properly
+    proxy_set_header X-RStudio-Request $scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Root-Path /rstudio;
+    proxy_set_header Host $http_host;
+
+    access_log /var/log/nginx/rstudio.access.log json if=$loggable;
+}
+###############

--- a/rstudio/c9s-python-3.9/rsession.conf
+++ b/rstudio/c9s-python-3.9/rsession.conf
@@ -1,0 +1,2 @@
+# Set library path
+r-libs-user=/opt/app-root/src/Rpackages/4.2

--- a/rstudio/c9s-python-3.9/rsession.sh
+++ b/rstudio/c9s-python-3.9/rsession.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/lib/rstudio-server/bin/rsession "$@"

--- a/rstudio/c9s-python-3.9/run-nginx.sh
+++ b/rstudio/c9s-python-3.9/run-nginx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+# disabled, only used to source nginx files in user directory
+#process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
+
+if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
+fi
+
+# substitute NB_PREFIX in proxy configuratin if it exists
+if [ -z "$NB_PREFIX" ]; then
+    cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
+else
+    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+fi
+
+nginx

--- a/rstudio/c9s-python-3.9/run-rstudio.sh
+++ b/rstudio/c9s-python-3.9/run-rstudio.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Load bash libraries
+SCRIPT_DIR=$(dirname -- "$0")
+source ${SCRIPT_DIR}/utils/*.sh
+
+# Start nginx and fastcgiwrap
+run-nginx.sh &
+spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+
+# Create lib folders if it does not exist
+mkdir -p  /opt/app-root/src/Rpackages/4.2
+
+# rstudio terminal cant see environment variables set by the container runtime
+# (which breaks kubectl, to fix this we store the KUBERNETES_* env vars in Renviron.site)
+env | grep KUBERNETES_ >> /usr/lib64/R/etc/Renviron.site
+
+export USER=$(whoami)
+
+# Initilize access logs for culling
+echo '[{"id":"rstudio","name":"rstudio","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/rstudio.access.log
+
+# Create RStudio launch command
+launch_command=$(python /opt/app-root/bin/setup_rstudio.py)
+
+echo $launch_command
+
+start_process $launch_command

--- a/rstudio/c9s-python-3.9/setup_rstudio.py
+++ b/rstudio/c9s-python-3.9/setup_rstudio.py
@@ -1,0 +1,83 @@
+import getpass
+import os
+import shutil
+import subprocess
+import tempfile
+from textwrap import dedent
+from urllib.parse import urlparse, urlunparse
+
+def get_rstudio_executable(prog):
+    # Find prog in known locations
+    other_paths = [
+        # When rstudio-server deb is installed
+        os.path.join('/usr/lib/rstudio-server/bin', prog),
+        # When just rstudio deb is installed
+        os.path.join('/usr/lib/rstudio/bin', prog),
+    ]
+    if shutil.which(prog):
+        return shutil.which(prog)
+
+    for op in other_paths:
+        if os.path.exists(op):
+            return op
+
+    raise FileNotFoundError(f'Could not find {prog} in PATH')
+
+def db_config(db_dir):
+    '''
+    Create a temporary directory to hold rserver's database, and create
+    the configuration file rserver uses to find the database.
+
+    https://docs.rstudio.com/ide/server-pro/latest/database.html
+    https://github.com/rstudio/rstudio/tree/v1.4.1103/src/cpp/server/db
+    '''
+    # create the rserver database config
+    db_conf = dedent("""
+        provider=sqlite
+        directory={directory}
+    """).format(directory=db_dir)
+    f = tempfile.NamedTemporaryFile(mode='w', delete=False, dir=db_dir)
+    db_config_name = f.name
+    f.write(db_conf)
+    f.close()
+    return db_config_name
+
+def _support_arg(arg):
+    ret = subprocess.check_output([get_rstudio_executable('rserver'), '--help'])
+    return ret.decode().find(arg) != -1
+
+def _get_cmd(port):
+    ntf = tempfile.NamedTemporaryFile()
+
+    # use mkdtemp() so the directory and its contents don't vanish when
+    # we're out of scope
+    server_data_dir = tempfile.mkdtemp()
+    database_config_file = db_config(server_data_dir)
+
+    cmd = [
+        get_rstudio_executable('rserver'),
+        '--server-daemonize=0',
+        '--server-working-dir=' + os.getenv('HOME'),
+        '--auth-none=1',
+        '--www-frame-origin=same',
+        #'--www-address=0.0.0.0',
+        '--www-port=' + str(port),
+        '--www-verify-user-agent=0',
+        '--rsession-which-r=' + get_rstudio_executable('R'),
+        '--secure-cookie-key-file=' + ntf.name,
+        '--server-user=' + getpass.getuser(),
+        '--rsession-path=/opt/app-root/bin/rsession.sh',
+    ]
+    # Support at least v1.2.1335 and up
+
+    #if _support_arg('www-root-path'):
+    #    cmd.append('--www-root-path=/rstudio/')
+    if _support_arg('server-data-dir'):
+        cmd.append(f'--server-data-dir={server_data_dir}')
+    if _support_arg('database-config-file'):
+        cmd.append(f'--database-config-file={database_config_file}')
+    
+    return(' '.join(cmd))
+
+if __name__ == "__main__":
+    print(_get_cmd(8787))

--- a/rstudio/c9s-python-3.9/utils/process.sh
+++ b/rstudio/c9s-python-3.9/utils/process.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+function start_process() {
+    trap stop_process TERM INT
+
+    echo "Running command: $@"
+    "$@" &
+
+    PID=$!
+    wait $PID
+    trap - TERM INT
+    wait $PID
+    STATUS=$?
+    exit $STATUS
+}
+
+function stop_process() {
+    echo "Stopping rstudio-server"
+    rstudio-server suspend-all
+    sleep 5 #Wait for the session to properly stop
+    kill -TERM $PID
+}


### PR DESCRIPTION
This PR introduces the new R Studio notebook into the list of the OOTB images.

Open Issue: https://github.com/opendatahub-io/notebooks/issues/74

Merge Notes: CI PR should be merged first https://github.com/openshift/release/pull/39415

## Description
This notebook has been derived from the base image `base-c9s-python-3.9`

## How Has This Been Tested?
Create the image by running: `make rstudio-c9s-python-3.9`

Run the Image locally:
`podman run --network=host --name validation-container  quay.io/rh_ee_atheodor/notebooks:rstudio-c9s-python-3.9-2023a_20230515`

Open the browser using the following URL:  http://127.0.0.1:8787/
You should expect to see the following IDE
![Screenshot from 2023-05-17 10-39-15](https://github.com/opendatahub-io/notebooks/assets/42587738/0d6bc818-821b-4bee-8dc2-9f01675b2a2e)

When you finish the inspection: podman stop validation-container && podman rm validation-container

Deploy: `make deploy-c9s-rstudio-c9s-python-3.9`
Test: `make validate-rstudio-image image=rstudio-c9s-python-3.9-2023a_YYYYMMDD`
Undeploy: `make undeploy-c9s-rstudio-c9s-python-3.9`


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
