### PR TITLE
[RHOAIENG-15710] fix the version of codeflare-sdk shown for 2024.1

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -70,7 +70,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -79,7 +79,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -80,7 +80,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -76,7 +76,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}


### PR DESCRIPTION
Fix the Codeflare-SDK version for the 2024.1 images.

* [1] https://issues.redhat.com/browse/RHOAIENG-15710

I checked the actual Codeflare-SDK version via quay package metadata feature for [images in the metadata](https://github.com/opendatahub-io/notebooks/blob/a95c64cccf6bd57d9545ade1d79a2a6e73ee9ca9/manifests/base/params.env) - all that have Codeflare-SDK installed have it in version 0.21.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
