### PR TITLE
Patch the imagestream by removing habana 1.11.0

### DIFF
--- a/manifests/base/jupyter-habana-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-habana-notebook-imagestream.yaml
@@ -15,25 +15,15 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    # 1.11.0 Version of the image n
-    - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Tensorflow","version":"2.12.1"},{"name":"PyTorch","version":"2.0.1"},{"name":"Elyra","version":"3.15"}]'
-        openshift.io/imported-from: quay.io/opendatahub/workbench-images
-      from:
-        kind: DockerImage
-        name: $(odh-habana-notebook-image-n)
-      name: "2023.2"
-      referencePolicy:
-        type: Source
     # 1.10.0 Version of the image n-1
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.10"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Tensorflow","version":"2.12.0"},{"name":"PyTorch","version":"2.0.1"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
       from:
         kind: DockerImage
-        name: $(odh-habana-notebook-image-n-1)
+        name: $(odh-habana-notebook-image-n)
       name: "2023.1"
       referencePolicy:
         type: Source

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -146,12 +146,5 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
-  - name: odh-habana-notebook-image-n-1
-    objref:
-      kind: ConfigMap
-      name: notebooks-parameters
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.odh-habana-notebook-image-n-1
 configurations:
   - params.yaml

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -15,5 +15,4 @@ odh-tensorflow-gpu-notebook-image-n-1=quay.io/opendatahub/workbench-images@sha25
 odh-tensorflow-gpu-notebook-image-n-2=quay.io/opendatahub/notebooks@sha256:fc52e4fbc8c1c70dfa22dbfe6b0353f5165c507c125df4438fca6a3f31fe976e
 odh-trustyai-notebook-image-n=quay.io/opendatahub/workbench-images@sha256:636fdf26877be4013bc516c5ef4a818b5f7f29119ec3f601005fefc6d49433f0
 odh-trustyai-notebook-image-n-1=quay.io/opendatahub/workbench-images@sha256:9c7dfc1c58bcbafbb4ffae58641e1bc4c3b5850886960bf27c652b7d0635d779
-odh-habana-notebook-image-n=quay.io/opendatahub/workbench-images@sha256:901001f289a248f9e1cf46021efd5c0601bdeadde1e89e79112083d30600d07a
-odh-habana-notebook-image-n-1=quay.io/opendatahub/workbench-images@sha256:b0821ae2abe45387a371108ac08e7474b64255e5c4519de5da594b4617fd79fe
+odh-habana-notebook-image-n=quay.io/opendatahub/workbench-images@sha256:b0821ae2abe45387a371108ac08e7474b64255e5c4519de5da594b4617fd79fe

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -72,7 +72,3 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-habana-notebook-image-n
-  - path: spec/tags[]/from/name
-    kind: ImageStream
-    apiGroup: image.openshift.io/v1
-    name: odh-habana-notebook-image-n-1


### PR DESCRIPTION
Patch the imagestream by removing habana 1.11.0

## Description

Related-to: #297 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Try: 
`kustomize build manifests/base/`
check the manifests of the habana imagestream

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
