### PR TITLE
RHOAIENG-16403: chore(Makefile): implement `.ONESHELL:` and `.SHELLFLAGS := -eu -o pipefail -c` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # https://tech.davis-hansson.com/p/make/
 SHELL := bash
-# todo: do not set .ONESHELL: for now
+.ONESHELL:
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
-#.SHELLFLAGS := -eu -o pipefail -c
+.SHELLFLAGS := -eu -o pipefail -c
 .DELETE_ON_ERROR:
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16403

## Description

https://tech.davis-hansson.com/p/make/ says all this is a good idea

Currently we have this
* https://github.com/opendatahub-io/notebooks/pull/778

{code}
# https://tech.davis-hansson.com/p/make/
SHELL := bash
# todo: do not set .ONESHELL: for now
# http://redsymbol.net/articles/unofficial-bash-strict-mode/
#.SHELLFLAGS := -eu -o pipefail -c
.DELETE_ON_ERROR:
MAKEFLAGS += --warn-undefined-variables
MAKEFLAGS += --no-builtin-rules

# todo: leave the default recipe prefix for now
ifeq ($(origin .RECIPEPREFIX), undefined)
  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later)
endif
.RECIPEPREFIX =
{code}

Let's uncomment the shell-related parts.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/12135631481

It causes a failure in all python 3.9 workbenches,

```
Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)
[...]
command terminated with exit code 1
make: *** [Makefile:495: test-jupyter-minimal-ubi9-python-3.9] Error 1
```

Maybe they all _should_ fail?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
