### PR TITLE
Remove explicit mention of architecture for oc download

### DIFF
--- a/base/anaconda-python-3.8/Dockerfile
+++ b/base/anaconda-python-3.8/Dockerfile
@@ -93,7 +93,7 @@ LABEL name="odh-notebook-base-ubi8-anaconda-python-3.8" \
 WORKDIR /opt/app-root/bin
 
 # Install the oc client
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \
     tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
     rm -f /tmp/openshift-client-linux.tar.gz

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -29,7 +29,7 @@ USER 1001
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # Install the oc client \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \
     tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
     rm -f /tmp/openshift-client-linux.tar.gz && \

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -30,7 +30,7 @@ RUN dnf install -y mesa-libGL libnghttp2 && dnf clean all
 USER 1001
 
 # Install the oc client
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \
     tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
     rm -f /tmp/openshift-client-linux.tar.gz

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -30,7 +30,7 @@ RUN dnf install -y mesa-libGL
 USER 1001
 
 # Install the oc client
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
         -o /tmp/openshift-client-linux.tar.gz && \
     tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
     rm -f /tmp/openshift-client-linux.tar.gz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR will remove the `x86_64` hardcoded arch from the Dockerfile, this will allow to build these images on any generic platforms other than x86_64

## How Has This Been Tested?
```
[root@mkumatag-vm-ai notebooks]# make base-ubi9-python-3.9 IMAGE_REGISTRY=quay.io/mkumatag/wb
[root@mkumatag-vm-ai notebooks]# podman run --entrypoint bash -ti quay.io/mkumatag/wb:base-ubi9-python-3.9-2023b_20240314
(app-root) bash-5.1$ which oc
/opt/app-root/bin/oc
(app-root) bash-5.1$ file /opt/app-root/bin/oc
/opt/app-root/bin/oc: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, Go BuildID=iL8b3dNU9ab5XzwiA1ng/5yKrcmLlPwcVW_GPDP3y/qQYVlWzD8kVMS_sTxal1/AJPjlK8CC05UaVWs9iN0, BuildID[sha1]=3ec1bf1b9993ceaa8b38fa08c49af8f9a3965a48, with debug_info, not stripped
(app-root) bash-5.1$ oc version
Client Version: 4.15.0
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
(app-root) bash-5.1$
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
