### PR TITLE
[2023b] RHOAIENG-8740 Fix spawn-fcgi-1.6.3-23.fc37.x86_64.rpm download location (#569)

### DIFF
--- a/codeserver/c9s-python-3.9/Dockerfile
+++ b/codeserver/c9s-python-3.9/Dockerfile
@@ -38,7 +38,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # spawn-fcgi is not in epel9 \
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.


### PR DESCRIPTION
This is a manual backport for the files
missing in 2024a for the changes done in [RHOAIENG-8255](https://issues.redhat.com//browse/RHOAIENG-8255)

* https://github.com/opendatahub-io/notebooks/pull/569

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
