### PR TITLE
Fix and improve CI unit test workaround 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,57 +312,78 @@ undeploy-c9s-%-c9s-python-3.9: bin/kubectl
 	$(info # Undeploying notebook from $(NOTEBOOK_DIR) directory...)
 	$(KUBECTL_BIN) delete -k $(NOTEBOOK_DIR)
 
+# Function for testing a notebook with papermill
+#   ARG 1: Notebook name
+#   ARG 1: UBI flavor
+#   ARG 1: Python kernel
+define test_with_papermill
+	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "python3 -m pip install papermill" ; \
+	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/$(1)/$(2)-$(3)/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb $(1)_$(2)_output.ipynb --kernel python3 --stderr-file $(1)_$(2)_error.txt" ; \
+    if [ $$? -ne 0 ]; then \
+		echo "ERROR: The $(1) $(2) notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-$(1)-$(2)-$(3)-test-e2e' directory or run 'cat $(1)_$(2)_error.txt' within your container. The make process has been aborted." ; \
+		exit 1 ; \
+	fi ; \
+	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "cat $(1)_$(2)_error.txt | grep --quiet FAILED" ; \
+	if [ $$? -eq 0 ]; then \
+		echo "ERROR: The $(1) $(2) notebook encountered a failure. The make process has been aborted." ; \
+		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "cat $(1)_$(2)_error.txt" ; \
+		exit 1 ; \
+	fi
+endef
+
 # Verify the notebook's readiness by pinging the /api endpoint and executing the corresponding test_notebook.ipynb file in accordance with the build chain logic.
 .PHONY: test
 test-%: bin/kubectl
+
+	# Verify the notebook's readiness by pinging the /api endpoint
 	$(eval NOTEBOOK_NAME := $(subst .,-,$(subst cuda-,,$*)))
 	$(info # Running tests for $(NOTEBOOK_NAME) notebook...)
 	$(KUBECTL_BIN) wait --for=condition=ready pod -l app=$(NOTEBOOK_NAME) --timeout=600s
 	$(KUBECTL_BIN) port-forward svc/$(NOTEBOOK_NAME)-notebook 8888:8888 & curl --retry 5 --retry-delay 5 --retry-connrefused http://localhost:8888/notebook/opendatahub/jovyan/api ; EXIT_CODE=$$?; echo && pkill --full "^$(KUBECTL_BIN).*port-forward.*"; \
 	$(eval FULL_NOTEBOOK_NAME = $(shell ($(KUBECTL_BIN) get pods -l app=$(NOTEBOOK_NAME) -o custom-columns=":metadata.name" | tr -d '\n')))
-	echo "=> Checking $(FULL_NOTEBOOK_NAME) notebook execution..." ; \
-	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "python3 -m pip install papermill" ; \
+	
+	# Tests notebook's functionalities 
 	if echo "$(FULL_NOTEBOOK_NAME)" | grep -q "minimal-ubi9"; then \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi9_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,minimal,ubi9,python-3.9) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "datascience-ubi9"; then \
 		$(MAKE) validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "pytorch-ubi9"; then \
 		$(MAKE) validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/pytorch/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb pytorch_ubi9_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,pytorch,ubi9,python-3.9) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "tensorflow-ubi9"; then \
 		$(MAKE) validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/tensorflow/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb tensorflow_ubi9_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,tensorflow,ubi9,python-3.9) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "trustyai-ubi9"; then \
 		$(MAKE) validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb trustyai_ubi9_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,trustyai,ubi9,python-3.9) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "minimal-ubi8"; then \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/minimal/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi8_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,minimal,ubi8,python-3.8) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "datascience-ubi8"; then \
 		$(MAKE) validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "pytorch-ubi8"; then \
 		$(MAKE) validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/pytorch/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb pytorch_ubi8_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,pytorch,ubi8,python-3.8) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "tensorflow-ubi8"; then \
 		$(MAKE) validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/tensorflow/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb tensorflow_ubi8_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,tensorflow,ubi8,python-3.8) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "trustyai-ubi8"; then \
 		$(MAKE) validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=$(FULL_NOTEBOOK_NAME); \
-		$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/trustyai/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb trustyai_ubi8_output.ipynb --kernel python3 > /dev/null" ; \
+		$(call test_with_papermill,trustyai,ubi8,python-3.8) \
 	elif echo "$(FULL_NOTEBOOK_NAME)" | grep -q "anaconda"; then \
-		echo "There is no test notebook implemented yet for Anaconda Notebook...." ; \
+		echo "There is no test notebook implemented yet for Anaconda Notebook...." \
 	else \
 		echo "No matching condition found for $(FULL_NOTEBOOK_NAME)." ; \
 	fi
 
 .PHONY: validate-ubi9-datascience
 validate-ubi9-datascience:
-	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi9_output.ipynb --kernel python3 > /dev/null" ; \
-	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb datascience_ubi9_output.ipynb --kernel python3 > /dev/null" ; \
+	$(call test_with_papermill,minimal,ubi9,python-3.9)
+	$(call test_with_papermill,datascience,ubi9,python-3.9)
 
 .PHONY: validate-ubi8-datascience
 validate-ubi8-datascience:
-	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/minimal/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi8_output.ipynb --kernel python3 > /dev/null" ; \
-	$(KUBECTL_BIN) exec $(FULL_NOTEBOOK_NAME) -- /bin/sh -c "wget ${NOTEBOOK_REPO_BRANCH_BASE}/jupyter/datascience/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb datascience_ubi8_output.ipynb --kernel python3 > /dev/null" ; \
+	$(call test_with_papermill,minimal,ubi8,python-3.8)
+	$(call test_with_papermill,datascience,ubi8,python-3.8)
 
 # Validate that runtime image meets minimum criteria
 # This validation is created from subset of https://github.com/elyra-ai/elyra/blob/9c417d2adc9d9f972de5f98fd37f6945e0357ab9/Makefile#L325


### PR DESCRIPTION
Related to: https://github.com/opendatahub-io/notebooks/issues/269 
Improvement of: https://github.com/opendatahub-io/notebooks/issues/176

Fix and improve CI unit test recipe. This can be a temporary solution till figure out the  `Possible other improvements` that the the issue is mentioning.

## Description
This PR improves the code quality of the recipe by utilizing functions and avoiding repetitive code, moreover, when a test_notebook.ipynb is broken or doesn't fulfill the unit tests it returns 0 code and stops the execution of the e2e test with an ERROR message.

## How Has This Been Tested?
Below are the logs on how the test behaves in healthy and problematic notebooks:

Problematic notebook:
`make test-jupyter-trustyai-ubi9-python-3.9`

```
# Running tests for jupyter-trustyai-ubi9-python-3-9 notebook...
# Test common notebook logic
bin/kubectl wait --for=condition=ready pod -l app=jupyter-trustyai-ubi9-python-3-9 --timeout=600s
pod/jupyter-trustyai-ubi9-python-3-9-notebook-0 condition met
bin/kubectl port-forward svc/jupyter-trustyai-ubi9-python-3-9-notebook 8888:8888 & curl --retry 5 --retry-delay 5 --retry-connrefused http://localhost:8888/notebook/opendatahub/jovyan/api ; EXIT_CODE=$?; echo && pkill --full "^bin/kubectl.*port-forward.*"
curl: (7) Failed to connect to localhost port 8888 after 0 ms: Connection refused
Warning: Problem : connection refused. Will retry in 5 seconds. 5 retries 
Warning: left.
Forwarding from 127.0.0.1:8888 -> 8888
Forwarding from [::1]:8888 -> 8888
Handling connection for 8888
{"version": "2.1.0"}
# Test specific notebooks
if echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "minimal-ubi9"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi9_output.ipynb --kernel python3 --stderr-file minimal_ubi9_error.txt && cat minimal_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The minimal ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-minimal-ubi9-python-3.9-test-e2e' directory or run 'cat minimal_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "datascience-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-trustyai-ubi9-python-3-9-notebook-0; \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "pytorch-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-trustyai-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/pytorch/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb pytorch_ubi9_output.ipynb --kernel python3 --stderr-file pytorch_ubi9_error.txt && cat pytorch_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The pytorch ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-pytorch-ubi9-python-3.9-test-e2e' directory or run 'cat pytorch_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "tensorflow-ubi9"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/tensorflow/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb tensorflow_ubi9_output.ipynb --kernel python3 --stderr-file tensorflow_ubi9_error.txt && cat tensorflow_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The tensorflow ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-tensorflow-ubi9-python-3.9-test-e2e' directory or run 'cat tensorflow_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "trustyai-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-trustyai-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb trustyai_ubi9_output.ipynb --kernel python3 --stderr-file trustyai_ubi9_error.txt && cat trustyai_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The trustyai ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-trustyai-ubi9-python-3.9-test-e2e' directory or run 'cat trustyai_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "minimal-ubi8"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi8_output.ipynb --kernel python3 --stderr-file minimal_ubi8_error.txt && cat minimal_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The minimal ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-minimal-ubi8-python-3.8-test-e2e' directory or run 'cat minimal_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "datascience-ubi8"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/datascience/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb datascience_ubi8_output.ipynb --kernel python3 --stderr-file datascience_ubi8_error.txt && cat datascience_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The datascience ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-datascience-ubi8-python-3.8-test-e2e' directory or run 'cat datascience_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "pytorch-ubi8"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/pytorch/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb pytorch_ubi8_output.ipynb --kernel python3 --stderr-file pytorch_ubi8_error.txt && cat pytorch_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The pytorch ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-pytorch-ubi8-python-3.8-test-e2e' directory or run 'cat pytorch_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "tensorflow-ubi8"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/tensorflow/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb tensorflow_ubi8_output.ipynb --kernel python3 --stderr-file tensorflow_ubi8_error.txt && cat tensorflow_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The tensorflow ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-tensorflow-ubi8-python-3.8-test-e2e' directory or run 'cat tensorflow_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "trustyai-ubi8"; then \
                bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/trustyai/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb trustyai_ubi8_output.ipynb --kernel python3 --stderr-file trustyai_ubi8_error.txt && cat trustyai_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The trustyai ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-trustyai-ubi8-python-3.8-test-e2e' directory or run 'cat trustyai_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-trustyai-ubi9-python-3-9-notebook-0" | grep -q "anaconda"; then \
        echo "There is no test notebook implemented yet for Anaconda Notebook...." \
else \
        echo "No matching condition found for jupyter-trustyai-ubi9-python-3-9-notebook-0." ; \
fi
make[1]: Entering directory '/home/atheodor/Documents/REPOS/notebooks'
bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi9_output.ipynb --kernel python3 --stderr-file minimal_ubi9_error.txt && cat minimal_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The minimal ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-minimal-ubi9-python-3.9-test-e2e' directory or run 'cat minimal_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi
Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.
ERROR: could not open HSTS store at '/opt/app-root/src/.wget-hsts'. HSTS will be disabled.
--2023-10-18 12:41:50--  https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1822 (1.8K) [text/plain]
Saving to: ‘test_notebook.ipynb’

     0K .                                                     100% 38.0M=0s

2023-10-18 12:41:51 (38.0 MB/s) - ‘test_notebook.ipynb’ saved [1822/1822]

Input Notebook:  test_notebook.ipynb
Output Notebook: minimal_ubi9_output.ipynb
Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)

Failed validating 'additionalProperties' in code_cell:

On instance['cells'][0]:
{'cell_type': 'code',
 'execution_count': None,
 'id': '2d972b6b-1211-4c21-a7e8-a1683b72a62c',
 'metadata': {},
 'outputs': ['...0 outputs...'],
 'source': 'import unittest\n'
           'import jupyterlab as jp\n'
           'from platform import pyt...'}
Executing:   0%|          | 0/1 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing: 100%|██████████| 1/1 [00:03<00:00,  3.20s/cell]
command terminated with exit code 1
bin/kubectl exec jupyter-trustyai-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb datascience_ubi9_output.ipynb --kernel python3 --stderr-file datascience_ubi9_error.txt && cat datascience_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The datascience ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-datascience-ubi9-python-3.9-test-e2e' directory or run 'cat datascience_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi
Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.
ERROR: could not open HSTS store at '/opt/app-root/src/.wget-hsts'. HSTS will be disabled.
--2023-10-18 12:41:58--  https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9909 (9.7K) [text/plain]
Saving to: ‘test_notebook.ipynb’

     0K .........                                             100% 6.59M=0.001s

2023-10-18 12:41:58 (6.59 MB/s) - ‘test_notebook.ipynb’ saved [9909/9909]

Input Notebook:  test_notebook.ipynb
Output Notebook: datascience_ubi9_output.ipynb
Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)

Failed validating 'additionalProperties' in code_cell:

On instance['cells'][0]:
{'cell_type': 'code',
 'execution_count': None,
 'id': '0c234518-7728-4cf7-95cc-32a53dd78853',
 'metadata': {},
 'outputs': ['...0 outputs...'],
 'source': 'import unittest\n'
           'from unittest import mock\n'
           'from platform import p...'}
Executing:   0%|          | 0/1 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing: 100%|██████████| 1/1 [00:06<00:00,  6.64s/cell]
command terminated with exit code 1
make[1]: Leaving directory '/home/atheodor/Documents/REPOS/notebooks'
Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.
ERROR: could not open HSTS store at '/opt/app-root/src/.wget-hsts'. HSTS will be disabled.
--2023-10-18 12:42:09--  https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4328 (4.2K) [text/plain]
Saving to: ‘test_notebook.ipynb’

     0K ....                                                  100% 59.7M=0s

2023-10-18 12:42:09 (59.7 MB/s) - ‘test_notebook.ipynb’ saved [4328/4328]

Input Notebook:  test_notebook.ipynb
Output Notebook: trustyai_ubi9_output.ipynb
Executing:   0%|          | 0/1 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing: 100%|██████████| 1/1 [00:13<00:00, 13.04s/cell]
...F
======================================================================
FAIL: test_trustyai_version (__main__.TestTrustyaiNotebook)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/ipykernel_310/2273224652.py", line 19, in test_trustyai_version
    self.assertEqual(actual_major_minor, expected_major_minor, "incorrect version")
AssertionError: '0.3' != '0.2'
- 0.3
?   ^
+ 0.2
?   ^
 : incorrect version

----------------------------------------------------------------------
Ran 4 tests in 6.672s

FAILED (failures=1)
ERROR: The trustyai ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-trustyai-ubi9-python-3.9-test-e2e' directory or run 'cat trustyai_ubi9_error.txt' within your container. The make process has been aborted.
make: *** [Makefile:351: test-jupyter-trustyai-ubi9-python-3.9] Error 1
```

Healthy Notebook:
`make test-jupyter-datascience-ubi9-python-3.9 `

```
# Running tests for jupyter-datascience-ubi9-python-3-9 notebook...
# Verify the notebook's readiness by pinging the /api endpoint
bin/kubectl wait --for=condition=ready pod -l app=jupyter-datascience-ubi9-python-3-9 --timeout=600s
pod/jupyter-datascience-ubi9-python-3-9-notebook-0 condition met
bin/kubectl port-forward svc/jupyter-datascience-ubi9-python-3-9-notebook 8888:8888 & curl --retry 5 --retry-delay 5 --retry-connrefused http://localhost:8888/notebook/opendatahub/jovyan/api ; EXIT_CODE=$?; echo && pkill --full "^bin/kubectl.*port-forward.*"
curl: (7) Failed to connect to localhost port 8888 after 0 ms: Connection refused
Warning: Problem : connection refused. Will retry in 5 seconds. 5 retries 
Warning: left.
Forwarding from 127.0.0.1:8888 -> 8888
Forwarding from [::1]:8888 -> 8888
Handling connection for 8888
{"version": "2.1.0"}
# Tests notebook's functionalities 
if echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "minimal-ubi9"; then \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi9_output.ipynb --kernel python3 --stderr-file minimal_ubi9_error.txt && cat minimal_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The minimal ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-minimal-ubi9-python-3.9-test-e2e' directory or run 'cat minimal_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "datascience-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "pytorch-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/pytorch/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb pytorch_ubi9_output.ipynb --kernel python3 --stderr-file pytorch_ubi9_error.txt && cat pytorch_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The pytorch ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-pytorch-ubi9-python-3.9-test-e2e' directory or run 'cat pytorch_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "tensorflow-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/tensorflow/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb tensorflow_ubi9_output.ipynb --kernel python3 --stderr-file tensorflow_ubi9_error.txt && cat tensorflow_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The tensorflow ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-tensorflow-ubi9-python-3.9-test-e2e' directory or run 'cat tensorflow_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "trustyai-ubi9"; then \
        make validate-ubi9-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb trustyai_ubi9_output.ipynb --kernel python3 --stderr-file trustyai_ubi9_error.txt && cat trustyai_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The trustyai ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-trustyai-ubi9-python-3.9-test-e2e' directory or run 'cat trustyai_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "minimal-ubi8"; then \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi8_output.ipynb --kernel python3 --stderr-file minimal_ubi8_error.txt && cat minimal_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The minimal ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-minimal-ubi8-python-3.8-test-e2e' directory or run 'cat minimal_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "datascience-ubi8"; then \
        make validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "pytorch-ubi8"; then \
        make validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/pytorch/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb pytorch_ubi8_output.ipynb --kernel python3 --stderr-file pytorch_ubi8_error.txt && cat pytorch_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The pytorch ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-pytorch-ubi8-python-3.8-test-e2e' directory or run 'cat pytorch_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "tensorflow-ubi8"; then \
        make validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/tensorflow/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb tensorflow_ubi8_output.ipynb --kernel python3 --stderr-file tensorflow_ubi8_error.txt && cat tensorflow_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The tensorflow ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-tensorflow-ubi8-python-3.8-test-e2e' directory or run 'cat tensorflow_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "trustyai-ubi8"; then \
        make validate-ubi8-datascience -e FULL_NOTEBOOK_NAME=jupyter-datascience-ubi9-python-3-9-notebook-0; \
                bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/trustyai/ubi8-python-3.8/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb trustyai_ubi8_output.ipynb --kernel python3 --stderr-file trustyai_ubi8_error.txt && cat trustyai_ubi8_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The trustyai ubi8 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-trustyai-ubi8-python-3.8-test-e2e' directory or run 'cat trustyai_ubi8_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi \
elif echo "jupyter-datascience-ubi9-python-3-9-notebook-0" | grep -q "anaconda"; then \
        echo "There is no test notebook implemented yet for Anaconda Notebook...." \
else \
        echo "No matching condition found for jupyter-datascience-ubi9-python-3-9-notebook-0." ; \
fi
make[1]: Entering directory '/home/atheodor/Documents/REPOS/notebooks'
bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb minimal_ubi9_output.ipynb --kernel python3 --stderr-file minimal_ubi9_error.txt && cat minimal_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The minimal ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-minimal-ubi9-python-3.9-test-e2e' directory or run 'cat minimal_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi
--2023-10-18 12:49:55--  https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/minimal/ubi9-python-3.9/test/test_notebook.ipynb
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.111.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1822 (1.8K) [text/plain]
Saving to: ‘test_notebook.ipynb’

     0K .                                                     100% 24.7M=0s

2023-10-18 12:49:55 (24.7 MB/s) - ‘test_notebook.ipynb’ saved [1822/1822]

Input Notebook:  test_notebook.ipynb
Output Notebook: minimal_ubi9_output.ipynb
Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)

Failed validating 'additionalProperties' in code_cell:

On instance['cells'][0]:
{'cell_type': 'code',
 'execution_count': None,
 'id': '2d972b6b-1211-4c21-a7e8-a1683b72a62c',
 'metadata': {},
 'outputs': ['...0 outputs...'],
 'source': 'import unittest\n'
           'import jupyterlab as jp\n'
           'from platform import pyt...'}
Executing:   0%|          | 0/1 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing: 100%|██████████| 1/1 [00:03<00:00,  3.17s/cell]
command terminated with exit code 1
bin/kubectl exec jupyter-datascience-ubi9-python-3-9-notebook-0 -- /bin/sh -c "wget https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb -O test_notebook.ipynb && python3 -m papermill test_notebook.ipynb datascience_ubi9_output.ipynb --kernel python3 --stderr-file datascience_ubi9_error.txt && cat datascience_ubi9_error.txt | grep FAILED > /dev/null" ; if [ $? -eq 0 ]; then echo "ERROR: The datascience ubi9 notebook encountered a failure. To investigate the issue, you can review the logs located in the ocp-ci cluster on 'artifacts/notebooks-e2e-tests/jupyter-datascience-ubi9-python-3.9-test-e2e' directory or run 'cat datascience_ubi9_error.txt' within your container. The make process has been aborted." ; exit 1 ; fi
Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.
ERROR: could not open HSTS store at '/opt/app-root/src/.wget-hsts'. HSTS will be disabled.
--2023-10-18 12:50:02--  https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.111.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9909 (9.7K) [text/plain]
Saving to: ‘test_notebook.ipynb’

     0K .........                                             100% 13.0M=0.001s

2023-10-18 12:50:02 (13.0 MB/s) - ‘test_notebook.ipynb’ saved [9909/9909]

Input Notebook:  test_notebook.ipynb
Output Notebook: datascience_ubi9_output.ipynb
Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)

Failed validating 'additionalProperties' in code_cell:

On instance['cells'][0]:
{'cell_type': 'code',
 'execution_count': None,
 'id': '0c234518-7728-4cf7-95cc-32a53dd78853',
 'metadata': {},
 'outputs': ['...0 outputs...'],
 'source': 'import unittest\n'
           'from unittest import mock\n'
           'from platform import p...'}
Executing:   0%|          | 0/1 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing: 100%|██████████| 1/1 [00:07<00:00,  7.10s/cell]
command terminated with exit code 1
make[1]: Leaving directory '/home/atheodor/Documents/REPOS/notebooks'
```



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
