### PR TITLE
RHOAIENG-16149: chore(Makefile) download arch-appropriate version of kubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else
 	WHERE_WHICH ?= which
 endif
 
+# linux/amd64 or darwin/arm64
+OS_ARCH=$(shell go env GOOS)/$(shell go env GOARCH)
+
 IMAGE_TAG		 ?= $(RELEASE)_$(DATE)
 KUBECTL_BIN      ?= bin/kubectl
 KUBECTL_VERSION  ?= v1.23.11
@@ -404,7 +407,7 @@ rocm-runtime-tensorflow-ubi9-python-3.11: rocm-ubi9-python-3.11
 bin/kubectl:
 ifeq (,$(wildcard $(KUBECTL_BIN)))
 	@mkdir -p bin
-	@curl -sSL https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl > \
+	@curl -sSL https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OS_ARCH)/kubectl > \
 		$(KUBECTL_BIN)
 	@chmod +x $(KUBECTL_BIN)
 endif


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16149

## Description

The kubectl binary is arch dependent. Download the correct one for the machine.

## How Has This Been Tested?
```
$ rm bin/kubectl
$ gmake bin/kubectl
$ bin/kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.11", GitCommit:"dc2898b20c6bd9602ae1c3b51333e2e4640ed249", GitTreeState:"clean", BuildDate:"2022-09-14T16:40:13Z", GoVersion:"go1.17.13", Compiler:"gc", Platform:"darwin/arm64"}
Server Version: version.Info{Major:"1", Minor:"31", GitVersion:"v1.31.2", GitCommit:"5864a4677267e6adeae276ad85882a8714d69d9d", GitTreeState:"clean", BuildDate:"2024-11-08T19:40:38Z", GoVersion:"go1.22.8", Compiler:"gc", Platform:"linux/arm64"}
WARNING: version difference between client (1.23) and server (1.31) exceeds the supported minor version skew of +/-1
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
