### PR TITLE
[CI] Add `kubectl kustomize` run to check our manifests definition

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -51,3 +51,18 @@ jobs:
           echo "Starting Hadolint"
           find . -name "Dockerfile" | xargs ./hadolint --config ./ci/hadolint-config.yaml
           echo "Hadolint done"
+
+      # This simply checks that the manifests and respective kustomization.yaml finishes without an error.
+      - name: Check kustomize manifest
+        id: kustomize-manifests
+        run: |
+          kubectl version --client=true
+          echo "----------------------------------------------------------"
+          echo "Starting 'kubectl kustomize manifests/base'"
+          echo "----------------------------------------------------------"
+          kubectl kustomize manifests/base
+
+          echo "----------------------------------------------------------"
+          echo "Starting 'kubectl kustomize manifests/overlays/additional'"
+          echo "----------------------------------------------------------"
+          kubectl kustomize manifests/overlays/additional


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a simple check to CI to run `kubectl kustomize` so we are sure that our kustomization.yml files don't fail with an error. This should avoid issues like this in the future hopefully red-hat-data-services/notebooks#253.

This is tested automatically by this PR.

This should be backported to our downstream repo.

https://issues.redhat.com/browse/RHOAIENG-7886

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
