### PR TITLE
fix name on the path for extension installations

### DIFF
--- a/codeserver/ubi9-python-3.9/run-code-server.sh
+++ b/codeserver/ubi9-python-3.9/run-code-server.sh
@@ -16,10 +16,10 @@ fi
 # Initilize access logs for culling
 echo '[{"id":"code-server","name":"code-server","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/codeserver.access.log
 
-# Check if code-server exists
-if [ ! -f "/opt/app-root/src/.local/share/codeserver" ]; then
+# Check if code-server folder exists
+if [ ! -f "/opt/app-root/src/.local/share/code-server" ]; then
 
-    # Check internet connection
+    # Check internet connection - this check is for disconected enviroments
     if curl -Is http://www.google.com | head -n 1 | grep -q "200 OK"; then
         # Internet connection is available
         echo "Internet connection available. Installing specific extensions."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://issues.redhat.com/browse/RHOAIENG-3213

## Description
Fix the name from `codeserver` -> `code-server`, as well as added better comments on the code.

It fixes the bellow message on the terminal:
![image](https://github.com/opendatahub-io/notebooks/assets/42587738/084e5ed2-a0f5-4cf0-bf4a-440e95b6063e)

After that change this message vanished:
![image](https://github.com/opendatahub-io/notebooks/assets/42587738/40a15a1e-8647-444d-af4d-2fd86d95c54a)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
