### PR TITLE
Run the static code checks on push and when manually triggered

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,6 +1,9 @@
 ---
 name: Code static analysis
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
GHA that only runs on pull_request is hard to test; I have to create PR to see it run. With this change, the action can be tested in my personal fork before I create a PR.

## How Has This Been Tested?
I watched the GHA running, https://github.com/jiridanek/notebooks/actions/runs/9307359587/job/25618467398

> The beauty of the morning; silent, bare,
Ships, towers, domes, theaters, and temples lie
Open unto [the](https://allpoetry.com/Composed-Upon-Westminster-Bridge,-September-3,-1802) fields, and to the sky;
All bright and glittering in the smokeless air.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
