### PR TITLE
[Fix/enhancement] dockerimage labels check and attempted to deduplicate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DATE 			 ?= $(shell date +'%Y%m%d')
 IMAGE_TAG		 ?= $(RELEASE)_$(DATE)
 KUBECTL_BIN      ?= bin/kubectl
 KUBECTL_VERSION  ?= v1.23.11
+AUTHORITATIVE_SOURCE_URL ?= https://github.com/opendatahub-io/notebooks
 NOTEBOOK_REPO_BRANCH_BASE ?= https://raw.githubusercontent.com/opendatahub-io/notebooks/main
 REQUIRED_RUNTIME_IMAGE_COMMANDS="curl python3"
 REQUIRED_CODE_SERVER_IMAGE_COMMANDS="curl python oc code-server"
@@ -18,12 +19,13 @@ REQUIRED_R_STUDIO_IMAGE_COMMANDS="curl python oc /usr/lib/rstudio-server/bin/rse
 define build_image
 	$(eval IMAGE_NAME := $(IMAGE_REGISTRY):$(1)-$(IMAGE_TAG))
 	$(info # Building $(IMAGE_NAME) image...)
+	$(eval BUILD_ARGS := --build-arg BUILD_COMMIT_REF=$(RELEASE) --build-arg IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
+		--build-arg AUTHORITATIVE_SOURCE_URL=$(AUTHORITATIVE_SOURCE_URL))
 	$(if $(3),
 		$(eval BASE_IMAGE_NAME := $(IMAGE_REGISTRY):$(3)-$(IMAGE_TAG))
-		$(eval BUILD_ARGS := --build-arg BASE_IMAGE=$(BASE_IMAGE_NAME)),
-		$(eval BUILD_ARGS :=)
+		$(eval BUILD_ARGS := $(BUILD_ARGS) --build-arg BASE_IMAGE=$(BASE_IMAGE_NAME)),
 	)
-	$(CONTAINER_ENGINE) build --no-cache  -t $(IMAGE_NAME) $(BUILD_ARGS) $(2)
+	$(CONTAINER_ENGINE) build --no-cache --tag $(IMAGE_NAME) $(BUILD_ARGS) $(2)
 endef
 
 # Push function for the notebok image:

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -1,14 +1,18 @@
 FROM quay.io/sclorg/python-39-c9s:c9s
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-base-centos-stream9-python-3.9" \
       summary="Python 3.9 CentOS Stream 9 base image for ODH notebooks" \
       description="Base Python 3.9 builder image based on CentOS Stream 9 for ODH notebooks" \
       io.k8s.display-name="Python 3.9 c9s base image for ODH notebooks" \
       io.k8s.description="Base Python 3.9 builder image based on C9S for ODH notebooks" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/c9s-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:base-c9s-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/base/c9s-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:base-c9s-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -1,14 +1,18 @@
 FROM registry.access.redhat.com/ubi8/python-38:latest
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-base-ubi8-python-3.8" \
       summary="Python 3.8 base image for ODH notebooks" \
       description="Base Python 3.8 builder image based on UBI8 for ODH notebooks" \
       io.k8s.display-name="Python 3.8 base image for ODH notebooks" \
       io.k8s.description="Base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/ubi8-python-3.8" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:base-ubi8-python-3.8"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/base/ubi8-python-3.8" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:base-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -1,14 +1,18 @@
 FROM registry.access.redhat.com/ubi9/python-39:latest
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \
       description="Base Python 3.9 builder image based on UBI9 for ODH notebooks" \
       io.k8s.display-name="Python 3.9 base image for ODH notebooks" \
       io.k8s.description="Base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/ubi9-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:base-ubi9-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/base/ubi9-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:base-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/codeserver/c9s-python-3.9/Dockerfile
+++ b/codeserver/c9s-python-3.9/Dockerfile
@@ -1,6 +1,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 ARG CODESERVER_VERSION=v4.16.1
 
 LABEL name="odh-notebook-code-server-c9s-python-3.9" \
@@ -8,10 +12,10 @@ LABEL name="odh-notebook-code-server-c9s-python-3.9" \
       description="code-server image with python 3.9 based on CentOS Stream 9" \
       io.k8s.display-name="code-server image with python 3.9 based on CentOS Stream 9" \
       io.k8s.description="code-server image with python 3.9 based on CentOS Stream 9" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/c9s-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-c9s-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/codeserver/c9s-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:codeserver-c9s-python-3.9"
 
 USER 0
 

--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 ARG CODESERVER_VERSION=v4.16.1
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.9" \
@@ -8,10 +12,10 @@ LABEL name="odh-notebook-code-server-ubi9-python-3.9" \
       description="code-server image with python 3.9 based on UBI9" \
       io.k8s.display-name="code-server image with python 3.9 based on UBI9" \
       io.k8s.description="code-server image with python 3.9 based on UBI9" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/ubi9-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/codeserver/ubi9-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:codeserver-ubi9-python-3.9"
 
 USER 0
 

--- a/cuda/c9s-python-3.9/Dockerfile
+++ b/cuda/c9s-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-cuda-c9s-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \
       description="CUDA Python 3.9 builder image based on CentOS Stream 9 for ODH notebooks" \
       io.k8s.display-name="CUDA Python 3.9 base image for ODH notebooks" \
       io.k8s.description="CUDA Python 3.9 builder image based on C9S for ODH notebooks" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/cuda/c9s-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-c9s-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/cuda/c9s-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:cuda-c9s-python-3.9"
 
 # Install CUDA base from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/base/Dockerfile

--- a/cuda/ubi8-python-3.8/Dockerfile
+++ b/cuda/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-cuda-ubi8-python-3.8" \
       summary="CUDA Python 3.8 base image for ODH notebooks" \
       description="CUDA Python 3.8 builder image based on UBI8 for ODH notebooks" \
       io.k8s.display-name="CUDA Python 3.8 base image for ODH notebooks" \
       io.k8s.description="CUDA Python 3.8 builder image based on UBI8 for ODH notebooks" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/cuda/ubi8-python-3.8" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-ubi8-python-3.8"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/cuda/ubi8-python-3.8" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:cuda-ubi8-python-3.8"
 
 # Install CUDA base from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubi8/base/Dockerfile

--- a/cuda/ubi9-python-3.9/Dockerfile
+++ b/cuda/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-cuda-ubi9-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \
       description="CUDA Python 3.9 builder image based on UBI8 for ODH notebooks" \
       io.k8s.display-name="CUDA Python 3.9 base image for ODH notebooks" \
       io.k8s.description="CUDA Python 3.9 builder image based on UBI8 for ODH notebooks" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/cuda/ubi9-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-ubi9-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/cuda/ubi9-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:cuda-ubi9-python-3.9"
 
 # Install CUDA base from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/base/Dockerfile

--- a/habana/1.10.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.10.0/ubi8-python-3.8/Dockerfile
@@ -7,6 +7,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 ARG ARTIFACTORY_URL="vault.habana.ai"
 ARG VERSION="1.10.0"
 ARG REVISION="494"
@@ -147,10 +151,10 @@ LABEL name="odh-notebook-habana-jupyter-1.10.0-ubi8-python-3.8" \
     description="Jupyter HabanaAI 1.10.0 notebook image with base Python 3.8 builder image based on ubi8 for ODH notebooks" \
     io.k8s.display-name="Jupyter HabanaAI 1.10.0 notebook image for ODH notebooks" \
     io.k8s.description="Jupyter HabanaAI 1.10.0 notebook image with base Python 3.8 builder image based on ubi8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/habana/1.10.0/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:habana-jupyter-1.10.0-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/habana/1.10.0/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:habana-jupyter-1.10.0-ubi8-python-3.8"
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x
 RUN sed -i -e "s/Python.*/$(python --version| cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \

--- a/habana/1.11.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.11.0/ubi8-python-3.8/Dockerfile
@@ -7,6 +7,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 ARG ARTIFACTORY_URL="vault.habana.ai"
 ARG VERSION="1.11.0"
 ARG REVISION="587"
@@ -151,10 +155,10 @@ LABEL name="odh-notebook-habana-jupyter-1.11.0-ubi8-python-3.8" \
     description="Jupyter HabanaAI 1.11.0 notebook image with base Python 3.8 builder image based on ubi8 for ODH notebooks" \
     io.k8s.display-name="Jupyter HabanaAI 1.11.0 notebook image for ODH notebooks" \
     io.k8s.description="Jupyter HabanaAI 1.11.0 notebook image with base Python 3.8 builder image based on ubi8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/habana/1.11.0/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:habana-jupyter-1.11.0-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/habana/1.11.0/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:habana-jupyter-1.11.0-ubi8-python-3.8"
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x
 RUN sed -i -e "s/Python.*/$(python --version| cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \

--- a/habana/1.9.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.9.0/ubi8-python-3.8/Dockerfile
@@ -7,6 +7,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 ARG ARTIFACTORY_URL="vault.habana.ai"
 ARG VERSION="1.9.0"
 ARG REVISION="580"
@@ -136,10 +140,10 @@ LABEL name="odh-notebook-habana-jupyter-1.9.0-ubi8-python-3.8" \
     description="Jupyter HabanaAI 1.9.0 notebook image with base Python 3.8 builder image based on ubi8 for ODH notebooks" \
     io.k8s.display-name="Jupyter HabanaAI 1.9.0 notebook image for ODH notebooks" \
     io.k8s.description="Jupyter HabanaAI 1.9.0 notebook image with base Python 3.8 builder image based on ubi8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/habana/1.9.0/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:habana-jupyter-1.9.0-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/habana/1.9.0/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:habana-jupyter-1.9.0-ubi8-python-3.8"
 
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x
 RUN sed -i -e "s/Python.*/$(python --version| cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \

--- a/jupyter/datascience/anaconda-python-3.8/Dockerfile
+++ b/jupyter/datascience/anaconda-python-3.8/Dockerfile
@@ -1,6 +1,10 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="jupyter-datascience-anaconda-python-3.8:latest" \
     summary="Minimal Jupyter Notebook Source-to-Image for Python 3.8 applications. Uses Anaconda CE instead of pip." \
     description="Notebook image based on Anaconda CE Python.These images can be used in OpenDatahub JupterHub." \
@@ -8,10 +12,10 @@ LABEL name="jupyter-datascience-anaconda-python-3.8:latest" \
     io.k8s.display-name="Anaconda s2i-minimal-notebook, python38" \
     io.openshift.expose-services="8888:http" \
     io.openshift.tags="python,python38,python-38,anaconda-python38" \
-    authoritative-source-url="https://quay.io//opendatahub/workbench-images:jupyter-datascience-anaconda-python-3.8" \
-    io.openshift.s2i.build.commit.ref="main" \
-    io.openshift.s2i.build.source-location="https://github.com/opendatahub-io/notebooks/jupyter/datascience/anaconda-python-3.8" \
-    io.openshift.s2i.build.image="quay.io/repository/opendatahub/workbench-images:jupyter-datascience-anaconda-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.s2i.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.s2i.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/datascience/anaconda-python-3.8" \
+    io.openshift.s2i.build.image="${IMAGE_REGISTRY}:jupyter-datascience-anaconda-python-3.8"
 
 ENV JUPYTER_ENABLE_LAB="1"
 USER root

--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-datascience-ubi8-python-3.8" \
     summary="Jupyter data science notebook image for ODH notebooks" \
     description="Jupyter data science notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Jupyter data science notebook image for ODH notebooks" \
     io.k8s.description="Jupyter data science notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-datascience-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/datascience/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-datascience-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.9" \
     summary="Jupyter data science notebook image for ODH notebooks" \
     description="Jupyter data science notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Jupyter data science notebook image for ODH notebooks" \
     io.k8s.description="Jupyter data science notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/datascience/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-datascience-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi8-python-3.8/Dockerfile
+++ b/jupyter/minimal/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-minimal-ubi8-python-3.8" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
     description="Minimal Jupyter notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Minimal Jupyter notebook image for ODH notebooks" \
     io.k8s.description="Minimal Jupyter notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-minimal-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/minimal/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-minimal-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.9" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
     description="Minimal Jupyter notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Minimal Jupyter notebook image for ODH notebooks" \
     io.k8s.description="Minimal Jupyter notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/minimal/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-minimal-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.9" \
     summary="Jupyter pytorch notebook image for ODH notebooks" \
     description="Jupyter pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Jupyter pytorch notebook image for ODH notebooks" \
     io.k8s.description="Jupyter pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-pytorch-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/pytorch/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-pytorch-ubi9-python-3.9"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock ./

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9" \
     summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
     description="Jupyter CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
     io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/tensorflow/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:cuda-jupyter-tensorflow-ubi9-python-3.9"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock ./

--- a/jupyter/trustyai/ubi8-python-3.8/Dockerfile
+++ b/jupyter/trustyai/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-trustyai-ubi8-python-3.8" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \
     description="Jupyter trustyai notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Jupyter trustyai notebook image for ODH notebooks" \
     io.k8s.description="Jupyter trustyai notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/trustyai/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-trustyai-ubi8-python-3.8"
 
 USER 0
 

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.9" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \
     description="Jupyter trustyai notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Jupyter trustyai notebook image for ODH notebooks" \
     io.k8s.description="Jupyter trustyai notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/jupyter/trustyai/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:jupyter-trustyai-ubi9-python-3.9"
 
 USER 0
 

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-rstudio-server-c9s-python-3.9" \
       summary="RStudio Server image with python 3.9 based on CentOS Stream 9" \
       description="RStudio server image with python 3.9 based on CentOS Stream 9" \
       io.k8s.display-name="RStudio server image with python 3.9 based on CentOS Stream 9" \
       io.k8s.description="RStudio server image with python 3.9 based on CentOS Stream 9" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/c9s-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-c9s-python-3.9"
+      authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/rstudio/c9s-python-3.9" \
+      io.openshift.build.image="${IMAGE_REGISTRY}:rstudio-c9s-python-3.9"
 
 USER 0
 

--- a/runtimes/datascience/ubi8-python-3.8/Dockerfile
+++ b/runtimes/datascience/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-runtime-datascience-ubi8-python-3.8" \
     summary="Runtime data science notebook image for ODH notebooks" \
     description="Runtime data science notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Runtime data science notebook image for ODH notebooks" \
     io.k8s.description="Runtime data science notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/datascience/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/datascience/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:runtime-datascience-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/datascience/ubi9-python-3.9/Dockerfile
+++ b/runtimes/datascience/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.9" \
     summary="Runtime data science notebook image for ODH notebooks" \
     description="Runtime data science notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Runtime data science notebook image for ODH notebooks" \
     io.k8s.description="Runtime data science notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/datascience/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/datascience/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:runtime-datascience-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/minimal/ubi8-python-3.8/Dockerfile
+++ b/runtimes/minimal/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-runtime-minimal-ubi8-python-3.8" \
     summary="Runtime minimal image for ODH notebooks" \
     description="Runtime minimal image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Runtime minimal image for ODH notebooks" \
     io.k8s.description="Runtime minimal image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/minimal/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-minimal-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/minimal/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:runtime-minimal-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/minimal/ubi9-python-3.9/Dockerfile
+++ b/runtimes/minimal/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.9" \
     summary="Runtime minimal image for ODH notebooks" \
     description="Runtime minimal image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Runtime minimal image for ODH notebooks" \
     io.k8s.description="Runtime minimal image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/minimal/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-minimal-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/minimal/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:runtime-minimal-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/pytorch/ubi8-python-3.8/Dockerfile
+++ b/runtimes/pytorch/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-runtime-pytorch-ubi8-python-3.8" \
     summary="Runtime pytorch notebook image for ODH notebooks" \
     description="Runtime pytorch notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Runtime pytorch notebook image for ODH notebooks" \
     io.k8s.description="Runtime pytorch notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/pytorch/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:runtime-pytorch-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.9" \
     summary="Runtime pytorch notebook image for ODH notebooks" \
     description="Runtime pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Runtime pytorch notebook image for ODH notebooks" \
     io.k8s.description="Runtime pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/pytorch/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:runtime-pytorch-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/tensorflow/ubi8-python-3.8/Dockerfile
+++ b/runtimes/tensorflow/ubi8-python-3.8/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi8-python-3.8" \
     summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
     description="Runtime CUDA tensorflow notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
     io.k8s.display-name="Runtime CUDA tensorflow notebook image for ODH notebooks" \
     io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.8 builder image based on UBI8 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi8-python-3.8" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi8-python-3.8"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/tensorflow/ubi8-python-3.8" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:cuda-runtime-tensorflow-ubi8-python-3.8"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,15 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG AUTHORITATIVE_SOURCE_URL
+ARG BUILD_COMMIT_REF
+ARG IMAGE_REGISTRY
+
 LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
     description="Runtime CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
     io.k8s.display-name="Runtime CUDA tensorflow notebook image for ODH notebooks" \
     io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi9-python-3.9" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi9-python-3.9"
+    authoritative-source-url="${AUTHORITATIVE_SOURCE_URL}" \
+    io.openshift.build.commit.ref="${BUILD_COMMIT_REF}" \
+    io.openshift.build.source-location="${AUTHORITATIVE_SOURCE_URL}/tree/${BUILD_COMMIT_REF}/runtimes/tensorflow/ubi9-python-3.9" \
+    io.openshift.build.image="${IMAGE_REGISTRY}:cuda-runtime-tensorflow-ubi9-python-3.9"
 
 WORKDIR /opt/app-root/bin
 


### PR DESCRIPTION
Relates to: https://github.com/opendatahub-io/notebooks/issues/292

<!--- Provide a general summary of your changes in the Title above -->
Docker image labels reviewed

## Description
<!--- Describe your changes in detail -->
This change tries to deduplicate some strings in our docker image labels with ability to propagate some common values directly from the Makefile so we don't need to change these values with every release branch or for every newly introduced docker image.

There were some minor fixes in the labels introduced too in this commit.

---

## Notable points for discussion:

1. I used value of the `RELEASE` variable for the build-ref at the moment - I understand that this may not be ideal. We may introduce separate value for this in Makefile or we can try to compute the value (either ref hash or branch name) dynamically in Makefile too. But in general - the value of the `RELEASE` should match what we've used so far.
2. Also, some labels (`authoritative-source-url` and `build commit ref` at least) could be propagated directly from Makefile - in this case I mean by using the `--label` parameter. There are two drawbacks I can think of:
   1. We could lost them in case of an individual build because this way these won't be enforced by Dockerfile itself
   2. In [this Dockerfile](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/datascience/anaconda-python-3.8/Dockerfile) we have a slightly different naming for some labels which includes `s2i` infix - we would have to assure we don't change it wrongly.
      * Actually - do we want these `s2i` infixes?
3. I didn't touch the Anaconda Base Dockerfile - looks like the labels there should deserve review too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did a brief build of one image so far to check the idea behind the changes works. Will do more once the conversation here is finalized:

```
make codeserver-ubi9-python-3.9 -e IMAGE_REGISTRY=quay.io/jstourac/workbench-images
```

Result images can be seen in https://quay.io/repository/jstourac/workbench-images?tab=tags&tag=latest

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
