### PR TITLE
Set the airgapped env var required by elyra

### DIFF
--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "registry.redhat.io/ubi8/python-38@sha256:ce9647e1967c8fbdc171a3ff99642fbaca344cd43010cd3ab9314cdcb8a74d98"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-minimal-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "registry.redhat.io/ubi8/python-38@sha256:ce9647e1967c8fbdc171a3ff99642fbaca344cd43010cd3ab9314cdcb8a74d98"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-minimal-ubi8-python-3.8-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
+++ b/jupyter/datascience/ubi8-python-3.8/setup-elyra.sh
@@ -18,3 +18,7 @@ fi
 # export PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"
 export KF_PIPELINES_SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
+# Environment vars set for accessing following dependencies for air-gapped enviroment
+export ELYRA_BOOTSTRAP_SCRIPT_URL="file:///opt/app-root/bin/utils/bootstrapper.py"
+export ELYRA_PIP_CONFIG_URL="file:///opt/app-root/bin/utils/pip.conf"
+export ELYRA_REQUIREMENTS_URL="file:///opt/app-root/bin/utils/requirements-elyra.txt"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.9-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.9-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi9-python-3.9-f93694f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi9-python-3.9-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.9 (UBI9)",
-        "image_name": "registry.redhat.io/ubi9/python-39@sha256:02427ad2ce51fad244ad46cb877c5e2aa9e09e79728c02ad137f6bf36c81948f"
+        "image_name": "quay.io/opendatahub/workbench-images:runtime-minimal-ubi9-python-3.9-6a6098d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
+++ b/jupyter/datascience/ubi9-python-3.9/setup-elyra.sh
@@ -18,3 +18,7 @@ fi
 # export PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"
 export KF_PIPELINES_SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
+# Environment vars set for accessing following dependencies for air-gapped enviroment
+export ELYRA_BOOTSTRAP_SCRIPT_URL="file:///opt/app-root/bin/utils/bootstrapper.py"
+export ELYRA_PIP_CONFIG_URL="file:///opt/app-root/bin/utils/pip.conf"
+export ELYRA_REQUIREMENTS_URL="file:///opt/app-root/bin/utils/requirements-elyra.txt"


### PR DESCRIPTION
Set the airgapped env var required by elyra

## Description

According to the following [documentation](https://elyra.readthedocs.io/en/latest/recipes/running-elyra-in-air-gapped-environment.html) to run Elyra in an air-gapped environment should identify resources that must be made available to successfully install and run Elyra in such an environment.

Follow-up: https://github.com/opendatahub-io/notebooks/pull/166
https://github.com/opendatahub-io/notebooks/pull/171

Fixes: https://github.com/opendatahub-io/notebooks/issues/127
https://github.com/opendatahub-io/notebooks/issues/146


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


1. Use the jupyter based image
2. Run the elyra pipeline to validate

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
