### PR TITLE
Fix issue with Run and Debug on code-server workbench

### DIFF
--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -44,6 +44,7 @@ COPY --chown=1001:0 utils utils/
 # Create and intall the extensions though build-time on a temporary directory. Later this directory will copied on the `/opt/app-root/src/.local/share/code-server/extensions` via run-code-server.sh file when it starts up. 
 RUN mkdir -p /opt/app-root/extensions-temp && \
     code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2024.2.1.vsix --extensions-dir /opt/app-root/extensions-temp && \
+    code-server --install-extension /opt/app-root/bin/utils/ms-python.debugpy-2024.2.0@linux-x64.vsix --extensions-dir /opt/app-root/extensions-temp && \
     code-server --install-extension  /opt/app-root/bin/utils/ms-toolsai.jupyter-2023.9.100.vsix --extensions-dir /opt/app-root/extensions-temp
 
 # Install NGINX to proxy code-server and pass probes check
@@ -112,6 +113,8 @@ COPY nginx/api/ /opt/app-root/api/
 COPY --chown=1001:0 run-code-server.sh run-nginx.sh ./
 
 ENV SHELL /bin/bash
+
+ENV PYTHONPATH=/opt/app-root/bin/python3
 
 WORKDIR /opt/app-root/src
 

--- a/codeserver/ubi9-python-3.9/run-code-server.sh
+++ b/codeserver/ubi9-python-3.9/run-code-server.sh
@@ -16,29 +16,55 @@ fi
 # Initilize access logs for culling
 echo '[{"id":"code-server","name":"code-server","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/codeserver.access.log
 
-# Directory for settings file
-user_dir="/opt/app-root/src/.local/share/code-server/User/"
+# Add "/opt/app-root/src/.vscode/" directory to set default interpreter also for Run & Debug
+user_dir="/opt/app-root/src/.vscode/"
 settings_filepath="${user_dir}settings.json"
+launch_filepath="${user_dir}launch.json"
+
+json_launch_settings='{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "python": "/opt/app-root/bin/python3"
+        }
+    ]
+}'
 
 json_settings='{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3"
-}'
+  }'
 
 # Check if User directory exists
 if [ ! -d "$user_dir" ]; then
   echo "Debug: User directory not found, creating '$user_dir'..."
   mkdir -p "$user_dir"
+  echo "$json_launch_settings" > "$launch_filepath"
+  echo "Debug: '$launch_filepath' file created."
   echo "$json_settings" > "$settings_filepath"
   echo "Debug: '$settings_filepath' file created."
 else
   echo "Debug: User directory already exists."
-  # Add settings.json if not present
-  if [ ! -f "$settings_filepath" ]; then
+  # Add settings.json and launch.json if not present
+  if [ ! -f "$launch_filepath" ]; then
+    echo "Debug: '$launch_filepath' file not found, creating..."
+    echo "$json_launch_settings" > "$launch_filepath"
+    echo "Debug: '$launch_filepath' file created."
+  elif [ ! -f "$settings_filepath" ]; then
     echo "Debug: '$settings_filepath' file not found, creating..."
     echo "$json_settings" > "$settings_filepath"
     echo "Debug: '$settings_filepath' file created."
   else
+    echo "Debug: '$launch_filepath' file already exists."
     echo "Debug: '$settings_filepath' file already exists."
+
   fi
 fi
 


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-2312 

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses an issue where users were unable to use the Run and Debug button in the code-server workbench to execute a Python file.

The fix involves adding a launch.json configuration to the .vscode directory. This configuration ensures that the debugger uses the correct Python interpreter, specifically /opt/app-root/bin/python3, which includes pre-installed packages such as numpy.

## How Has This Been Tested?
1.  PR code-server built image ` quay.io/opendatahub/workbench-images@sha256:a25623900cdd8e50135bf618cc231061c1e7a970caa96cd8c880ba596a8cc7cb`
- Replace the code-server:2024.1 image hash with the image from this PR, 
- OR import the PR image from ODH dashboard ->   Settings ->Notebook Images -> Import new image and use the newly imported image to spin up the code-server notebook. 

2. Reproduce the steps as shown on the video below: 
[Screencast from 2024-06-12 14-13-59.webm](https://github.com/opendatahub-io/notebooks/assets/42587738/b4e59de7-ce7d-4dad-869f-4fe195d79f01)



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
