### PR TITLE
Remove kfp_tekton from the testing notebooks

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/test/test_notebook.ipynb
+++ b/jupyter/datascience/ubi8-python-3.8/test/test_notebook.ipynb
@@ -27,7 +27,6 @@
     "from kafka import KafkaConsumer\n",
     "from kafka.errors import KafkaConfigurationError\n",
     "import boto3\n",
-    "import kfp_tekton\n",
     "import kfp\n",
     "from kfp import LocalClient, run_pipeline_func_locally\n",
     "\n",
@@ -220,13 +219,6 @@
     "    \n",
     "        if os.path.exists(src):\n",
     "            shutil.copyfile(src, kfp.components.OutputPath())\n",
-    "\n",
-    "class TestKFPTekton(unittest.TestCase):\n",
-    "\n",
-    "    def test_version(self):\n",
-    "        expected_major_minor = '1.6.0'\n",
-    "\n",
-    "        self.assertLess(kfp_tekton.__version__, expected_major_minor)\n",
     "\n",
     "unittest.main(argv=[''], verbosity=2, exit=False)"
    ]

--- a/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb
+++ b/jupyter/datascience/ubi9-python-3.9/test/test_notebook.ipynb
@@ -27,7 +27,6 @@
     "from kafka import KafkaConsumer\n",
     "from kafka.errors import KafkaConfigurationError\n",
     "import boto3\n",
-    "import kfp_tekton\n",
     "import kfp\n",
     "from kfp import LocalClient, run_pipeline_func_locally\n",
     "\n",
@@ -214,13 +213,6 @@
     "        boto3.setup_default_session()\n",
     "\n",
     "        self.assertEqual(boto3.DEFAULT_SESSION, session)\n",
-    "\n",
-    "class TestKFPTekton(unittest.TestCase):\n",
-    "\n",
-    "    def test_version(self):\n",
-    "        expected_major_minor = '1.6.0'\n",
-    "\n",
-    "        self.assertLess(kfp_tekton.__version__, expected_major_minor)\n",
     "\n",
     "unittest.main(argv=[''], verbosity=2, exit=False)"
    ]


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-4784
## Description

The end-to-end tests in the notebooks repository are failing because the kfp_tekton library has been removed and replaced with odh-elyra.

Ref on CI test: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_notebooks/476/pull-ci-opendatahub-io-notebooks-main-notebooks-e2e-tests/1771201766046568448#1:build-log.txt%3A518 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
