### PR TITLE
Move vscode server imagestream and configurations to 2023b branch

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/codeserver"
+    opendatahub.io/notebook-image-name: "Code Server"
+    opendatahub.io/notebook-image-desc: "Code Server workbench image, allows to run Visual Studio Code (VSCode) on a remote server through the browser."
+    opendatahub.io/notebook-image-order: "8"
+  name: code-server-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # N Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.16"}]'
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: "c91d58c"
+      from:
+        kind: DockerImage
+        name: $(odh-codeserver-notebook-n)
+      name: "2023.2"
+      referencePolicy:
+        type: Source
+    # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.11"}]'
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: "6332c3b"
+      from:
+        kind: DockerImage
+        name: $(odh-codeserver-notebook-n-1)
+      name: "2023.1"
+      referencePolicy:
+        type: Source

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - jupyter-tensorflow-notebook-imagestream.yaml
   - jupyter-trustyai-notebook-imagestream.yaml
   - jupyter-habana-notebook-imagestream.yaml
+  - code-server-notebook-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"
@@ -146,5 +147,19 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
+  - name: odh-codeserver-notebook-n
+    objref:
+      kind: ConfigMap
+      name: notebooks-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-n
+  - name: odh-codeserver-notebook-n-1
+    objref:
+      kind: ConfigMap
+      name: notebooks-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-n-1
 configurations:
   - params.yaml

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -16,3 +16,5 @@ odh-tensorflow-gpu-notebook-image-n-2=quay.io/opendatahub/notebooks@sha256:fc52e
 odh-trustyai-notebook-image-n=quay.io/opendatahub/workbench-images@sha256:bf2087d3a1859f3bb9cd3d4636ad1507bc4b1c44f0e12aa2f95e9d50e6f8d6eb
 odh-trustyai-notebook-image-n-1=quay.io/opendatahub/workbench-images@sha256:5b5bae7a11f2e34b67726a86d24b8f2c35c701a48d80abbdbc91030033d2fc1f
 odh-habana-notebook-image-n=quay.io/opendatahub/workbench-images@sha256:b0821ae2abe45387a371108ac08e7474b64255e5c4519de5da594b4617fd79fe
+odh-codeserver-notebook-n=quay.io/opendatahub/workbench-images@sha256:1c5bcbfc222dfb59849fee67e050719c688c93d3608f7b46edbe5666263641f3
+odh-codeserver-notebook-n-1=quay.io/opendatahub/workbench-images@sha256:fd5b9f65c0f46d4c093e2f58fce305eeb125bf19ee1d88f67b9fafe56142e92d

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -72,3 +72,11 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-habana-notebook-image-n
+  - path: spec/tags[]/from/name
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-n
+  - path: spec/tags[]/from/name
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-n-1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move vscode server imagestream and configurations to 2023b branch

**IMPORTANT NOTE** Remaining item for the feature freeze sync, is to **update** the `params.env` file with the latest SHA digest produced by the 2023b ocp-ci configuration and the `notebook-build-commit` annotation with the short version of the build commit 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
