### PR TITLE
fix: add workaround patch for elyra validate

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/Dockerfile
+++ b/jupyter/datascience/ubi8-python-3.8/Dockerfile
@@ -56,6 +56,9 @@ RUN mkdir /opt/app-root/runtimes && \
     # Workaround for passing ssl_sa_cert
     patch /opt/app-root/lib/python3.8/site-packages/elyra/pipeline/kfp/kfp_authentication.py -i utils/kfp_authentication.patch && \
     patch /opt/app-root/lib/python3.8/site-packages/elyra/pipeline/kfp/processor_kfp.py -i utils/processor_kfp.patch && \
+    # Workaround for elyra pipeline validation command
+    patch /opt/app-root/lib/python3.8/site-packages/elyra/cli/pipeline_app.py -i utils/pipeline_app.patch && \
+    patch /opt/app-root/lib/python3.8/site-packages/elyra/pipeline/pipeline_definition.py -i utils/pipeline_definition.patch && \
     # switch to Data Science Pipeline in component catalog \
     DIR_COMPONENT="/opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/local-directory-catalog.json" && \
     FILE_COMPONENT="/opt/app-root/lib/python3.8/site-packages/elyra/metadata/schemas/local-file-catalog.json" && \

--- a/jupyter/datascience/ubi8-python-3.8/utils/pipeline_app.patch
+++ b/jupyter/datascience/ubi8-python-3.8/utils/pipeline_app.patch
@@ -1,0 +1,12 @@
+--- a/pipeline_app.py	2023-11-09 13:36:35
++++ b/pipeline_app.py	2023-11-09 12:10:35
+@@ -296,7 +296,8 @@
+         _validate_pipeline_definition(pipeline_definition)
+     except Exception:
+         raise click.ClickException("Pipeline validation FAILED.")
+-
++    
++    print_info("Pipeline validation SUCCEEDED.", [])
+ 
+ def validate_timeout_option(ctx, param, value):
+     """Callback for monitor-timeout parameter validation"""

--- a/jupyter/datascience/ubi8-python-3.8/utils/pipeline_definition.patch
+++ b/jupyter/datascience/ubi8-python-3.8/utils/pipeline_definition.patch
@@ -1,0 +1,12 @@
+--- a/pipeline_definition.py	2023-11-09 13:36:35
++++ b/pipeline_definition.py	2023-11-07 20:07:49
+@@ -265,6 +265,9 @@
+         if parameter_class is None:
+             return None  # runtime type does not support parameters, skip
+ 
++        if not ElyraProperty.subclass_exists_for_property(parameter_class.property_id):
++            ElyraProperty.build_property_map()
++
+         # Convert pipeline parameters to runtime-specific instances
+         converted_value = ElyraProperty.create_instance(parameter_class.property_id, self.pipeline_parameters)
+         if converted_value is not None:

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -56,6 +56,9 @@ RUN mkdir /opt/app-root/runtimes && \
     # Workaround for passing ssl_sa_cert and to ensure that Elyra redirects to a correct pipeline run URL
     patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/kfp/kfp_authentication.py -i utils/kfp_authentication.patch && \
     patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/kfp/processor_kfp.py -i utils/processor_kfp.patch && \
+    # Workaround for elyra pipeline validation command
+    patch /opt/app-root/lib/python3.9/site-packages/elyra/cli/pipeline_app.py -i utils/pipeline_app.patch && \
+    patch /opt/app-root/lib/python3.9/site-packages/elyra/pipeline/pipeline_definition.py -i utils/pipeline_definition.patch && \
     # switch to Data Science Pipeline in component catalog \
     DIR_COMPONENT="/opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/local-directory-catalog.json" && \
     FILE_COMPONENT="/opt/app-root/lib/python3.9/site-packages/elyra/metadata/schemas/local-file-catalog.json" && \

--- a/jupyter/datascience/ubi9-python-3.9/utils/pipeline_app.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/pipeline_app.patch
@@ -1,0 +1,12 @@
+--- a/pipeline_app.py	2023-11-09 13:36:35
++++ b/pipeline_app.py	2023-11-09 12:10:35
+@@ -296,7 +296,8 @@
+         _validate_pipeline_definition(pipeline_definition)
+     except Exception:
+         raise click.ClickException("Pipeline validation FAILED.")
+-
++    
++    print_info("Pipeline validation SUCCEEDED.", [])
+ 
+ def validate_timeout_option(ctx, param, value):
+     """Callback for monitor-timeout parameter validation"""

--- a/jupyter/datascience/ubi9-python-3.9/utils/pipeline_definition.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/pipeline_definition.patch
@@ -1,0 +1,12 @@
+--- a/pipeline_definition.py	2023-11-09 13:36:35
++++ b/pipeline_definition.py	2023-11-07 20:07:49
+@@ -265,6 +265,9 @@
+         if parameter_class is None:
+             return None  # runtime type does not support parameters, skip
+ 
++        if not ElyraProperty.subclass_exists_for_property(parameter_class.property_id):
++            ElyraProperty.build_property_map()
++
+         # Convert pipeline parameters to runtime-specific instances
+         converted_value = ElyraProperty.create_instance(parameter_class.property_id, self.pipeline_parameters)
+         if converted_value is not None:


### PR DESCRIPTION
Patch to fix failing of elyra validation command for pipelines with default values.

Fixes #257 

## Description
`elyra-validate` cmd was failing for pipelines that contain both pipeline parameters and default properties.

## How Has This Been Tested?

1. Run the image in bash. 

```
podman run -it --rm -p 8888:8888 quay.io/opendatahub/workbench-images:jupyter-datascience-ubi8-python-3.8-pr-324 bash
```

2. Copy the files `params.pipeline` and `params-test.py` from [here](https://github.com/harshad16/elyra-tests/tree/main/pipeline-params).
4. Validate pipeline using `elyra-validate` command.
```
elyra-pipeline validate params.pipeline
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
