### PR TITLE
Update datascience pipeline run URL in Elyra

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir /opt/app-root/runtimes && \
     sed -i "s/Kubeflow Pipelines/Data Science Pipelines/g" /opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/kfp.json && \
     sed -i "s/kubeflow-service/data-science-pipeline-service/g" /opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/kfp.json && \
     sed -i "s/\"default\": \"Argo\",/\"default\": \"Tekton\",/g" /opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/kfp.json && \
-    # Workaround for passing ssl_sa_cert
+    # Workaround for passing ssl_sa_cert and to ensure that Elyra redirects to a correct pipeline run URL
     patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/kfp/kfp_authentication.py -i utils/kfp_authentication.patch && \
     patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/kfp/processor_kfp.py -i utils/processor_kfp.patch && \
     # switch to Data Science Pipeline in component catalog \

--- a/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
@@ -8,3 +8,22 @@
                  )
              else:
                  client = ArgoClient(
+@@ -435,7 +435,7 @@
+ 
+             self.log_pipeline_info(
+                 pipeline_name,
+-                f"pipeline submitted: {public_api_endpoint}/#/runs/details/{run.id}",
++                f"pipeline submitted: {public_api_endpoint}/{run.id}",
+                 duration=time.time() - t0,
+             )
+ 
+@@ -451,7 +451,7 @@
+ 
+         return KfpPipelineProcessorResponse(
+             run_id=run.id,
+-            run_url=f"{public_api_endpoint}/#/runs/details/{run.id}",
++            run_url=f"{public_api_endpoint}/{run.id}",
+             object_storage_url=object_storage_url,
+             object_storage_path=object_storage_path,
+         )
+


### PR DESCRIPTION
Resolves:#130

Complementary PR from the odh-dashboard side: opendatahub-io/odh-dashboard#1461

## Description
Extended the already-present Elyra patch used in `datascience-ubi9-python-3.9` Dockerfile to change the base URL pointing to datascience pipeline runs, so that it correctly identifies particular runs.

## How Has This Been Tested?
Not fully tested yet, testing in progress

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
