### PR TITLE
RHOAIENG-14520: fix(vscode): change supervisord files location

### DIFF
--- a/codeserver/ubi9-python-3.11/supervisord/supervisord.conf
+++ b/codeserver/ubi9-python-3.11/supervisord/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [program:fcgiwrap]
 command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket

--- a/codeserver/ubi9-python-3.9/supervisord/supervisord.conf
+++ b/codeserver/ubi9-python-3.9/supervisord/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [program:fcgiwrap]
 command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket

--- a/rstudio/c9s-python-3.11/supervisord/supervisord.conf
+++ b/rstudio/c9s-python-3.11/supervisord/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [program:fcgiwrap]
 command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket

--- a/rstudio/c9s-python-3.9/supervisord/supervisord.conf
+++ b/rstudio/c9s-python-3.9/supervisord/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [program:fcgiwrap]
 command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket


### PR DESCRIPTION
The current supervisord configuration creates two file in /opt/app-root/src:
- supervisord.pid
- supervisord.log

This can be confusing for users, who don't know where they come from, what they do, if they can/should delete them... Especially as even if they are deleted they will keep coming back.

This PR modifies supervisord configuration to put those files under /tmp. That way they are hidden to the user, and reinitialized at each restart of the workbench (instead of having the log file growing).