### PR TITLE
Use RHEL9 repository for UBI9 and CentOs Stream 9 Cuda images

### DIFF
--- a/cuda/c9s-python-3.9/cuda.repo-x86_64
+++ b/cuda/c9s-python-3.9/cuda.repo-x86_64
@@ -1,6 +1,6 @@
 [cuda]
 name=cuda
-baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/cuda/ubi9-python-3.9/cuda.repo-x86_64
+++ b/cuda/ubi9-python-3.9/cuda.repo-x86_64
@@ -1,6 +1,6 @@
 [cuda]
 name=cuda
-baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This updates the used Nvidia repository for CUDA packages in our UBI9 and CoreOs 9 Stream images.

## Description
<!--- Describe your changes in detail -->
Nvidia provides RHEL9 repository of their packages. We use RHEL8 for all of our images at the moment (UBI8, UBI9, CoreOs 9 Stream). I think we should use RHEL9 repository for UBI9 and CoreOS 9 Stream, since I believe these are closer to the RHEL9.

I haven't checked content and difference of the Nvidia `rhel8` vs `rhel9` repositories yet, I can do it if you ask. It's possible that most of the packages there will be identical, not sure how they build.

Please, let me know whether this change is welcomed actually. Thank you.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
!!!! This hasn't been tested and since this is quite a big change we should definitely test before we merge this !!!!

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
