### PR TITLE
Include patch to version pipeline runs with numbers instead of timestamp

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
@@ -8,7 +8,25 @@
                  )
              else:
                  client = ArgoClient(
-@@ -416,7 +417,7 @@
+@@ -309,8 +310,16 @@
+ 
+                 # Create an instance id that will be used to store
+                 # the pipelines' dependencies, if applicable
+-                pipeline_instance_id = f"{pipeline_name}-{timestamp}"
++                pipeline_instance_id = ""
+ 
++                # Use environment variable to set version as suffix instead of timestamp
++                if os.environ.get("KFP_SUFFIX_USE_VERSION") == "true" :
++                    # Version is determined by the count of existing pipeline versions
++                    version = client.list_pipeline_versions(pipeline_id=pipeline_id).total_size
++                    pipeline_instance_id = f"{pipeline_name}-v{version}"
++                else :
++                    pipeline_instance_id = f"{pipeline_name}-{timestamp}"
++
+                 # Generate Python DSL from workflow
+                 pipeline_dsl = self._generate_pipeline_dsl(
+                     pipeline=pipeline,
+@@ -416,7 +425,7 @@
  
                  # create pipeline run (or specified pipeline version)
                  run = client.run_pipeline(
@@ -17,7 +35,7 @@
                  )
  
              except Exception as ex:
-@@ -435,7 +436,7 @@
+@@ -435,7 +444,7 @@
  
              self.log_pipeline_info(
                  pipeline_name,
@@ -26,7 +44,7 @@
                  duration=time.time() - t0,
              )
  
-@@ -451,7 +452,7 @@
+@@ -451,7 +460,7 @@
  
          return KfpPipelineProcessorResponse(
              run_id=run.id,
@@ -34,5 +52,4 @@
 +            run_url=f"{public_api_endpoint}/{run.id}",
              object_storage_url=object_storage_url,
              object_storage_path=object_storage_path,
-
          )


### PR DESCRIPTION
Patch to enable elyra use version names for pipeline runs instead of timestamp to make it more convenient for user.

## Description
Currently, when pipelines are created using elyra from the Notebooks, each additional iteration of the pipeline run creates a new pipeline version identified by timestamp.

The PR will allow user to switch from timestamp identifiers to versions numbers (v1, etc) using an environment variable `KFP_SUFFIX_USE_VERSION`. This will make the pipeline runs easily distinguishable.

Fixes #206 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
