### PR TITLE
fix: disable announcement of jupyterlab notification

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -30,6 +30,9 @@ USER root
 # Install usefull OS packages
 RUN dnf install -y jq unixODBC git-lfs libsndfile
 
+# Disable announcement plugin of jupyterlab
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Install MongoDB Client, We need a special repo for MongoDB as they do their own distribution
 COPY mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
 

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -30,6 +30,9 @@ USER root
 # Install usefull OS packages
 RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile
 
+# Disable announcement plugin of jupyterlab
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Install MongoDB Client, We need a special repo for MongoDB as they do their own distribution
 COPY mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
 

--- a/jupyter/minimal/ubi8-python-3.8/Dockerfile
+++ b/jupyter/minimal/ubi8-python-3.8/Dockerfile
@@ -20,6 +20,9 @@ COPY Pipfile.lock start-notebook.sh ./
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
+# Disable announcement plugin of jupyterlab
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
       fix-permissions /opt/app-root -P

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -20,6 +20,9 @@ COPY Pipfile.lock start-notebook.sh ./
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 
+# Disable announcement plugin of jupyterlab
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
       fix-permissions /opt/app-root -P

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -18,7 +18,9 @@ RUN echo "Installing softwares and packages" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # Disable announcement plugin of jupyterlab \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -19,6 +19,9 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
+# Disable announcement plugin of jupyterlab
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -28,6 +28,9 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
+# Disable announcement plugin of jupyterlab
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # Fix permissions to support pip in Openshift environments
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix: disable announcement of jupyterlab notification

## Description
<!--- Describe your changes in detail -->
disable announcement of jupyterlab notification
https://jupyterlab.readthedocs.io/en/latest/privacy_policies.html#announcements-plugin

Related-to: https://github.com/opendatahub-io/notebooks/issues/331

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Execute all the image build from this PR. PR-318
2. Check if the notebook, is still showing the notification.
or
Run the following command in the notebook terminal: `$ jupyter labextension list`
It would provide: 
```
Disabled extensions:
    @jupyterlab/apputils-extension:announcements
    @jupyterlab/launcher-extension (all plugins)
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
