### PR TITLE
Add documentation that exists on the Wiki page also in the doc folder

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,160 @@
+The following sections are aimed to provide a comprehensive guide for developers, enabling them to understand the project's architecture and seamlessly contribute to its development.
+
+## Getting Started
+This project utilizes three branches for the development: the **main** branch, which hosts the latest development, and t**wo additional branches for each release**.
+These release branches follow a specific naming format: YYYYx, where "YYYY" represents the year, and "x" is an increasing letter. Thus, they help to keep working on minor updates and bug fixes on the supported versions (N & N-1) of each workbench. 
+
+## Architecture
+The structure of the notebook's build chain is derived from the parent image. To better comprehend this concept, refer to the following graph.
+
+<p align="center">
+<img src="https://github.com/opendatahub-io/notebooks/assets/42587738/9e5df03f-01f4-4bba-9792-3b56e9b5b912" data-canonical-src="https://github.com/opendatahub-io/notebooks/assets/42587738/9e5df03f-01f4-4bba-9792-3b56e9b5b912" width="820" height="520" />
+</p>
+
+
+Each notebook inherits the properties of its parent. For instance, the TrustyAI notebook inherits all the installed packages from the Standard Data Science notebook, which in turn inherits the characteristics from its parent, the Minimal notebook.
+
+Detailed instructions on how developers can contribute to this project can be found in the [contribution.md](https://github.com/opendatahub-io/notebooks/blob/main/CONTRIBUTING.md#some-basic-instructions-to-create-a-new-notebook) file.
+
+## Workbench ImageStreams
+
+ODH supports multiple out-of-the-box pre-built workbench images ([provided in this repository](https://github.com/opendatahub-io/notebooks)). For each of those workbench images, there is a dedicated ImageStream object definition. This ImageStream object references the actual image tag(s) and contains additional metadata that describe the workbench image.
+  
+### **Annotations**
+
+Aside from the general ImageStream config values, there are additional annotations that can be provided in the workbench ImageStream definition. This additional data is leveraged further by the [odh-dashboard](https://github.com/opendatahub-io/odh-dashboard/).
+
+### **ImageStream-specific annotations**  
+The following labels and annotations are specific to the particular workbench image. They are provided in their respective sections in the `metadata` section. 
+```yaml
+metadata:
+  labels:
+    ...
+  annotations:
+    ...
+```
+### **Available labels**  
+-  **`opendatahub.io/notebook-image:`** - a flag that determines whether the ImageStream references a workbench image that is meant be shown in the UI
+### **Available annotations**
+- **`opendatahub.io/notebook-image-url:`** - a URL reference to the source of the particular workbench image
+- **`opendatahub.io/notebook-image-name:`** - a desired display name string for the particular workbench image (used in the UI)
+- **`opendatahub.io/notebook-image-desc:`** - a desired description string of the of the particular workbench image (used in the UI) 
+- **`opendatahub.io/notebook-image-order:`** - an index value for the particular workbench ImageStream (used by the UI to list available workbench images in a specific order)
+- **`opendatahub.io/recommended-accelerators`** - a string that represents the list of recommended hardware accelerators for the particular workbench ImageStream (used in the UI)
+
+### **Tag-specific annotations**  
+One ImageStream can reference multiple image tags. The following annotations are specific to a particular workbench image tag and are provided in its `annotations:` section.
+```yaml
+spec:
+  tags:
+    - annotations:
+        ...
+      from:
+        kind: DockerImage
+        name: image-repository/tag
+      name: tag-name
+```
+### **Available annotations**  
+  - **`opendatahub.io/notebook-software:`** - a string that represents the technology stack included within the workbench image. Each technology in the list is described by its name and the version used (e.g. `'[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]`')
+  - **`opendatahub.io/notebook-python-dependencies:`** -  a string that represents the list of Python libraries included within the workbench image. Each library is described by its name and currently used version (e.g. `'[{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"}]'`)
+  - **`openshift.io/imported-from:`** - a reference to the image repository where the workbench image was obtained (e.g. `quay.io/repository/opendatahub/workbench-images`)
+  - **`opendatahub.io/workbench-image-recommended:`** - a flag that allows the ImageStream tag to be marked as Recommended (used by the UI to distinguish which tags are recommended for use, e.g., when the workbench image offers multiple tags to choose from)
+
+### **ImageStream definitions for the supported out-of-the-box images in ODH**  
+
+The ImageStream definitions of the out-of-the-box workbench images for ODH can be found [here](https://github.com/opendatahub-io/odh-manifests/tree/master/notebook-images).
+
+### **Example ImageStream object definition**  
+
+An exemplary, non-functioning ImageStream object definition that uses all the aforementioned annotations is provided below.
+
+```yaml
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/example-workbench-source-repository/tree/path-to-source"
+    opendatahub.io/notebook-image-name: "Example Jupyter Notebook"
+    opendatahub.io/notebook-image-desc: "Exemplary Jupyter notebook image just for demonstrative purposes"
+    opendatahub.io/notebook-image-order: "1"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu", "habana.com/gen1"]'
+  name: example-jupyter-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
+      openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      opendatahub.io/workbench-image-recommended: 'true'
+    from:
+      kind: DockerImage
+      name: quay.io/opendatahub/workbench-images@sha256:value-of-the-image-tag
+    name: example-tag-name
+    referencePolicy:
+      type: Source
+```
+
+## Continuous Integration
+This repository has been added to the[ Openshift CI](https://github.com/openshift/release/blob/master/ci-operator/config/opendatahub-io/notebooks/opendatahub-io-notebooks-main.yaml) to build the different notebooks using the flow described in the Container Image Layering section. Every notebook will use a previous notebook as the base image:
+
+```
+images:
+  - context_dir: ${NOTEBOOK_DIR}
+    dockerfile_path: Dockerfile
+    from: ${NOTEBOOK_BASE_IMAGE_NAME}
+    to: ${NOTEBOOK_IMAGE_NAME}
+```
+The opendatahub-io-ci-image-mirror job will be used to mirror the images from the Openshift CI internal registry to the ODH Quay repository.
+
+```
+tests:
+  - as: ${NOTEBOOK_IMAGE_NAME}-image-mirror
+    steps:
+  	dependencies:
+    	  SOURCE_IMAGE_REF: ${NOTEBOOK_IMAGE_NAME}
+  	env:
+    	  IMAGE_REPO: notebooks
+  	workflow: opendatahub-io-ci-image-mirror
+```
+The images mirrored under 2 different scenarios:
+1. A new PR is opened.
+1. A PR is merged.
+
+The Openshift CI is also configured to run the unit and integration tests:
+
+```
+tests:
+  - as: notebooks-e2e-tests 
+    steps:
+      test:
+        - as: ${NOTEBOOK_IMAGE_NAME}-e2e-tests
+          commands: |
+            make test
+          from: src
+```
+
+## GitHub Actions
+This section provides an overview of the automation functionalities.
+
+**Piplock Renewal** [[Link](https://github.com/opendatahub-io/notebooks/blob/main/.github/workflows/piplock-renewal-2023a.yml)]
+
+This GitHub action is configured to be triggered on a weekly basis, specifically every Monday at 22:00 PM UTC. Its main objective is to automatically update the Pipfile.lock files by fetching the most recent minor versions available. Additionally, it also updates the hashes for the downloaded files of Python dependencies, including any sub-dependencies. Once the updated files are pushed, the CI pipeline is triggered to generate new updated images based on these changes.
+
+**Sync the downstream release branch with the upstream** [[Link](https://github.com/red-hat-data-services/notebooks/blob/main/.github/workflows/sync-release-branch-2023a.yml)]
+
+This GitHub action is configured to be triggered on a weekly basis, specifically every Tuesday at 08:00 AM UTC. Its main objective is to automatically update the downstream release branch with the upstream branch. 
+
+**Digest Updater workflow on the manifests** [[Link](https://github.com/opendatahub-io/odh-manifests/blob/master/.github/workflows/notebooks-digest-updater-upstream.yaml)]
+ 
+This GitHub action is designed to be triggered on a weekly basis, specifically every Friday at 12:00 AM UTC. Its primary purpose is to automate the process of updating the SHA digest of the notebooks. It achieves this by fetching the new SHA values from the quay.io registry and updating the [param.env](https://github.com/opendatahub-io/odh-manifests/blob/master/notebook-images/base/params.env) file, which is hosted on the odh-manifest repository. By automatically updating the SHA digest, this action ensures that the notebooks remain synchronized with the latest changes.
+
+**Digest Updater workflow on the live-builder** [[Link](https://gitlab.cee.redhat.com/data-hub/rhods-live-builder/-/blob/main/.gitlab/notebook-sha-digest-updater.yml)]
+
+This GitHub action works with the same logic as the above and is designed to be triggered on a weekly basis, specifically every Friday. It is also update the SHA digest of the images into the [CSV](https://gitlab.cee.redhat.com/data-hub/rhods-live-builder/-/blob/main/rhods-operator-live/bundle/template/manifests/clusterserviceversion.yml.j2#L725) file on the live-builder repo. 
+  
+  
+[Previous Page](https://github.com/opendatahub-io/notebooks/wiki/Workbenches) | [Next Page](https://github.com/opendatahub-io/notebooks/wiki/User-Guide)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,46 @@
+The following sections are aimed to provide a comprehensive guide on effectively utilizing an out-of-the-box notebook by a user.
+There are two options for launching a workbench image: either through the Enabled applications or the Data Science Project.
+
+## Notebook Spawner 
+
+In the ODH dashboard, you can navigate to Applications -> Enabled -> Launch Application from the Jupyter tile. The notebook server spawner page displays a list of available container images you can run as a single user."
+
+<p align="center">
+<img src="https://github.com/opendatahub-io/notebooks/assets/42587738/8ff97ee4-4c47-4b87-b476-fe5adec4462d" data-canonical-src="https://github.com/opendatahub-io/notebooks/assets/42587738/8ff97ee4-4c47-4b87-b476-fe5adec4462d" width="700" height="950" />
+</p>
+
+
+## Data Science Project
+
+A user can navigate to the Data Science Project menu and create a project like the following:
+
+<p align="center">
+<img src="https://github.com/opendatahub-io/notebooks/assets/42587738/487b99b0-01a4-4fb6-8f68-17b558c3808f" data-canonical-src="https://github.com/opendatahub-io/notebooks/assets/42587738/487b99b0-01a4-4fb6-8f68-17b558c3808f" width="950" height="920" />
+</p>
+
+## Updates
+
+This section provides an overview of the rebuilding plan. There are two types of updates that are implemented:
+
+1. Release updates - These updates will be carried out twice a year and incorporate major updates to the notebook images.
+1. Patch updates - These updates will be carried out weekly and will focus on incorporating security updates to the notebook images.
+
+
+**Scope and frequency of the updates**
+
+When performing major updates to the notebook images, all components are reviewed for updates, including the base OS image, OS packages, Python version, and Python packages and libraries. A major update, which will be named “YYYYx” release (where YYYY is the year and x is an increased letter), will fix the set of components that are included, as well as their MAJOR and MINOR versions.
+During the release lifecycle, which is the period during which the update is supported, the only updates that will be made are patches to allow for security updates and fixes while maintaining compatibility. These weekly updates will only modify the PATCH version, leaving the major and minor versions unchanged.
+
+**Support**
+
+Our goal is to ensure that notebook images are supported for a minimum of one year, meaning that typically two supported images will be available at any given time. This provides sufficient time for users to update their code to use components from the latest notebook images. We will continue to make older images available in the registry for users to add as custom notebook images, even if they are no longer supported. This way, users can still access the older images if needed.
+Example lifecycle (not actual dates):
+
+2023-01-01 - only one version of the notebook images is available - version 1 for all images.  
+2023-06-01 - release updated images - version 2 (v2023a). Versions 1 & 2 are supported and available for selection in the UI.  
+2023-12-01 - release updated images - version 3 (v2023b). Versions 2 & 3 are supported and available for selection in the UI.  
+2024-06-01 - release updated images - version 4 (v2024a). Versions 3 & 4 are supported and available for selection in the UI.  
+
+
+[Previous Page](https://github.com/opendatahub-io/notebooks/wiki/Developer-Guide)
+

--- a/docs/workbenches.md
+++ b/docs/workbenches.md
@@ -1,0 +1,69 @@
+
+Workbench images are supported for a minimum of one year. Major updates to pre-configured notebook images occur approximately every six months. Therefore, two supported notebook images are typically available at any given time. If necessary, you can still access older notebook images from the registry, even if they are no longer supported. You can then add the older notebook images as custom notebook images to cater to the project’s specific requirements.
+
+Open Data Hub contains the following workbench images with different variations:
+
+| Workbenches          | ODH | RHODS | OS     | GPU | Runtimes |
+|----------------------|-----|-------|--------|-----|----------|
+| Jupyter Minimal      |  V  | V     | UBI8/9 | -   | -        |
+| CUDA                 | V   | V     | UBI8/9 | V   | -        |
+| Jupyter Data Science | V   | V     | UBI8/9 | -   | V        |
+| Jupyter Tensorflow   | V   | V     | UBI8/9 | V   | V        |
+| Jupyter PyTorch      | V   | V     | UBI8/9 | V   | V        |
+| Jupyter TrustyAI     | V   | V     | UBI9   | -   | -        |
+| Code Server          | V   | -     | C9S    | -   | -        |
+| R Studio             | V   | -     | C9S    | V   | -        |
+
+These notebooks are incorporated to be used in conjunction with Open Data Hub, specifically utilizing the ODH Notebook Controller as the launching platform.
+
+## Jupyter Minimal
+
+If you do not require advanced machine learning features or additional resources for compute-intensive data science work, you can use the Minimal Python image to develop your models.
+
+[Installed Packages](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/minimal/ubi9-python-3.9/Pipfile)
+
+
+## CUDA
+
+If you are working with compute-intensive data science models that require GPU support, use the Compute Unified Device Architecture (CUDA) notebook image to gain access to the NVIDIA CUDA Toolkit. Using this toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
+
+[Installed Packages](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/minimal/ubi9-python-3.9/Pipfile)
+
+## Jupyter Data Science
+
+Use the Standard Data Science notebook image for models that do not require TensorFlow or PyTorch. This image contains commonly used libraries to assist you in developing your machine-learning models. 	
+
+[Installed Packages](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/datascience/ubi9-python-3.9/Pipfile)
+
+## Jupyter Tensorflow 
+
+TensorFlow is an open-source platform for machine learning. With TensorFlow, you can build, train and deploy your machine learning models. TensorFlow contains advanced data visualization features, such as computational graph visualizations. It also allows you to easily monitor and track the progress of your models.
+
+[Installed Packages](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/tensorflow/ubi9-python-3.9/Pipfile)
+
+## Jupyter PyTorch 
+
+PyTorch is an open-source machine learning library optimized for deep learning. If you are working with computer vision or natural language processing models, use the Pytorch notebook image. 	
+
+[Installed Packages](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch/ubi9-python-3.9/Pipfile)
+
+## Jupyter TrustyAI
+
+Use the TrustyAI notebook image to leverage your data science work with model explainability, tracing and accountability, and runtime monitoring. 	
+
+[Installed Packages](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/trustyai/ubi9-python-3.9/Pipfile)
+
+ ## Code Server
+
+Code Server (VS Code) provides a browser-based integrated development environment (IDE) where you can write, edit, and debug code using the familiar interface and features of VS Code. It is particularly useful for collaborating with team members, as everyone can access the same development environment from their own devices. In order to unlock the code server notebook is required to enable the additional overlay layer on the kfdef.
+
+## R Studio
+
+It provides a powerful integrated development environment specifically designed for R programming. By integrating R Studio IDE into ODH, you equip data analysts with a dedicated environment for exploring and manipulating data, building models, and generating insightful visualizations. Moreover, If you are working with compute-intensive data science models that require GPU support, use the CUDA R Studio notebook image to gain access to the NVIDIA CUDA Toolkit. In order to unlock the R Studio notebook is required to enable the additional overlay layer on the kfdef.
+
+  
+  
+[Previous Page](https://github.com/opendatahub-io/notebooks/wiki) | [Next Page](https://github.com/opendatahub-io/notebooks/wiki/Developer-Guide)
+  
+
+


### PR DESCRIPTION
Add the documentation that is on the Wiki page also in the doc folder.

## Description
<!--- Describe your changes in detail -->
Since all of the rest repos keep the documentation in a particular folder on the repo we want to do the same.

Related to: 
- https://github.com/opendatahub-io/notebooks/issues/160
- https://github.com/opendatahub-io/notebooks/issues/161
- https://github.com/opendatahub-io/notebooks/issues/162

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
