### PR TITLE
Intel AI Tools Images rebased

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ intel-runtime-tensorflow-ubi9-python-3.9: intel-base-gpu-ubi9-python-3.9
 
 # Build and push jupyter-intel-tensorflow-ubi9-python-3.9 image to the registry
 .PHONY: jupyter-intel-tensorflow-ubi9-python-3.9
-jupyter-intel-tensorflow-ubi9-python-3.9: intel-runtime-tensorflow-ubi9-python-3.9
+jupyter-intel-tensorflow-ubi9-python-3.9: intel-base-gpu-ubi9-python-3.9
 	$(call image,$@,jupyter/intel/tensorflow/ubi9-python-3.9,$<)
 
 # Build and push intel-runtime-pytorch-ubi9-python-3.9 image to the registry
@@ -232,7 +232,7 @@ intel-runtime-pytorch-ubi9-python-3.9: intel-base-gpu-ubi9-python-3.9
 
 # Build and push jupyter-intel-pytorch-ubi9-python-3.9 image to the registry
 .PHONY: jupyter-intel-pytorch-ubi9-python-3.9
-jupyter-intel-pytorch-ubi9-python-3.9: intel-runtime-pytorch-ubi9-python-3.9
+jupyter-intel-pytorch-ubi9-python-3.9: intel-base-gpu-ubi9-python-3.9
 	$(call image,$@,jupyter/intel/pytorch/ubi9-python-3.9,$<)
 
 # Build and push intel-runtime-ml-ubi9-python-3.9 image to the registry
@@ -242,7 +242,7 @@ intel-runtime-ml-ubi9-python-3.9: base-ubi9-python-3.9
 
 # Build and push jupyter-intel-ml-ubi9-python-3.9 image to the registry
 .PHONY: jupyter-intel-ml-ubi9-python-3.9
-jupyter-intel-ml-ubi9-python-3.9: intel-runtime-ml-ubi9-python-3.9
+jupyter-intel-ml-ubi9-python-3.9: base-ubi9-python-3.9
 	$(call image,$@,jupyter/intel/ml/ubi9-python-3.9,$<)
 
 ####################################### Buildchain for Python 3.9 using C9S #######################################

--- a/intel/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -17,7 +17,9 @@ ARG ONEAPI_VERSION=2024.0
 COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
-    dnf install -y intel-basekit-${ONEAPI_VERSION} && \
+    dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
+        intel-oneapi-mkl-${ONEAPI_VERSION} \
+        intel-oneapi-dnnl-${ONEAPI_VERSION} && \
     dnf clean all -y && \
     rm -rf /var/cache/dnf/* && \
     rm /etc/yum.repos.d/oneAPI.repo

--- a/intel/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -17,7 +17,9 @@ ARG ONEAPI_VERSION=2024.0
 COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
-    dnf install -y intel-basekit-${ONEAPI_VERSION} && \
+    dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
+        intel-oneapi-mkl-${ONEAPI_VERSION} \
+        intel-oneapi-dnnl-${ONEAPI_VERSION} && \
     dnf clean all -y && \
     rm -rf /var/cache/dnf/* && \
     rm /etc/yum.repos.d/oneAPI.repo
@@ -43,6 +45,7 @@ RUN unlink /opt/app-root/lib64 && \
     fix-permissions /opt/app-root -P
 
 ENV CPU_ENV=/opt/app-root-cpu
+ENV GPU_ENV=/opt/app-root
 COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 #CPU env

--- a/jupyter/intel/ml/ubi9-python-3.9/.patch_sklearn.py
+++ b/jupyter/intel/ml/ubi9-python-3.9/.patch_sklearn.py
@@ -1,0 +1,4 @@
+from sklearnex import patch_sklearn
+from sklearnex import unpatch_sklearn
+patch_sklearn()
+print("To disable Intel(R) Extension for Scikit-learn*, you can run: unpatch_sklearn()")

--- a/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
@@ -16,6 +16,9 @@ WORKDIR /opt/app-root/bin
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock Pipfile.lock
 
+COPY --chown=1001:0 .patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
+ENV PYTHONSTARTUP="/opt/app-root/bin/.patch_sklearn.py"
+
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \

--- a/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
@@ -11,6 +11,21 @@ LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.9" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/intel/pytorch/ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-intel-pytorch-ubi9-python-3.9"
 
+USER root
+
+ARG ONEAPI_VERSION=2024.0
+COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+
+RUN dnf update -y && \
+    dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
+        intel-oneapi-mkl-${ONEAPI_VERSION} \
+        intel-oneapi-dnnl-${ONEAPI_VERSION} && \
+    dnf clean all -y && \
+    rm -rf /var/cache/dnf/* && \
+    rm /etc/yum.repos.d/oneAPI.repo
+
+USER 1001
+
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
@@ -33,10 +48,16 @@ COPY --chown=1001:0 builder /opt/app-root/builder
 COPY --chown=1001:0 utils /opt/app-root/bin/utils
 
 #CPU env
+ENV CPU_ENV=/opt/app-root-cpu
+ENV GPU_ENV=/opt/app-root
 COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 WORKDIR ${CPU_ENV} 
-RUN source ${CPU_ENV}/bin/activate && \
+RUN python3.9 -m venv ${CPU_ENV} && \
+    chown -R 1001:0 ${CPU_ENV} && \
+    fix-permissions ${CPU_ENV} -P && \
+    source ${CPU_ENV}/bin/activate && \
+    pip install --no-cache-dir -U "micropipenv[toml]" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     python -m ipykernel install --prefix=/opt/app-root --name 'pytorch-cpu' --display-name='pytorch-cpu' && \

--- a/jupyter/intel/pytorch/ubi9-python-3.9/oneAPI.repo
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/oneAPI.repo
@@ -1,0 +1,7 @@
+[oneAPI]
+name=Intel® oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
@@ -11,12 +11,29 @@ LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.9" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/intel/tensorflow/ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-intel-tensorflow-ubi9-python-3.9"
 
+USER root
+
+ARG ONEAPI_VERSION=2024.0
+COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+
+RUN dnf update -y && \
+    dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
+        intel-oneapi-mkl-${ONEAPI_VERSION} \
+        intel-oneapi-dnnl-${ONEAPI_VERSION} && \
+    dnf clean all -y && \
+    rm -rf /var/cache/dnf/* && \
+    rm /etc/yum.repos.d/oneAPI.repo
+
+USER 1001
+
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock.gpu Pipfile.lock
 
-RUN echo "Installing softwares and packages" && \
+RUN unlink /opt/app-root/lib64 && \
+    cp -r /opt/app-root/lib /opt/app-root/lib64 && \
+    echo "Installing softwares and packages" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
@@ -32,11 +49,19 @@ COPY --chown=1001:0 builder /opt/app-root/builder
 COPY --chown=1001:0 utils /opt/app-root/bin/utils
 
 #CPU env
+ENV CPU_ENV=/opt/app-root-cpu
+ENV GPU_ENV=/opt/app-root
 COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 WORKDIR ${CPU_ENV}
 
-RUN source ${CPU_ENV}/bin/activate && \
+RUN python3.9 -m venv ${CPU_ENV} && \
+    chown -R 1001:0 ${CPU_ENV} && \
+    fix-permissions ${CPU_ENV} -P && \
+    unlink ${CPU_ENV}/lib64 && \
+    cp -r ${CPU_ENV}/lib ${CPU_ENV}/lib64 && \
+    source ${CPU_ENV}/bin/activate && \
+    pip install --no-cache-dir -U "micropipenv[toml]" && \
     micropipenv install && \
     rm -f ./Pipfile.lock && \
     python -m ipykernel install --prefix=/opt/app-root --name 'tensorflow-cpu' --display-name='tensorflow-cpu' && \

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/oneAPI.repo
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/oneAPI.repo
@@ -1,0 +1,7 @@
+[oneAPI]
+name=Intel® oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR changes the base of the jupyter images of intel AI Tools from runtime images to the intel-gpu base images for TF and PyTorch and ubi9-python for Intel ML. This is done to remove the dependency on runtime images and reduce the size of the images.

## Description
<!--- Describe your changes in detail -->
1. Intel AI Tools TF Jupyter image's base image changed to Intel GPU base image
2. Intel AI Tools PyTorch Jupyter image's base image changed to Intel GPU base image
3. Intel AI Tools ML Jupyter image's base image changed to Python UBI9 base image
4. Installation of Intel oneAPI basekit replaced with individual necessary components for Intel AI Tools PyTorch and TF Runtime images.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests with make commands

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
