### PR TITLE
[RHOAIENG-12621] Update the updater github action to the latest branch

### DIFF
--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -13,8 +13,8 @@ on:  # yamllint disable-line rule:truthy
 env:
   DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
   BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
-  RELEASE_VERSION_N: 2024a
-  RELEASE_VERSION_N_1: 2023b
+  RELEASE_VERSION_N: 2024b
+  RELEASE_VERSION_N_1: 2024a
 jobs:
   initialize:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -36,9 +36,9 @@ jobs:
       # Create a new branch
       - name: Create a new branch
         run: |
-         echo ${{ env.DIGEST_UPDATER_BRANCH }}
-         git checkout -b ${{ env.DIGEST_UPDATER_BRANCH }}
-         git push --set-upstream origin ${{ env.DIGEST_UPDATER_BRANCH }}
+          echo ${{ env.DIGEST_UPDATER_BRANCH }}
+          git checkout -b ${{ env.DIGEST_UPDATER_BRANCH }}
+          git push --set-upstream origin ${{ env.DIGEST_UPDATER_BRANCH }}
 
   update-n-version:
     needs: [initialize]
@@ -48,8 +48,8 @@ jobs:
     steps:
       - name: Configure Git
         run: |
-         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-         git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
 
       # Get latest build commit from the https://github.com/opendatahub-io/notebooks/${release_branch} using this as identifier for the latest tag name
       - name: Retrive latest commit hash from the release branch
@@ -65,64 +65,64 @@ jobs:
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
-      - name: Update the param.env file
+      - name: Update the params.env file
         run: |
-              PARAMS_ENV_PATH="manifests/base/params.env"
+          PARAMS_ENV_PATH="manifests/base/params.env"
 
-              echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
+          echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
 
-              # Get the complete list of images N-version to update
-              IMAGES=$(cat "${PARAMS_ENV_PATH}" | grep "\-n=" | cut -d "=" -f 1)
+          # Get the complete list of images N-version to update
+          IMAGES=$(grep "\-n=" "${PARAMS_ENV_PATH}" | cut -d "=" -f 1)
 
-              for image in ${IMAGES}; do
-                echo "CHECKING: '${image}'"
-                img=$(grep -E "${image}=" "${PARAMS_ENV_PATH}" | cut -d '=' -f2)
-                registry=$(echo "${img}" | cut -d '@' -f1)
+          for image in ${IMAGES}; do
+            echo "CHECKING: '${image}'"
+            img=$(grep -E "${image}=" "${PARAMS_ENV_PATH}" | cut -d '=' -f2)
+            registry=$(echo "${img}" | cut -d '@' -f1)
 
-                skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
+            skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
 
-                src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
-                regex="^$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
-                latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-                # use `--no-tags` for skopeo once available in newer version
-                digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')
-                output="${registry}@${digest}"
-                echo "NEW: ${output}"
-                sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
-              done
+            src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
+            regex="^$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
+            latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+            # use `--no-tags` for skopeo once available in newer version
+            digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')
+            output="${registry}@${digest}"
+            echo "NEW: ${output}"
+            sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
+          done
 
-              if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                  git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                  git add "${PARAMS_ENV_PATH}" && \
-                  git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
-                  git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
-              else
-                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
-              fi
+          if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+            git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git add "${PARAMS_ENV_PATH}" && \
+            git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+            git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+          else
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
+          fi
 
       - name: Update the commit.env file
         run: |
-            COMMIT_ENV_PATH="manifests/base/commit.env"
+          COMMIT_ENV_PATH="manifests/base/commit.env"
 
-            echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
-            # Get the complete list of images N-1-version to update
-            COMMIT=$(grep "\-n=" "${COMMIT_ENV_PATH}" | cut -d "=" -f 1)
+          echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
+          # Get the complete list of commits N-version to update
+          COMMIT=$(grep "\-n=" "${COMMIT_ENV_PATH}" | cut -d "=" -f 1)
 
-            for val in ${COMMIT}; do
-              echo "${val}"
-              sed -i "s|${val}=.*|${val}=${{ steps.hash-n.outputs.HASH_N }}|" "${COMMIT_ENV_PATH}"
-            done
+          for val in ${COMMIT}; do
+            echo "${val}"
+            sed -i "s|${val}=.*|${val}=${{ steps.hash-n.outputs.HASH_N }}|" "${COMMIT_ENV_PATH}"
+          done
 
-            if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-              git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                git add "${COMMIT_ENV_PATH}" && \
-                git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
-                git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
-            else
-              echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
-            fi
+          if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+            git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git add "${COMMIT_ENV_PATH}" && \
+            git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+            git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+          else
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
+          fi
 
   update-n-1-version:
     needs: [initialize, update-n-version]
@@ -132,8 +132,8 @@ jobs:
     steps:
       - name: Configure Git
         run: |
-         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-         git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
 
       # Get latest build commit from the https://github.com/opendatahub-io/notebooks/${release_branch} using this as identifier for the latest tag name
       - name: Retrive latest commit hash from the release branch
@@ -151,62 +151,62 @@ jobs:
 
       - name: Update the param.env file
         run: |
-              PARAMS_ENV_PATH="manifests/base/params.env"
+          PARAMS_ENV_PATH="manifests/base/params.env"
 
-              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1 }}
+          echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1 }}
 
-              # Get the complete list of images N-1-version to update
-              IMAGES=$(cat "${PARAMS_ENV_PATH}" | grep "\-n-1=" | cut -d "=" -f 1)
+          # Get the complete list of images N-1-version to update
+          IMAGES=$(grep "\-n-1=" "${PARAMS_ENV_PATH}" | cut -d "=" -f 1)
 
-              for image in ${IMAGES}; do
-                echo "CHECKING: '${image}'"
-                img=$(grep -E "${image}=" "${PARAMS_ENV_PATH}" | cut -d '=' -f2)
-                registry=$(echo "${img}" | cut -d '@' -f1)
+          for image in ${IMAGES}; do
+            echo "CHECKING: '${image}'"
+            img=$(grep -E "${image}=" "${PARAMS_ENV_PATH}" | cut -d '=' -f2)
+            registry=$(echo "${img}" | cut -d '@' -f1)
 
-                skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
+            skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
 
-                src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
-                regex="^$src_tag-${{ env.RELEASE_VERSION_N_1}}-\d+-${{ steps.hash-n-1.outputs.HASH_N_1 }}\$"
-                latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-                # use `--no-tags` for skopeo once available in newer version
-                digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')
-                output="${registry}@${digest}"
-                echo "NEW: ${output}"
-                sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
-              done
+            src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
+            regex="^$src_tag-${{ env.RELEASE_VERSION_N_1}}-\d+-${{ steps.hash-n-1.outputs.HASH_N_1 }}\$"
+            latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+            # use `--no-tags` for skopeo once available in newer version
+            digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')
+            output="${registry}@${digest}"
+            echo "NEW: ${output}"
+            sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
+          done
 
-              if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                  git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                  git add "${PARAMS_ENV_PATH}" && \
-                  git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
-                  git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
-              else
-                  echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1 }}"
-              fi
+          if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+            git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git add "${PARAMS_ENV_PATH}" && \
+            git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+            git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+          else
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1 }}"
+          fi
 
       - name: Update the commit.env file
         run: |
-              COMMIT_ENV_PATH="manifests/base/commit.env"
+          COMMIT_ENV_PATH="manifests/base/commit.env"
 
-              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1 }}
-              # Get the complete list of images N-1-version to update
-              COMMIT=$(grep "\-n-1=" "${COMMIT_ENV_PATH}" | cut -d "=" -f 1)
+          echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1 }}
+          # Get the complete list of images N-1-version to update
+          COMMIT=$(grep "\-n-1=" "${COMMIT_ENV_PATH}" | cut -d "=" -f 1)
 
-              for val in ${COMMIT}; do
-                echo "${val}"
-                sed -i "s|${val}=.*|${val}=${{ steps.hash-n-1.outputs.HASH_N_1 }}|" "${COMMIT_ENV_PATH}"
-              done
+          for val in ${COMMIT}; do
+            echo "${val}"
+            sed -i "s|${val}=.*|${val}=${{ steps.hash-n-1.outputs.HASH_N_1 }}|" "${COMMIT_ENV_PATH}"
+          done
 
-              if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                  git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-                  git add "${COMMIT_ENV_PATH}" && \
-                  git commit -m "Update image commits for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
-                  git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
-              else
-                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
-              fi
+          if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+            git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git add "${COMMIT_ENV_PATH}" && \
+            git commit -m "Update image commits for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+            git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+          else
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1 }}"
+          fi
 
   open-pull-request:
     needs: [update-n-version, update-n-1-version]
@@ -221,7 +221,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ${{ env.DIGEST_UPDATER_BRANCH }}
-          destination_branch: ${{ env.BRANCH_NAME}}
+          destination_branch: ${{ env.BRANCH_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_label: "automated pr"
           pr_title: "[Digest Updater Action] Update Notebook Images"
@@ -233,4 +233,4 @@ jobs:
             - `manifests/base/params.env` file with the latest updated SHA digests of the notebooks (N & N-1).
             - `manifests/base/commit.env` file with the latest commit (N & N-1).
 
-            :exclamation: **IMPORTANT NOTE**: Remember to delete the ` ${{ env.DIGEST_UPDATER_BRANCH }}` branch after merging the changes
+            :exclamation: **IMPORTANT NOTE**: Remember to delete the `${{ env.DIGEST_UPDATER_BRANCH }}` branch after merging the changes

--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -82,7 +82,8 @@ jobs:
             skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
 
             src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
-            regex="^$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
+            src_tag2=$(echo $src_tag | sed 's/python-3.9/python-3.11/')
+            regex="^$src_tag2-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
             latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
             # use `--no-tags` for skopeo once available in newer version
             digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')

--- a/.github/workflows/runtimes-digest-updater-upstream.yaml
+++ b/.github/workflows/runtimes-digest-updater-upstream.yaml
@@ -66,48 +66,42 @@ jobs:
 
       - name: Update Runtimes
         run: |
-            echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
-            PATHS=("jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json"
-            "jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json"
-            "jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json"
-            "jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json"
-            "jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json"
-            "jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json")
+            echo "Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}"
 
-            for ((i=0;i<${#PATHS[@]};++i)); do
-              path=${PATHS[$i]}
+            find . -name runtime-images -type d -exec find {} -type f -print \; | grep python-3.11 | while read -r path; do
+              echo "Processing the '${path}' file."
 
-              if [[ ! -f "$path" ]]; then
-                echo "File $path does not exist. Skipping..."
-                continue
-              fi
-
-              img=$(cat ${path} | jq -r '.metadata.image_name')
+              img=$(jq -r '.metadata.image_name' "${path}")
               name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
               py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]*')
               # Handling specific cases
               if [[ $name == tensorflow* ]]; then
-                  name="cuda-$name"
+                name="cuda-$name"
               elif [[ $name == ubi* ]]; then
-                  name="minimal-$name"
+                name="minimal-$name"
               fi
-              registry=$(echo $img | cut -d '@' -f1)
-              regex="^runtime-$name-$py_version-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
-              latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-              echo "CHECKING: "  $latest_tag
-              if [[ -z "$latest_tag" ]]; then
+              registry=$(echo "$img" | cut -d '@' -f1)
+              regex="^runtime-$name-$py_version-${{ env.RELEASE_VERSION_N }}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
+              latest_tag=$(skopeo inspect --retry-times 3 "docker://$img" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+              echo "CHECKING: ${latest_tag}"
+              if [[ -z "${latest_tag}" ]]; then
                 echo "No matching tag found"
                 exit 1
               fi
-              digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
-              output=$registry@$digest
-              echo "NEW: " $output
+              digest=$(skopeo inspect --retry-times 3 "docker://$registry:$latest_tag" | jq .Digest | tr -d '"')
+              output="${registry}@${digest}"
+              echo "NEW: ${output}"
               jq --arg output "$output" '.metadata.image_name = $output' "$path" > "$path.tmp" && mv "$path.tmp" "$path"
             done
+
             if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-              git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git add jupyter/datascience/* && git commit -m "Update file via  ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+              git fetch origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
+                git pull origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
+                git add jupyter/datascience/* && \
+                git commit -m "Update file via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                git push origin "${{ env.DIGEST_UPDATER_BRANCH }}"
             else
-              echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+              echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
             fi
 
   open-pull-request:
@@ -123,7 +117,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ${{ env.DIGEST_UPDATER_BRANCH }}
-          destination_branch: ${{ env.BRANCH_NAME}}
+          destination_branch: ${{ env.BRANCH_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_label: "automated pr"
           pr_title: "[Digest Updater Action] Update Runtimes Images"

--- a/.github/workflows/runtimes-digest-updater-upstream.yaml
+++ b/.github/workflows/runtimes-digest-updater-upstream.yaml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
   BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
-  RELEASE_VERSION_N: 2024a
+  RELEASE_VERSION_N: 2024b
 jobs:
   initialize:
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
 
               img=$(cat ${path} | jq -r '.metadata.image_name')
               name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
-              py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]')
+              py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]*')
               # Handling specific cases
               if [[ $name == tensorflow* ]]; then
                   name="cuda-$name"


### PR DESCRIPTION
This updates the digest updater GHA scripts for both regular workbench images and also runtime images.

On top of that, the runtime images GHA script was a bit enhanced and cleaned of a couple of shellcheck warnings (I can put it as a separate PR if it will be preferred).

https://issues.redhat.com/browse/RHOAIENG-12621

## How Has This Been Tested?
Started relevant GHA via https://github.com/jstourac/notebooks/actions

Standard workbench images:
* https://github.com/jstourac/notebooks/actions/runs/11057100656
* Resulting PR - TBD

Runtime images:
* https://github.com/jstourac/notebooks/actions/runs/11057072140
* Resulting PR - TBD

---

The GHAs failed as we don't have any 2024b builds in https://quay.io/repository/opendatahub/workbench-images?tab=tags&tag=latest --- will re-run once we have some.

Note: one can see results of the openshift-ci jobs here https://prow.ci.openshift.org/?repo=opendatahub-io%2Fnotebooks.

Also, at the moment there is one extra commit in this PR that replaces names images for version N from python-3.9 to python-3.11 because otherwise it would still search for the python-3.9 based images! Version N-1 should be good without this hack. As a result, I plan to incorporate the update for the images as a part of this PR. This hack won't be necessary in the followup updates until we change the python version again.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
