### PR TITLE
Update runtime updater workflow to search for the  new ROCm runtimes

### DIFF
--- a/.github/workflows/runtimes-digest-updater-upstream.yaml
+++ b/.github/workflows/runtimes-digest-updater-upstream.yaml
@@ -78,7 +78,9 @@ jobs:
             "jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json"
             "jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json"
             "jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json"
-            "jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json")
+            "jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json"
+            "jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json"
+            "jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json")
 
             for ((i=0;i<${#PATHS[@]};++i)); do
               path=${PATHS[$i]}
@@ -86,15 +88,19 @@ jobs:
               name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
               py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]')
               # Handling specific cases
-              if [[ $name == *tensorflow* ]]; then
+              if [[ $name == tensorflow* ]]; then
                   name="cuda-$name"
               elif [[ $name == ubi* ]]; then
                   name="minimal-$name"
               fi
               registry=$(echo $img | cut -d '@' -f1)
               regex="^runtime-$name-$py_version-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
-              echo "CHECKING: "  $regex
               latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+              echo "CHECKING: "  $latest_tag
+              if [[ -z "$latest_tag" ]]; then
+                echo "No matching tag found"
+                exit 1
+              fi
               digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
               output=$registry@$digest
               echo "NEW: " $output


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-6445

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the runtime updater workflow to search for the  new ROCm runtimes.

## How Has This Been Tested?
Here it is a local repo that simulates the behaviour of the workflow [link](https://github.com/atheo89/autorefresh-image-digest-workflow/actions/runs/10493012688/job/29065916952)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
