### PR TITLE
dropped z stream from python version in notebook

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir /opt/app-root/runtimes && \
     # Remove Elyra logo from JupyterLab because this is not a pure Elyra image \
     sed -i 's/widget\.id === \x27jp-MainLogo\x27/widget\.id === \x27jp-MainLogo\x27 \&\& false/' /opt/app-root/share/jupyter/labextensions/@elyra/theme-extension/static/lib_index_js.*.js && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    sed -i -e "s/Python.*/$(python --version| cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Fix permissions to support pip in Openshift environments \

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir /opt/app-root/runtimes && \
     # Remove Elyra logo from JupyterLab because this is not a pure Elyra image \
     sed -i 's/widget\.id === \x27jp-MainLogo\x27/widget\.id === \x27jp-MainLogo\x27 \&\& false/' /opt/app-root/share/jupyter/labextensions/@elyra/theme-extension/static/lib_index_js.*.js && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Fix permissions to support pip in Openshift environments \

--- a/jupyter/minimal/ubi8-python-3.8/Dockerfile
+++ b/jupyter/minimal/ubi8-python-3.8/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
 WORKDIR /opt/app-root/src
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 ENTRYPOINT ["start-notebook.sh"]
 

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
 WORKDIR /opt/app-root/src
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 ENTRYPOINT ["start-notebook.sh"]
 

--- a/jupyter/pytorch/ubi8-python-3.8/Dockerfile
+++ b/jupyter/pytorch/ubi8-python-3.8/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "Installing softwares and packages" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "Installing softwares and packages" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2s)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "Installing softwares and packages" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2s)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \

--- a/jupyter/tensorflow/ubi8-python-3.8/Dockerfile
+++ b/jupyter/tensorflow/ubi8-python-3.8/Dockerfile
@@ -17,7 +17,7 @@ COPY Pipfile.lock ./
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -17,7 +17,7 @@ COPY Pipfile.lock ./
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -26,7 +26,7 @@ COPY Pipfile.lock ./
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixes: #49 

I have added` “cut -d '.' -f-2)”` to the original code  `"RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json"
`in order to resolve the problem of the .z stream showing within the python version in  JL. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/opendatahub-io/notebooks/issues/49#issuecomment-1631234455
![Screenshot 2023-07-13 at 3 52 24 PM (2)](https://github.com/opendatahub-io/notebooks/assets/135062655/f6cfd46e-dcdc-4f0f-b4ab-e5bc676aed57)
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
