### PR TITLE
Update: Makefile flag for podman and JDK version in Dockerfile for TrustyAI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ define build_image
 		$(eval BUILD_ARGS := --build-arg BASE_IMAGE=$(BASE_IMAGE_NAME)),
 		$(eval BUILD_ARGS :=)
 	)
-	$(CONTAINER_ENGINE) build -t $(IMAGE_NAME) $(BUILD_ARGS) $(2)
+	$(CONTAINER_ENGINE) build --no-cache  -t $(IMAGE_NAME) $(BUILD_ARGS) $(2)
 endef
 
 # Push function for the notebok image:

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -14,7 +14,7 @@ LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.9" \
 USER 0
 
 # Install jre that is needed to run the trustyai library
-RUN INSTALL_PKGS="java-11-openjdk" && \
+RUN INSTALL_PKGS="java-17-openjdk" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
 


### PR DESCRIPTION
- add --no-cache flag for podman build
- update jdk from 11 to 17 to match version used when build trustyai

## Description
to use --no-cache flag should have no difference for openshift-ci build (since it is done in pod every time) but it might take longer time if it runs locally, the benefits is "do not use existing cached images for the container build. Build from the start with a new set of cached layers."
to uplift jdk version is to only make the runtime env close to build env. also 17 is the LTS.



## How Has This Been Tested?
flag --no-cache will impact all image build

```
[wenzhou@wenzhou notebooks]$ make jupyter-trustyai-ubi9-python-3.9
# Building quay.io/opendatahub/workbench-images:base-ubi9-python-3.9-2023a_20230612 image...
# Pushing quay.io/opendatahub/workbench-images:base-ubi9-python-3.9-2023a_20230612 image...
podman build --no-cache -t quay.io/opendatahub/workbench-images:base-ubi9-python-3.9-2023a_20230612  base/ubi9-python-3.9
.....
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
