### PR TITLE
Update runtimes workflow to don't break when a file doe not exists

### DIFF
--- a/.github/workflows/runtimes-digest-updater-upstream.yaml
+++ b/.github/workflows/runtimes-digest-updater-upstream.yaml
@@ -84,6 +84,12 @@ jobs:
 
             for ((i=0;i<${#PATHS[@]};++i)); do
               path=${PATHS[$i]}
+
+              if [[ ! -f "$path" ]]; then
+                echo "File $path does not exist. Skipping..."
+                continue
+              fi
+
               img=$(cat ${path} | jq -r '.metadata.image_name')
               name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
               py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]')


### PR DESCRIPTION
Update runtimes workflow to don't break when a file doe not exists

Bug found here: https://github.com/opendatahub-io/notebooks/actions/runs/10610954620/job/29409452122#step:5:78 

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
