### PR TITLE
ci: implement ghcr.io expiration for images and cache layers

### DIFF
--- a/.github/workflows/purge-ghcr.yaml
+++ b/.github/workflows/purge-ghcr.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Delete old test images
     steps:
       # https://github.com/snok/container-retention-policy?tab=readme-ov-file#parameters
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03  # v3.0.0
         with:
           # account must be the gh org name when running for an org, and 'user' when running for a user
           account: ${{ (github.repository_owner == github.actor) && 'user' || github.repository_owner }}

--- a/.github/workflows/purge-ghcr.yaml
+++ b/.github/workflows/purge-ghcr.yaml
@@ -1,0 +1,35 @@
+---
+name: "Purge old ghcr.io test images periodically"
+
+"on":
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+        description: "Do a dry run?"
+  schedule:
+    - cron: "0 5 * * *"  # at 05:00 every day
+
+permissions:
+  packages: write
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    name: Delete old test images
+    steps:
+      # https://github.com/snok/container-retention-policy?tab=readme-ov-file#parameters
+      - uses: snok/container-retention-policy@v3.0.0
+        with:
+          # account must be the gh org name when running for an org, and 'user' when running for a user
+          account: ${{ (github.repository_owner == github.actor) && 'user' || github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: |
+            ${{ github.event.repository.name }}/workbench-images
+            ${{ github.event.repository.name }}/workbench-images/build-cache
+          image-tags: "*"
+          cut-off: "3w"
+          dry-run: ${{ inputs.dry_run || false }}
+        env:
+          RUST_BACKTRACE: 1


### PR DESCRIPTION
## Description

Fixes #568

## How Has This Been Tested?

See the action in action at https://github.com/jiridanek/notebooks/actions/runs/9717613825/job/26823642202#step:3:18

The repos this is cleaning are https://github.com/jiridanek/notebooks/pkgs/container/notebooks%2Fworkbench-images and https://github.com/jiridanek/notebooks/pkgs/container/notebooks%2Fworkbench-images%2Fbuild-cache

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
