### PR TITLE
Combine `RUN` commands to reduce rocm image size

### DIFF
--- a/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
@@ -14,14 +14,10 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.9" \
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock ./
 
-RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
-    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # Disable announcement plugin of jupyterlab \
-    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
-    fix-permissions /opt/app-root -P
+    # Disable announcement plugin of jupyterlab
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && fix-permissions /opt/app-root -P

--- a/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
@@ -14,14 +14,10 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.9" \
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock ./
 
-RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
-
-# Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-
-# Disable announcement plugin of jupyterlab
-RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
-    fix-permissions /opt/app-root -P
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # Disable announcement plugin of jupyterlab
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && fix-permissions /opt/app-root -P


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Image size comparison before -> after these changes:

- `rocm-jupyter-tensorflow-ubi9-python-3.9`: 38 GB -> 35 GB
- `rocm-jupyter-pytorch-ubi9-python-3.9`: 60 GB -> 46 GB

Note: Both files are now exactly the same, except for the labels.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the build workflow with the changes included

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
