### PR TITLE
Update trusty from 0.3 to 0.6 to fix vulnerabilities

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.9/Pipfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 # TrustyAI and useful extensions
-trustyai = "~=0.3.0"
+trustyai = "~=0.6.0"
 
 # Datascience and useful extensions
 elyra-pipeline-editor-extension = "~=3.15.0"

--- a/jupyter/trustyai/ubi9-python-3.9/Pipfile.lock
+++ b/jupyter/trustyai/ubi9-python-3.9/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "14c05b52434ecf9ffa6dd8a8557d925f4f69fa29fc528de14f8bed9962d27680"
+            "sha256": "553b885bedd681c4c671897f5a946108f7658fc830a3238d9af7871f2a06c322"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -174,11 +174,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94",
-                "sha256:e8a0083b4bb28fcffb6207a3bfc9e5d0a68be951dd7e336d5dcf639c682388c0"
+                "sha256:3eae9ea67c11c858cdd2c91337d2e816bd019ac897ca07d7b346ac10105fceb3",
+                "sha256:7099b5a60985529d8d46858befa103b82d0d05a5a5e8b816b5303ed96075e1d9"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.2.2"
+            "version": "==3.2.3"
         },
         "asttokens": {
             "hashes": [
@@ -277,7 +277,6 @@
                 "sha256:fa85b67147c8dc99b6e7c699fc086103f958f9677db934f70659e6e6a72a818c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.26.165"
         },
         "botocore": {
@@ -916,11 +915,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:042c4702efa9f7d3c48d3a69341c209381b125faa6dbf3ebe56bc7e40ae05c23",
-                "sha256:87805c36970047247c8afe614d4e3af8eceafc1ebba0c679fe75ddd1d575e871"
+                "sha256:49315be72c55a6a37d62819e3573f6b416aca00721f7e3e31a008d928bf64022",
+                "sha256:53326ea2ebec768070a94bee4e1b9194c9646ea0c2bd72422785bd0f9abfad7b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "version": "==2.32.0"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -1180,9 +1179,7 @@
             "version": "==3.0.0"
         },
         "jsonschema": {
-            "extras": [
-                "format-nongpl"
-            ],
+            "extras": [],
             "hashes": [
                 "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4",
                 "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"
@@ -1204,7 +1201,6 @@
                 "sha256:676d74bd8b95c7467d5e7ea1c954b306c7768b7bfa2bb3dd32e64efdf7dc09ee"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.0.7"
         },
         "jupyter-client": {
@@ -1261,7 +1257,6 @@
                 "sha256:efaae5e4f0d5f22c7f2f2dc848635036ee74a2df02abed52d30d9d95121ad382"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.1.0"
         },
         "jupyter-server-mathjax": {
@@ -1278,7 +1273,6 @@
                 "sha256:632e489b5764669345defe62848a3502cf8cfa37ca6e6501cae161779619c474"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==3.2.4"
         },
         "jupyter-server-terminals": {
@@ -1287,7 +1281,6 @@
                 "sha256:75779164661cec02a8758a5311e18bb8eb70c4e86c6b699403100f1585a12a36"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==0.4.4"
         },
         "jupyterlab": {
@@ -1296,7 +1289,6 @@
                 "sha256:8e1a4414b681dafd3f19bd45cb0c79cb713bc78ef4e8440b95d86881c23a9fe5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.5.3"
         },
         "jupyterlab-git": {
@@ -1305,7 +1297,6 @@
                 "sha256:ed82cf235e6b9ca011254d1260e1a4ac66ebbe05422d55f68f4881c13f24a6ad"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==0.41.0"
         },
         "jupyterlab-lsp": {
@@ -1314,7 +1305,6 @@
                 "sha256:559ad4692f97f42dd6b9f0b330ab92703f02b8e45bbaf6e9cf59898a897222a0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.10.2"
         },
         "jupyterlab-pygments": {
@@ -1331,7 +1321,6 @@
                 "sha256:676eb3bca4b45e1c2e6a3c7102084690ac722799b82aa0f7213eef5d98081e3a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==0.10.1"
         },
         "jupyterlab-server": {
@@ -1348,7 +1337,6 @@
                 "sha256:dd5ac679593c969af29c9bed054c24f26842baa51352114736756bc035deee27"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.0.11"
         },
         "kafka-python": {
@@ -1384,7 +1372,6 @@
                 "sha256:cbd116898e359c7a3ad1f1f02e3f8f9612e893139a95ec152c371f3d984725ba"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.6.1'",
             "version": "==1.5.10"
         },
         "kiwisolver": {
@@ -1624,7 +1611,6 @@
                 "sha256:ff2aa84e74f80891e6bcf292ebb1dd57714ffbe13177642d65fee25384a30894"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.6.3"
         },
         "matplotlib-inline": {
@@ -1799,7 +1785,6 @@
                 "sha256:ea4ddf919e3035800ef8bd5552b814522207cb154ca7512565e4539a54c74dbf"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==3.1.1"
         },
         "nbformat": {
@@ -1882,7 +1867,6 @@
                 "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.24.4"
         },
         "oauthlib": {
@@ -1932,7 +1916,6 @@
                 "sha256:f76d097d12c82a535fda9dfe5e8dd4127952b45fea9b0276cb30cca5ea313fbc"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.5.3"
         },
         "pandocfilters": {
@@ -2074,7 +2057,6 @@
                 "sha256:f776a5c664908450c6c1727f61e8e2e22798d9c6c69d37a9057735365084a2fa"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==5.13.1"
         },
         "pluggy": {
@@ -2176,34 +2158,45 @@
         },
         "pyarrow": {
             "hashes": [
-                "sha256:0846ace49998825eda4722f8d7f83fa05601c832549c9087ea49d6d5397d8cec",
-                "sha256:0d8b90efc290e99a81d06015f3a46601c259ecc81ffb6d8ce288c91bd1b868c9",
-                "sha256:0e36425b1c1cbf5447718b3f1751bf86c58f2b3ad299f996cd9b1aa040967656",
-                "sha256:19c812d303610ab5d664b7b1de4051ae23565f9f94d04cbea9e50569746ae1ee",
-                "sha256:1b50bb9a82dca38a002d7cbd802a16b1af0f8c50ed2ec94a319f5f2afc047ee9",
-                "sha256:1d568acfca3faa565d663e53ee34173be8e23a95f78f2abfdad198010ec8f745",
-                "sha256:23a77d97f4d101ddfe81b9c2ee03a177f0e590a7e68af15eafa06e8f3cf05976",
-                "sha256:2466be046b81863be24db370dffd30a2e7894b4f9823fb60ef0a733c31ac6256",
-                "sha256:272f147d4f8387bec95f17bb58dcfc7bc7278bb93e01cb7b08a0e93a8921e18e",
-                "sha256:280289ebfd4ac3570f6b776515baa01e4dcbf17122c401e4b7170a27c4be63fd",
-                "sha256:2cc63e746221cddb9001f7281dee95fd658085dd5b717b076950e1ccc607059c",
-                "sha256:3b97649c8a9a09e1d8dc76513054f1331bd9ece78ee39365e6bf6bc7503c1e94",
-                "sha256:3d1733b1ea086b3c101427d0e57e2be3eb964686e83c2363862a887bb5c41fa8",
-                "sha256:5b0810864a593b89877120972d1f7af1d1c9389876dbed92b962ed81492d3ffc",
-                "sha256:7a7b6a765ee4f88efd7d8348d9a1f804487d60799d0428b6ddf3344eaef37282",
-                "sha256:7b5b9f60d9ef756db59bec8d90e4576b7df57861e6a3d6a8bf99538f68ca15b3",
-                "sha256:92fb031e6777847f5c9b01eaa5aa0c9033e853ee80117dce895f116d8b0c3ca3",
-                "sha256:993287136369aca60005ee7d64130f9466489c4f7425f5c284315b0a5401ccd9",
-                "sha256:a1c4fce253d5bdc8d62f11cfa3da5b0b34b562c04ce84abb8bd7447e63c2b327",
-                "sha256:a7cd32fe77f967fe08228bc100433273020e58dd6caced12627bcc0a7675a513",
-                "sha256:b99e559d27db36ad3a33868a475f03e3129430fc065accc839ef4daa12c6dab6",
-                "sha256:bc4ea634dacb03936f50fcf59574a8e727f90c17c24527e488d8ceb52ae284de",
-                "sha256:d8c26912607e26c2991826bbaf3cf2b9c8c3e17566598c193b492f058b40d3a4",
-                "sha256:e6be4d85707fc8e7a221c8ab86a40449ce62559ce25c94321df7c8500245888f",
-                "sha256:ea830d9f66bfb82d30b5794642f83dd0e4a718846462d22328981e9eb149cba8"
+                "sha256:0140c7e2b740e08c5a459439d87acd26b747fc408bde0a8806096ee0baaa0c15",
+                "sha256:01e44de9749cddc486169cb632f3c99962318e9dacac7778315a110f4bf8a450",
+                "sha256:05fe7994745b634c5fb16ce5717e39a1ac1fac3e2b0795232841660aa76647cd",
+                "sha256:06ca79080ef89d6529bb8e5074d4b4f6086143b2520494fcb7cf8a99079cde93",
+                "sha256:097828b55321897db0e1dbfc606e3ff8101ae5725673498cbfa7754ee0da80e4",
+                "sha256:0f6f053cb66dc24091f5511e5920e45c83107f954a21032feadc7b9e3a8e7851",
+                "sha256:11e045dfa09855b6d3e7705a37c42e2dc2c71d608fab34d3c23df2e02df9aec3",
+                "sha256:1a8ae88c0038d1bc362a682320112ee6774f006134cd5afc291591ee4bc06505",
+                "sha256:1daab52050a1c48506c029e6fa0944a7b2436334d7e44221c16f6f1b2cc9c510",
+                "sha256:2a145dab9ed7849fc1101bf03bcdc69913547f10513fdf70fc3ab6c0a50c7eee",
+                "sha256:30d8494870d9916bb53b2a4384948491444741cb9a38253c590e21f836b01222",
+                "sha256:323cbe60210173ffd7db78bfd50b80bdd792c4c9daca8843ef3cd70b186649db",
+                "sha256:32542164d905002c42dff896efdac79b3bdd7291b1b74aa292fac8450d0e4dcd",
+                "sha256:33c1f6110c386464fd2e5e4ea3624466055bbe681ff185fd6c9daa98f30a3f9a",
+                "sha256:3c76807540989fe8fcd02285dd15e4f2a3da0b09d27781abec3adc265ddbeba1",
+                "sha256:3f6d5faf4f1b0d5a7f97be987cf9e9f8cd39902611e818fe134588ee99bf0283",
+                "sha256:450e4605e3c20e558485f9161a79280a61c55efe585d51513c014de9ae8d393f",
+                "sha256:470ae0194fbfdfbf4a6b65b4f9e0f6e1fa0ea5b90c1ee6b65b38aecee53508c8",
+                "sha256:4756a2b373a28f6166c42711240643fb8bd6322467e9aacabd26b488fa41ec23",
+                "sha256:58c889851ca33f992ea916b48b8540735055201b177cb0dcf0596a495a667b00",
+                "sha256:6263cffd0c3721c1e348062997babdf0151301f7353010c9c9a8ed47448f82ab",
+                "sha256:78d4a77a46a7de9388b653af1c4ce539350726cd9af62e0831e4f2bd0c95a2f4",
+                "sha256:7a8089d7e77d1455d529dbd7cff08898bbb2666ee48bc4085203af1d826a33cc",
+                "sha256:906b0dc25f2be12e95975722f1e60e162437023f490dbd80d0deb7375baf3171",
+                "sha256:922e8b49b88da8633d6cac0e1b5a690311b6758d6f5d7c2be71acb0f1e14cd61",
+                "sha256:96d64e5ba7dceb519a955e5eeb5c9adcfd63f73a56aea4722e2cc81364fc567a",
+                "sha256:981670b4ce0110d8dcb3246410a4aabf5714db5d8ea63b15686bce1c914b1f83",
+                "sha256:a8eeef015ae69d104c4c3117a6011e7e3ecd1abec79dc87fd2fac6e442f666ee",
+                "sha256:b8b3f4fe8d4ec15e1ef9b599b94683c5216adaed78d5cb4c606180546d1e2ee1",
+                "sha256:be28e1a07f20391bb0b15ea03dcac3aade29fc773c5eb4bee2838e9b2cdde0cb",
+                "sha256:c7331b4ed3401b7ee56f22c980608cf273f0380f77d0f73dd3c185f78f5a6220",
+                "sha256:cf87e2cec65dd5cf1aa4aba918d523ef56ef95597b545bbaad01e6433851aa10",
+                "sha256:d0351fecf0e26e152542bc164c22ea2a8e8c682726fce160ce4d459ea802d69c",
+                "sha256:d264ad13605b61959f2ae7c1d25b1a5b8505b112715c961418c8396433f213ad",
+                "sha256:e592e482edd9f1ab32f18cd6a716c45b2c0f2403dc2af782f4e9674952e6dd27",
+                "sha256:fada8396bc739d958d0b81d291cfd201126ed5e7913cb73de6bc606befc30226"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==12.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==14.0.1"
         },
         "pyasn1": {
             "hashes": [
@@ -2809,7 +2802,6 @@
                 "sha256:fe175ee1dab589d2e1033657c5b6bec92a8a3b69103e3dd361b58014729975c3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.2.2"
         },
         "scipy": {
@@ -2837,7 +2829,6 @@
                 "sha256:fae8a7b898c42dffe3f7361c40d5952b6bf32d10c4569098d276b4c547905ee1"
             ],
             "index": "pypi",
-            "markers": "python_version < '3.12' and python_version >= '3.8'",
             "version": "==1.10.1"
         },
         "send2trash": {
@@ -2850,11 +2841,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05",
-                "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"
+                "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5",
+                "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==70.2.0"
+            "version": "==70.3.0"
         },
         "shellingham": {
             "hashes": [
@@ -2988,11 +2979,11 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:af914f5a9c59ed9d0762c7b64d3b5d5df007448eb9cd2edc8a46b1eafead172f",
-                "sha256:eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c"
+                "sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72",
+                "sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.12.5"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.13.0"
         },
         "tornado": {
             "hashes": [
@@ -3029,12 +3020,11 @@
         },
         "trustyai": {
             "hashes": [
-                "sha256:b037a9528f363cef249a1c3415befb5848418273a46078bb892b97a24609fb7f",
-                "sha256:cd2adc1dfe93621d1342a62cfb7e774857d728b1033f3d7caf514d871a7894e6"
+                "sha256:b9e99641a982da803dcecdfb40b3630e8738c1f1d169b4fed571d3613588d116",
+                "sha256:fd0844204dc7cfbcef91fe9cc67274195d29a669c74b1d71a5c37f54e7e126a8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.3.0"
+            "version": "==0.6.0"
         },
         "typer": {
             "hashes": [
@@ -3247,7 +3237,6 @@
                 "sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==0.38.4"
         },
         "widgetsnbextension": {


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-6457
## Description
This PR updates also the 2023a image version is order to get the vulnerability of PyArrow fixed on rhoai 2.8. This should flow to downstream 2023a and then update the manifests of rhoai2.8

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
