### PR TITLE
ci: filter GitHub Actions PR build by changed files and `.dockerignore`s

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# This file is stored in .dockerignore in the root of the repository
+# and is symlinked to every image directory below, so that each .dockerignore has the same content
+
+README.md

--- a/amd/c9s-python-3.9/.dockerignore
+++ b/amd/c9s-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/base/anaconda-python-3.8/.dockerignore
+++ b/base/anaconda-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/base/c9s-python-3.9/.dockerignore
+++ b/base/c9s-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/base/ubi8-python-3.8/.dockerignore
+++ b/base/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/base/ubi9-python-3.9/.dockerignore
+++ b/base/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/ci/cached-builds/gha_filter_dockerignored_files/go.mod
+++ b/ci/cached-builds/gha_filter_dockerignored_files/go.mod
@@ -1,0 +1,7 @@
+module main
+
+go 1.21.0
+
+toolchain go1.21.9
+
+require github.com/moby/patternmatcher v0.6.0

--- a/ci/cached-builds/gha_filter_dockerignored_files/go.sum
+++ b/ci/cached-builds/gha_filter_dockerignored_files/go.sum
@@ -1,0 +1,2 @@
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=

--- a/ci/cached-builds/gha_filter_dockerignored_files/main.go
+++ b/ci/cached-builds/gha_filter_dockerignored_files/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/moby/patternmatcher"
+	"log"
+	"os"
+	"regexp"
+)
+
+// main takes path to .dockerignore as a command line argument and reads filenames from stdin
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("Provide one argument: path to .dockerignore")
+	}
+	file := os.Args[1]
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		log.Fatalf("Cannot read file '%s': %s\n", file, err)
+	}
+
+	lines := regexp.MustCompile("\r?\n").Split(string(data), -1)
+	matcher, err := patternmatcher.New(lines)
+	if err != nil {
+		log.Fatalf("Failed to parse file '%s': %s", file, err)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches, err := matcher.MatchesOrParentMatches(line)
+		if err != nil {
+			log.Fatalf("Failed to match '%s' against the .dockerignore: %s", line, err)
+		}
+		if !matches {
+			fmt.Println(line)
+		}
+	}
+}

--- a/codeserver/ubi9-python-3.9/.dockerignore
+++ b/codeserver/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/cuda/c9s-python-3.9/.dockerignore
+++ b/cuda/c9s-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/cuda/ubi8-python-3.8/.dockerignore
+++ b/cuda/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/cuda/ubi9-python-3.9/.dockerignore
+++ b/cuda/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/habana/1.10.0/ubi8-python-3.8/.dockerignore
+++ b/habana/1.10.0/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/habana/1.11.0/ubi8-python-3.8/.dockerignore
+++ b/habana/1.11.0/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/habana/1.13.0/ubi8-python-3.8/.dockerignore
+++ b/habana/1.13.0/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/habana/1.9.0/ubi8-python-3.8/.dockerignore
+++ b/habana/1.9.0/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/intel/base/gpu/ubi9-python-3.9/.dockerignore
+++ b/intel/base/gpu/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/intel/runtimes/ml/ubi9-python-3.9/.dockerignore
+++ b/intel/runtimes/ml/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/intel/runtimes/pytorch/ubi9-python-3.9/.dockerignore
+++ b/intel/runtimes/pytorch/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/intel/runtimes/tensorflow/ubi9-python-3.9/.dockerignore
+++ b/intel/runtimes/tensorflow/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/jupyter/amd/pytorch/ubi9-python-3.9/.dockerignore
+++ b/jupyter/amd/pytorch/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/jupyter/amd/tensorflow/ubi9-python-3.9/.dockerignore
+++ b/jupyter/amd/tensorflow/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/jupyter/datascience/anaconda-python-3.8/.dockerignore
+++ b/jupyter/datascience/anaconda-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/datascience/ubi8-python-3.8/.dockerignore
+++ b/jupyter/datascience/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/datascience/ubi9-python-3.9/.dockerignore
+++ b/jupyter/datascience/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/intel/ml/ubi9-python-3.9/.dockerignore
+++ b/jupyter/intel/ml/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/jupyter/intel/pytorch/ubi9-python-3.9/.dockerignore
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/.dockerignore
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../../.dockerignore

--- a/jupyter/minimal/ubi8-python-3.8/.dockerignore
+++ b/jupyter/minimal/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/minimal/ubi9-python-3.9/.dockerignore
+++ b/jupyter/minimal/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/pytorch/ubi9-python-3.9/.dockerignore
+++ b/jupyter/pytorch/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/tensorflow/ubi9-python-3.9/.dockerignore
+++ b/jupyter/tensorflow/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/trustyai/ubi8-python-3.8/.dockerignore
+++ b/jupyter/trustyai/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/jupyter/trustyai/ubi9-python-3.9/.dockerignore
+++ b/jupyter/trustyai/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/rstudio/c9s-python-3.9/.dockerignore
+++ b/rstudio/c9s-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/runtimes/datascience/ubi8-python-3.8/.dockerignore
+++ b/runtimes/datascience/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/datascience/ubi9-python-3.9/.dockerignore
+++ b/runtimes/datascience/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/minimal/ubi8-python-3.8/.dockerignore
+++ b/runtimes/minimal/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/minimal/ubi9-python-3.9/.dockerignore
+++ b/runtimes/minimal/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/pytorch/ubi8-python-3.8/.dockerignore
+++ b/runtimes/pytorch/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/pytorch/ubi9-python-3.9/.dockerignore
+++ b/runtimes/pytorch/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/tensorflow/ubi8-python-3.8/.dockerignore
+++ b/runtimes/tensorflow/ubi8-python-3.8/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore

--- a/runtimes/tensorflow/ubi9-python-3.9/.dockerignore
+++ b/runtimes/tensorflow/ubi9-python-3.9/.dockerignore
@@ -1,0 +1,1 @@
+../../../.dockerignore


### PR DESCRIPTION
## Description
Fixes #581

## How Has This Been Tested?

I'm not conviced this is worth doing. Pretty much the only file that we can `.dockerignore` are the `README.md`s under `habana/`. The issue mentions `*.yaml`s and so on, but these files aren't located in the container image directories, so when they are modified, the images won't rebuild simply because of #558.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
