### PR TITLE
RHOAIENG-9473: Optionally enable Trivy for pull requests

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -120,37 +120,6 @@ jobs:
           IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
           CONTAINER_BUILD_CACHE_ARGS: "--cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
 
-      - name: "schedule: run Trivy vulnerability scanner"
-        if: "${{ fromJson(inputs.github).event_name == 'schedule' }}"
-        run: |
-          TRIVY_VERSION=0.53.0
-          REPORT_FOLDER=${{ github.workspace }}/report
-          REPORT_FILE=trivy-report.md
-          REPORT_TEMPLATE=trivy-markdown.tpl
-
-          mkdir -p $REPORT_FOLDER
-          cp ci/$REPORT_TEMPLATE $REPORT_FOLDER
-
-          IMAGE_NAME=ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}
-          echo "Scanning $IMAGE_NAME"
-
-          # have trivy access podman socket,
-          # https://github.com/aquasecurity/trivy/issues/580#issuecomment-666423279
-          podman run --rm \
-              -v ${PODMAN_SOCK}:/var/run/podman/podman.sock \
-              -v ${REPORT_FOLDER}:/report \
-              docker.io/aquasec/trivy:$TRIVY_VERSION \
-                image \
-                --image-src podman \
-                --podman-host /var/run/podman/podman.sock \
-                --scanners vuln,secret \
-                --exit-code 0 --timeout 30m \
-                --severity CRITICAL,HIGH \
-                --format template --template "@/report/$REPORT_TEMPLATE" -o /report/$REPORT_FILE \
-                $IMAGE_NAME
-
-          cat $REPORT_FOLDER/$REPORT_FILE >> $GITHUB_STEP_SUMMARY
-
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
       - name: "pull_request: make ${{ inputs.target }}"
         run: |
@@ -165,6 +134,62 @@ jobs:
           IMAGE_TAG: "${{ github.sha }}"
           IMAGE_REGISTRY: "localhost:5000/workbench-images"
           CONTAINER_BUILD_CACHE_ARGS: "--cache-from ${{ env.CACHE }}"
+
+      - name: "pull_request|schedule: resolve image name if Trivy scan should run"
+        id: resolve-image
+        if: ${{ fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'schedule' }}
+        env:
+          EVENT_NAME: ${{ fromJson(inputs.github).event_name }}
+          HAS_TRIVY_LABEL: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" && "$HAS_TRIVY_LABEL" == "true" ]]; then
+            IMAGE_NAME="localhost:5000/workbench-images:${{ inputs.target }}-${{ github.sha }}"
+            echo "image=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            IMAGE_NAME="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}"
+            echo "image=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ -z "$IMAGE_NAME" ]]; then
+            echo "Trivy scan won't run"
+          fi
+
+      - name: Run Trivy vulnerability scanner
+        if: ${{ steps.resolve-image.outputs.image }}
+        run: |
+          TRIVY_VERSION=0.53.0
+          REPORT_FOLDER=${{ github.workspace }}/report
+          REPORT_FILE=trivy-report.md
+          REPORT_TEMPLATE=trivy-markdown.tpl
+
+          mkdir -p $REPORT_FOLDER
+          cp ci/$REPORT_TEMPLATE $REPORT_FOLDER
+
+          IMAGE_NAME=${{ steps.resolve-image.outputs.image }}
+          echo "Scanning $IMAGE_NAME"
+
+          SEVERITY_OPTION=""
+          # Report only higher vulnerabilities if not a pull request
+          if [ "${{ fromJson(inputs.github).event_name }}" != "pull_request" ]; then
+            SEVERITY_OPTION="--severity CRITICAL,HIGH"
+          fi
+
+          # have trivy access podman socket,
+          # https://github.com/aquasecurity/trivy/issues/580#issuecomment-666423279
+          podman run --rm \
+              -v ${PODMAN_SOCK}:/var/run/podman/podman.sock \
+              -v ${REPORT_FOLDER}:/report \
+              docker.io/aquasec/trivy:$TRIVY_VERSION \
+                image \
+                --image-src podman \
+                --podman-host /var/run/podman/podman.sock \
+                --scanners vuln --ignore-unfixed \
+                --exit-code 0 --timeout 30m \
+                $SEVERITY_OPTION \
+                --format template --template "@/report/$REPORT_TEMPLATE" -o /report/$REPORT_FILE \
+                $IMAGE_NAME
+
+          cat $REPORT_FOLDER/$REPORT_FILE >> $GITHUB_STEP_SUMMARY
 
       - run: df -h
         if: "${{ !cancelled() }}"

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -8,6 +8,10 @@ permissions:
   packages: read
   pull-requests: read
 
+concurrency:
+  group: ${{ format('build-notebooks-pr-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: true
+
 jobs:
   gen:
     name: Generate job matrix


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://issues.redhat.com/browse/RHOAIENG-9473

## Description
<!--- Describe your changes in detail -->
This PR enables Trivy scan for PRs. It won't run by default for all PRs because it adds extra minutes to the jobs and the report won't be needed for all PRs. In order to execute the scan, the label `trivy-scan` must be added to the PR before its creation. The workflow does not react to label changes, so a new commit must be pushed to run the scan if the `trivy-scan` label is added after the PR is opened.

Also on this PR:
- The `--severity` option includes all of them when the trigger is PR, while the daily report only includes `HIGH` and `CRITICAL` ones. This is because low and medium issues are numerous and could be more interesting to be listed in a PR, rather than the daily report.
- Added the `--ignore-unfixed` option to reduce the size of the report table. An issue that does not have a fixed version is not very useful to be listed.
- Added `concurrency` for the PR workflow that builds notebooks to reduce redundant builds.
- Removed scan for secrets as it takes more time and it's not bringing value to the reports.
- For reviewers: I didn't touch the `pull_request: make ${{ inputs.target }}` step; I only moved it up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've executed the tests on my fork.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
