### PR TITLE
RHOAIENG-16076: tests(gha): mount the lvm volume with performance flags

### DIFF
--- a/ci/cached-builds/gha_lvm_overlay.sh
+++ b/ci/cached-builds/gha_lvm_overlay.sh
@@ -64,7 +64,9 @@ if [[ ${overprovision_lvm} == 'true' ]]; then
 else
   sudo mkfs.ext4 -Enodiscard -m0 "/dev/mapper/${VG_NAME}-buildlv"
 fi
-sudo mount "/dev/mapper/${VG_NAME}-buildlv" "${build_mount_path}"
+mkdir -p "${build_mount_path}"
+# https://www.alibabacloud.com/help/en/ecs/use-cases/mount-parameters-for-ext4-file-systems?spm=a2c63.p38356.help-menu-25365.d_5_10_12.48ce3be5RixoUB#8e740ed072m5o
+sudo mount -o defaults,noatime,nodiratime,nobarrier,nodelalloc,data=writeback "/dev/mapper/${VG_NAME}-buildlv" "${build_mount_path}"
 sudo chown -R "${build_mount_path_ownership}" "${build_mount_path}"
 
 # if build mount path is a parent of $GITHUB_WORKSPACE, and has been deleted, recreate it


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16076

Another chunk of the

* https://github.com/opendatahub-io/notebooks/pull/775

changes to be reviewed and merged.

## Description

I did not actually benchmark this, and the speed of the disk does not matter much, but since I found a guide and the suggested options look reasonable, and they don't break anything functionally, then, why not?

## How Has This Been Tested?

GHA

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
