### PR TITLE
remove the r-studio n-2 reference from the manifests

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -144,13 +144,6 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-rstudio-notebook-n-1
-  - name: odh-rstudio-notebook-n-2
-    objref:
-      kind: ConfigMap
-      name: notebooks-parameters
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.odh-rstudio-notebook-n-2
   - name: odh-rstudio-gpu-notebook-n
     objref:
       kind: ConfigMap
@@ -165,13 +158,6 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-rstudio-gpu-notebook-n-1
-  - name: odh-rstudio-gpu-notebook-n-2
-    objref:
-      kind: ConfigMap
-      name: notebooks-parameters
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.odh-rstudio-gpu-notebook-n-2
   - name: odh-minimal-notebook-image-commit-n
     objref:
       kind: ConfigMap


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
remove the r-studio n-2 reference from the manifests


## Description
<!--- Describe your changes in detail -->
fixes:
```
Error: field specified in var '{odh-rstudio-notebook-n-2 ConfigMap.v1.[noGrp] {data.odh-rstudio-notebook-n-2}}' not found in corresponding resource
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

kustomize build manifests/base/

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
