### PR TITLE
Enable all severities on the Trivy daily report

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -168,12 +168,6 @@ jobs:
           IMAGE_NAME=${{ steps.resolve-image.outputs.image }}
           echo "Scanning $IMAGE_NAME"
 
-          SEVERITY_OPTION=""
-          # Report only higher vulnerabilities if not a pull request
-          if [ "${{ fromJson(inputs.github).event_name }}" != "pull_request" ]; then
-            SEVERITY_OPTION="--severity CRITICAL,HIGH"
-          fi
-
           # have trivy access podman socket,
           # https://github.com/aquasecurity/trivy/issues/580#issuecomment-666423279
           podman run --rm \
@@ -185,7 +179,6 @@ jobs:
                 --podman-host /var/run/podman/podman.sock \
                 --scanners vuln --ignore-unfixed \
                 --exit-code 0 --timeout 30m \
-                $SEVERITY_OPTION \
                 --format template --template "@/report/$REPORT_TEMPLATE" -o /report/$REPORT_FILE \
                 $IMAGE_NAME
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Given that not only `HIGH` and `CRITICAL` issues are worked on, let's enable all types of severity for the daily report too. This way, we can compare when a new PR that fixes an issue is opened (see [this discussion](https://github.com/opendatahub-io/notebooks/pull/613/files/f9f3586aeaddc7d6e60563e35b2bed83a98098c0#diff-6ac338da83efa67a23d1f59dcf6107320bd79f4ea30edd9ac21e48036820eb43)).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally. The default is all severities if you don't provide the `--severity` option.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
