### PR TITLE
Update CUDA layer to 12.1

### DIFF
--- a/cuda/c9s-python-3.9/Dockerfile
+++ b/cuda/c9s-python-3.9/Dockerfile
@@ -12,26 +12,26 @@ LABEL name="odh-notebook-cuda-c9s-python-3.9" \
       io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-c9s-python-3.9"
 
 # Install CUDA base from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/base/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/base/Dockerfile
 USER 0
 WORKDIR /opt/app-root/bin
 
 ENV NVARCH x86_64
-ENV NVIDIA_REQUIRE_CUDA "cuda>=11.8 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471"
-ENV NV_CUDA_CUDART_VERSION 11.8.89-1
+ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
+ENV NV_CUDA_CUDART_VERSION 12.1.105-1
 
 COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION 11.8.0
+ENV CUDA_VERSION 12.1.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \
-    cuda-cudart-11-8-${NV_CUDA_CUDART_VERSION} \
-    cuda-compat-11-8 \
+    cuda-cudart-12-1-${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-12-1 \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
@@ -49,63 +49,70 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 # Install CUDA runtime from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/runtime/Dockerfile
-ENV NV_CUDA_LIB_VERSION 11.8.0-1
-ENV NV_NVTX_VERSION 11.8.86-1
-ENV NV_LIBNPP_VERSION 11.8.0.86-1
-ENV NV_LIBNPP_PACKAGE libnpp-11-8-${NV_LIBNPP_VERSION}
-ENV NV_LIBCUBLAS_VERSION 11.11.3.6-1
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/runtime/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVTX_VERSION 12.1.105-1
+ENV NV_LIBNPP_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_PACKAGE libnpp-12-1-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION 12.1.3.1-1
 ENV NV_LIBNCCL_PACKAGE_NAME libnccl
-ENV NV_LIBNCCL_PACKAGE_VERSION 2.15.5-1
-ENV NV_LIBNCCL_VERSION 2.15.5
-ENV NCCL_VERSION 2.15.5
-ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda11.8
+ENV NV_LIBNCCL_PACKAGE_VERSION 2.17.1-1
+ENV NV_LIBNCCL_VERSION 2.17.1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
 
 RUN yum install -y \
-    cuda-libraries-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-nvtx-11-8-${NV_NVTX_VERSION} \
+    cuda-libraries-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-12-1-${NV_NVTX_VERSION} \
     ${NV_LIBNPP_PACKAGE} \
-    libcublas-11-8-${NV_LIBCUBLAS_VERSION} \
+    libcublas-12-1-${NV_LIBCUBLAS_VERSION} \
     ${NV_LIBNCCL_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
+# Set this flag so that libraries can find the location of CUDA
+ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
+
 # Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION 11.8.0-1
-ENV NV_NVPROF_VERSION 11.8.87-1
-ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-11-8-${NV_NVPROF_VERSION}
-ENV NV_CUDA_CUDART_DEV_VERSION 11.8.89-1
-ENV NV_NVML_DEV_VERSION 11.8.86-1
-ENV NV_LIBCUBLAS_DEV_VERSION 11.11.3.6-1
-ENV NV_LIBNPP_DEV_VERSION 11.8.0.86-1
-ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-11-8-${NV_LIBNPP_DEV_VERSION}
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVPROF_VERSION 12.1.105-1
+ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-12-1-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION 12.1.105-1
+ENV NV_NVML_DEV_VERSION 12.1.105-1
+ENV NV_LIBCUBLAS_DEV_VERSION 12.1.3.1-1
+ENV NV_LIBNPP_DEV_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
 ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.15.5-1
-ENV NCCL_VERSION 2.15.5
-ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda11.8
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.17.1-1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION 12.1.1-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
 
 RUN yum install -y \
     make \
-    cuda-command-line-tools-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-11-8-${NV_CUDA_CUDART_DEV_VERSION} \
+    findutils \
+    cuda-command-line-tools-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-devel-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-cudart-devel-12-1-${NV_CUDA_CUDART_DEV_VERSION} \
     ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-11-8-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-11-8-${NV_LIBCUBLAS_DEV_VERSION} \
+    cuda-nvml-devel-12-1-${NV_NVML_DEV_VERSION} \
+    libcublas-devel-12-1-${NV_LIBCUBLAS_DEV_VERSION} \
     ${NV_LIBNPP_DEV_PACKAGE} \
     ${NV_LIBNCCL_DEV_PACKAGE} \
+    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
 # Install CUDA devel cudnn8 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/devel/cudnn8/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/cudnn8/Dockerfile
 ENV NV_CUDNN_VERSION 8.9.0.131-1
-ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda11.8
-ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda11.8
+ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
+ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
@@ -115,8 +122,8 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA toolkit 11.8
-RUN yum -y install cuda-toolkit-11-8 && \
+# Install CUDA toolkit 12.1
+RUN yum -y install cuda-toolkit-12-1 && \
     yum -y clean all --enablerepo="*"
 
 # Set this flag so that libraries can find the location of CUDA

--- a/cuda/c9s-python-3.9/cuda.repo-arm64
+++ b/cuda/c9s-python-3.9/cuda.repo-arm64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/cuda/ubi8-python-3.8/Dockerfile
+++ b/cuda/ubi8-python-3.8/Dockerfile
@@ -12,13 +12,13 @@ LABEL name="odh-notebook-cuda-ubi8-python-3.8" \
       io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-ubi8-python-3.8"
 
 # Install CUDA base from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubi8/base/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi8/base/Dockerfile
 USER 0
 WORKDIR /opt/app-root/bin
 
 ENV NVARCH x86_64
-ENV NVIDIA_REQUIRE_CUDA "cuda>=11.4 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=450,driver<451"
-ENV NV_CUDA_CUDART_VERSION 11.4.108-1
+ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
+ENV NV_CUDA_CUDART_VERSION 12.1.105-1
 
 COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
@@ -26,13 +26,12 @@ RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION 11.4.2
+ENV CUDA_VERSION 12.1.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \
-    cuda-cudart-11-4-${NV_CUDA_CUDART_VERSION} \
-    cuda-compat-11-4 \
-    && ln -s cuda-11.4 /usr/local/cuda \
+    cuda-cudart-12-1-${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-12-1 \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
@@ -50,63 +49,67 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 # Install CUDA runtime from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubi8/runtime/Dockerfile
-ENV NV_CUDA_LIB_VERSION 11.4.2-1
-ENV NV_NVTX_VERSION 11.4.120-1
-ENV NV_LIBNPP_VERSION 11.4.0.110-1
-ENV NV_LIBNPP_PACKAGE libnpp-11-4-${NV_LIBNPP_VERSION}
-ENV NV_LIBCUBLAS_VERSION 11.6.1.51-1
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi8/runtime/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVTX_VERSION 12.1.105-1
+ENV NV_LIBNPP_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_PACKAGE libnpp-12-1-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION 12.1.3.1-1
 ENV NV_LIBNCCL_PACKAGE_NAME libnccl
-ENV NV_LIBNCCL_PACKAGE_VERSION 2.11.4-1
-ENV NV_LIBNCCL_VERSION 2.11.4
-ENV NCCL_VERSION 2.11.4
-ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda11.4
+ENV NV_LIBNCCL_PACKAGE_VERSION 2.17.1-1
+ENV NV_LIBNCCL_VERSION 2.17.1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
 
 RUN yum install -y \
-    cuda-libraries-11-4-${NV_CUDA_LIB_VERSION} \
-    cuda-nvtx-11-4-${NV_NVTX_VERSION} \
+    cuda-libraries-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-12-1-${NV_NVTX_VERSION} \
     ${NV_LIBNPP_PACKAGE} \
-    libcublas-11-4-${NV_LIBCUBLAS_VERSION} \
+    libcublas-12-1-${NV_LIBCUBLAS_VERSION} \
     ${NV_LIBNCCL_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
 # Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubi8/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION 11.4.2-1
-ENV NV_NVPROF_VERSION 11.4.120-1
-ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-11-4-${NV_NVPROF_VERSION}
-ENV NV_CUDA_CUDART_DEV_VERSION 11.4.108-1
-ENV NV_NVML_DEV_VERSION 11.4.120-1
-ENV NV_LIBCUBLAS_DEV_VERSION 11.6.1.51-1
-ENV NV_LIBNPP_DEV_VERSION 11.4.0.110-1
-ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-11-4-${NV_LIBNPP_DEV_VERSION}
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi8/devel/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVPROF_VERSION 12.1.105-1
+ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-12-1-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION 12.1.105-1
+ENV NV_NVML_DEV_VERSION 12.1.105-1
+ENV NV_LIBCUBLAS_DEV_VERSION 12.1.3.1-1
+ENV NV_LIBNPP_DEV_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
 ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.11.4-1
-ENV NCCL_VERSION 2.11.4
-ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda11.4
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.17.1-1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION 12.1.1-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
 
 RUN yum install -y \
     make \
-    cuda-command-line-tools-11-4-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-11-4-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-11-4-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-11-4-${NV_CUDA_CUDART_DEV_VERSION} \
+    findutils \
+    cuda-command-line-tools-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-devel-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-cudart-devel-12-1-${NV_CUDA_CUDART_DEV_VERSION} \
     ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-11-4-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-11-4-${NV_LIBCUBLAS_DEV_VERSION} \
+    cuda-nvml-devel-12-1-${NV_NVML_DEV_VERSION} \
+    libcublas-devel-12-1-${NV_LIBCUBLAS_DEV_VERSION} \
     ${NV_LIBNPP_DEV_PACKAGE} \
     ${NV_LIBNCCL_DEV_PACKAGE} \
+    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
 # Install CUDA devel cudnn8 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubi8/devel/cudnn8/Dockerfile
-ENV NV_CUDNN_VERSION 8.2.4.15-1
-ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda11.4
-ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda11.4
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi8/devel/cudnn8/Dockerfile
+ENV NV_CUDNN_VERSION 8.9.0.131-1
+ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
+ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 

--- a/cuda/ubi8-python-3.8/cuda.repo-arm64
+++ b/cuda/ubi8-python-3.8/cuda.repo-arm64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/cuda/ubi8-python-3.8/cuda.repo-ppc64le
+++ b/cuda/ubi8-python-3.8/cuda.repo-ppc64le
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel8/ppc64le
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/cuda/ubi9-python-3.9/Dockerfile
+++ b/cuda/ubi9-python-3.9/Dockerfile
@@ -12,26 +12,26 @@ LABEL name="odh-notebook-cuda-ubi9-python-3.9" \
       io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-ubi9-python-3.9"
 
 # Install CUDA base from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/base/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/base/Dockerfile
 USER 0
 WORKDIR /opt/app-root/bin
 
 ENV NVARCH x86_64
-ENV NVIDIA_REQUIRE_CUDA "cuda>=11.8 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471"
-ENV NV_CUDA_CUDART_VERSION 11.8.89-1
+ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
+ENV NV_CUDA_CUDART_VERSION 12.1.105-1
 
 COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION 11.8.0
+ENV CUDA_VERSION 12.1.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \
-    cuda-cudart-11-8-${NV_CUDA_CUDART_VERSION} \
-    cuda-compat-11-8 \
+    cuda-cudart-12-1-${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-12-1 \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
@@ -49,23 +49,23 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 # Install CUDA runtime from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/runtime/Dockerfile
-ENV NV_CUDA_LIB_VERSION 11.8.0-1
-ENV NV_NVTX_VERSION 11.8.86-1
-ENV NV_LIBNPP_VERSION 11.8.0.86-1
-ENV NV_LIBNPP_PACKAGE libnpp-11-8-${NV_LIBNPP_VERSION}
-ENV NV_LIBCUBLAS_VERSION 11.11.3.6-1
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/runtime/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVTX_VERSION 12.1.105-1
+ENV NV_LIBNPP_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_PACKAGE libnpp-12-1-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION 12.1.3.1-1
 ENV NV_LIBNCCL_PACKAGE_NAME libnccl
-ENV NV_LIBNCCL_PACKAGE_VERSION 2.15.5-1
-ENV NV_LIBNCCL_VERSION 2.15.5
-ENV NCCL_VERSION 2.15.5
-ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda11.8
+ENV NV_LIBNCCL_PACKAGE_VERSION 2.17.1-1
+ENV NV_LIBNCCL_VERSION 2.17.1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
 
 RUN yum install -y \
-    cuda-libraries-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-nvtx-11-8-${NV_NVTX_VERSION} \
+    cuda-libraries-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-12-1-${NV_NVTX_VERSION} \
     ${NV_LIBNPP_PACKAGE} \
-    libcublas-11-8-${NV_LIBCUBLAS_VERSION} \
+    libcublas-12-1-${NV_LIBCUBLAS_VERSION} \
     ${NV_LIBNCCL_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
@@ -74,41 +74,45 @@ RUN yum install -y \
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
 # Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION 11.8.0-1
-ENV NV_NVPROF_VERSION 11.8.87-1
-ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-11-8-${NV_NVPROF_VERSION}
-ENV NV_CUDA_CUDART_DEV_VERSION 11.8.89-1
-ENV NV_NVML_DEV_VERSION 11.8.86-1
-ENV NV_LIBCUBLAS_DEV_VERSION 11.11.3.6-1
-ENV NV_LIBNPP_DEV_VERSION 11.8.0.86-1
-ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-11-8-${NV_LIBNPP_DEV_VERSION}
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVPROF_VERSION 12.1.105-1
+ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-12-1-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION 12.1.105-1
+ENV NV_NVML_DEV_VERSION 12.1.105-1
+ENV NV_LIBCUBLAS_DEV_VERSION 12.1.3.1-1
+ENV NV_LIBNPP_DEV_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
 ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.15.5-1
-ENV NCCL_VERSION 2.15.5
-ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda11.8
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.17.1-1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION 12.1.1-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
 
 RUN yum install -y \
     make \
-    cuda-command-line-tools-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-11-8-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-11-8-${NV_CUDA_CUDART_DEV_VERSION} \
+    findutils \
+    cuda-command-line-tools-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-devel-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-cudart-devel-12-1-${NV_CUDA_CUDART_DEV_VERSION} \
     ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-11-8-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-11-8-${NV_LIBCUBLAS_DEV_VERSION} \
+    cuda-nvml-devel-12-1-${NV_NVML_DEV_VERSION} \
+    libcublas-devel-12-1-${NV_LIBCUBLAS_DEV_VERSION} \
     ${NV_LIBNPP_DEV_PACKAGE} \
     ${NV_LIBNCCL_DEV_PACKAGE} \
+    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
 # Install CUDA devel cudnn8 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/devel/cudnn8/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/cudnn8/Dockerfile
 ENV NV_CUDNN_VERSION 8.9.0.131-1
-ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda11.8
-ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda11.8
+ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
+ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 

--- a/cuda/ubi9-python-3.9/cuda.repo-arm64
+++ b/cuda/ubi9-python-3.9/cuda.repo-arm64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-4344

## Description
This pull request implements a significant update to the CUDA layer, transitioning from version `11.8.0` to `12.1.1`.

The choice of version 12.1.1 was made due to its compatibility with both TensorFlow and PyTorch packages:

- For PyTorch:
The latest available version of PyTorch, 2.2.0, is compatible with CUDA version 12.1 This compatibility ensures smooth integration with PyTorch functionalities.
Reference: https://pytorch.org/get-started/previous-versions/#linux-and-windows

- For TensorFlow:
The compatible version of TensorFlow with CUDA 12.1 is version 2.15.0, ensuring seamless operation and support for TensorFlow GPU-accelerated tasks.
Reference: https://www.tensorflow.org/install/source#gpu


## How Has This Been Tested?
Need first to merge this [PR](https://github.com/opendatahub-io/notebooks/pull/449) that updates the the above mentioned python packages.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
