### PR TITLE
[Fix] typo of the TensorFlow name in HabanaAI notebook manifest

### DIFF
--- a/manifests/base/jupyter-habana-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-habana-notebook-imagestream.yaml
@@ -18,7 +18,7 @@ spec:
     # 1.10.0 Version of the image n-1
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.10"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Tensorflow","version":"2.12.0"},{"name":"PyTorch","version":"2.0.1"},{"name":"Elyra","version":"3.15"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"TensorFlow","version":"2.12.0"},{"name":"PyTorch","version":"2.0.1"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: "e5b5f1f"


### PR DESCRIPTION
Fixes the typo of TensorFlow name in the imagestream manifest for HabanaAI

<!--- Provide a general summary of your changes in the Title above -->
This is just a fix of a typo to have it unified in the same name as TensorFlow workbench has it. This is not a functional change, just UI thing how this information is presented to the user.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [/] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
