### PR TITLE
fix: add workaround patch for providing ssl_ca_certs to argo client

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi8-python-3.8/utils/processor_kfp.patch
@@ -1,6 +1,6 @@
---- a/processor_kfp.py	2023-06-09 10:19:08.882563609 -0400
-+++ b/processor_kfp.py	2024-02-02 00:35:38.064021086 -0500
-@@ -213,6 +213,7 @@
+--- a/elyra/pipeline/kfp/processor_kfp.py
++++ b/elyra/pipeline/kfp/processor_kfp.py
+@@ -213,6 +213,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                      credentials=auth_info.get("credentials", None),
                      existing_token=auth_info.get("existing_token", None),
                      namespace=user_namespace,
@@ -8,7 +8,15 @@
                  )
              else:
                  client = ArgoClient(
-@@ -435,7 +436,7 @@
+@@ -221,6 +222,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
+                     credentials=auth_info.get("credentials", None),
+                     existing_token=auth_info.get("existing_token", None),
+                     namespace=user_namespace,
++                    ssl_ca_cert=auth_info.get("ssl_ca_cert", None),
+                 )
+         except Exception as ex:
+             # a common cause of these errors is forgetting to include `/pipeline` or including it with an 's'
+@@ -435,7 +437,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
  
              self.log_pipeline_info(
                  pipeline_name,
@@ -17,7 +25,7 @@
                  duration=time.time() - t0,
              )
  
-@@ -451,7 +452,7 @@
+@@ -451,7 +453,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
  
          return KfpPipelineProcessorResponse(
              run_id=run.id,

--- a/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
+++ b/jupyter/datascience/ubi9-python-3.9/utils/processor_kfp.patch
@@ -1,6 +1,6 @@
---- a/processor_kfp.py	2023-06-09 10:19:08.882563609 -0400
-+++ b/processor_kfp.py	2024-02-02 00:35:38.064021086 -0500
-@@ -213,6 +213,7 @@
+--- a/elyra/pipeline/kfp/processor_kfp.py
++++ b/elyra/pipeline/kfp/processor_kfp.py
+@@ -213,6 +213,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                      credentials=auth_info.get("credentials", None),
                      existing_token=auth_info.get("existing_token", None),
                      namespace=user_namespace,
@@ -8,7 +8,15 @@
                  )
              else:
                  client = ArgoClient(
-@@ -435,7 +436,7 @@
+@@ -221,6 +222,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
+                     credentials=auth_info.get("credentials", None),
+                     existing_token=auth_info.get("existing_token", None),
+                     namespace=user_namespace,
++                    ssl_ca_cert=auth_info.get("ssl_ca_cert", None),
+                 )
+         except Exception as ex:
+             # a common cause of these errors is forgetting to include `/pipeline` or including it with an 's'
+@@ -435,7 +437,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
  
              self.log_pipeline_info(
                  pipeline_name,
@@ -17,7 +25,7 @@
                  duration=time.time() - t0,
              )
  
-@@ -451,7 +452,7 @@
+@@ -451,7 +453,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
  
          return KfpPipelineProcessorResponse(
              run_id=run.id,


### PR DESCRIPTION
Patch to pass ssl_ca_certs to argo client in Elyra.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
