### PR TITLE
Specify version id to 9.3 on intel repository

### DIFF
--- a/intel/base/gpu/ubi9-python-3.9/Dockerfile
+++ b/intel/base/gpu/ubi9-python-3.9/Dockerfile
@@ -15,6 +15,8 @@ USER 0
 WORKDIR /opt/app-root/src
 
 RUN . /etc/os-release && \
+    #TODO: Remove explicit declaration of VERSION_ID once available on version 9.4
+    VERSION_ID=9.3 && \
     dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo \
         https://repositories.intel.com/gpu/rhel/${VERSION_ID}/lts/2350/unified/intel-gpu-${VERSION_ID}.repo  && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Related to: https://github.com/opendatahub-io/notebooks/issues/520


The intel-base-gpu-ubi9-python-3.9 image build is failing on OCP-CI with the following error causing issue on e2e tests:

```
Adding repo from: https://repositories.intel.com/gpu/rhel/9.4/lts/2350/unified/intel-gpu-9.4.repo
Status code: 403 for https://repositories.intel.com/gpu/rhel/9.4/lts/2350/unified/intel-gpu-9.4.repo (IP: 18.239.225.69)
push_pin
Error: Configuration of repo failed
error: build error: building at STEP "RUN . /etc/os-release &&     dnf install -y 'dnf-command(config-manager)' &&     dnf config-manager --add-repo         https://repositories.intel.com/gpu/rhel/${VERSION_ID}/lts/2350/unified/intel-gpu-${VERSION_ID}.repo  &&     dnf install -y         intel-opencl         level-zero intel-level-zero-gpu level-zero-devel         intel-metrics-discovery         intel-metrics-library  &&     dnf clean all -y &&     rm -rf /var/cache/dnf/*": while running runtime: exit status 1
[Ref link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_notebooks/518/pull-ci-opendatahub-io-notebooks-main-notebooks-e2e-tests/1785737359413743616#1:build-log.txt%3A144)
```

[REF link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_notebooks/518/pull-ci-opendatahub-io-notebooks-main-notebooks-e2e-tests/1785737359413743616#1:build-log.txt%3A81)

This bug was discovered during the end-to-end tests running on the open pull requests.


## How Has This Been Tested?
Tested locally by running the following command:
`make intel-base-gpu-ubi9-python-3.9  -e  IMAGE_REGISTRY=quay.io/${YOUR_USER}/workbench-images `
The build should be executed without errors


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
