### PR TITLE
Issue #713: fix(gha): don't crash when branch name matches file name in the repo

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -16,7 +16,8 @@ def get_github_token() -> str:
 def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     logging.debug("Getting list of changed files from git diff")
 
-    files = subprocess.check_output(["git", "diff", "--name-only", from_ref, to_ref],
+    # https://github.com/red-hat-data-services/notebooks/pull/361: add -- in case to_ref matches a file name in the repo
+    files = subprocess.check_output(["git", "diff", "--name-only", from_ref, to_ref, '--'],
                                     encoding='utf-8').splitlines()
 
     logging.debug(f"Determined {len(files)} changed files: {files[:100]} (..., printing up to 100 files)")


### PR DESCRIPTION
## Description

* Fixes #713

## How Has This Been Tested?

GHA

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
