### PR TITLE
Fix reference to quay.io/repository/opendatahub on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Welcome to the OpenDataHub Notebooks repository! This repository provides a collection of notebooks tailored for data analysis, machine learning, research and coding within the OpenDataHub ecosystem. Designed to streamline data science workflows, these notebooks offer an integrated environment equipped with the latest tools and libraries. These notebooks were created to be used with OpenDataHub ecosystem with the ODH Notebook Controller as the launcher.
 
-These workbenches are available at: [quay.io/opendatahub/workbench-images](https://quay.io/opendatahub/workbench-images)
+These workbenches are available at: [quay.io/repository/opendatahub/workbench-images](https://quay.io/repository/opendatahub/workbench-images)
 
 ## Getting Started
 For a deeper understanding of the architecture underlying this repository, please explore our wiki page [Wiki](https://github.com/opendatahub-io/notebooks/wiki/Workbenches)


### PR DESCRIPTION
The README file contains a reference to the quay.io repository, but the link is currently returning 404.

The current link points to `quay.io/opendatahub/workbench-images` while the correct one should point to `quay.io/repository/opendatahub/workbench-images`

## Description
The README.md file has a reference to the repository hosted on quay.io, but if the user is using the new beta UI, then this link will return 404.

If the user is using the old UI, then a redirect happens.

If the link points to `https://quay.io/repository/opendatahub/workbench-images`, then both old and beta UI will work properly.

## How Has This Been Tested?
The test was conducted manually, with both old and new (beta) UI.

Screenshots are available with the details:

![Snapshot_2024-08-15_12-49-25](https://github.com/user-attachments/assets/3e62d228-f523-4154-9240-1c6a32ba626a)
![Snapshot_2024-08-15_12-50-05](https://github.com/user-attachments/assets/a68d3015-ab66-4b26-94da-ac51309c4711)
![Snapshot_2024-08-15_12-50-45](https://github.com/user-attachments/assets/e2b31be6-ed14-4f9a-806e-289fe266f674)

In case of old UI, a redirect occurs, so it was not possible to screenshot it.


## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] The developer has manually tested the changes and verified that the changes work
