### PR TITLE
Add new GitHub workflow to sync branches through PR

### DIFF
--- a/.github/workflows/sync-branches-through-pr.yml
+++ b/.github/workflows/sync-branches-through-pr.yml
@@ -1,0 +1,47 @@
+---
+name: Sync branches through Pull Request
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      source:
+        description: Source branch
+        required: true
+      target:
+        description: Target branch
+        required: true
+
+jobs:
+  sync:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target }}
+          fetch-depth: 0
+
+      - name: Prepare sync branch
+        id: prepare
+        run: |
+          git fetch origin ${{ github.event.inputs.source }}
+          git reset --hard origin/${{ github.event.inputs.source }}
+
+          TIMESTAMP=$(date +'%Y%m%d%H%M%S')
+          SYNC_BRANCH=sync__${{ github.event.inputs.source }}__${{ github.event.inputs.target }}__${TIMESTAMP}
+          echo "branch=$SYNC_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6.1.0
+        with:
+          branch: ${{ steps.prepare.outputs.branch }}
+          title: "Sync `${{ github.event.inputs.target }}` branch with `${{ github.event.inputs.source }}` branch"
+          body: |
+            :robot: This is an automated Pull Request created by `/.github/workflows/sync-branches-through-pr.yml`.
+
+            It merges all commits from `${{ github.event.inputs.source }}` branch into `${{ github.event.inputs.target }}` branch.
+
+            :warning: **IMPORTANT NOTE**: Remember to delete the `${{ steps.prepare.outputs.branch }}` branch after merging the changes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://issues.redhat.com/browse/RHOAIENG-8784

This PR includes a new GitHub workflow to sync two branches through a PR ([reference](https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-branch-up-to-date-with-another)). 
The user must provide `source` and `target` branches as inputs. 

Some notes:
- The workflow will fail if any of the inputs are invalid. 
- The workflow won't create a PR if there are no changes to merge.
- The workflow will create a PR even if there are conflicts. In this case, someone must send the fixes to the sync branch in a new PR. Once the fix PR is merged, the sync PR will be fixed as well.
- The repository must have `write` permissions for workflows and also allow workflows to create PRs. I believe this repository already has these settings on.
- Ideally, tests should be enough to guarantee that the PR is ready to be merged. Depending on the changes, we can decide to checkout the sync branch locally and perform some sanity checks.
- Currently, this workflow is manually triggered but we can set this up to run on a schedule for particular branches, if it makes sense.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added this workflow in a new repository and tested different scenarios.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
