### PR TITLE
Include patch option for providing ssl_ca_certs

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -36,6 +36,9 @@ RUN mkdir /opt/app-root/runtimes && \
     sed -i "s/Kubeflow Pipelines/Data Science Pipelines/g" /opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/kfp.json && \
     sed -i "s/kubeflow-service/data-science-pipeline-service/g" /opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/kfp.json && \
     sed -i "s/\"default\": \"Argo\",/\"default\": \"Tekton\",/g" /opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/kfp.json && \
+    # Workaround for passing ssl_sa_cert
+    patch /opt/app-root/lib/python3.8/site-packages/elyra/pipeline/kfp/kfp_authentication.py -i utils/kfp_authentication.patch && \
+    patch /opt/app-root/lib/python3.8/site-packages/elyra/pipeline/kfp/processor_kfp.py -i utils/processor_kfp.patch && \
     # switch to Data Science Pipeline in component catalog \
     DIR_COMPONENT="/opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/local-directory-catalog.json" && \
     FILE_COMPONENT="/opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/local-file-catalog.json" && \

--- a/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
+++ b/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
@@ -44,6 +44,6 @@ if [ "$(ls -A /opt/app-root/runtimes/)" ]; then
 fi
 
 # Environment vars set for accessing ssl_sa_certs and sa_token
-export KF_PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+# export PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"
 export KF_PIPELINES_SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/jupyter/datascience/ubi8-python-3.8/utils/kfp_authentication.patch
+++ b/jupyter/datascience/ubi8-python-3.8/utils/kfp_authentication.patch
@@ -1,0 +1,18 @@
+--- a/kfp_authentication.py	2023-06-09 10:13:11.412910808 -0400
++++ b/kfp_authentication.py	2023-06-09 10:14:39.879565175 -0400
+@@ -230,6 +230,7 @@
+         """
+ 
+         kf_url = urlsplit(api_endpoint)._replace(path="").geturl()
++        kf_pipelines_ssl_sa_cert = os.getenv("PIPELINES_SSL_SA_CERTS", None)
+ 
+         # return data structure for successful requests
+         auth_info = {
+@@ -239,6 +240,7 @@
+             "cookies": None,  # passed to KFP SDK client as "cookies" param value
+             "credentials": None,  # passed to KFP SDK client as "credentials" param value
+             "existing_token": None,  # passed to KFP SDK client as "existing_token" param value
++            "ssl_ca_cert": kf_pipelines_ssl_sa_cert,  # passed to KFP SDK Client as "ssl_ca_cert" param value
+         }
+ 
+         try:

--- a/jupyter/datascience/ubi8-python-3.8/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi8-python-3.8/utils/processor_kfp.patch
@@ -1,0 +1,10 @@
+--- a/processor_kfp.py	2023-06-09 10:17:15.659461927 -0400
++++ b/processor_kfp.py	2023-06-09 10:16:20.062429914 -0400
+@@ -213,6 +213,7 @@
+                     credentials=auth_info.get("credentials", None),
+                     existing_token=auth_info.get("existing_token", None),
+                     namespace=user_namespace,
++                    ssl_ca_cert=auth_info.get("ssl_ca_cert", None),
+                 )
+             else:
+                 client = ArgoClient(

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -36,6 +36,9 @@ RUN mkdir /opt/app-root/runtimes && \
     sed -i "s/Kubeflow Pipelines/Data Science Pipelines/g" /opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/kfp.json && \
     sed -i "s/kubeflow-service/data-science-pipeline-service/g" /opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/kfp.json && \
     sed -i "s/\"default\": \"Argo\",/\"default\": \"Tekton\",/g" /opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/kfp.json && \
+    # Workaround for passing ssl_sa_cert
+    patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/kfp/kfp_authentication.py -i utils/kfp_authentication.patch && \
+    patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/kfp/processor_kfp.py -i utils/processor_kfp.patch && \
     # switch to Data Science Pipeline in component catalog \
     DIR_COMPONENT="/opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/local-directory-catalog.json" && \
     FILE_COMPONENT="/opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/local-file-catalog.json" && \

--- a/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
+++ b/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
@@ -44,6 +44,6 @@ if [ "$(ls -A /opt/app-root/runtimes/)" ]; then
 fi
 
 # Environment vars set for accessing ssl_sa_certs and sa_token
-export KF_PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+# export PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"
 export KF_PIPELINES_SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/jupyter/datascience/ubi9-python-3.9/utils/kfp_authentication.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/kfp_authentication.patch
@@ -1,0 +1,18 @@
+--- a/kfp_authentication.py	2023-06-09 10:13:11.412910808 -0400
++++ b/kfp_authentication.py	2023-06-09 10:14:39.879565175 -0400
+@@ -230,6 +230,7 @@
+         """
+ 
+         kf_url = urlsplit(api_endpoint)._replace(path="").geturl()
++        kf_pipelines_ssl_sa_cert = os.getenv("PIPELINES_SSL_SA_CERTS", None)
+ 
+         # return data structure for successful requests
+         auth_info = {
+@@ -239,6 +240,7 @@
+             "cookies": None,  # passed to KFP SDK client as "cookies" param value
+             "credentials": None,  # passed to KFP SDK client as "credentials" param value
+             "existing_token": None,  # passed to KFP SDK client as "existing_token" param value
++            "ssl_ca_cert": kf_pipelines_ssl_sa_cert,  # passed to KFP SDK Client as "ssl_ca_cert" param value
+         }
+ 
+         try:

--- a/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
@@ -1,0 +1,10 @@
+--- a/processor_kfp.py	2023-06-09 10:17:15.659461927 -0400
++++ b/processor_kfp.py	2023-06-09 10:16:20.062429914 -0400
+@@ -213,6 +213,7 @@
+                     credentials=auth_info.get("credentials", None),
+                     existing_token=auth_info.get("existing_token", None),
+                     namespace=user_namespace,
++                    ssl_ca_cert=auth_info.get("ssl_ca_cert", None),
+                 )
+             else:
+                 client = ArgoClient(


### PR DESCRIPTION
Include a patch option for providing ssl_ca_certs

## Description
Fixes: #116 

The ssl_ca_certs in an unsecured cluster could be provided by adding env var:
`PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- setup a workspace
- setup dsp pipeline
- create a notebook with image from this PR
- include env var and test the pipeline execution.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
