### PR TITLE
feat(Dockerfiles): switch from s2i python images to plain ubi/cs9 ones

### DIFF
--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -41,6 +41,7 @@ USER root
 # Install usefull OS packages
 RUN dnf install -y \
       mesa-libGL \
+      patch \
       wget \
     && dnf clean all && rm -rf /var/cache/yum
 

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -2,10 +2,11 @@ FROM quay.io/centos/centos:stream9
 
 # perform the setup that python image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
-ENV VIRTUAL_ENV="/opt/app-root"
+ENV APP_ROOT="/opt/app-root"
+ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0 ${VIRTUAL_ENV} && \
-    useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
+RUN mkdir --parents --mode 0771 "${APP_ROOT}/src" && chown --recursive 1001:0 ${APP_ROOT} && \
+    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -3,13 +3,13 @@ FROM quay.io/centos/centos:stream9
 # perform the setup that python image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV APP_ROOT="/opt/app-root"
-ENV HOME="${APP_ROOT}"
+ENV HOME="${APP_ROOT}/src"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHON_VERSION=3.9
 ENV PIP_NO_CACHE_DIR=off
-RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
-    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
+RUN mkdir --parents "${HOME}" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
+    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${HOME}" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/rpm-file-permissions /usr/bin/

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/centos/centos:stream9
 # perform the setup that python image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV APP_ROOT="/opt/app-root"
+ENV HOME="${APP_ROOT}"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHON_VERSION=3.9

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -36,7 +36,10 @@ COPY Pipfile.lock ./
 USER root
 
 # Install usefull OS packages
-RUN dnf install -y mesa-libGL && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y \
+      mesa-libGL \
+      wget \
+    && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user
 USER 1001

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -5,14 +5,16 @@ FROM quay.io/centos/centos:stream9
 ENV APP_ROOT="/opt/app-root"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN mkdir --parents --mode 0771 "${APP_ROOT}/src" && chown --recursive 1001:0 ${APP_ROOT} && \
+ENV PYTHON_VERSION=3.9
+ENV PIP_NO_CACHE_DIR=off
+RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
     useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
 
 USER 1001
-RUN python3.9 -m venv "${VIRTUAL_ENV}"
+RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-centos-stream9-python-3.9" \
       summary="Python 3.9 CentOS Stream 9 base image for ODH notebooks" \

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -4,7 +4,8 @@ FROM quay.io/centos/centos:stream9
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV VIRTUAL_ENV="/opt/app-root"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
+RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0 ${VIRTUAL_ENV} && \
+    useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0
     useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
+COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
 
 USER 1001
 RUN python3.9 -m venv "${VIRTUAL_ENV}"

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -1,4 +1,15 @@
-FROM quay.io/sclorg/python-39-c9s:c9s
+FROM quay.io/centos/centos:stream9
+
+# perform the setup that python image used to do for us
+#  but this way it uses a lot less disk space (hundreds of megabytes less)
+ENV VIRTUAL_ENV="/opt/app-root"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
+      --comment "Default Application User" --shell /bin/bash default && \
+    dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/* && \
+    python3.9 -m venv "${VIRTUAL_ENV}"
+
+USER 1001
 
 LABEL name="odh-notebook-base-centos-stream9-python-3.9" \
       summary="Python 3.9 CentOS Stream 9 base image for ODH notebooks" \

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && c
     useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
-COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
+COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/rpm-file-permissions /usr/bin/
 
 USER 1001
 RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}"

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -6,10 +6,10 @@ ENV VIRTUAL_ENV="/opt/app-root"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
       --comment "Default Application User" --shell /bin/bash default && \
-    dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/* && \
-    python3.9 -m venv "${VIRTUAL_ENV}"
+    dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 
 USER 1001
+RUN python3.9 -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-centos-stream9-python-3.9" \
       summary="Python 3.9 CentOS Stream 9 base image for ODH notebooks" \

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -5,14 +5,16 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 ENV APP_ROOT="/opt/app-root"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN mkdir --parents --mode 0771 "${APP_ROOT}/src" && chown --recursive 1001:0 ${APP_ROOT} && \
+ENV PYTHON_VERSION=3.8
+ENV PIP_NO_CACHE_DIR=off
+RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
     useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
 
 USER 1001
-RUN python3.8 -m venv "${VIRTUAL_ENV}"
+RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-ubi8-python-3.8" \
       summary="Python 3.8 base image for ODH notebooks" \

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && c
     useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
-COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
+COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/rpm-file-permissions /usr/bin/
 
 USER 1001
 RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}"

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0
     useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
+COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
 
 USER 1001
 RUN python3.8 -m venv "${VIRTUAL_ENV}"

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -2,10 +2,11 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 # perform the setup that python s2i image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
-ENV VIRTUAL_ENV="/opt/app-root"
+ENV APP_ROOT="/opt/app-root"
+ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0 ${VIRTUAL_ENV} && \
-    useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
+RUN mkdir --parents --mode 0771 "${APP_ROOT}/src" && chown --recursive 1001:0 ${APP_ROOT} && \
+    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -1,4 +1,15 @@
-FROM registry.access.redhat.com/ubi8/python-38:latest
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# perform the setup that python s2i image used to do for us
+#  but this way it uses a lot less disk space (hundreds of megabytes less)
+ENV VIRTUAL_ENV="/opt/app-root"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
+      --comment "Default Application User" --shell /bin/bash default && \
+    dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/* && \
+    python3.8 -m venv "${VIRTUAL_ENV}"
+
+USER 1001
 
 LABEL name="odh-notebook-base-ubi8-python-3.8" \
       summary="Python 3.8 base image for ODH notebooks" \

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -6,10 +6,10 @@ ENV VIRTUAL_ENV="/opt/app-root"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
       --comment "Default Application User" --shell /bin/bash default && \
-    dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/* && \
-    python3.8 -m venv "${VIRTUAL_ENV}"
+    dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
 
 USER 1001
+RUN python3.8 -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-ubi8-python-3.8" \
       summary="Python 3.8 base image for ODH notebooks" \

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -4,7 +4,8 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV VIRTUAL_ENV="/opt/app-root"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
+RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0 ${VIRTUAL_ENV} && \
+    useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
 

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -3,13 +3,13 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 # perform the setup that python s2i image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV APP_ROOT="/opt/app-root"
-ENV HOME="${APP_ROOT}"
+ENV HOME="${APP_ROOT}/src"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHON_VERSION=3.8
 ENV PIP_NO_CACHE_DIR=off
-RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
-    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
+RUN mkdir --parents "${HOME}" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
+    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${HOME}" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python38-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/rpm-file-permissions /usr/bin/

--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 # perform the setup that python s2i image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV APP_ROOT="/opt/app-root"
+ENV HOME="${APP_ROOT}"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHON_VERSION=3.8

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -41,7 +41,11 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
 USER root
 
 # Install usefull OS packages
-RUN dnf install -y mesa-libGL && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y \
+      mesa-libGL \
+      patch \
+      wget \
+    && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user
 USER 1001

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -6,10 +6,10 @@ ENV VIRTUAL_ENV="/opt/app-root"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
       --comment "Default Application User" --shell /bin/bash default && \
-    dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/* && \
-    python3.9 -m venv "${VIRTUAL_ENV}"
+    dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 
 USER 1001
+python3.9 -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -3,13 +3,13 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 # perform the setup that python s2i image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV APP_ROOT="/opt/app-root"
-ENV HOME="${APP_ROOT}"
+ENV HOME="${APP_ROOT}/src"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHON_VERSION=3.9
 ENV PIP_NO_CACHE_DIR=off
-RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
-    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
+RUN mkdir --parents "${HOME}" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
+    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${HOME}" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/rpm-file-permissions /usr/bin/

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -2,10 +2,11 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 
 # perform the setup that python s2i image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
-ENV VIRTUAL_ENV="/opt/app-root"
+ENV APP_ROOT="/opt/app-root"
+ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0 ${VIRTUAL_ENV} && \
-    useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
+RUN mkdir --parents --mode 0771 "${APP_ROOT}/src" && chown --recursive 1001:0 ${APP_ROOT} && \
+    useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -5,14 +5,16 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 ENV APP_ROOT="/opt/app-root"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN mkdir --parents --mode 0771 "${APP_ROOT}/src" && chown --recursive 1001:0 ${APP_ROOT} && \
+ENV PYTHON_VERSION=3.9
+ENV PIP_NO_CACHE_DIR=off
+RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && chown --recursive 1001:0 ${APP_ROOT} && \
     useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
 
 USER 1001
-RUN python3.9 -m venv "${VIRTUAL_ENV}"
+RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -4,12 +4,13 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV VIRTUAL_ENV="/opt/app-root"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
+RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0 ${VIRTUAL_ENV} && \
+    useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
 
 USER 1001
-python3.9 -m venv "${VIRTUAL_ENV}"
+RUN python3.9 -m venv "${VIRTUAL_ENV}"
 
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -1,4 +1,15 @@
-FROM registry.access.redhat.com/ubi9/python-39:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
+
+# perform the setup that python s2i image used to do for us
+#  but this way it uses a lot less disk space (hundreds of megabytes less)
+ENV VIRTUAL_ENV="/opt/app-root"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+RUN useradd --uid 1001 --gid 0 --create-home --base-dir / --home-dir /opt/app-root/src \
+      --comment "Default Application User" --shell /bin/bash default && \
+    dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/* && \
+    python3.9 -m venv "${VIRTUAL_ENV}"
+
+USER 1001
 
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir --parents --mode 0771 "${VIRTUAL_ENV}/src" && chown --recursive 1001:0
     useradd --uid 1001 --gid 0 --home-dir "${VIRTUAL_ENV}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
+COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
 
 USER 1001
 RUN python3.9 -m venv "${VIRTUAL_ENV}"

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 # perform the setup that python s2i image used to do for us
 #  but this way it uses a lot less disk space (hundreds of megabytes less)
 ENV APP_ROOT="/opt/app-root"
+ENV HOME="${APP_ROOT}"
 ENV VIRTUAL_ENV="${APP_ROOT}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHON_VERSION=3.9

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir --parents "${APP_ROOT}/src" && chmod --recursive 0771 ${APP_ROOT} && c
     useradd --uid 1001 --gid 0 --no-create-home --home-dir "${APP_ROOT}/src" \
       --comment "Default Application User" --shell /bin/bash default && \
     dnf install -y python3-pip && dnf clean all && rm -rf /var/cache/yum/*
-COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/fix-permissions
+COPY --from=quay.io/sclorg/s2i-core-c9s:latest /usr/bin/fix-permissions /usr/bin/rpm-file-permissions /usr/bin/
 
 USER 1001
 RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}"


### PR DESCRIPTION
## Description

The main benefit is size and cve exposure, as the python images come with packages we don't use; python and pip is enough for us.

Additionally, using plain ubi makes things more explicit.

## How Has This Been Tested?

I'll test this when making this change is planned into a sprint.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
