### PR TITLE
[GHA] Pin kustomize version we use in our test to the particular version

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -116,16 +116,23 @@ jobs:
           echo "Hadolint done"
 
       # This simply checks that the manifests and respective kustomization.yaml finishes without an error.
+      # Version of the kustomize that operator use in runtime to apply these changes is determined by:
+      # https://github.com/red-hat-data-services/rhods-operator/blob/7ccc405135f99c014982d7e297b8949e970dd750/go.mod#L28-L29
+      # and then to match appropriate kustomize release https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.2
       - name: Check kustomize manifest
         id: kustomize-manifests
         run: |
-          kubectl version --client=true
+          KUSTOMIZE_VERSION=5.0.2
+          wget "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          tar -xvf kustomize*
+
+          ./kustomize version
           echo "----------------------------------------------------------"
-          echo "Starting 'kubectl kustomize manifests/base'"
+          echo "Starting './kustomize build manifests/base'"
           echo "----------------------------------------------------------"
-          kubectl kustomize manifests/base
+          ./kustomize build manifests/base
 
           echo "----------------------------------------------------------"
-          echo "Starting 'kubectl kustomize manifests/overlays/additional'"
+          echo "Starting './kustomize build manifests/overlays/additional'"
           echo "----------------------------------------------------------"
-          kubectl kustomize manifests/overlays/additional
+          ./kustomize build manifests/overlays/additional


### PR DESCRIPTION
Recently the kustomize test started to fail for us since the kustomize version 5.4 introduced some breaking changes for which we will need to update our manifests to be compatible. This work will be tracked in [1]. In the meantime, we should pin kustomize version in our GHA to the version that is used by the opendatahub-operator in runtime [2].

[1] https://issues.redhat.com/browse/RHOAIENG-11679
[2] https://github.com/red-hat-data-services/rhods-operator/blob/rhoai-2.12/go.mod#L30-L31

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
