### PR TITLE
RHOAIENG-8299: Fix CentOS Stream 8 download location

### DIFF
--- a/habana/1.10.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.10.0/ubi8-python-3.8/Dockerfile
@@ -19,12 +19,12 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN echo "[appstream]" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "name=CentOS Linux 8 - AppStream" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=AppStream&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/AppStream/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo
 
 RUN echo "[BaseOS]" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "name=CentOS Linux 8 - BaseOS" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=BaseOS&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/BaseOS/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
 
 RUN dnf install -y \
@@ -66,7 +66,7 @@ RUN echo "[habanalabs]" > /etc/yum.repos.d/habanalabs.repo && \
 
 RUN echo "[powertools]" > /etc/yum.repos.d/powertools.repo && \
     echo "name=powertools" >> /etc/yum.repos.d/powertools.repo && \
-    echo "baseurl=http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/"  >> /etc/yum.repos.d/powertools.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/PowerTools/\$basearch/os/"  >> /etc/yum.repos.d/powertools.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/powertools.repo
 
 RUN dnf install -y habanalabs-rdma-core-"$VERSION"-"$REVISION".el8 \

--- a/habana/1.11.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.11.0/ubi8-python-3.8/Dockerfile
@@ -19,13 +19,13 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN echo "[appstream]" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "name=CentOS Linux 8 - AppStream" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=AppStream&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/AppStream/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo
 
 
 RUN echo "[BaseOS]" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "name=CentOS Linux 8 - BaseOS" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=BaseOS&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/BaseOS/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
 
 RUN dnf install -y \
@@ -67,7 +67,7 @@ RUN echo "[habanalabs]" > /etc/yum.repos.d/habanalabs.repo && \
 
 RUN echo "[powertools]" > /etc/yum.repos.d/powertools.repo && \
     echo "name=powertools" >> /etc/yum.repos.d/powertools.repo && \
-    echo "baseurl=http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/"  >> /etc/yum.repos.d/powertools.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/PowerTools/\$basearch/os/"  >> /etc/yum.repos.d/powertools.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/powertools.repo
 
 RUN dnf install -y habanalabs-rdma-core-"$VERSION"-"$REVISION".el8 \

--- a/habana/1.13.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.13.0/ubi8-python-3.8/Dockerfile
@@ -19,13 +19,13 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN echo "[appstream]" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "name=CentOS Linux 8 - AppStream" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=AppStream&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/AppStream/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo
 
 
 RUN echo "[BaseOS]" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "name=CentOS Linux 8 - BaseOS" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=BaseOS&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/BaseOS/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
 
 RUN dnf install -y \
@@ -67,7 +67,7 @@ RUN echo "[habanalabs]" > /etc/yum.repos.d/habanalabs.repo && \
 
 RUN echo "[powertools]" > /etc/yum.repos.d/powertools.repo && \
     echo "name=powertools" >> /etc/yum.repos.d/powertools.repo && \
-    echo "baseurl=http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/"  >> /etc/yum.repos.d/powertools.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/PowerTools/\$basearch/os/"  >> /etc/yum.repos.d/powertools.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/powertools.repo
 
 RUN dnf install -y habanalabs-rdma-core-"$VERSION"-"$REVISION".el8 \

--- a/habana/1.9.0/ubi8-python-3.8/Dockerfile
+++ b/habana/1.9.0/ubi8-python-3.8/Dockerfile
@@ -19,13 +19,13 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN echo "[appstream]" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "name=CentOS Linux 8 - AppStream" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=AppStream&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/AppStream/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo
 
 
 RUN echo "[BaseOS]" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "name=CentOS Linux 8 - BaseOS" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
-    echo "mirrorlist=http://mirrorlist.centos.org/?release=\$releasever-stream&arch=\$basearch&repo=BaseOS&infra=\$infra" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/BaseOS/\$basearch/os/" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
 
 RUN dnf install -y \
@@ -66,7 +66,7 @@ RUN echo "[habanalabs]" > /etc/yum.repos.d/habanalabs.repo && \
 
 RUN echo "[powertools]" > /etc/yum.repos.d/powertools.repo && \
     echo "name=powertools" >> /etc/yum.repos.d/powertools.repo && \
-    echo "baseurl=http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/"  >> /etc/yum.repos.d/powertools.repo && \
+    echo "baseurl=https://vault.centos.org/\$releasever-stream/PowerTools/\$basearch/os/"  >> /etc/yum.repos.d/powertools.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/powertools.repo
 
 RUN dnf install -y habanalabs-thunk-"$VERSION"-"$REVISION".el8 \


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-8299

## Description

Previously used location is now unavailable and returns 404 error. This is because CentOS Stream 8 has been EOLd

This new location is an archive and is no longer receiving updates.

## How Has This Been Tested?
I thought about it really hard and I was very careful, promise. Oh yeah, and I did a podman image build, btw.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
