### PR TITLE
Update GH actions to use Node20

### DIFF
--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@v2
+        uses: getsentry/action-github-app-token@v3
         with:
           app_id: ${{ secrets.DEVOPS_APP_ID }}
           private_key: ${{ secrets.DEVOPS_APP_PRIVATE_KEY }}

--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Checkout the branch
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH_NAME }}
 
@@ -53,7 +53,7 @@ jobs:
 
       # Get the latest weekly build commit hash: https://github.com/opendatahub-io/notebooks/commits/2024a
       - name: Checkout upstream notebooks repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N }}
@@ -66,7 +66,7 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
@@ -111,7 +111,7 @@ jobs:
 
       # Get the latest weekly build commit hash: https://github.com/opendatahub-io/notebooks/commits/2023b
       - name: Checkout upstream notebooks repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N_1 }}
@@ -124,7 +124,7 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
@@ -164,7 +164,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: pull-request
         uses: repo-sync/pull-request@v2

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -12,7 +12,7 @@ jobs:
   validation-of-params-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/piplock-renewal-2023a.yml
+++ b/.github/workflows/piplock-renewal-2023a.yml
@@ -21,14 +21,14 @@ jobs:
     steps:
       # Checkout the paricular branch
       - name: Checkout code from the release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 2023a
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       # Setup Python environment
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: |
             3.8

--- a/.github/workflows/piplock-renewal-2023b.yml
+++ b/.github/workflows/piplock-renewal-2023b.yml
@@ -21,14 +21,14 @@ jobs:
     steps:
       # Checkout the paricular branch
       - name: Checkout code from the release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 2023b
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       # Setup Python environment
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: |
             3.8

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: Install skopeo
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install skopeo
       - name: Get Pull Request Number
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: get_pr_number
         with:
           script: |

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Checkout the branch
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH_NAME }}
 
@@ -52,7 +52,7 @@ jobs:
 
       # Get the latest weekly build commit hash: https://github.com/opendatahub-io/notebooks/commits/2023b
       - name: Checkout upstream notebooks repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N }}
@@ -64,7 +64,7 @@ jobs:
           echo "HASH_N=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: Checkout "N - 1" branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N_1 }}
@@ -76,7 +76,7 @@ jobs:
           echo "HASH_N_1=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: Checkout "main" branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opendatahub-io/notebooks.git
           ref: main
@@ -89,12 +89,12 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.SEC_SCAN_BRANCH }}
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'  # install the python version needed
 
@@ -126,7 +126,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: pull-request
         uses: repo-sync/pull-request@v2


### PR DESCRIPTION
Following warning can be seen in the GH Actions runs:

```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: <action name>. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Note - this project doesn't provide any update for this migration yet: https://github.com/actions/add-to-project/releases

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
