### PR TITLE
feature: Included annotation to the outdated image tags

### DIFF
--- a/docs/workbench-imagestreams.md
+++ b/docs/workbench-imagestreams.md
@@ -41,6 +41,7 @@ spec:
   - **`opendatahub.io/notebook-python-dependencies:`** -  a string that represents the list of Python libraries included within the workbench image. Each library is described by its name and currently used version (e.g. `'[{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"}]'`)
   - **`openshift.io/imported-from:`** - a reference to the image repository where the workbench image was obtained (e.g. `quay.io/repository/opendatahub/workbench-images`)
   - **`opendatahub.io/workbench-image-recommended:`** - a flag that allows the ImageStream tag to be marked as Recommended (used by the UI to distinguish which tags are recommended for use, e.g., when the workbench image offers multiple tags to choose from)
+  - **`opendatahub.io/image-tag-outdated:`** - a reference to the image version Tags that are outdated and out of regular maintaince cycle. The image tag would be eventually removed.
 
 ### **ImageStream definitions for the supported out-of-the-box images in ODH**  
 
@@ -72,6 +73,7 @@ spec:
       opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/opendatahub/workbench-images
       opendatahub.io/workbench-image-recommended: 'true'
+      opendatahub.io/image-tag-outdated: 'false'
     from:
       kind: DockerImage
       name: quay.io/opendatahub/workbench-images@sha256:value-of-the-image-tag

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -42,6 +42,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: $(odh-generic-data-science-notebook-image-n-2)

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -43,6 +43,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2"},{"name":"Notebook","version":"6.4"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: $(odh-minimal-gpu-notebook-image-n-2)

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -43,6 +43,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.2"}, {"name": "Notebook","version": "6.4"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: $(odh-minimal-notebook-image-n-2)

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -43,6 +43,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: $(odh-pytorch-gpu-notebook-image-n-2)

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -43,6 +43,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: $(odh-tensorflow-gpu-notebook-image-n-2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
feature: Included annotation to the outdated image tags

## Description
<!--- Describe your changes in detail -->

Setup an annotation: `opendatahub.io/image-tag-outdated` to specific an image version that is out-of-date and no longer in the regular upgrade cycle.
Related-to: https://github.com/opendatahub-io/notebooks/issues/154

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not much testing available.
Apply the imagestream to a OpenDatahub cluster
check if the annotations are visible.
![Screenshot from 2023-11-07 02-51-44](https://github.com/opendatahub-io/notebooks/assets/14028058/00599bee-e37f-4692-80da-ca65d3dcd3c1)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
