### PR TITLE
Add mesa-libGL on the base notebooks

### DIFF
--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -18,6 +18,15 @@ RUN pip install -U "micropipenv[toml]"
 # Install Python dependencies from Pipfile.lock file
 COPY Pipfile.lock ./
 
+# OS Packages needs to be installed as root
+USER root
+
+# Install usefull OS packages
+RUN dnf install -y mesa-libGL
+
+# Other apps and tools installed as default user
+USER 1001
+
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # Install the oc client \
     curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -20,6 +20,15 @@ COPY Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
+# OS Packages needs to be installed as root
+USER root
+
+# Install usefull OS packages
+RUN dnf install -y mesa-libGL
+
+# Other apps and tools installed as default user
+USER 1001
+
 # Install the oc client
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -20,6 +20,15 @@ COPY Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
+# OS Packages needs to be installed as root
+USER root
+
+# Install usefull OS packages
+RUN dnf install -y mesa-libGL
+
+# Other apps and tools installed as default user
+USER 1001
+
 # Install the oc client
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \


### PR DESCRIPTION
Add mesa-libGL on the base notebooks

## Description
This PR installs `mesa-libGL` on the base notebooks UBI8, UBI9 and C9S

related to: https://github.com/opendatahub-io/notebooks/issues/219

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
