### PR TITLE
Inject rocm runtimes to runtime-images folder

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json
@@ -1,0 +1,12 @@
+{
+    "display_name": "Pytorch with ROCm and Python 3.9 (UBI9)",
+    "metadata": {
+      "tags": [
+        "rocm-pytorch"
+      ],
+      "display_name": "Pytorch with ROCm and Python 3.9 (UBI9)",
+      "image_name": "quay.io/opendatahub/workbench-images@sha256:519b7f4ea9a16065ba2213389de4e38ee4afa3084f3b8b770157818928ad0f7a",
+      "pull_policy": "IfNotPresent"
+    },
+    "schema_name": "runtime-image"
+  }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json
@@ -1,0 +1,12 @@
+{
+    "display_name": "TensorFlow with ROCm and Python 3.9 (UBI9)",
+    "metadata": {
+      "tags": [
+        "rocm-tensorflow"
+      ],
+      "display_name": "TensorFlow with ROCm and Python 3.9 (UBI9)",
+      "image_name": "quay.io/opendatahub/workbench-images@sha256:a1bbf6153921b60cb58f094d110bf6dc054d13a07c4c513a6b994d1b74a8b60e",
+      "pull_policy": "IfNotPresent"
+    },
+    "schema_name": "runtime-image"
+  }


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-9680
Depends on: https://github.com/openshift/release/pull/54567

## Description
Add rocm runtimes to runtime-images folder


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
