### PR TITLE
[GHA] digest updater workflow fixes and updates

### DIFF
--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -67,41 +67,61 @@ jobs:
 
       - name: Update the param.env file
         run: |
-              echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
-              IMAGES=$(cat manifests/base/params.env | grep "\-n=" | cut -d "=" -f 1)
+              PARAMS_ENV_PATH="manifests/base/params.env"
+
+              echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
+
+              # Get the complete list of images N-version to update
+              IMAGES=$(cat "${PARAMS_ENV_PATH}" | grep "\-n=" | cut -d "=" -f 1)
 
               for image in ${IMAGES}; do
                 echo "CHECKING: '${image}'"
-                img=$(cat manifests/base/params.env | grep -E "${image}=" | cut -d '=' -f2)
-                registry=$(echo $img | cut -d '@' -f1)
-                src_tag=$(skopeo inspect docker://$img | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
+                img=$(grep -E "${image}=" "${PARAMS_ENV_PATH}" | cut -d '=' -f2)
+                registry=$(echo "${img}" | cut -d '@' -f1)
+
+                skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
+
+                src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
                 regex="^$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
-                latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-                digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
-                output=$registry@$digest
-                echo "NEW:" $output
-                sed -i "s|${image}=.*|${image}=$output|" manifests/base/params.env
+                latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+                # use `--no-tags` for skopeo once available in newer version
+                digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')
+                output="${registry}@${digest}"
+                echo "NEW: ${output}"
+                sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
               done
+
               if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git add manifests/base/params.env && git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git add "${PARAMS_ENV_PATH}" && \
+                  git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                  git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
               else
-                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
               fi
 
       - name: Update the commit.env file
         run: |
-            echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
+            COMMIT_ENV_PATH="manifests/base/commit.env"
+
+            echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
             # Get the complete list of images N-1-version to update
-            COMMIT=$(cat manifests/base/commit.env | grep "\-n=" | cut -d "=" -f 1)
+            COMMIT=$(grep "\-n=" "${COMMIT_ENV_PATH}" | cut -d "=" -f 1)
 
             for val in ${COMMIT}; do
-              echo $val
-              sed -i "s|${val}=.*|${val}=${{ steps.hash-n.outputs.HASH_N }}|" manifests/base/commit.env
+              echo "${val}"
+              sed -i "s|${val}=.*|${val}=${{ steps.hash-n.outputs.HASH_N }}|" "${COMMIT_ENV_PATH}"
             done
+
             if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-              git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git add manifests/base/commit.env && git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+              git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                git add "${COMMIT_ENV_PATH}" && \
+                git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
             else
-              echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+              echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
             fi
 
   update-n-1-version:
@@ -131,40 +151,61 @@ jobs:
 
       - name: Update the param.env file
         run: |
-              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1}}
-              IMAGES=$(cat manifests/base/params.env | grep "\-n-1=" | cut -d "=" -f 1)
+              PARAMS_ENV_PATH="manifests/base/params.env"
+
+              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1 }}
+
+              # Get the complete list of images N-1-version to update
+              IMAGES=$(cat "${PARAMS_ENV_PATH}" | grep "\-n-1=" | cut -d "=" -f 1)
 
               for image in ${IMAGES}; do
                 echo "CHECKING: '${image}'"
-                img=$(cat manifests/base/params.env | grep -E "${image}=" | cut -d '=' -f2)
-                registry=$(echo $img | cut -d '@' -f1)
-                src_tag=$(skopeo inspect docker://$img | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
+                img=$(grep -E "${image}=" "${PARAMS_ENV_PATH}" | cut -d '=' -f2)
+                registry=$(echo "${img}" | cut -d '@' -f1)
+
+                skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
+
+                src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
                 regex="^$src_tag-${{ env.RELEASE_VERSION_N_1}}-\d+-${{ steps.hash-n-1.outputs.HASH_N_1 }}\$"
-                latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-                digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
-                output=$registry@$digest
-                echo "NEW:" $output
-                sed -i "s|${image}=.*|${image}=$output|" manifests/base/params.env
+                latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+                # use `--no-tags` for skopeo once available in newer version
+                digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')
+                output="${registry}@${digest}"
+                echo "NEW: ${output}"
+                sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
               done
+
               if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git add manifests/base/params.env && git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git add "${PARAMS_ENV_PATH}" && \
+                  git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                  git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
               else
-                  echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1}}"
+                  echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1 }}"
               fi
+
       - name: Update the commit.env file
         run: |
-              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1}}
+              COMMIT_ENV_PATH="manifests/base/commit.env"
+
+              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1 }}
               # Get the complete list of images N-1-version to update
-              COMMIT=$(cat manifests/base/commit.env | grep "\-n-1=" | cut -d "=" -f 1)
+              COMMIT=$(grep "\-n-1=" "${COMMIT_ENV_PATH}" | cut -d "=" -f 1)
 
               for val in ${COMMIT}; do
-                echo $val
-                sed -i "s|${val}=.*|${val}=${{ steps.hash-n-1.outputs.HASH_N_1 }}|" manifests/base/commit.env
+                echo "${val}"
+                sed -i "s|${val}=.*|${val}=${{ steps.hash-n-1.outputs.HASH_N_1 }}|" "${COMMIT_ENV_PATH}"
               done
+
               if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git add manifests/base/commit.env && git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git add "${COMMIT_ENV_PATH}" && \
+                  git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                  git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
               else
-                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
               fi
 
   open-pull-request:

--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -84,7 +84,7 @@ jobs:
                 img=$(cat manifests/base/params.env | grep -E "${image}=" | cut -d '=' -f2)
                 registry=$(echo $img | cut -d '@' -f1)
                 src_tag=$(skopeo inspect docker://$img | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
-                regex="$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}"
+                regex="^$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
                 latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
                 digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
                 output=$registry@$digest
@@ -164,7 +164,7 @@ jobs:
                 img=$(cat manifests/base/params.env | grep -E "${image}=" | cut -d '=' -f2)
                 registry=$(echo $img | cut -d '@' -f1)
                 src_tag=$(skopeo inspect docker://$img | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
-                regex="$src_tag-${{ env.RELEASE_VERSION_N_1}}-\d+-${{ steps.hash-n-1.outputs.HASH_N_1 }}"
+                regex="^$src_tag-${{ env.RELEASE_VERSION_N_1}}-\d+-${{ steps.hash-n-1.outputs.HASH_N_1 }}\$"
                 latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
                 digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
                 output=$registry@$digest

--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -68,19 +68,10 @@ jobs:
       - name: Update the param.env file
         run: |
               echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
-              IMAGES=("odh-minimal-notebook-image-n"
-               "odh-minimal-gpu-notebook-image-n"
-               "odh-pytorch-gpu-notebook-image-n"
-               "odh-generic-data-science-notebook-image-n"
-               "odh-tensorflow-gpu-notebook-image-n"
-               "odh-trustyai-notebook-image-n"
-               "odh-codeserver-notebook-image-n"
-               "odh-rstudio-notebook-image-n"
-               "odh-rstudio-gpu-notebook-image-n")
+              IMAGES=$(cat manifests/base/params.env | grep "\-n=" | cut -d "=" -f 1)
 
-              for ((i=0;i<${#IMAGES[@]};++i)); do
-                image=${IMAGES[$i]}
-                echo "CHECKING: " $image
+              for image in ${IMAGES}; do
+                echo "CHECKING: '${image}'"
                 img=$(cat manifests/base/params.env | grep -E "${image}=" | cut -d '=' -f2)
                 registry=$(echo $img | cut -d '@' -f1)
                 src_tag=$(skopeo inspect docker://$img | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
@@ -100,17 +91,10 @@ jobs:
       - name: Update the commit.env file
         run: |
             echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
-            COMMIT=("odh-minimal-notebook-image-commit-n"
-             "odh-minimal-gpu-notebook-image-commit-n"
-             "odh-pytorch-gpu-notebook-image-commit-n"
-             "odh-generic-data-science-notebook-image-commit-n"
-             "odh-tensorflow-gpu-notebook-image-commit-n"
-             "odh-trustyai-notebook-image-commit-n"
-             "odh-codeserver-notebook-image-commit-n"
-             "odh-rstudio-notebook-image-commit-n"
-             "odh-rstudio-gpu-notebook-image-commit-n")
+            # Get the complete list of images N-1-version to update
+            COMMIT=$(cat manifests/base/commit.env | grep "\-n=" | cut -d "=" -f 1)
 
-            for val in "${COMMIT[@]}"; do
+            for val in ${COMMIT}; do
               echo $val
               sed -i "s|${val}=.*|${val}=${{ steps.hash-n.outputs.HASH_N }}|" manifests/base/commit.env
             done
@@ -148,19 +132,10 @@ jobs:
       - name: Update the param.env file
         run: |
               echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1}}
-              IMAGES=("odh-minimal-notebook-image-n-1"
-               "odh-minimal-gpu-notebook-image-n-1"
-               "odh-pytorch-gpu-notebook-image-n-1"
-               "odh-generic-data-science-notebook-image-n-1"
-               "odh-tensorflow-gpu-notebook-image-n-1"
-               "odh-trustyai-notebook-image-n-1"
-               "odh-codeserver-notebook-image-n-1"
-               "odh-rstudio-notebook-image-n-1"
-               "odh-rstudio-gpu-notebook-image-n-1")
+              IMAGES=$(cat manifests/base/params.env | grep "\-n-1=" | cut -d "=" -f 1)
 
-              for ((i=0;i<${#IMAGES[@]};++i)); do
-                image=${IMAGES[$i]}
-                echo "CHECKING: " $image
+              for image in ${IMAGES}; do
+                echo "CHECKING: '${image}'"
                 img=$(cat manifests/base/params.env | grep -E "${image}=" | cut -d '=' -f2)
                 registry=$(echo $img | cut -d '@' -f1)
                 src_tag=$(skopeo inspect docker://$img | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
@@ -179,17 +154,10 @@ jobs:
       - name: Update the commit.env file
         run: |
               echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1}}
-              COMMIT=("odh-minimal-notebook-image-commit-n-1"
-               "odh-minimal-gpu-notebook-image-commit-n-1"
-               "odh-pytorch-gpu-notebook-image-commit-n-1"
-               "odh-generic-data-science-notebook-image-commit-n-1"
-               "odh-tensorflow-gpu-notebook-image-commit-n-1"
-               "odh-trustyai-notebook-image-commit-n-1"
-               "odh-codeserver-notebook-image-commit-n-1"
-               "odh-rstudio-notebook-image-commit-n-1"
-               "odh-rstudio-gpu-notebook-image-commit-n-1")
+              # Get the complete list of images N-1-version to update
+              COMMIT=$(cat manifests/base/commit.env | grep "\-n-1=" | cut -d "=" -f 1)
 
-              for val in "${COMMIT[@]}"; do
+              for val in ${COMMIT}; do
                 echo $val
                 sed -i "s|${val}=.*|${val}=${{ steps.hash-n-1.outputs.HASH_N_1 }}|" manifests/base/commit.env
               done

--- a/.github/workflows/runtimes-digest-updater-upstream.yaml
+++ b/.github/workflows/runtimes-digest-updater-upstream.yaml
@@ -92,7 +92,7 @@ jobs:
                   name="minimal-$name"
               fi
               registry=$(echo $img | cut -d '@' -f1)
-              regex="runtime-$name-$py_version-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}"
+              regex="^runtime-$name-$py_version-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
               echo "CHECKING: "  $regex
               latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
               digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')

--- a/ci/security-scan/quay_security_analysis.py
+++ b/ci/security-scan/quay_security_analysis.py
@@ -81,9 +81,9 @@ def process_image(image, commit_id_path, RELEASE_VERSION_N, HASH_N):
     regex = ""
 
     if RELEASE_VERSION_N == "":
-        regex = f"{src_tag}-(\\d+-)?{HASH_N}"
+        regex = f"^{src_tag}-(\\d+-)?{HASH_N}$"
     else:
-        regex = f"{src_tag}-{RELEASE_VERSION_N}-\\d+-{HASH_N}"
+        regex = f"^{src_tag}-{RELEASE_VERSION_N}-\\d+-{HASH_N}$"
 
     latest_tag_cmd = f'skopeo inspect docker://{img} | jq -r --arg regex "{regex}" \'.RepoTags | map(select(. | test($regex))) | .[0]\''
     latest_tag = subprocess.check_output(latest_tag_cmd, shell=True, text=True).strip()


### PR DESCRIPTION
This contains changes for the digest update workflow for the update of notebook images and commit shas. There are couple of fixes and a small refactoring done, more details in particular commits:

* [GHA] fix the regexp used for the latest image tag selection
* [GHA] fix the missing habana image update record for the digest updater
* [GHA] Minor refactoring

---

Truth is that I don't fully understand, how is possible that in this case #565 the rstudio images were selected properly :thinking: 
* update: okay, I see now - Harshad [fixed that manually](https://github.com/opendatahub-io/notebooks/pull/565/commits/be022e2096e7213d69e43bb3f7caec2c4245cf1d) :upside_down_face: 
* also see my [comment there](https://github.com/opendatahub-io/notebooks/pull/565#issuecomment-2170423486) with some motivation

---

https://issues.redhat.com/browse/RHOAIENG-8813

How I tested, [check my comment below](https://github.com/opendatahub-io/notebooks/pull/566#issuecomment-2179233613). As stated there, my plan was also to deduplicate the code, but it's WIP on my machine right now, so if this is needed, we can merge this and I will raise another followup PR after my PTO.

## How Has This Been Tested?
Right now, it hasn't been tested, will do later.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
