### PR TITLE
RHOAIENG-7489: Code-Server: Prevent auto updating of the pre-installed extensions

### DIFF
--- a/codeserver/ubi9-python-3.11/run-code-server.sh
+++ b/codeserver/ubi9-python-3.11/run-code-server.sh
@@ -46,7 +46,9 @@ universal_json_settings='{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3",
   "telemetry.telemetryLevel": "off",
   "telemetry.enableTelemetry": false,
-  "workbench.enableExperiments": false
+  "workbench.enableExperiments": false,
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false
 }'
 
 # Define python debuger settings

--- a/codeserver/ubi9-python-3.9/run-code-server.sh
+++ b/codeserver/ubi9-python-3.9/run-code-server.sh
@@ -46,7 +46,9 @@ universal_json_settings='{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3",
   "telemetry.telemetryLevel": "off",
   "telemetry.enableTelemetry": false,
-  "workbench.enableExperiments": false
+  "workbench.enableExperiments": false,
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false
 }'
 
 # Define python debuger settings


### PR DESCRIPTION
This PR aims to disable the auto update from installed extensions in the Code Server notebook image.

**Jira:**
- [RHOAIENG-7489 - Code-Server: Prevent auto updating of the pre-installed extensions](https://issues.redhat.com/browse/RHOAIENG-7489)

**References:**
- [Visual Studio Code - Opt out of extension updates](https://code.visualstudio.com/docs/supporting/FAQ#_opt-out-of-extension-updates)
- [Visual Studio Code - Extension auto-update](https://code.visualstudio.com/docs/editor/extension-marketplace#_extension-autoupdate)

## Description
All extensions installed on Code Server will try to update automatically. To keep stability on the deployed notebook image, we aim to disable auto-update extensions, in a way that the user will update if it's really necessary.

Before this change, the extensions were marked for auto updates, as follows:

![pre-autoupdate](https://github.com/user-attachments/assets/dbc6ff72-1cce-43cb-8ead-6ccec5962913)

After the code change, now the user can select to auto update extensions on their own, without the risk of having them updated in a not ideal timing:

![post-autoupdate](https://github.com/user-attachments/assets/636ace39-b08d-4cee-a99a-9feb6d79d884)

## How Has This Been Tested?
This has been locally tested, which consisted on running the CodeServer image locally with the following commands (example of code-server on ubi9-python-3.9, but the same command was executed for python-3.11):

```bash
$ export QUAY_IO=quay.io/{user}/workbench-images
$ export WORKBENCH_RELEASE=2024b
$ make codeserver-ubi9-python-3.9 \
       -e IMAGE_REGISTRY=$QUAY_IO \
       -e RELEASE=$WORKBENCH_RELEASE \
       -e PUSH_IMAGES=no \
       -e CONTAINER_BUILD_CACHE_ARGS=""
```

This way the image could easily be built and tested, without pushing any images to our quay repository yet.

Now you can run with Podman:

```bash
$ export LATEST_TAG=`podman images --format "{{.Repository}}:{{.Tag}}" | grep "$QUAY_IO:codeserver-ubi9-python-3.9-$WORKBENCH_RELEASE" | sort -r | head -n1 | cut -d':' -f2`
$ podman run -it -p 8787:8787 $QUAY_IO:$LATEST_TAG
```

From there, you could open up in the browser, click on the `Extensions` tab on the left and check each extension.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
