### PR TITLE
remove depreciated bases kustomize feature

### DIFF
--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -1,12 +1,13 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
+
 resources:
+  - ../../base
   - code-server-notebook-imagestream.yaml
   - rstudio-notebook-imagestream.yaml
   - rstudio-gpu-notebook-imagestream.yaml
+
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: notebooks


### PR DESCRIPTION
## Description
`bases` was depreciated in kustomize 2.1.0.

ODH Operator emits the following warning when applying the notebooks manifests:

```
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

## How Has This Been Tested?
Generate kustomize from main branch.  Generate kustomize for changes.  Compare changes to ensure that they are 100% the same.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
