### PR TITLE
RHOAIENG-10783: fix(rocm): remove more files that instructlab also removes

### DIFF
--- a/rocm/ubi9-python-3.9/Dockerfile
+++ b/rocm/ubi9-python-3.9/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /opt/app-root/bin
 ARG ROCM_VERSION=6.1
 ARG AMDGPU_VERSION=6.1
 
+# default: same targets and ROCm version as https://github.com/tiran/instructlab-containers/blob/main/containers/rocm/Containerfile.c9s#L47
+ARG AMDGPU_TARGETS=gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx1030;gfx1100
+
 # Enable epel-release repositories
 
 # Install the ROCm rpms
@@ -33,7 +36,15 @@ RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "enabled=1" >> /etc/yum.repos.d/amdgpu.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo && \
     yum install -y rocm && \
-    yum clean all && rm -rf /var/cache/yum
+    yum clean all && rm -rf /var/cache/yum && \
+    # force remove 'rocm-llvm' from runtime, saves 3.6 GB on disk
+    rpm -e --nodeps rocm-llvm && \
+    # remove gfx files for unused ISAs, saves about 1.7 GB on disk
+    # sed creates regular expression '.*\(gfx900\|gfx906\|...\).*'
+    find /opt/rocm/lib/ -type f \
+        -and -name '*gfx*' \
+        -and -not -regex '.*\('$(echo $AMDGPU_TARGETS | sed -e 's/;/\\|/g' -e 's/:xnack[-+]//g')'\).*' \
+        -print0 | xargs -0 rm -v
 
 # Restore notebook user workspace
 USER 1001


### PR DESCRIPTION
* [RHOAIENG-10783](https://issues.redhat.com/browse/RHOAIENG-10783) Optimize ROCm images to reduce the size so they can be built on OpenShift CI

## Description

Turns out we can remove the llvm installation if we do it forcibly, without removing dependencies. Additionally, there are gfx files for all supported cards, so since we support less, we can remove many.

See https://github.com/tiran/instructlab-containers/blob/main/containers/rocm/Containerfile.c9s#L47

## How Has This Been Tested?

* https://github.com/opendatahub-io/notebooks/pull/652

before 
```
rocm-ubi9-python-3.9-main_37df13c29fdde3fa4f8e455d30b5bf39d80f6dfb  1f64a39a93d7  7 days ago   27.8 GB
```

after
```
rocm-ubi9-python-3.9-99b24d8574bffe38c4c480007a0cf69f9eeb48ce                     c7dfe8bee592  3 minutes ago   23 GB
```

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
