### PR TITLE
Add daily check for vulnerability issues using Trivy

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -43,6 +43,14 @@ jobs:
 
           df -h
 
+          sudo apt-get update
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^mongodb-.*'
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          sudo rm -rf /usr/local/.ghcup &
           sudo rm -rf /usr/local/lib/android &
           sudo rm -rf /usr/local/share/boost &
           sudo rm -rf /usr/local/lib/node_modules &
@@ -96,13 +104,39 @@ jobs:
           mkdir -p $HOME/.local/share/containers/storage/tmp
 
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
-      - name: "push: make ${{ inputs.target }}"
+      - name: "push|schedule: make ${{ inputs.target }}"
         run: "make ${{ inputs.target }}"
-        if: "${{ fromJson(inputs.github).event_name == 'push' }}"
+        if: ${{ fromJson(inputs.github).event_name == 'push' || fromJson(inputs.github).event_name == 'schedule' }}
         env:
           IMAGE_TAG: "${{ github.ref_name }}_${{ github.sha }}"
           IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
           CONTAINER_BUILD_CACHE_ARGS: "--cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
+
+      - name: "schedule: run Trivy vulnerability scanner"
+        if: "${{ fromJson(inputs.github).event_name == 'schedule' }}"
+        run: |
+          TRIVY_VERSION=0.52.2
+          REPORT_FOLDER=${{ github.workspace }}/report
+          REPORT_FILE=trivy-report.md
+          REPORT_TEMPLATE=trivy-markdown.tpl
+
+          mkdir -p $REPORT_FOLDER
+          cp ci/$REPORT_TEMPLATE $REPORT_FOLDER
+
+          IMAGE_NAME=ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}
+          echo "Scanning $IMAGE_NAME"
+
+          podman run --rm \
+              -v $REPORT_FOLDER:/report \
+              docker.io/aquasec/trivy:$TRIVY_VERSION \
+                image \
+                --scanners vuln,secret \
+                --exit-code 0 --timeout 30m \
+                --severity CRITICAL,HIGH \
+                --format template --template "@/report/$REPORT_TEMPLATE" -o /report/$REPORT_FILE \
+                $IMAGE_NAME
+
+          cat $REPORT_FOLDER/$REPORT_FILE >> $GITHUB_STEP_SUMMARY
 
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
       - name: "pull_request: make ${{ inputs.target }}"

--- a/.github/workflows/build-notebooks.yaml
+++ b/.github/workflows/build-notebooks.yaml
@@ -7,7 +7,12 @@
     },
     "on": {
         "push": {},
-        "workflow_dispatch": {}
+        "workflow_dispatch": {},
+        "schedule": [
+            {
+                "cron": "0 2 * * *"
+            }
+        ]
     },
     "jobs": {
         "base-ubi8-python-3_8": {

--- a/ci/cached-builds/gen_gha_matrix_jobs.py
+++ b/ci/cached-builds/gen_gha_matrix_jobs.py
@@ -106,6 +106,7 @@ def write_github_workflow_file(tree: dict[str, list[str]], path: pathlib.Path) -
         "on": {
             "push": {},
             "workflow_dispatch": {},
+            "schedule": [{ "cron": "0 2 * * *"}], # 2am UTC everyday
         },
         "jobs": jobs,
     }

--- a/ci/trivy-markdown.tpl
+++ b/ci/trivy-markdown.tpl
@@ -1,0 +1,58 @@
+## Vulnerability Report by [Trivy](https://trivy.dev)
+
+<details>
+  {{- if . }}
+    {{- range . }}
+      {{- if or (gt (len .Vulnerabilities) 0) (gt (len .Misconfigurations) 0) }}
+        <h3>Target: <code>{{- if and (eq .Class "os-pkgs") .Type }}{{ .Type | toString | escapeXML }} ({{ .Class | toString | escapeXML }}){{- else }}{{ .Target | toString | escapeXML }}{{ if .Type }} ({{ .Type | toString | escapeXML }}){{ end }}{{- end }}</code></h3>
+        {{- if (gt (len .Vulnerabilities) 0) }}
+          <h4>Vulnerabilities ({{ len .Vulnerabilities }})</h4>
+          <table>
+              <tr>
+                  <th>Package</th>
+                  <th>ID</th>
+                  <th>Severity</th>
+                  <th>Installed Version</th>
+                  <th>Fixed Version</th>
+              </tr>
+              {{- range .Vulnerabilities }}
+                <tr>
+                    <td><code>{{ escapeXML .PkgName }}</code></td>
+                    <td>{{ escapeXML .VulnerabilityID }}</td>
+                    <td>{{ escapeXML .Severity }}</td>
+                    <td>{{ escapeXML .InstalledVersion }}</td>
+                    <td>{{ escapeXML .FixedVersion }}</td>
+                </tr>
+              {{- end }}
+          </table>
+        {{- end }}
+        {{- if (gt (len .Misconfigurations ) 0) }}
+          <h4>Misconfigurations</h4>
+          <table>
+              <tr>
+                  <th>Type</th>
+                  <th>ID</th>
+                  <th>Check</th>
+                  <th>Severity</th>
+                  <th>Message</th>
+              </tr>
+              {{- range .Misconfigurations }}
+                <tr>
+                    <td>{{ escapeXML .Type }}</td>
+                    <td>{{ escapeXML .ID }}</td>
+                    <td>{{ escapeXML .Title }}</td>
+                    <td>{{ escapeXML .Severity }}</td>
+                    <td>
+                      {{ escapeXML .Message }}
+                      <br><a href={{ escapeXML .PrimaryURL | printf "%q" }}>{{ escapeXML .PrimaryURL }}</a></br>
+                    </td>
+                </tr>
+              {{- end }}
+          </table>
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    <h3>Empty report</h3>
+  {{- end }}
+</details>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://issues.redhat.com/browse/RHOAIENG-8779

## Description
<!--- Describe your changes in detail -->
This PR introduces the usage of [Trivy](https://trivy.dev/) to scan the container images and consolidate vulnerability reports. I've configured the `Build Notebooks` workflow to be triggered daily at 2 am UTC to generate the report (the scan runs after each image is built). I didn't see the need to run it on each `push` but we can enable it if it makes sense. Each report is uploaded to the workflow summary as soon as each individual job is completed. Finally, reports follow a markdown template.

Demo

https://github.com/opendatahub-io/notebooks/assets/638737/68f92ecb-40a2-4fa9-8f19-c5037f98458d

Here is an [example of workflow run](https://github.com/caponetto/opendatahub-io-notebooks/actions/runs/9713547448) where you can see real reports.

**Note**: I haven't added the checks for PRs because the scan operation adds an extra ~10 minutes, which would slow our PR jobs down.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've executed the workflow on my fork.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
