### PR TITLE
Incorporate settings.json file on vscode server workbench 

### DIFF
--- a/codeserver/ubi9-python-3.9/run-code-server.sh
+++ b/codeserver/ubi9-python-3.9/run-code-server.sh
@@ -16,6 +16,32 @@ fi
 # Initilize access logs for culling
 echo '[{"id":"code-server","name":"code-server","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/codeserver.access.log
 
+# Directory for settings file
+user_dir="/opt/app-root/src/.local/share/code-server/User/"
+settings_filepath="${user_dir}settings.json"
+
+json_settings='{
+  "python.defaultInterpreterPath": "/opt/app-root/bin/python3"
+}'
+
+# Check if User directory exists
+if [ ! -d "$user_dir" ]; then
+  echo "Debug: User directory not found, creating '$user_dir'..."
+  mkdir -p "$user_dir"
+  echo "$json_settings" > "$settings_filepath"
+  echo "Debug: '$settings_filepath' file created."
+else
+  echo "Debug: User directory already exists."
+  # Add settings.json if not present
+  if [ ! -f "$settings_filepath" ]; then
+    echo "Debug: '$settings_filepath' file not found, creating..."
+    echo "$json_settings" > "$settings_filepath"
+    echo "Debug: '$settings_filepath' file created."
+  else
+    echo "Debug: '$settings_filepath' file already exists."
+  fi
+fi
+
 # Check if code-server folder exists
 if [ ! -f "/opt/app-root/src/.local/share/code-server" ]; then
 


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-2312

## Description
This PR enables passing the settings.json file located within local/share/code-server/User/ in vscode. This is done to utilize the defaultInterpreterPath setting, thereby facilitating the selection of the interpreter.

On the official [documentation]( https://code.visualstudio.com/docs/python/settings-reference) is mentioned the following:

_Note: Changes to this setting made after an interpreter has been selected for a workspace will not be applied or considered by the Python extension. The Python extension doesn't automatically add or change this setting._

Therefore, in accordance with that, and since we have already pre-installed the Python extension, the user should specify the "/opt/app-root/bin/python3" interpreter at least once.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
