### PR TITLE
[CI] Enhance params env check script

### DIFF
--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -1,11 +1,13 @@
 ---
 name: Validation of image references (image SHAs) in params.env and runtime images
 on:  # yamllint disable-line rule:truthy
+  push:
   pull_request:
     paths:
       - 'manifests/base/commit.env'
       - 'manifests/base/params.env'
       - 'ci/check-params-env.sh'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -31,6 +31,7 @@ EXPECTED_NUM_RECORDS=20
 
 function check_variables_uniq() {
     local env_file_path="${1}"
+    local allow_value_duplicity="${2:=false}"
     local ret_code=0
 
     echo "Checking that all variables in the file '${env_file_path}' are unique and expected"
@@ -45,9 +46,30 @@ function check_variables_uniq() {
     num_uniq_records=$(echo "${content}" | uniq | wc -l)
 
     test "${num_records}" -eq "${num_uniq_records}" || {
-        echo "Some of the records in the file aren't unique!"
+        echo "Some of the variables in the file aren't unique!"
         ret_code=1
     }
+
+    # ----
+    if test "${allow_value_duplicity}" = "false"; then
+        echo "Checking that all values assigned to variables in the file '${env_file_path}' are unique and expected"
+
+        content=$(sed 's#.*=\(.*\)#\1#' "${env_file_path}" | sort)
+
+        local num_values
+        num_values=$(echo "${content}" | wc -l)
+
+        local num_uniq_values
+        num_uniq_values=$(echo "${content}" | uniq | wc -l)
+
+        test "${num_values}" -eq "${num_uniq_values}" || {
+            echo "Some of the values in the file aren't unique!"
+            ret_code=1
+        }
+    fi
+
+    # ----
+    echo "Checking that there are expected number of records in the file '${env_file_path}'"
 
     test "${num_records}" -eq "${EXPECTED_NUM_RECORDS}" || {
         echo "Number of records in the file is incorrect - expected '${EXPECTED_NUM_RECORDS}' but got '${num_records}'!"
@@ -282,13 +304,13 @@ ret_code=0
 echo "Starting check of image references in files: '${COMMIT_ENV_PATH}' and '${PARAMS_ENV_PATH}'"
 echo "---------------------------------------------"
 
-check_variables_uniq "${COMMIT_ENV_PATH}" || {
+check_variables_uniq "${COMMIT_ENV_PATH}" "true" || {
     echo "ERROR: Variable names in the '${COMMIT_ENV_PATH}' file failed validation!"
     echo "----------------------------------------------------"
     ret_code=1
 }
 
-check_variables_uniq "${PARAMS_ENV_PATH}" || {
+check_variables_uniq "${PARAMS_ENV_PATH}" "false" || {
     echo "ERROR: Variable names in the '${PARAMS_ENV_PATH}' file failed validation!"
     echo "----------------------------------------------------"
     ret_code=1

--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -248,6 +248,7 @@ function check_image() {
     local image_name
     local image_commit_id
     local image_commitref
+    local image_created
 
     image_metadata="$(skopeo inspect --config "docker://${image_url}")" || {
         echo "Couldn't download image metadata with skopeo tool!"
@@ -263,6 +264,10 @@ function check_image() {
     }
     image_commitref=$(echo "${image_metadata}" | jq --raw-output '.config.Labels."io.openshift.build.commit.ref"') ||  {
         echo "Couldn't parse '.config.Labels."io.openshift.build.commit.ref"' from image metadata!"
+        return 1
+    }
+    image_created=$(echo "${image_metadata}" | jq --raw-output '.created') ||  {
+        echo "Couldn't parse '.created' from image metadata!"
         return 1
     }
 
@@ -289,6 +294,7 @@ function check_image() {
     }
 
     echo "Image name retrieved: '${image_name}'"
+    echo "Image created: '${image_created}'"
 
     check_image_variable_matches_name_and_commitref "${image_variable}" "${image_name}" "${image_commitref}" "${openshift_build_name}" || return 1
 

--- a/ci/check-runtime-images.sh
+++ b/ci/check-runtime-images.sh
@@ -27,6 +27,7 @@ function check_image() {
     local img_tag
     local img_url
     local img_metadata
+    local img_created
 
     img_tag=$(jq -r '.metadata.tags[0]' "${runtime_image_file}") || {
         echo "ERROR: Couldn't parse image tags metadata for '${runtime_image_file}' runtime image file!"
@@ -42,12 +43,19 @@ function check_image() {
         return 1
     }
 
+    img_created=$(echo "${img_metadata}" | jq --raw-output '.created') ||  {
+        echo "Couldn't parse '.created' from image metadata!"
+        return 1
+    }
+
     local expected_string="runtime-${img_tag}-ubi"
     echo "Checking that '${expected_string}' is present in the image metadata"
     echo "${img_metadata}" | grep --quiet "${expected_string}" || {
         echo "ERROR: The string '${expected_string}' isn't present in the image metadata at all. Please check that the referenced image '${img_url}' is the correct one!"
         return 1
     }
+
+    echo "Image created: '${img_created}'"
 
     # TODO: we shall extend this check to check also Label "io.openshift.build.commit.ref" value (e.g. '2024a') or something similar
 }


### PR DESCRIPTION
* [CI] let's run params-env workflow also on push
* [CI] enhance the check-params-env.sh to also check uniqueness of values
* [CI] check-params-env.sh prints also time of creation of the checked image

More info as description of each commit.

https://issues.redhat.com/browse/RHOAIENG-8812

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
In the root of the repository, run:
* ./ci/check-params-env.sh
* ./ci/check-runtime-images.sh

---

We should backport this to relevant branches upstream and downstream.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
