### PR TITLE
Patch pipeline_run to also use pipeline_id for pipeline_version_id

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
@@ -1,5 +1,5 @@
---- a/processor_kfp.py	2023-06-09 10:17:15.659461927 -0400
-+++ b/processor_kfp.py	2023-06-09 10:16:20.062429914 -0400
+--- a/processor_kfp.py	2023-06-09 10:19:08.882563609 -0400
++++ b/processor_kfp.py	2023-07-13 19:31:43.572407879 -0400
 @@ -213,6 +213,7 @@
                      credentials=auth_info.get("credentials", None),
                      existing_token=auth_info.get("existing_token", None),
@@ -8,7 +8,16 @@
                  )
              else:
                  client = ArgoClient(
-@@ -435,7 +435,7 @@
+@@ -416,7 +417,7 @@
+ 
+                 # create pipeline run (or specified pipeline version)
+                 run = client.run_pipeline(
+-                    experiment_id=experiment.id, job_name=job_name, pipeline_id=pipeline_id, version_id=version_id
++                    experiment_id=experiment.id, job_name=job_name, pipeline_id=pipeline_id, version_id=pipeline_id
+                 )
+ 
+             except Exception as ex:
+@@ -435,7 +436,7 @@
  
              self.log_pipeline_info(
                  pipeline_name,
@@ -17,7 +26,7 @@
                  duration=time.time() - t0,
              )
  
-@@ -451,7 +451,7 @@
+@@ -451,7 +452,7 @@
  
          return KfpPipelineProcessorResponse(
              run_id=run.id,
@@ -25,5 +34,5 @@
 +            run_url=f"{public_api_endpoint}/{run.id}",
              object_storage_url=object_storage_url,
              object_storage_path=object_storage_path,
-         )
 
+         )


### PR DESCRIPTION
Patch pipeline_run to also use pipeline_id for pipeline_version_id
NOTE: This change enables each execution of a pipeline run of the same pipeline to display under the same pipeline in the odh-dashboard run view

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes: #129 

The odh-dashboard list runs based on pipeline_id 
https://github.com/opendatahub-io/odh-dashboard/blob/c1848e331143329c5bdd7ce70bc170c6feba42c8/frontend/src/api/pipelines/custom.ts#L79
this patch creates runs with pipeline_version_id as pipeline_id
which would allow this to display runs of similar pipelines under one section.

## How Has This Been Tested?

- Setup an ODH cluster
- setup data-science project and pipeline server
- Apply this image in the cluster and start a notebook
- Execute a sample pipeline twice to see the effects.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
