### PR TITLE
chores: set the python 3.11 content for refresh-pipfile-lock cmd in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,6 +629,22 @@ refresh-pipfilelock-files:
 	cd runtimes/tensorflow/ubi9-python-3.9 && pipenv lock
 	cd runtimes/rocm-tensorflow/ubi9-python-3.9 && pipenv lock
 	cd runtimes/rocm-pytorch/ubi9-python-3.9 && pipenv lock
+	cd base/c9s-python-3.11 && pipenv lock
+	cd base/ubi9-python-3.11 && pipenv lock
+	cd codeserver/ubi9-python-3.11 && pipenv lock
+	cd jupyter/minimal/ubi9-python-3.11 && pipenv lock
+	cd jupyter/datascience/ubi9-python-3.11 && pipenv lock
+	cd jupyter/pytorch/ubi9-python-3.11 && pipenv lock
+	cd jupyter/tensorflow/ubi9-python-3.11 && pipenv lock
+	cd jupyter/trustyai/ubi9-python-3.11 && pipenv lock
+	cd jupyter/rocm/tensorflow/ubi9-python-3.11 && pipenv lock
+	cd jupyter/rocm/pytorch/ubi9-python-3.11 && pipenv lock
+	cd runtimes/minimal/ubi9-python-3.11 && pipenv lock
+	cd runtimes/datascience/ubi9-python-3.11 && pipenv lock
+	cd runtimes/pytorch/ubi9-python-3.11 && pipenv lock
+	cd runtimes/tensorflow/ubi9-python-3.11 && pipenv lock
+	cd runtimes/rocm-tensorflow/ubi9-python-3.11 && pipenv lock
+	cd runtimes/rocm-pytorch/ubi9-python-3.11 && pipenv lock
 
 
 	


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
set the python 3.11 content for refresh-pipfile-lock cmd in Makefile

This would help with automation github action for updating the pipfile.lock.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Execute: ` make refresh-pipfilelock-files`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
