### PR TITLE
Fix pytorch and tensorflow runtime workdir

### DIFF
--- a/runtimes/pytorch/ubi8-python-3.8/Dockerfile
+++ b/runtimes/pytorch/ubi8-python-3.8/Dockerfile
@@ -11,6 +11,8 @@ LABEL name="odh-notebook-runtime-pytorch-ubi8-python-3.8" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi8-python-3.8" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8"
 
+WORKDIR /opt/app-root/bin
+
 # Install Python packages from Pipfile.lock
 COPY Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
@@ -22,3 +24,5 @@ RUN echo "Installing softwares and packages" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
     fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src

--- a/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -11,6 +11,8 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.9" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9"
 
+WORKDIR /opt/app-root/bin
+
 # Install Python packages from Pipfile.lock
 COPY Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
@@ -22,3 +24,5 @@ RUN echo "Installing softwares and packages" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src

--- a/runtimes/tensorflow/ubi8-python-3.8/Dockerfile
+++ b/runtimes/tensorflow/ubi8-python-3.8/Dockerfile
@@ -11,6 +11,8 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi8-python-3.8" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi8-python-3.8" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi8-python-3.8"
 
+WORKDIR /opt/app-root/bin
+
 # Install Python packages from Pipfile.lock
 COPY Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
@@ -22,3 +24,5 @@ RUN echo "Installing softwares and packages" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
     fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src

--- a/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -11,6 +11,8 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.9" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi8-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi9-python-3.9"
 
+WORKDIR /opt/app-root/bin
+
 # Install Python packages from Pipfile.lock
 COPY Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
@@ -22,3 +24,5 @@ RUN echo "Installing softwares and packages" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix PyTorch and TensorFlow runtime workdir

## Description

With the current runtime PyTorch and Tensorflow the workingdir are not set properly:
Causing following issues:
```
$ podman run -it quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9-70700f2 bash
(app-root) (app-root) ls /opt/app-root/bin/utils
ls: cannot access '/opt/app-root/bin/utils': No such file or directory
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Run the PR image 
2. see follow output:

```
podman run -it quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9-pr-173 bash
(app-root) (app-root) ls /opt/app-root/bin/utils/
bootstrapper.py  pip.conf  requirements-elyra.txt
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
