### PR TITLE
chore(ci): Run Trivy scan `fs` instead of `image` for rocm+pytorch image due to resource constraints

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -22,6 +22,8 @@ jobs:
     env:
       # GitHub image registry used for storing $(CONTAINER_ENGINE)'s cache
       CACHE: "ghcr.io/${{ github.repository }}/workbench-images/build-cache"
+      # Targets (and their folder) that should be scanned using FS instead of IMAGE scan due to resource constraints
+      TRIVY_SCAN_FS_JSON: '{"rocm-jupyter-pytorch-ubi9-python-3.9": "jupyter/rocm/pytorch/ubi9-python-3.9"}'
 
     steps:
 
@@ -138,27 +140,42 @@ jobs:
       - name: "Show podman images information"
         run: podman images
 
-      - name: "pull_request|schedule: resolve image name if Trivy scan should run"
-        id: resolve-image
+      - name: "pull_request|schedule: resolve target if Trivy scan should run"
+        id: resolve-target
         if: ${{ fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'schedule' }}
         env:
           EVENT_NAME: ${{ fromJson(inputs.github).event_name }}
           HAS_TRIVY_LABEL: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
+          FS_SCAN_FOLDER: ${{ fromJson(env.TRIVY_SCAN_FS_JSON)[inputs.target] }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" && "$HAS_TRIVY_LABEL" == "true" ]]; then
-            IMAGE_NAME="localhost:5000/workbench-images:${{ inputs.target }}-${{ github.sha }}"
-            echo "image=$IMAGE_NAME" >> $GITHUB_OUTPUT
+            if [[ -n "$FS_SCAN_FOLDER" ]]; then
+              TARGET="$FS_SCAN_FOLDER"
+              TYPE="fs"
+            else
+              TARGET="localhost:5000/workbench-images:${{ inputs.target }}-${{ github.sha }}"
+              TYPE="image"
+            fi
           elif [[ "$EVENT_NAME" == "schedule" ]]; then
-            IMAGE_NAME="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}"
-            echo "image=$IMAGE_NAME" >> $GITHUB_OUTPUT
+            if [[ -n "$FS_SCAN_FOLDER" ]]; then
+              TARGET="$FS_SCAN_FOLDER"
+              TYPE="fs"
+            else
+              TARGET="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}"
+              TYPE="image"
+            fi
           fi
 
-          if [[ -z "$IMAGE_NAME" ]]; then
+          if [[ -n "$TARGET" ]]; then
+            echo "target=$TARGET" >> $GITHUB_OUTPUT
+            echo "type=$TYPE" >> $GITHUB_OUTPUT
+            echo "Trivy scan will run on $TARGET ($TYPE)"
+          else
             echo "Trivy scan won't run"
           fi
 
       - name: Run Trivy vulnerability scanner
-        if: ${{ steps.resolve-image.outputs.image }}
+        if: ${{ steps.resolve-target.outputs.target }}
         run: |
           TRIVY_VERSION=0.53.0
           REPORT_FOLDER=${{ github.workspace }}/report
@@ -168,22 +185,31 @@ jobs:
           mkdir -p $REPORT_FOLDER
           cp ci/$REPORT_TEMPLATE $REPORT_FOLDER
 
-          IMAGE_NAME=${{ steps.resolve-image.outputs.image }}
-          echo "Scanning $IMAGE_NAME"
+          SCAN_TARGET=${{ steps.resolve-target.outputs.target }}
+          SCAN_TYPE=${{ steps.resolve-target.outputs.type }}
+          echo "Scanning $SCAN_TARGET ($SCAN_TYPE)"
+
+          if [[ "$SCAN_TYPE" == "image" ]]; then
+            SCAN_ARGS="--image-src podman --podman-host /var/run/podman/podman.sock"
+            PODMAN_ARGS="-v ${PODMAN_SOCK}:/var/run/podman/podman.sock"
+          elif [[ "$SCAN_TYPE" == "fs" ]]; then
+            WORKSPACE_FOLDER="/workspace"
+            SCAN_TARGET="$WORKSPACE_FOLDER/$SCAN_TARGET"
+            PODMAN_ARGS="-v ${{ github.workspace }}:$WORKSPACE_FOLDER"
+          fi
 
           # have trivy access podman socket,
           # https://github.com/aquasecurity/trivy/issues/580#issuecomment-666423279
           podman run --rm \
-              -v ${PODMAN_SOCK}:/var/run/podman/podman.sock \
+              $PODMAN_ARGS \
               -v ${REPORT_FOLDER}:/report \
               docker.io/aquasec/trivy:$TRIVY_VERSION \
-                image \
-                --image-src podman \
-                --podman-host /var/run/podman/podman.sock \
+                $SCAN_TYPE \
+                $SCAN_ARGS \
                 --scanners vuln --ignore-unfixed \
                 --exit-code 0 --timeout 30m \
                 --format template --template "@/report/$REPORT_TEMPLATE" -o /report/$REPORT_FILE \
-                $IMAGE_NAME
+                $SCAN_TARGET
 
           cat $REPORT_FOLDER/$REPORT_FILE >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Run Trivy scan `fs` instead of `image` for rocm+pytorch image due to resource constraints. At least, the daily report and PR will pass and will show the results for the lock file while we don't reduce the image size.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the updated workflow for the pytorch image and another one to check both behaviors (image and fs)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
