### PR TITLE
RHOAIENG-11156: Add a loading spinner to JupyterLab index page

### DIFF
--- a/jupyter/intel/ml/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.11/Dockerfile
@@ -32,6 +32,9 @@ COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
 COPY --chown=1001:0 builder /opt/app-root/builder
 COPY --chown=1001:0 utils /opt/app-root/bin/utils
 
+# Apply JupyterLab addons
+RUN /opt/app-root/bin/utils/addons/apply.sh
+
 WORKDIR /opt/app-root/src
 
 ENV JUPYTER_PRELOAD_REPOS="https://github.com/IntelAI/oneAPI-samples"

--- a/jupyter/intel/ml/ubi9-python-3.11/utils/addons/apply.sh
+++ b/jupyter/intel/ml/ubi9-python-3.11/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/intel/ml/ubi9-python-3.11/utils/addons/partial-body.html
+++ b/jupyter/intel/ml/ubi9-python-3.11/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/intel/ml/ubi9-python-3.11/utils/addons/partial-head.html
+++ b/jupyter/intel/ml/ubi9-python-3.11/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
@@ -32,6 +32,9 @@ COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
 COPY --chown=1001:0 builder /opt/app-root/builder
 COPY --chown=1001:0 utils /opt/app-root/bin/utils
 
+# Apply JupyterLab addons
+RUN /opt/app-root/bin/utils/addons/apply.sh
+
 WORKDIR /opt/app-root/src
 
 ENV JUPYTER_PRELOAD_REPOS="https://github.com/IntelAI/oneAPI-samples"

--- a/jupyter/intel/ml/ubi9-python-3.9/utils/addons/apply.sh
+++ b/jupyter/intel/ml/ubi9-python-3.9/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/intel/ml/ubi9-python-3.9/utils/addons/partial-body.html
+++ b/jupyter/intel/ml/ubi9-python-3.9/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/intel/ml/ubi9-python-3.9/utils/addons/partial-head.html
+++ b/jupyter/intel/ml/ubi9-python-3.9/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/intel/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.11/Dockerfile
@@ -65,7 +65,9 @@ RUN python3.11 -m venv ${CPU_ENV} && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     chmod -R g+w ${CPU_ENV}/lib/python3.11/site-packages && \
     fix-permissions ${CPU_ENV} -P && \
-    chmod -R g+w /opt/app-root/src
+    chmod -R g+w /opt/app-root/src && \
+    # Apply JupyterLab addons
+    /opt/app-root/bin/utils/addons/apply.sh
 
 COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/pytorch-cpu/kernel.json
 

--- a/jupyter/intel/pytorch/ubi9-python-3.11/utils/addons/apply.sh
+++ b/jupyter/intel/pytorch/ubi9-python-3.11/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/intel/pytorch/ubi9-python-3.11/utils/addons/partial-body.html
+++ b/jupyter/intel/pytorch/ubi9-python-3.11/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/intel/pytorch/ubi9-python-3.11/utils/addons/partial-head.html
+++ b/jupyter/intel/pytorch/ubi9-python-3.11/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
@@ -38,7 +38,6 @@ RUN echo "Installing softwares and packages" && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P
-    
 
 #Replacing kernel manually with oneapi variable setting script
 COPY --chown=1001:0 start-kernel /opt/app-root/bin/start-kernel
@@ -52,7 +51,7 @@ ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
 COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
-WORKDIR ${CPU_ENV} 
+WORKDIR ${CPU_ENV}
 RUN python3.9 -m venv ${CPU_ENV} && \
     chown -R 1001:0 ${CPU_ENV} && \
     fix-permissions ${CPU_ENV} -P && \
@@ -65,7 +64,9 @@ RUN python3.9 -m venv ${CPU_ENV} && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     chmod -R g+w ${CPU_ENV}/lib/python3.9/site-packages && \
     fix-permissions ${CPU_ENV} -P && \
-    chmod -R g+w /opt/app-root/src
+    chmod -R g+w /opt/app-root/src && \
+    # Apply JupyterLab addons
+    /opt/app-root/bin/utils/addons/apply.sh
 
 COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/pytorch-cpu/kernel.json
 

--- a/jupyter/intel/pytorch/ubi9-python-3.9/utils/addons/apply.sh
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/intel/pytorch/ubi9-python-3.9/utils/addons/partial-body.html
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/intel/pytorch/ubi9-python-3.9/utils/addons/partial-head.html
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/intel/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.11/Dockerfile
@@ -69,7 +69,9 @@ RUN python3.11 -m venv ${CPU_ENV} && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     chmod -R g+w ${CPU_ENV}/lib/python3.11/site-packages && \
     fix-permissions ${CPU_ENV} -P && \
-    chmod -R g+w /opt/app-root/src
+    chmod -R g+w /opt/app-root/src && \
+    # Apply JupyterLab addons
+    /opt/app-root/bin/utils/addons/apply.sh
 
 COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/tensorflow-cpu/kernel.json
 

--- a/jupyter/intel/tensorflow/ubi9-python-3.11/utils/addons/apply.sh
+++ b/jupyter/intel/tensorflow/ubi9-python-3.11/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/intel/tensorflow/ubi9-python-3.11/utils/addons/partial-body.html
+++ b/jupyter/intel/tensorflow/ubi9-python-3.11/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/intel/tensorflow/ubi9-python-3.11/utils/addons/partial-head.html
+++ b/jupyter/intel/tensorflow/ubi9-python-3.11/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
@@ -69,7 +69,9 @@ RUN python3.9 -m venv ${CPU_ENV} && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     chmod -R g+w ${CPU_ENV}/lib/python3.9/site-packages && \
     fix-permissions ${CPU_ENV} -P && \
-    chmod -R g+w /opt/app-root/src
+    chmod -R g+w /opt/app-root/src && \
+    # Apply JupyterLab addons
+    /opt/app-root/bin/utils/addons/apply.sh
 
 COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/tensorflow-cpu/kernel.json
 

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/utils/addons/apply.sh
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/utils/addons/partial-body.html
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/utils/addons/partial-head.html
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile
@@ -23,7 +23,9 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
-    fix-permissions /opt/app-root -P
+    fix-permissions /opt/app-root -P && \
+    # Apply JupyterLab addons
+    /opt/app-root/bin/utils/addons/apply.sh
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/minimal/ubi9-python-3.11/utils/addons/apply.sh
+++ b/jupyter/minimal/ubi9-python-3.11/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/minimal/ubi9-python-3.11/utils/addons/partial-body.html
+++ b/jupyter/minimal/ubi9-python-3.11/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/minimal/ubi9-python-3.11/utils/addons/partial-head.html
+++ b/jupyter/minimal/ubi9-python-3.11/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -23,7 +23,9 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
-    fix-permissions /opt/app-root -P
+    fix-permissions /opt/app-root -P && \
+    # Apply JupyterLab addons
+    /opt/app-root/bin/utils/addons/apply.sh
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/minimal/ubi9-python-3.9/utils/addons/apply.sh
+++ b/jupyter/minimal/ubi9-python-3.9/utils/addons/apply.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# See https://github.com/jupyterlab/jupyterlab/issues/5463
+# This is a hack to apply partial HTML code to JupyterLab's `index.html` file
+# Look for the other duplicates in case a change is needed to this file
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+
+static_dir="/opt/app-root/share/jupyter/lab/static"
+index_file="$static_dir/index.html"
+
+head_file="$script_dir/partial-head.html"
+body_file="$script_dir/partial-body.html"
+
+if [ ! -f "$index_file" ]; then
+  echo "File '$index_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$head_file" ]; then
+  echo "File '$head_file' not found"
+  exit 1
+fi
+
+if [ ! -f "$body_file" ]; then
+  echo "File '$body_file' not found"
+  exit 1
+fi
+
+curl -o "$static_dir/pf.css" "$pf_url"
+
+head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
+body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
+
+perl -i -0pe "s|</head>|$head_content\n</head>|" "$index_file"
+perl -i -0pe "s|</body>|$body_content\n</body>|" "$index_file"
+
+echo "Content from partial HTML files successfully injected into JupyterLab's 'index.html' file"

--- a/jupyter/minimal/ubi9-python-3.9/utils/addons/partial-body.html
+++ b/jupyter/minimal/ubi9-python-3.9/utils/addons/partial-body.html
@@ -1,0 +1,23 @@
+<div id="loading-container">
+  <svg
+    class="pf-v6-c-spinner"
+    role="progressbar"
+    viewBox="0 0 100 100"
+    aria-label="Loading..."
+  >
+    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+  </svg>
+</div>
+
+<script>
+  function checkForTargetElement() {
+    const targetElement = document.querySelector(".lm-Widget.jp-LabShell#main");
+    const loadingContainer = document.getElementById("loading-container");
+    if (targetElement && loadingContainer) {
+      loadingContainer.remove();
+      return;
+    }
+    requestAnimationFrame(checkForTargetElement);
+  }
+  requestAnimationFrame(checkForTargetElement);
+</script>

--- a/jupyter/minimal/ubi9-python-3.9/utils/addons/partial-head.html
+++ b/jupyter/minimal/ubi9-python-3.9/utils/addons/partial-head.html
@@ -1,0 +1,14 @@
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{page_config.fullStaticUrl}}/pf.css"
+/>
+<style>
+  #loading-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://issues.redhat.com/browse/RHOAIENG-11156

## Description
<!--- Describe your changes in detail -->
This PR includes a script to inject a simple loading spinner into JupyterLab's `index.html` page. The script runs as part of the build image process. The set of necessary files had to be duplicated to be present on all JupyterLab-based images. The duplication can be removed as part of [this task](https://issues.redhat.com/browse/RHOAIENG-11274). 

This is a workaround; ideally, it should be handled at https://github.com/jupyterlab/jupyterlab/issues/5463.

Demo (cache disabled + Fast 4G):

https://github.com/user-attachments/assets/4d2ffc46-33c8-4f64-a34c-1982f1598384

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run a JupyterLab-based image from this PR, for instance:
```bash
podman|docker run -p 8888:8888 ghcr.io/caponetto/opendatahub-io-notebooks/workbench-images:jupyter-intel-ml-ubi9-python-3.9-RHOAIENG-11156_80df8ffc8ea12f30a5727d91a6befe0fa8a3bfb3

podman|docker run -p 8888:8888 ghcr.io/caponetto/opendatahub-io-notebooks/workbench-images:jupyter-trustyai-ubi9-python-3.11-RHOAIENG-11156_80df8ffc8ea12f30a5727d91a6befe0fa8a3bfb3 
```
Wait for the image to start and open JupyterLab URL (the URL with token appears in the terminal):
```
http://127.0.0.1:8888/lab?token=XXXXXX
```
Once opened, you should see a loading spinner instead of a blank screen. If you're using Chrome, you can open DevTools and go to the Network tab to disable cache and select Fast/Slow 4G, which slows down everything.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
