### PR TITLE
RHOAIENG-2003: feat(metadata/codeserver): update VSCode imagestream annotations with installed software

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -16,8 +16,25 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"code-server","version":"4.92"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "code-server", "version": "4.92"},
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Boto3", "version": "1.34"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Matplotlib", "version": "3.8"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.12"},
+            {"name": "Sklearn-onnx", "version": "1.16"},
+            {"name": "ipykernel", "version": "6.29"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n)
@@ -29,8 +46,26 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"code-server","version":"4.22"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "code-server", "version": "4.22"},
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Boto3", "version": "1.34"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Matplotlib", "version": "3.8"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Plotly", "version": "5.19"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.12"},
+            {"name": "Sklearn-onnx", "version": "1.16"},
+            {"name": "ipykernel", "version": "6.29"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n-1)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-2003

## Description

Took into account the good suggestions from https://issues.redhat.com/browse/RHOAIRFE-320 as well.

* The n annotations are for https://github.com/opendatahub-io/notebooks/blob/main/codeserver/ubi9-python-3.11/Pipfile
* The n-1 annotations describe https://github.com/opendatahub-io/notebooks/blob/2024a/codeserver/ubi9-python-3.9/Pipfile

I've also added the `# language=json` injection comment described at https://www.jetbrains.com/help/idea/using-language-injections.html#use-language-injection-comments. If there's something similar for people using different IDEs, we can change it for something more portable later.

Finally, I put some newlines into the annotation, to make it easier for people to read it.

![Screenshot 2024-10-29 at 1 53 18 PM](https://github.com/user-attachments/assets/da4ce0f4-a92a-41a7-8dd2-96e4164ce1d8)

## How Has This Been Tested?

I'm going to run Kustomize, copy out the rendered manifest, rename it, and put it into my cluster. Then I'll check in the dashboard how it renders.

```
oc login --web
cd manifests/base
../../kustomize-5.0.2 edit set namespace redhat-ods-application
../../kustomize-5.0.2 edit set nameprefix main-
../../kustomize-5.0.2 build . | oc apply -f -
```

![Screenshot 2024-10-29 at 4 53 35 PM](https://github.com/user-attachments/assets/bb51fc82-714b-40e1-bafe-f5e0d0b0a0bc)

![Screenshot 2024-10-29 at 4 52 58 PM](https://github.com/user-attachments/assets/82ff9301-15df-4de3-af48-5ade56c78b67)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
