### PR TITLE
Allow runtime script to cp the package from bin to Rpackage default path

### DIFF
--- a/rstudio/c9s-python-3.9/run-rstudio.sh
+++ b/rstudio/c9s-python-3.9/run-rstudio.sh
@@ -16,7 +16,13 @@ fi
 
 # Create lib folders if it does not exist
 mkdir -p  /opt/app-root/src/Rpackages/4.3
-cp -r /opt/app-root/bin/Rpackages/4.3/* /opt/app-root/src/Rpackages/4.3/
+for package in /opt/app-root/bin/Rpackages/4.3/*/;
+do
+  package_folder=$(basename "$package")
+  if [ ! -d "/opt/app-root/src/Rpackages/4.3/$package_folder" ]; then
+    cp -r /opt/app-root/bin/Rpackages/4.3/$package_folder /opt/app-root/src/Rpackages/4.3/
+  fi
+done  
 # rstudio terminal cant see environment variables set by the container runtime
 # (which breaks kubectl, to fix this we store the KUBERNETES_* env vars in Renviron.site)
 env | grep KUBERNETES_ >> /usr/lib64/R/etc/Renviron.site


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes for https://issues.redhat.com/browse/RHOAIENG-3007
## Description
<!--- Describe your changes in detail -->
Made a change to stop reinstallation of packages. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change buildconfig on cluster to uri: 'https://github.com/dibryant/notebooks'
ref: fix
Run the new build
Open new notebook
Install packages
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
