### PR TITLE
NO-JIRA: chore(gha): pin github runner to ubuntu-22.04 to avoid flaky failures in podman

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -18,7 +18,7 @@ name: Build & Publish Notebook Servers (TEMPLATE)
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # GitHub image registry used for storing $(CONTAINER_ENGINE)'s cache
       CACHE: "ghcr.io/${{ github.repository }}/workbench-images/build-cache"
@@ -97,6 +97,7 @@ jobs:
 
       - name: Configure Podman
         run: |
+          set -x
           mkdir -p $HOME/.config/containers/
           cp ci/cached-builds/containers.conf $HOME/.config/containers/containers.conf
           cp ci/cached-builds/storage.conf $HOME/.config/containers/storage.conf


### PR DESCRIPTION
On main, we are having a failure https://github.com/opendatahub-io/notebooks/actions/runs/11330148742

```
mount: /home/runner/.local/share/containers: mount point does not exist.
       dmesg(1) may have more information after failed mount system call.
Error: Process completed with exit code 32.
```

and then I sometimes see in `strace -f`

```
[pid  2790] write(2, "time=\"2024-10-14T15:41:51Z\" level=error msg=\"running `/usr/bin/newuidmap 2798 0 1001 1 1 165536 65536`: newuidmap: write to uid_map failed: Operation not permitted\\n\"\n", 167 <unfinished ...>
[pid  2795] futex(0xc00007dd48, FUTEX_WAIT_PRIVATE, 0, NULLtime="2024-10-14T15:41:51Z" level=error msg="running `/usr/bin/newuidmap 2798 0 1001 1 1 165536 65536`: newuidmap: write to uid_map failed: Operation not permitted\n"
```

Here's the GHA running on my fork before, notice that some builds fail and some pass, seemingly at random https://github.com/jiridanek/notebooks/actions/runs/11331224673

Here's a run with older ubuntu runner, everything passes https://github.com/jiridanek/notebooks/actions/runs/11331346965