### PR TITLE
Revert the patch of pipeline_version_id as pipeline_id

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi8-python-3.8/utils/processor_kfp.patch
@@ -1,5 +1,5 @@
---- a/processor_kfp.py	2023-06-09 10:17:15.659461927 -0400
-+++ b/processor_kfp.py	2023-06-09 10:16:20.062429914 -0400
+--- a/processor_kfp.py	2023-06-09 10:19:08.882563609 -0400
++++ b/processor_kfp.py	2024-02-02 00:35:38.064021086 -0500
 @@ -213,6 +213,7 @@
                      credentials=auth_info.get("credentials", None),
                      existing_token=auth_info.get("existing_token", None),
@@ -8,3 +8,21 @@
                  )
              else:
                  client = ArgoClient(
+@@ -435,7 +436,7 @@
+ 
+             self.log_pipeline_info(
+                 pipeline_name,
+-                f"pipeline submitted: {public_api_endpoint}/#/runs/details/{run.id}",
++                f"pipeline submitted: {public_api_endpoint}/{run.id}",
+                 duration=time.time() - t0,
+             )
+ 
+@@ -451,7 +452,7 @@
+ 
+         return KfpPipelineProcessorResponse(
+             run_id=run.id,
+-            run_url=f"{public_api_endpoint}/#/runs/details/{run.id}",
++            run_url=f"{public_api_endpoint}/{run.id}",
+             object_storage_url=object_storage_url,
+             object_storage_path=object_storage_path,
+         )

--- a/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
@@ -1,5 +1,5 @@
 --- a/processor_kfp.py	2023-06-09 10:19:08.882563609 -0400
-+++ b/processor_kfp.py	2023-07-13 19:31:43.572407879 -0400
++++ b/processor_kfp.py	2024-02-02 00:35:38.064021086 -0500
 @@ -213,6 +213,7 @@
                      credentials=auth_info.get("credentials", None),
                      existing_token=auth_info.get("existing_token", None),
@@ -8,15 +8,6 @@
                  )
              else:
                  client = ArgoClient(
-@@ -416,7 +417,7 @@
- 
-                 # create pipeline run (or specified pipeline version)
-                 run = client.run_pipeline(
--                    experiment_id=experiment.id, job_name=job_name, pipeline_id=pipeline_id, version_id=version_id
-+                    experiment_id=experiment.id, job_name=job_name, pipeline_id=pipeline_id, version_id=pipeline_id
-                 )
- 
-             except Exception as ex:
 @@ -435,7 +436,7 @@
  
              self.log_pipeline_info(
@@ -34,5 +25,4 @@
 +            run_url=f"{public_api_endpoint}/{run.id}",
              object_storage_url=object_storage_url,
              object_storage_path=object_storage_path,
-
          )


### PR DESCRIPTION
Revert the patch of pipeline_version_id as pipeline_id

## Description

Based on a3fa683c, pipeline_version_id was set the same as pipeline_id to show proper display on the ODH Dashboard. This feature is now corrected on ODH Dashboard.

Fixes: https://github.com/opendatahub-io/notebooks/issues/255
Related-to: https://issues.redhat.com/browse/RHOAIENG-2469


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A dev image was created: `quay.io/harshad16/data-science-runtime-ubi9:pv`
Use this as Notebook imagestream in ODH cluster.
To setup compatible ODH Dashboard, set the below config in DSC:
```
    dashboard:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: base
            uri: >-
              https://github.com/opendatahub-io/odh-dashboard/tarball/v2.19.1-incubation-release
      managementState: Managed
```

Execute a pipeline, with same pipeline name , just with few little changes,
see how it gets displayed on the ODH dashboard.

![Screenshot from 2024-02-08 02-06-17](https://github.com/opendatahub-io/notebooks/assets/14028058/bf344d08-aa31-4ec7-bea7-796650ace56f)

On the above example:
The pipeline `new` is created with these changes, and one can click on view runs and see the changes.
whereas the pipeline `hello-generic-world` is created with old setup, 
if we click on view runs, the additional versions would not shows execution runs.
for pipeline `new` it would function well.


If you want to check,  feel free to see the already set setup:
https://odh-dashboard-opendatahub.apps.hnalla.dev.datahub.redhat.com/pipelines/test
reach out for access.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
