### PR TITLE
RHOAIENG-14518: feat(codeserver): disable the VSCode workspace trust mechanism and the trust prompt

### DIFF
--- a/codeserver/ubi9-python-3.11/run-code-server.sh
+++ b/codeserver/ubi9-python-3.11/run-code-server.sh
@@ -8,7 +8,7 @@ source ${SCRIPT_DIR}/utils/*.sh
 run-nginx.sh &
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 
-# Add .bashrc for custom promt if not present
+# Add .bashrc for custom prompt if not present
 if [ ! -f "/opt/app-root/src/.bashrc" ]; then
   echo 'PS1="\[\033[34;1m\][\$(pwd)]\[\033[0m\]\n\[\033[1;0m\]$ \[\033[0m\]"' > /opt/app-root/src/.bashrc
 fi
@@ -42,16 +42,22 @@ create_dir_and_file() {
 # Define universal settings
 universal_dir="/opt/app-root/src/.local/share/code-server/User/"
 user_settings_filepath="${universal_dir}settings.json"
-universal_json_settings='{
+universal_json_settings='// vscode settings are written in json-with-comments
+/* https://code.visualstudio.com/docs/languages/json#_json-with-comments */
+{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3",
   "telemetry.telemetryLevel": "off",
   "telemetry.enableTelemetry": false,
   "workbench.enableExperiments": false,
   "extensions.autoCheckUpdates": false,
-  "extensions.autoUpdate": false
+  "extensions.autoUpdate": false,
+
+  // RHOAIENG-14518: Disable the "Do you trust the authors [...]" startup prompt
+  "security.workspace.trust.enabled": false,
+  "security.workspace.trust.startupPrompt": "never"
 }'
 
-# Define python debuger settings
+# Define python debugger settings
 vscode_dir="/opt/app-root/src/.vscode/"
 settings_filepath="${vscode_dir}settings.json"
 launch_filepath="${vscode_dir}launch.json"
@@ -72,7 +78,7 @@ json_settings='{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3"
 }'
 
-# Create necessary directories and files for python debuger and universal settings
+# Create necessary directories and files for python debugger and universal settings
 create_dir_and_file "$universal_dir" "$user_settings_filepath" "$universal_json_settings"
 create_dir_and_file "$vscode_dir" "$settings_filepath" "$json_settings"
 create_dir_and_file "$vscode_dir" "$launch_filepath" "$json_launch_settings"

--- a/codeserver/ubi9-python-3.9/run-code-server.sh
+++ b/codeserver/ubi9-python-3.9/run-code-server.sh
@@ -8,7 +8,7 @@ source ${SCRIPT_DIR}/utils/*.sh
 run-nginx.sh &
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 
-# Add .bashrc for custom promt if not present
+# Add .bashrc for custom prompt if not present
 if [ ! -f "/opt/app-root/src/.bashrc" ]; then
   echo 'PS1="\[\033[34;1m\][\$(pwd)]\[\033[0m\]\n\[\033[1;0m\]$ \[\033[0m\]"' > /opt/app-root/src/.bashrc
 fi
@@ -42,16 +42,22 @@ create_dir_and_file() {
 # Define universal settings
 universal_dir="/opt/app-root/src/.local/share/code-server/User/"
 user_settings_filepath="${universal_dir}settings.json"
-universal_json_settings='{
+universal_json_settings='// vscode settings are written in json-with-comments
+/* https://code.visualstudio.com/docs/languages/json#_json-with-comments */
+{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3",
   "telemetry.telemetryLevel": "off",
   "telemetry.enableTelemetry": false,
   "workbench.enableExperiments": false,
   "extensions.autoCheckUpdates": false,
-  "extensions.autoUpdate": false
+  "extensions.autoUpdate": false,
+
+  // RHOAIENG-14518: Disable the "Do you trust the authors [...]" startup prompt
+  "security.workspace.trust.enabled": false,
+  "security.workspace.trust.startupPrompt": "never"
 }'
 
-# Define python debuger settings
+# Define python debugger settings
 vscode_dir="/opt/app-root/src/.vscode/"
 settings_filepath="${vscode_dir}settings.json"
 launch_filepath="${vscode_dir}launch.json"
@@ -72,7 +78,7 @@ json_settings='{
   "python.defaultInterpreterPath": "/opt/app-root/bin/python3"
 }'
 
-# Create necessary directories and files for python debuger and universal settings
+# Create necessary directories and files for python debugger and universal settings
 create_dir_and_file "$universal_dir" "$user_settings_filepath" "$universal_json_settings"
 create_dir_and_file "$vscode_dir" "$settings_filepath" "$json_settings"
 create_dir_and_file "$vscode_dir" "$launch_filepath" "$json_launch_settings"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-14518

## Description

Trust the authors popup appears the first time user opens code-server (VSCode) workbench. It is super scary and confuses users. What is this folder /opt/app-root/src? Is a security risk for my company if I authorize this?

We are taking the decision to spare our users such considerations by removing the VSCode workspace trust completely. Therefore the workspace will be automatically trusted and user will not be prompted about no trust whatsoever.

Alternatively, same thing could've been implemented by running `code-server --disable-workspace-trust` instead of modifying settings.

I looked into the Workspace Trust Editor, https://github.com/microsoft/vscode/blob/56b535f40900080fac8202c77914c5ce49fa4aae/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts, trying to find where it stores trusted paths, since then maybe we could preconfigure /opt/app-root/src to be already trusted, but I did not find this.

## How Has This Been Tested?

* 3.9 image: quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.9-pr-754
* 3.11 image: quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.11-pr-754

I've loaded images into rhoai 2.13, checked that I don't see scary modal anymore at startup, and checked settings to see that they look like what I expected.

![Screenshot 2024-10-25 at 2 27 21 PM](https://github.com/user-attachments/assets/bfb81b83-ac06-4e61-8f01-5b061dac6830)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
