### PR TITLE
hot-fix: set the workbench-image-recommended anno to false for 2023.1

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -32,6 +32,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.11"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "6332c3b"
       from:
         kind: DockerImage

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -32,6 +32,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:
         kind: DockerImage

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -33,6 +33,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:
         kind: DockerImage

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -33,6 +33,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.5"}, {"name": "Notebook","version": "6.5"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:
         kind: DockerImage

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -33,6 +33,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:
         kind: DockerImage

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -33,6 +33,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:
         kind: DockerImage

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -32,6 +32,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.3"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "17c2e49"
       from:
         kind: DockerImage

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -33,6 +33,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"r-studio","version":"4.3"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "6332c3b"
       from:
         kind: DockerImage

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -32,6 +32,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"r-studio","version":"4.3"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: "6332c3b"
       from:
         kind: DockerImage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
set the workbench-image-recommended anno to false for 2023.1

## Description
<!--- Describe your changes in detail -->

Related-to: https://github.com/opendatahub-io/notebooks/issues/373

In ODH 2.2 upgrade to 2.4 + version, the recommend-tag annotation shows up for 2023.2 and 2023.1.
The 2023.1 would not have the recommended tag with the annotation set to false.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. On a cluster, which was upgrade to 2.4 , mark the recommended annotation to false.
![Screenshot from 2023-11-28 12-39-52](https://github.com/opendatahub-io/notebooks/assets/14028058/a3b6e471-3cc3-444a-813e-4504a22e4116)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
