### PR TITLE
RHOAIENG-8255: Fix spawn-fcgi-1.6.3-23.fc37.x86_64.rpm download location

### DIFF
--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -63,7 +63,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # spawn-fcgi is not in epel9 \
-    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -63,7 +63,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # spawn-fcgi is not in epel9 \
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -78,7 +78,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -78,7 +78,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-8255

## Description

Previously used location is now unavailable and returns 404 error.

This new location comes from https://koji.fedoraproject.org/koji/buildinfo?buildID=2028619

## How Has This Been Tested?

Docker build succeeded

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
