### PR TITLE
Fix UBI version used on particular places with regards the Pyton version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ cuda-jupyter-tensorflow-ubi8-python-3.8: cuda-jupyter-datascience-ubi8-python-3.
 
 # Build and push jupyter-pytorch-ubi8-python-3.8 image to the registry
 .PHONY: jupyter-pytorch-ubi8-python-3.8
-jupyter-pytorch-ubi8-python-3.8: cuda-jupyter-datascience-ubi9-python-3.9
+jupyter-pytorch-ubi8-python-3.8: cuda-jupyter-datascience-ubi8-python-3.8
 	$(call image,$@,jupyter/pytorch/ubi8-python-3.8,$<)
 
 # Build and push runtime-minimal-ubi8-python-3.8 image to the registry

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -8,7 +8,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9" \
     io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
     io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi8-python-3.9" \
+    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.9"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock

--- a/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -8,7 +8,7 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.9" \
     io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
     io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi8-python-3.9" \
+    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR contains fixes to narrow down appropriate UBI version with the Python version in use.

## Description
<!--- Describe your changes in detail -->
Two of the changes are mainly trivial because it's part of the image labels only.

One thing is a little bit more important, I think, since it has a direct impact on the way how the `jupyter-pytorch-ubi8-python-3.8` image is built (dependency in Makefile used).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested at all right, now - if you tell me what to do, I'm happy to do some testing.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

Note - this actually follows up on the changes in PR #194, @rkpattnaik780 JFYI so you don't duplicate effort eventually :)