### PR TITLE
ci: use a smarter `git status` check for uncommitted files

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -19,16 +19,14 @@ jobs:
 
       - name: Check there aren't any modified files present
         run: |
-          if [[ $(git ls-files . -d -m -o --exclude-standard --full-name -v | tee modified.log | wc -l) -gt 0 ]]; then
-            echo "There are changed files"
-            exit 1
+          clean=$(git status --porcelain)
+          if [[ -z "$clean" ]]; then
+              echo "Empty git status --porcelain: $clean"
+          else
+              echo "Uncommitted file changes detected: $clean"
+              git diff
+              exit 1
           fi
-
-      - name: Print modified files
-        if: ${{ failure() }}
-        run: |
-          cat modified.log
-          git diff
 
   code-static-analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This is stolen from a recent kubeflow PR by @ederign. Compared to the previous version, this also reports on new untracked files. Also, the command is much simpler to read.

## How Has This Been Tested?

See GHA results.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
