### PR TITLE
feat(RHOAIENG-8298): Replace `spawn-fcgi` with `supervisord` in code-server and r-studio server

### DIFF
--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -60,12 +60,12 @@ ENV NGINX_VERSION=1.24 \
 
 # Modules does not exist
 RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    INSTALL_PKGS="bind-utils nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    INSTALL_PKGS="bind-utils nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig supervisor" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    # spawn-fcgi is not in epel9 \
-    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
+
+COPY --chown=1001:0 supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
 COPY nginx/root/ /

--- a/codeserver/ubi9-python-3.9/run-code-server.sh
+++ b/codeserver/ubi9-python-3.9/run-code-server.sh
@@ -4,9 +4,9 @@
 SCRIPT_DIR=$(dirname -- "$0")
 source ${SCRIPT_DIR}/utils/*.sh
 
-# Start nginx and fastcgiwrap
+# Start nginx and supervisord
 run-nginx.sh &
-spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 
 # Add .bashrc for custom promt if not present
 if [ ! -f "/opt/app-root/src/.bashrc" ]; then

--- a/codeserver/ubi9-python-3.9/supervisord/supervisord.conf
+++ b/codeserver/ubi9-python-3.9/supervisord/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:fcgiwrap]
+command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket
+autostart=true
+autorestart=true
+redirect_stderr=true

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -73,13 +73,13 @@ ENV NGINX_VERSION=1.24 \
 
 # Modules does not exist
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig supervisor" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
-    # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
+
+COPY --chown=1001:0 supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
 COPY nginx/root/ /

--- a/rstudio/c9s-python-3.9/run-rstudio.sh
+++ b/rstudio/c9s-python-3.9/run-rstudio.sh
@@ -4,9 +4,9 @@
 SCRIPT_DIR=$(dirname -- "$0")
 source ${SCRIPT_DIR}/utils/*.sh
 
-# Start nginx and fastcgiwrap
+# Start nginx and supervisord
 run-nginx.sh &
-spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 
 
 # Add .bashrc for custom promt if not present

--- a/rstudio/c9s-python-3.9/supervisord/supervisord.conf
+++ b/rstudio/c9s-python-3.9/supervisord/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:fcgiwrap]
+command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket
+autostart=true
+autorestart=true
+redirect_stderr=true


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-8298
## Description
<!--- Describe your changes in detail -->

- [x]  Seperate PR on downstream to update the rstudio rhel flavor: https://github.com/red-hat-data-services/notebooks/pull/278 
 
## How Has This Been Tested?
1. Import the code-server and Rstudio server to ODH/RHOAI as custom notebooks Or do the same as Jiri did on this [comment](https://github.com/opendatahub-io/notebooks/pull/587#issuecomment-2188730014)
2. Spin up each of them 
3. Ensure that they work properly

### Images:

code-server: 
- ocp-ci: `quay.io/opendatahub/workbench-images@sha256:178ac76be7bf836955804d512bc7bfb2a0f18493e5256050a77d3306fcb80f86`
- gha: `ghcr.io/atheo89/notebooks/workbench-images:codeserver-ubi9-python-3.9-RHOAIENG-3348_61c2fd959be157d298e7b6bbff5d3ff53512a186`

RStudio-server: 

- ocp-ci: `quay.io/opendatahub/workbench-images@sha256:8dc52d287420f973e1cb4491cbb3a191bbb3fbc7096242ddc7141df18f58c78d`
- gha: `ghcr.io/atheo89/notebooks/workbench-images:rstudio-c9s-python-3.9-replace-spawn-fcgi_2ca3a1f7eaa3782efa9cb1412973e62bb74e3061`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
