### PR TITLE
NO-JIRA: chore(gha): fix poetry install in GitHub Actions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -45,7 +45,13 @@ jobs:
 
       - name: Install poetry
         if: steps.cache-poetry-restore.outputs.cache-hit != 'true'
-        run: pip install poetry==${{ env.poetry_version }}
+        run: pipx install poetry==${{ env.poetry_version }}
+        env:
+          PIPX_HOME: /home/runner/.local/pipx
+          PIPX_BIN_DIR: /home/runner/.local/bin
+
+      - name: Check poetry is installed correctly
+        run: poetry env info
 
       - name: Save cache
         if: steps.cache-poetry-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description

Currently, `pip install` refuses to install outside of a virtual env without `--break-system-packages`.

To fix this, let's install with `pipx` and let's configure pipx for GHA caching.

## How Has This Been Tested?

GHA

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
