### PR TITLE
ci: start podman.socket and pass it to trivy to avoid unnecessary pulls

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -103,6 +103,14 @@ jobs:
           podman system reset --force
           mkdir -p $HOME/.local/share/containers/storage/tmp
 
+          # start systemd user service
+          # since `brew services start podman` is buggy, let's do our own brew-compatible service
+          mkdir -p "${HOME}/.config/systemd/user/"
+          cp ci/cached-builds/homebrew.podman.service "${HOME}/.config/systemd/user/homebrew.podman.service"
+          systemctl --user daemon-reload
+          systemctl --user start homebrew.podman.service
+          echo "PODMAN_SOCK=/run/user/${UID}/podman/podman.sock" >> $GITHUB_ENV
+
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
       - name: "push|schedule: make ${{ inputs.target }}"
         run: "make ${{ inputs.target }}"
@@ -115,7 +123,7 @@ jobs:
       - name: "schedule: run Trivy vulnerability scanner"
         if: "${{ fromJson(inputs.github).event_name == 'schedule' }}"
         run: |
-          TRIVY_VERSION=0.52.2
+          TRIVY_VERSION=0.53.0
           REPORT_FOLDER=${{ github.workspace }}/report
           REPORT_FILE=trivy-report.md
           REPORT_TEMPLATE=trivy-markdown.tpl
@@ -126,10 +134,15 @@ jobs:
           IMAGE_NAME=ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}
           echo "Scanning $IMAGE_NAME"
 
+          # have trivy access podman socket,
+          # https://github.com/aquasecurity/trivy/issues/580#issuecomment-666423279
           podman run --rm \
-              -v $REPORT_FOLDER:/report \
+              -v ${PODMAN_SOCK}:/var/run/podman/podman.sock \
+              -v ${REPORT_FOLDER}:/report \
               docker.io/aquasec/trivy:$TRIVY_VERSION \
                 image \
+                --image-src podman \
+                --podman-host /var/run/podman/podman.sock \
                 --scanners vuln,secret \
                 --exit-code 0 --timeout 30m \
                 --severity CRITICAL,HIGH \

--- a/ci/cached-builds/homebrew.podman.service
+++ b/ci/cached-builds/homebrew.podman.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Homebrew generated unit for podman
+
+[Install]
+WantedBy=default.target
+
+[Service]
+Type=simple
+ExecStart=/home/linuxbrew/.linuxbrew/opt/podman/bin/podman system service --time=0
+WorkingDirectory=/home/linuxbrew/.linuxbrew
+Environment="PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin"


### PR DESCRIPTION
Followup on

* https://github.com/opendatahub-io/notebooks/pull/600

This does not help appreciably with the scan runtime, but still it's an improvement in efficiency.

## Description

When I try running

> $ podman run -v /run/user/1000/podman/podman.sock:/var/run/podman/podman.sock --rm -it docker.io/aquasec/trivy image --podman-host /var/run/podman/podman.sock --image-src podman ghcr.io/jiridanek/notebooks/workbench-images:jupyter-datascience-anaconda-python-3.8-jd_speed_up_trivy_17c0717f5e8cfc1f464c2ccc5d9850844f4c1019

then trivy scans local image that I previously downloaded with `podman pull`

If I leave out the podman socket, then trivy downloads the image at the beginning

> $ podman run --rm -it docker.io/aquasec/trivy image ghcr.io/jiridanek/notebooks/workbench-images:jupyter-datascience-anaconda-python-3.8-jd_speed_up_trivy_17c0717f5e8cfc1f464c2ccc5d9850844f4c1019

then trivy has to download the image anew.

Logically speaking, providing the podman socket should allow Trivy to run faster. But actually that's not the case from my testing.

## How Has This Been Tested?

Here's it running, https://github.com/jiridanek/notebooks/actions/runs/9760779225/job/26941336383

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
