### PR TITLE
RHOAIENG-15242: ref(manifests): add some newlines and indentation into the json strings with package version information

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -16,8 +16,30 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.35"},{"name":"Kafka-Python-ng","version":"2.2"},{"name":"Kfp","version":"2.9"},{"name":"Matplotlib","version":"3.9"},{"name":"Numpy","version":"2.1"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.5"},{"name":"Scipy","version":"1.14"},{"name":"Odh-Elyra","version":"4.1"},{"name":"PyMongo","version":"4.8"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.22"}, {"name":"Sklearn-onnx","version":"1.17"}, {"name":"Psycopg","version":"3.2"}, {"name":"MySQL Connector/Python","version":"9.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Boto3", "version": "1.35"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.9"},
+            {"name": "Matplotlib", "version": "3.9"},
+            {"name": "Numpy", "version": "2.1"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.5"},
+            {"name": "Scipy", "version": "1.14"},
+            {"name": "Odh-Elyra", "version": "4.1"},
+            {"name": "PyMongo", "version": "4.8"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.22"},
+            {"name": "Sklearn-onnx", "version": "1.17"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-generic-data-science-notebook-image-commit-n)
@@ -29,8 +51,30 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.34"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp","version":"2.8"},{"name":"Matplotlib","version":"3.8"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.4"},{"name":"Scipy","version":"1.12"},{"name":"Odh-Elyra","version":"3.16"},{"name":"PyMongo","version":"4.6"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.19"}, {"name":"Sklearn-onnx","version":"1.16"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.3"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Boto3", "version": "1.34"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Kfp", "version": "2.8"},
+            {"name": "Matplotlib", "version": "3.8"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.12"},
+            {"name": "Odh-Elyra", "version": "3.16"},
+            {"name": "PyMongo", "version": "4.6"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Sklearn-onnx", "version": "1.16"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.3"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-generic-data-science-notebook-image-commit-n-1)

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -17,8 +17,17 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.4"},{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"4.2"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.4"},
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-minimal-gpu-notebook-image-commit-n)
@@ -30,8 +39,18 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.1"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.6"},{"name": "Notebook","version": "6.5"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.1"},
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "3.6"},
+            {"name": "Notebook","version": "6.5"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-minimal-gpu-notebook-image-commit-n-1)

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -16,8 +16,16 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "4.2"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.2"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/default-image: "true"
@@ -30,8 +38,17 @@ spec:
         type: Source
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.6"}, {"name": "Notebook","version": "6.5"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "3.6"},
+            {"name": "Notebook","version": "6.5"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/default-image: "true"

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -17,8 +17,34 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.4"},{"name":"Python","version":"v3.11"},{"name":"PyTorch","version":"2.4"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.4"},{"name":"Tensorboard","version":"2.17"},{"name":"Boto3","version":"1.35"},{"name":"Kafka-Python-ng","version":"2.2"},{"name":"Kfp","version":"2.9"},{"name":"Matplotlib","version":"3.9"},{"name":"Numpy","version":"2.1"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.5"},{"name":"Scipy","version":"1.14"},{"name":"Odh-Elyra","version":"4.1"},{"name":"PyMongo","version":"4.8"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.22"}, {"name":"Sklearn-onnx","version":"1.17"}, {"name":"Psycopg","version":"3.2"}, {"name":"MySQL Connector/Python","version":"9.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.4"},
+            {"name": "Python", "version": "v3.11"},
+            {"name": "PyTorch", "version": "2.4"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "PyTorch", "version": "2.4"},
+            {"name": "Tensorboard", "version": "2.17"},
+            {"name": "Boto3", "version": "1.35"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.9"},
+            {"name": "Matplotlib", "version": "3.9"},
+            {"name": "Numpy", "version": "2.1"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.5"},
+            {"name": "Scipy", "version": "1.14"},
+            {"name": "Odh-Elyra", "version": "4.1"},
+            {"name": "PyMongo", "version": "4.8"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.22"},
+            {"name": "Sklearn-onnx", "version": "1.17"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-pytorch-gpu-notebook-image-commit-n)
@@ -30,8 +56,35 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.1"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"2.2"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.2"},{"name":"Tensorboard","version":"2.16"},{"name":"Boto3","version":"1.34"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp","version":"2.8"},{"name":"Matplotlib","version":"3.8"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.4"},{"name":"Scipy","version":"1.12"},{"name":"Odh-Elyra","version":"3.16"},{"name":"PyMongo","version":"4.6"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.19"}, {"name":"Sklearn-onnx","version":"1.16"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.3"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.1"},
+            {"name": "Python", "version": "v3.9"},
+            {"name": "PyTorch", "version": "2.2"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "PyTorch", "version": "2.2"},
+            {"name": "Tensorboard", "version": "2.16"},
+            {"name": "Boto3", "version": "1.34"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Kfp", "version": "2.8"},
+            {"name": "Matplotlib", "version": "3.8"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.12"},
+            {"name": "Odh-Elyra", "version": "3.16"},
+            {"name": "PyMongo", "version": "4.6"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Sklearn-onnx", "version": "1.16"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.3"}
+          ]
+
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-pytorch-gpu-notebook-image-commit-n-1)

--- a/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -17,8 +17,17 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"ROCm","version":"6.1"},{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"4.2"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "ROCm", "version": "6.1"},
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-rocm-minimal-notebook-image-commit-n)

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -17,8 +17,31 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"},{"name":"ROCm-PyTorch","version":"2.4"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"ROCm-PyTorch","version":"2.4"},{"name":"Tensorboard","version":"2.16"},{"name":"Kafka-Python-ng","version":"2.2"},{"name":"Matplotlib","version":"3.9"},{"name":"Numpy","version":"2.1"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.5"},{"name":"Scipy","version":"1.14"},{"name":"Odh-Elyra","version":"4.1"},{"name":"PyMongo","version":"4.8"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.22"}, {"name":"Sklearn-onnx","version":"1.17"}, {"name":"Psycopg","version":"3.2"}, {"name":"MySQL Connector/Python","version":"9.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.11"},
+            {"name": "ROCm-PyTorch", "version": "2.4"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "ROCm-PyTorch", "version": "2.4"},
+            {"name": "Tensorboard", "version": "2.16"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.9"},
+            {"name": "Numpy", "version": "2.1"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.5"},
+            {"name": "Scipy", "version": "1.14"},
+            {"name": "Odh-Elyra", "version": "4.1"},
+            {"name": "PyMongo", "version": "4.8"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.22"},
+            {"name": "Sklearn-onnx", "version": "1.17"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-rocm-pytorch-notebook-image-commit-n)

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -17,8 +17,31 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"},{"name":"ROCm-TensorFlow","version":"2.14"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"ROCm-TensorFlow","version":"2.14"},{"name":"Tensorboard","version":"2.14"},{"name":"Kafka-Python-ng","version":"2.2"},{"name":"Matplotlib","version":"3.9"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.5"},{"name":"Scipy","version":"1.14"},{"name":"Odh-Elyra","version":"4.1"},{"name":"PyMongo","version":"4.8"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.22"}, {"name":"Sklearn-onnx","version":"1.17"}, {"name":"Psycopg","version":"3.2"}, {"name":"MySQL Connector/Python","version":"9.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.11"},
+            {"name": "ROCm-TensorFlow", "version": "2.14"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "ROCm-TensorFlow", "version": "2.14"},
+            {"name": "Tensorboard", "version": "2.14"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.9"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.5"},
+            {"name": "Scipy", "version": "1.14"},
+            {"name": "Odh-Elyra", "version": "4.1"},
+            {"name": "PyMongo", "version": "4.8"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.22"},
+            {"name": "Sklearn-onnx", "version": "1.17"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-rocm-tensorflow-notebook-image-commit-n)

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -17,8 +17,35 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.4"},{"name":"Python","version":"v3.11"},{"name":"TensorFlow","version":"2.17"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.17"},{"name":"Tensorboard","version":"2.17"},{"name":"Nvidia-CUDA-CU12-Bundle","version":"12.3"},{"name":"Boto3","version":"1.35"},{"name":"Kafka-Python-ng","version":"2.2"},{"name":"Kfp","version":"2.5"},{"name":"Matplotlib","version":"3.9"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.5"},{"name":"Scipy","version":"1.14"},{"name":"Odh-Elyra","version":"4.1"},{"name":"PyMongo","version":"4.8"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.22"}, {"name":"Sklearn-onnx","version":"1.17"}, {"name":"Psycopg","version":"3.2"}, {"name":"MySQL Connector/Python","version":"9.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.4"},
+            {"name": "Python", "version": "v3.11"},
+            {"name": "TensorFlow", "version": "2.17"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "TensorFlow", "version": "2.17"},
+            {"name": "Tensorboard", "version": "2.17"},
+            {"name": "Nvidia-CUDA-CU12-Bundle", "version": "12.3"},
+            {"name": "Boto3", "version": "1.35"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.5"},
+            {"name": "Matplotlib", "version": "3.9"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.5"},
+            {"name": "Scipy", "version": "1.14"},
+            {"name": "Odh-Elyra", "version": "4.1"},
+            {"name": "PyMongo", "version": "4.8"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.22"},
+            {"name": "Sklearn-onnx", "version": "1.17"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-tensorflow-gpu-notebook-image-commit-n)
@@ -30,8 +57,34 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.1"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.15"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.15"},{"name":"Tensorboard","version":"2.15"},{"name":"Boto3","version":"1.34"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp","version":"2.5"},{"name":"Matplotlib","version":"3.8"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"2.2"},{"name":"Scikit-learn","version":"1.4"},{"name":"Scipy","version":"1.12"},{"name":"Odh-Elyra","version":"3.16"},{"name":"PyMongo","version":"4.6"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.19"}, {"name":"Sklearn-onnx","version":"1.16"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.3"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.1"},
+            {"name": "Python", "version": "v3.9"},
+            {"name": "TensorFlow", "version": "2.15"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "TensorFlow", "version": "2.15"},
+            {"name": "Tensorboard", "version": "2.15"},
+            {"name": "Boto3", "version": "1.34"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Kfp", "version": "2.5"},
+            {"name": "Matplotlib", "version": "3.8"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.12"},
+            {"name": "Odh-Elyra", "version": "3.16"},
+            {"name": "PyMongo", "version": "4.6"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Sklearn-onnx", "version": "1.16"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.3"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-tensorflow-gpu-notebook-image-commit-n-1)

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -16,8 +16,35 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.6"},{"name":"Transformers","version":"4.36"},{"name":"Datasets","version":"2.21"},{"name":"Accelerate","version":"0.34"},{"name":"Torch","version":"2.2"},{"name":"Boto3","version":"1.35"},{"name":"Kafka-Python-ng","version":"2.2"},{"name":"Kfp","version":"2.9"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.14"},{"name":"Odh-Elyra","version":"4.1"},{"name":"PyMongo","version":"4.8"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.22"}, {"name":"Sklearn-onnx","version":"1.17"}, {"name":"Psycopg","version":"3.2"}, {"name":"MySQL Connector/Python","version":"9.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "TrustyAI", "version": "0.6"},
+            {"name": "Transformers", "version": "4.36"},
+            {"name": "Datasets", "version": "2.21"},
+            {"name": "Accelerate", "version": "0.34"},
+            {"name": "Torch", "version": "2.2"},
+            {"name": "Boto3", "version": "1.35"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.9"},
+            {"name": "Matplotlib", "version": "3.6"},
+            {"name": "Numpy", "version": "1.24"},
+            {"name": "Pandas", "version": "1.5"},
+            {"name": "Scikit-learn", "version": "1.2"},
+            {"name": "Scipy", "version": "1.14"},
+            {"name": "Odh-Elyra", "version": "4.1"},
+            {"name": "PyMongo", "version": "4.8"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.22"},
+            {"name": "Sklearn-onnx", "version": "1.17"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-trustyai-notebook-image-commit-n)
@@ -29,8 +56,31 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.6"},{"name":"Boto3","version":"1.34"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp","version":"2.8"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.4"},{"name":"Scipy","version":"1.12"},{"name":"Odh-Elyra","version":"3.16"},{"name":"PyMongo","version":"4.6"},{"name":"Pyodbc","version":"5.1"}, {"name":"Codeflare-SDK","version":"0.19"}, {"name":"Sklearn-onnx","version":"1.16"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.3"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "TrustyAI", "version": "0.6"},
+            {"name": "Boto3", "version": "1.34"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Kfp", "version": "2.8"},
+            {"name": "Matplotlib", "version": "3.6"},
+            {"name": "Numpy", "version": "1.24"},
+            {"name": "Pandas", "version": "1.5"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.12"},
+            {"name": "Odh-Elyra", "version": "3.16"},
+            {"name": "PyMongo", "version": "4.6"},
+            {"name": "Pyodbc", "version": "5.1"},
+            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Sklearn-onnx", "version": "1.16"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.3"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-trustyai-notebook-image-commit-n-1)

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -17,8 +17,18 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.4"},{"name":"R","version":"v4.4"},{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"4.4"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.4"},
+            {"name": "R", "version": "v4.4"},
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "rstudio-server", "version": "4.4"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-rstudio-gpu-notebook-image-commit-n)
@@ -30,8 +40,18 @@ spec:
         type: Source
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.1"},{"name":"R","version":"v4.3"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"4.3"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.1"},
+            {"name": "R", "version": "v4.3"},
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "rstudio-server", "version": "4.3"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-rstudio-gpu-notebook-image-commit-n-1)

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -16,8 +16,17 @@ spec:
   tags:
     # N  Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"R","version":"v4.4"},{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"4.4"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "R", "version": "v4.4"},
+            {"name": "Python", "version": "v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "rstudio-server", "version": "4.4"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: $(odh-rstudio-notebook-image-commit-n)
@@ -29,8 +38,17 @@ spec:
         type: Source
     # N - 1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"R","version":"v4.3"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"4.3"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "R", "version": "v4.3"},
+            {"name": "Python", "version": "v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "rstudio-server", "version": "4.3"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-rstudio-notebook-image-commit-n-1)

--- a/manifests/overlays/additional/jupyter-intel-ml-notebook-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-intel-ml-notebook-imagestream.yaml
@@ -16,8 +16,31 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"Intel-ML","version":"2.14"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Intel-ML","version":"2.14"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"2.1"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.19"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.9"},
+            {"name": "Intel-ML", "version": "2.14"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Intel-ML", "version": "2.14"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Matplotlib", "version": "3.6"},
+            {"name": "Numpy", "version": "1.24"},
+            {"name": "Pandas", "version": "2.1"},
+            {"name": "Scikit-learn", "version": "1.3"},
+            {"name": "Scipy", "version": "1.11"},
+            {"name": "Elyra", "version": "3.15"},
+            {"name": "PyMongo", "version": "4.5"},
+            {"name": "Pyodbc", "version": "4.0"},
+            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Sklearn-onnx", "version": "1.15"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.0"}
+          ]
+
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: 'c010eb0'

--- a/manifests/overlays/additional/jupyter-intel-pytorch-notebook-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-intel-pytorch-notebook-imagestream.yaml
@@ -16,8 +16,31 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"Intel-PyTorch","version":"2.1"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Intel-PyTorch","version":"2.1"},{"name":"Tensorboard","version":"2.14"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.4"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.13"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.9"},
+            {"name": "Intel-PyTorch", "version": "2.1"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Intel-PyTorch", "version": "2.1"},
+            {"name": "Tensorboard", "version": "2.14"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Matplotlib", "version": "3.6"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "1.5"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.11"},
+            {"name": "Elyra", "version": "3.15"},
+            {"name": "PyMongo", "version": "4.5"},
+            {"name": "Pyodbc", "version": "4.0"},
+            {"name": "Codeflare-SDK", "version": "0.13"},
+            {"name": "Sklearn-onnx", "version": "1.15"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: 'c010eb0'

--- a/manifests/overlays/additional/jupyter-intel-tensorflow-notebook-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-intel-tensorflow-notebook-imagestream.yaml
@@ -16,8 +16,31 @@ spec:
   tags:
     # N Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"Intel-TensorFlow","version":"2.14"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Intel-TensorFlow","version":"2.14"},{"name":"Tensorboard","version":"2.14"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.26"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.4"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.13"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.9"},
+            {"name": "Intel-TensorFlow", "version": "2.14"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Intel-TensorFlow", "version": "2.14"},
+            {"name": "Tensorboard", "version": "2.14"},
+            {"name": "Kafka-Python", "version": "2.0"},
+            {"name": "Matplotlib", "version": "3.6"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "1.5"},
+            {"name": "Scikit-learn", "version": "1.4"},
+            {"name": "Scipy", "version": "1.11"},
+            {"name": "Elyra", "version": "3.15"},
+            {"name": "PyMongo", "version": "4.5"},
+            {"name": "Pyodbc", "version": "4.0"},
+            {"name": "Codeflare-SDK", "version": "0.13"},
+            {"name": "Sklearn-onnx", "version": "1.15"},
+            {"name": "Psycopg", "version": "3.1"},
+            {"name": "MySQL Connector/Python", "version": "8.0"}
+          ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
         opendatahub.io/notebook-build-commit: 'c010eb0'


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15242

## Description

Previously, we used to have every json string on a single line, which meant we had long hard-to-read lines in our manifests. Now there is some human-friendly indentation in the files so it should be easier to read.

This is to have no impact on the data stored, it is a code formatting change only.

![image](https://github.com/user-attachments/assets/d4e7eeb6-6a6d-418e-a3e9-925a4762b9b8)

## How Has This Been Tested?

I've ran the sample code from a comment on https://issues.redhat.com/browse/RHOAIENG-15333 that extracts and formats the installed software fields as a Markdown table. I then compared the outputs before and after this change, and looked for differences.

```
poetry run ci/package_versions.py > after.md
poetry run ci/package_versions.py > before.md
diff before.md after.md
```

Then I took the manifests and deployed them on some cluster

```
oc login --web
cd manifests/base
../../kustomize-5.0.2 edit set namespace redhat-ods-application
../../kustomize-5.0.2 edit set nameprefix main-
../../kustomize-5.0.2 build . | oc apply -f -
```

and then I also remembered to do it with overlays/additional images.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
