### PR TITLE
[Bug] Add missing Dockerfile for TrustyAI ubi8

### DIFF
--- a/jupyter/trustyai/ubi8-python-3.8/Dockerfile
+++ b/jupyter/trustyai/ubi8-python-3.8/Dockerfile
@@ -1,0 +1,33 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+LABEL name="odh-notebook-jupyter-trustyai-ubi8-python-3.8" \
+    summary="Jupyter trustyai notebook image for ODH notebooks" \
+    description="Jupyter trustyai notebook image with base Python 3.8 builder image based on UBI9 for ODH notebooks" \
+    io.k8s.display-name="Jupyter trustyai notebook image for ODH notebooks" \
+    io.k8s.description="Jupyter trustyai notebook image with base Python 3.8 builder image based on UBI9 for ODH notebooks" \
+    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+    io.openshift.build.commit.ref="main" \
+    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai/ubi8-python-3.8" \
+    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi8-python-3.8"
+
+USER 0
+
+# Install jre that is needed to run the trustyai library
+RUN INSTALL_PKGS="java-17-openjdk" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+USER 1001
+
+# Install Python packages and Jupyterlab extensions from Pipfile.lock
+COPY Pipfile.lock ./
+
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
+
+# Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
+RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+
+# Fix permissions to support pip in Openshift environments
+RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
+    fix-permissions /opt/app-root -P


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

After checking why the `prow/image` test is failing (ref [link](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/opendatahub-io_notebooks/359/pull-ci-opendatahub-io-notebooks-2023a-images/1726524130980794368)), found out that the on the UBI8 TrustyAI flavor was missing the Dockerfile.  

Related to: https://github.com/opendatahub-io/notebooks/pull/359

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
