### PR TITLE
Install R-Packages with version lock

### DIFF
--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -31,8 +31,8 @@ RUN chmod -R a+w /usr/lib64/R/library
 ENV LIBLOC /usr/lib64/R/library
 
 # set User R Library path
-RUN mkdir -p /opt/app-root/src/Rpackages/4.3 && chmod -R a+w /opt/app-root/src/Rpackages/4.3
-ENV R_LIBS_USER /opt/app-root/src/Rpackages/4.3
+RUN mkdir -p /opt/app-root/bin/Rpackages/4.3 && chmod -R a+w /opt/app-root/bin/Rpackages/4.3
+ENV R_LIBS_USER /opt/app-root/bin/Rpackages/4.3
 
 WORKDIR /tmp/
 
@@ -50,9 +50,17 @@ COPY rsession.conf /etc/rstudio/rsession.conf
 # package installation 
 RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" \
     && dnf clean all && rm -rf /var/cache/yum
-RUN R -e "install.packages('Rcpp')"
+# Install R packages
+RUN R -e "install.packages('remotes')"
+RUN R -e "require('remotes'); \
+    remotes::install_version('Rcpp','1.0.12'); \
+    remotes::install_version('tidyverse','2.0.0'); \
+    remotes::install_version('tidymodels','1.1.1'); \
+    remotes::install_version('plumber','1.2.1'); \
+    remotes::install_version('vetiver','0.2.5'); \
+    remotes::install_version('devtools','2.4.5');"
 
-# Install NGINX to proxy RStudio and pass probes check 
+# Install NGINX to proxy RStudio and pass probes check
 ENV NGINX_VERSION=1.24 \
     NGINX_SHORT_VER=124 \
     NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \

--- a/rstudio/c9s-python-3.9/run-rstudio.sh
+++ b/rstudio/c9s-python-3.9/run-rstudio.sh
@@ -16,7 +16,7 @@ fi
 
 # Create lib folders if it does not exist
 mkdir -p  /opt/app-root/src/Rpackages/4.3
-
+cp -r /opt/app-root/bin/Rpackages/4.3/* /opt/app-root/src/Rpackages/4.3/
 # rstudio terminal cant see environment variables set by the container runtime
 # (which breaks kubectl, to fix this we store the KUBERNETES_* env vars in Renviron.site)
 env | grep KUBERNETES_ >> /usr/lib64/R/etc/Renviron.site


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes for https://issues.redhat.com/browse/RHOAIENG-2799
## Description
<!--- Describe your changes in detail -->
  Added R packages with fixed version lock

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use either the image build in the PR or built from this commit:
```
git checkout dibryant:rs-packages

cd rstudio/c9s-python-3.9/
podman build -t rstudio . --build-arg BASE_IMAGE=quay.io/opendatahub/workbench-images:base-c9s-python-3.9-20240124
```

And the run the image in local or directly in cluster
```
podman run -p 8787:8787 quay.io/opendatahub/workbench-images:rstudio-c9s-python-3.9-pr-405
```




## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
