### PR TITLE
fix: trustyai annotation and habana version to 2023.2

### DIFF
--- a/manifests/base/jupyter-habana-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-habana-notebook-imagestream.yaml
@@ -25,6 +25,6 @@ spec:
       from:
         kind: DockerImage
         name: $(odh-habana-notebook-image-n)
-      name: "2023.1"
+      name: "2023.2"
       referencePolicy:
         type: Source

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -30,7 +30,7 @@ spec:
     # N-1 Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.2"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.3"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
trustyai annotation and habana version to 2023.2

## Description

Related-to: https://github.com/opendatahub-io/notebooks/issues/301
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1.  Execute the current n-1 image: found [here](https://github.com/opendatahub-io/notebooks/blob/1d11963cd2da269848c4bc5ddd30a969342490ba/manifests/base/params.env#L17)

Run the image and check the trustyai version:
```
podman run -p 8888:8888 quay.io/opendatahub/workbench-images@sha256:9c7dfc1c58bcbafbb4ffae58641e1bc4c3b5850886960bf27c652b7d0635d779
```
Execute the following command in terminal
$ pip show trustyai
```
Name: trustyai
Version: 0.3.0
Summary: Python bindings to the TrustyAI explainability library.
Home-page: 
Author: 
Author-email: Rui Vieira <rui@redhat.com>
License: Apache License Version 2.0
Location: /opt/app-root/lib/python3.9/site-packages
Requires: Jpype1, jupyter-bokeh, matplotlib, numpy, pandas, pyarrow
Required-by: 
```
2. Also can be seen here: https://github.com/opendatahub-io/notebooks/blob/3ad46bb631c2f52771df8bb94d9219da42b26c5f/jupyter/trustyai/ubi9-python-3.9/Pipfile#L10
 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
