### PR TITLE
RHOAIENG-10783: fix(Dockerfiles): combine `fix-permissions` RUN with the preceding RUN when possible

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -20,7 +20,10 @@ COPY setup-elyra.sh ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
-    rm -f ./Pipfile.lock
+    rm -f ./Pipfile.lock && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+    fix-permissions /opt/app-root -P
 
 COPY utils ./utils/
 

--- a/jupyter/minimal/ubi8-python-3.8/Dockerfile
+++ b/jupyter/minimal/ubi8-python-3.8/Dockerfile
@@ -18,13 +18,11 @@ COPY utils utils/
 COPY Pipfile.lock start-notebook.sh ./
 
 # Install Python dependencies from Pipfile.lock file
-RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
-
-# Disable announcement plugin of jupyterlab
-RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Disable announcement plugin of jupyterlab \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
       fix-permissions /opt/app-root -P
 
 WORKDIR /opt/app-root/src

--- a/jupyter/minimal/ubi8-python-3.8/Dockerfile
+++ b/jupyter/minimal/ubi8-python-3.8/Dockerfile
@@ -23,7 +23,7 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
-      fix-permissions /opt/app-root -P
+    fix-permissions /opt/app-root -P
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -23,7 +23,7 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
-      fix-permissions /opt/app-root -P
+    fix-permissions /opt/app-root -P
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -18,13 +18,11 @@ COPY utils utils/
 COPY Pipfile.lock start-notebook.sh ./
 
 # Install Python dependencies from Pipfile.lock file
-RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
-
-# Disable announcement plugin of jupyterlab
-RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Disable announcement plugin of jupyterlab \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
       fix-permissions /opt/app-root -P
 
 WORKDIR /opt/app-root/src

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -20,8 +20,7 @@ RUN echo "Installing softwares and packages" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Disable announcement plugin of jupyterlab \
-    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
@@ -24,5 +24,5 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Disable announcement plugin of jupyterlab
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
-    # Fix permissions to support pip in Openshift environments
+    # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && fix-permissions /opt/app-root -P

--- a/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     rm ./de-vendor-torch.sh && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # Disable announcement plugin of jupyterlab
+    # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && fix-permissions /opt/app-root -P

--- a/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
@@ -15,9 +15,9 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.9" \
 COPY Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
-    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
+    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # Disable announcement plugin of jupyterlab
+    # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
-    # Fix permissions to support pip in Openshift environments
+    # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && fix-permissions /opt/app-root -P

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -19,14 +19,11 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
 
 # Temporary:Workaround for fixing the kfp-kubernetes 1.0.0 for elyra pipeline execution
 # TODO: Remove this patch once the issue is fixed with kfp-kubernetes upgrade.
-RUN patch /opt/app-root/lib/python3.9/site-packages/elyra/templates/kubeflow/v2/python_dsl_template.jinja2 -i utils/python_dsl_template.patch
-
-# Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-
-# Disable announcement plugin of jupyterlab
-RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+RUN patch /opt/app-root/lib/python3.9/site-packages/elyra/templates/kubeflow/v2/python_dsl_template.jinja2 -i utils/python_dsl_template.patch && \
+    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # Disable announcement plugin of jupyterlab
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
 RUN patch /opt/app-root/lib/python3.9/site-packages/elyra/templates/kubeflow/v2/python_dsl_template.jinja2 -i utils/python_dsl_template.patch && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # Disable announcement plugin of jupyterlab
+    # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -28,6 +28,6 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
-    # Fix permissions to support pip in Openshift environments
+    # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -27,7 +27,7 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Disable announcement plugin of jupyterlab \
-    RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -23,14 +23,11 @@ USER 1001
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
 COPY Pipfile.lock ./
 
-RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
-
-# Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
-RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-
-# Disable announcement plugin of jupyterlab
-RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-
-# Fix permissions to support pip in Openshift environments
-RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # Disable announcement plugin of jupyterlab \
+    RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    # Fix permissions to support pip in Openshift environments
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P


### PR DESCRIPTION
* [RHOAIENG-10783](https://issues.redhat.com/browse/RHOAIENG-10783) Optimize ROCm images to reduce the size so they can be built on OpenShift CI

Fixes #539

Makes changes to more images than

* https://github.com/opendatahub-io/notebooks/pull/634

## Description

The below step in [jupyter-pytorch-ubi9-python-3_9](https://github.com/jiridanek/notebooks/actions/runs/9204976491/job/25320438373#logs) and probably other images creates a large layer. Fix the permissions in the previous step already.

```
STEP 5/5: RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages &&     fix-permissions /opt/app-root -P
COMMIT ghcr.io/jiridanek/notebooks/workbench-images:jupyter-pytorch-ubi9-python-3.9-2024a_20240523
```

> Note that changing the metadata of files, for example, changing file permissions or ownership of a file, can also result in a copy_up operation, therefore duplicating the file to the writable layer.

from https://docs.docker.com/storage/storagedriver/

## How Has This Been Tested?

Build images in CI, check sizes.

After:

```
jupyter-pytorch-ubi9-python-3.9-7d67798ec8625f47b5152882b27a2b79da8745dd           5bfda56883dc  2 minutes ago   20.6 GB
```

Before:

```
jupyter-pytorch-ubi9-python-3.9-main_4520c936792a92270f31044ac81e542a90ba6929           0c3707b5a463  5 days ago   25.9 GB
```

The pytorch images show the largest size difference, for the other images the impact is very small.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
