### PR TITLE
RHOAIENG-16076: tests(gha): pre-pull trivy vulnerabilities db to prevent failures to download later

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -115,9 +115,43 @@ jobs:
           systemctl --user start homebrew.podman.service
           echo "PODMAN_SOCK=/run/user/${UID}/podman/podman.sock" >> $GITHUB_ENV
 
+      - name: "pull_request|schedule: resolve target if Trivy scan should run"
+        id: resolve-target
+        if: ${{ fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'schedule' }}
+        env:
+          EVENT_NAME: ${{ fromJson(inputs.github).event_name }}
+          HAS_TRIVY_LABEL: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
+          FS_SCAN_FOLDER: ${{ fromJson(env.TRIVY_SCAN_FS_JSON)[inputs.target] }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" && "$HAS_TRIVY_LABEL" == "true" ]]; then
+            if [[ -n "$FS_SCAN_FOLDER" ]]; then
+              TARGET="$FS_SCAN_FOLDER"
+              TYPE="fs"
+            else
+              TARGET="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.sha }}"
+              TYPE="image"
+            fi
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            if [[ -n "$FS_SCAN_FOLDER" ]]; then
+              TARGET="$FS_SCAN_FOLDER"
+              TYPE="fs"
+            else
+              TARGET="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}"
+              TYPE="image"
+            fi
+          fi
+
+          if [[ -n "$TARGET" ]]; then
+            echo "target=$TARGET" >> $GITHUB_OUTPUT
+            echo "type=$TYPE" >> $GITHUB_OUTPUT
+            echo "Trivy scan will run on $TARGET ($TYPE)"
+          else
+            echo "Trivy scan won't run"
+          fi
+
       # only one db can be downloaded in one call https://github.com/aquasecurity/trivy/issues/3616
       - name: Pre-pull Trivy vulnerabilities DB
-        if: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
+        if: ${{ steps.resolve-target.outputs.target }}
         run: |
           mkdir trivy_db
           podman run --rm \
@@ -162,40 +196,6 @@ jobs:
 
       - name: "Show podman images information"
         run: podman images --digests
-
-      - name: "pull_request|schedule: resolve target if Trivy scan should run"
-        id: resolve-target
-        if: ${{ fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'schedule' }}
-        env:
-          EVENT_NAME: ${{ fromJson(inputs.github).event_name }}
-          HAS_TRIVY_LABEL: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
-          FS_SCAN_FOLDER: ${{ fromJson(env.TRIVY_SCAN_FS_JSON)[inputs.target] }}
-        run: |
-          if [[ "$EVENT_NAME" == "pull_request" && "$HAS_TRIVY_LABEL" == "true" ]]; then
-            if [[ -n "$FS_SCAN_FOLDER" ]]; then
-              TARGET="$FS_SCAN_FOLDER"
-              TYPE="fs"
-            else
-              TARGET="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.sha }}"
-              TYPE="image"
-            fi
-          elif [[ "$EVENT_NAME" == "schedule" ]]; then
-            if [[ -n "$FS_SCAN_FOLDER" ]]; then
-              TARGET="$FS_SCAN_FOLDER"
-              TYPE="fs"
-            else
-              TARGET="ghcr.io/${{ github.repository }}/workbench-images:${{ inputs.target }}-${{ github.ref_name }}_${{ github.sha }}"
-              TYPE="image"
-            fi
-          fi
-
-          if [[ -n "$TARGET" ]]; then
-            echo "target=$TARGET" >> $GITHUB_OUTPUT
-            echo "type=$TYPE" >> $GITHUB_OUTPUT
-            echo "Trivy scan will run on $TARGET ($TYPE)"
-          else
-            echo "Trivy scan won't run"
-          fi
 
       - name: Run Trivy vulnerability scanner
         if: ${{ steps.resolve-target.outputs.target }}

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -22,6 +22,7 @@ jobs:
     env:
       # GitHub image registry used for storing $(CONTAINER_ENGINE)'s cache
       CACHE: "ghcr.io/${{ github.repository }}/workbench-images/build-cache"
+      TRIVY_VERSION: 0.57.1
       # Targets (and their folder) that should be scanned using FS instead of IMAGE scan due to resource constraints
       TRIVY_SCAN_FS_JSON: '{}'
 
@@ -114,6 +115,26 @@ jobs:
           systemctl --user start homebrew.podman.service
           echo "PODMAN_SOCK=/run/user/${UID}/podman/podman.sock" >> $GITHUB_ENV
 
+      # only one db can be downloaded in one call https://github.com/aquasecurity/trivy/issues/3616
+      - name: Pre-pull Trivy vulnerabilities DB
+        if: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
+        run: |
+          mkdir trivy_db
+          podman run --rm \
+            --env PODMAN_SOCK \
+            -v ${PWD}/trivy_db:/cache \
+            docker.io/aquasec/trivy:$TRIVY_VERSION \
+              --cache-dir /cache \
+              image \
+              --download-db-only
+          podman run --rm \
+            --env PODMAN_SOCK \
+            -v ${PWD}/trivy_db:/cache \
+            docker.io/aquasec/trivy:$TRIVY_VERSION \
+              --cache-dir /cache \
+              image \
+              --download-java-db-only
+
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
       - name: "push|schedule: make ${{ inputs.target }}"
         run: |
@@ -179,7 +200,6 @@ jobs:
       - name: Run Trivy vulnerability scanner
         if: ${{ steps.resolve-target.outputs.target }}
         run: |
-          TRIVY_VERSION=0.53.0
           REPORT_FOLDER=${{ github.workspace }}/report
           REPORT_FILE=trivy-report.md
           REPORT_TEMPLATE=trivy-markdown.tpl
@@ -205,9 +225,12 @@ jobs:
           podman run --rm \
               $PODMAN_ARGS \
               -v ${REPORT_FOLDER}:/report \
+              -v ${PWD}/trivy_db:/cache \
               docker.io/aquasec/trivy:$TRIVY_VERSION \
+                --cache-dir /cache \
                 $SCAN_TYPE \
                 $SCAN_ARGS \
+                --skip-db-update \
                 --scanners vuln --ignore-unfixed \
                 --exit-code 0 --timeout 30m \
                 --format template --template "@/report/$REPORT_TEMPLATE" -o /report/$REPORT_FILE \


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16076

## Description

Another chunk of the

* https://github.com/opendatahub-io/notebooks/pull/775

changes to be reviewed and merged.

Turns out that Trivy does not fail to pull the db if the pull happens soon enough after the GHA starts.

## How Has This Been Tested?

GHA

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
