### PR TITLE
Remove unncessary one-time workaround from the digest updater GHA

### DIFF
--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -82,8 +82,7 @@ jobs:
             skopeo_metadata=$(skopeo inspect --retry-times 3 "docker://${img}")
 
             src_tag=$(echo "${skopeo_metadata}" | jq '.Env[] | select(startswith("OPENSHIFT_BUILD_NAME=")) | split("=")[1]' | tr -d '"' | sed 's/-amd64$//')
-            src_tag2=$(echo $src_tag | sed 's/python-3.9/python-3.11/')
-            regex="^$src_tag2-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
+            regex="^$src_tag-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
             latest_tag=$(echo "${skopeo_metadata}" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
             # use `--no-tags` for skopeo once available in newer version
             digest=$(skopeo inspect --retry-times 3 "docker://${registry}:${latest_tag}" | jq .Digest | tr -d '"')


### PR DESCRIPTION
This change was never intended to be merged as it was marked with the DONT COMMIT message in the draft PR. Since it got merged and the GHA has been executed updating the base images for the new N (2024b) version, we can safely remove this workaround now.

This is a followup of #716.

Note: I presume that 2024b branch manifests in this opendatahub-io org will be updated by merging changes from main to 2024b, correct? :thinking: @harshad16 If not, then this should stay open until this GHA is run over the 2024b branch also.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
