### PR TITLE
Set $scheme correctly on vscode and rstudio on nginx configuration

### DIFF
--- a/codeserver/c9s-python-3.9/nginx/httpconf/http.conf
+++ b/codeserver/c9s-python-3.9/nginx/httpconf/http.conf
@@ -32,3 +32,8 @@ log_format json escape=json '[{'
     '"execution_state":"busy",'
     '"connections": 1'
     '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/codeserver/c9s-python-3.9/nginx/serverconf/proxy.conf.template
+++ b/codeserver/c9s-python-3.9/nginx/serverconf/proxy.conf.template
@@ -16,7 +16,7 @@ location /api/ {
 # api calls from culler get to CGI processing
 ###############
 location = /api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -36,11 +36,11 @@ location /api/kernels/ {
 # root and prefix get to VSCode endpoint
 ###############
 location = / {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location = /vscode {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location /vscode/ {
@@ -54,6 +54,7 @@ location /vscode/ {
     # Needed to make it work properly
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
     proxy_set_header Host $http_host;
     proxy_set_header X-NginX-Proxy true;
     proxy_redirect off;

--- a/codeserver/c9s-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/codeserver/c9s-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
@@ -16,12 +16,12 @@ location ${NB_PREFIX}/api/ {
 # api calls from culler get to CGI processing
 ###############
 location = ${NB_PREFIX}/api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -41,19 +41,19 @@ location /api/kernels/ {
 # root and prefix get to VSCode endpoint
 ###############
 location = ${NB_PREFIX} {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location ${NB_PREFIX}/ {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location = /vscode {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location = / {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location /vscode/ {
@@ -64,6 +64,7 @@ location /vscode/ {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
     proxy_read_timeout 20d;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
 
     access_log /var/log/nginx/vscode.access.log json if=$loggable;
 }

--- a/rstudio/c9s-python-3.9/nginx/httpconf/http.conf
+++ b/rstudio/c9s-python-3.9/nginx/httpconf/http.conf
@@ -32,3 +32,8 @@ log_format json escape=json '[{'
     '"execution_state":"busy",'
     '"connections": 1'
     '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template
+++ b/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template
@@ -1,8 +1,8 @@
 ###############
 # Fix rstudio-server auth-sign-in redirect bug
 ###############
-rewrite ^/auth-sign-in(.*) "$scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
-rewrite ^/auth-sign-out(.*) "$scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-in(.*) "$custom_scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$custom_scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
 ###############
 
 ###############
@@ -20,7 +20,7 @@ location /api/ {
 }
 
 location = /api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -40,11 +40,11 @@ location /api/kernels/ {
 # api calls from culler get to CGI processing
 ###############
 location = / {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location = /rstudio {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location /rstudio/ {
@@ -57,9 +57,10 @@ location /rstudio/ {
     proxy_read_timeout 20d;
 
     # Needed to make it work properly
-    proxy_set_header X-RStudio-Request $scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
     proxy_set_header X-RStudio-Root-Path /rstudio;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
 
     access_log /var/log/nginx/rstudio.access.log json if=$loggable;
 }

--- a/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/rstudio/c9s-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
@@ -1,8 +1,8 @@
 ###############
 # Fix rstudio-server auth-sign-in redirect bug
 ###############
-rewrite ^/auth-sign-in(.*) "$scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
-rewrite ^/auth-sign-out(.*) "$scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-in(.*) "$custom_scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$custom_scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
 ###############
 
 ###############
@@ -34,12 +34,12 @@ location /api/ {
 # api calls from culler get to CGI processing
 ###############
 location = ${NB_PREFIX}/api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -59,19 +59,19 @@ location /api/kernels/ {
 # root and prefix get to RStudio endpoint
 ###############
 location = ${NB_PREFIX} {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location ${NB_PREFIX}/ {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location = /rstudio {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location = / {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location /rstudio/ {
@@ -84,9 +84,10 @@ location /rstudio/ {
     proxy_read_timeout 20d;
 
     # Needed to make it work properly
-    proxy_set_header X-RStudio-Request $scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
     proxy_set_header X-RStudio-Root-Path /rstudio;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
 
     access_log /var/log/nginx/rstudio.access.log json if=$loggable;
 }


### PR DESCRIPTION
Set $scheme correctly on vscode and rstudio on nginx configuration

## Description
In the connection flow, there is a redirect to an http session (before being sent back to https) that makes thing impossible to work on networks filtering http traffic (the first call, normally answered with a redirect, never makes it to OpenShift).

Redirections to other locations were made to http, whatever the original scheme.
Route would take care of redirecting back to https, but this did not work when other proxies between browser and OpenShift would filter out any http traffic.
The patches make all redirections follow the original scheme, http or https.

Original issue:[ #34](https://github.com/opendatahub-io-contrib/workbench-images/issues/34 ) 
Fixes: https://github.com/opendatahub-io/notebooks/issues/227

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
