### PR TITLE
RHOAIENG-11274: chore(Makefile): widen the container build context to the whole repo, so we can start reusing code between images in the future

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git/
+.idea/
+.venv/
+bin/
+ci/
+tests/
+
+**/.mypy_cache/
+**/.pytest_cache/
+**/__pycache__/
+**/*.pyc
+
+**/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# https://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
+ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
 # https://tech.davis-hansson.com/p/make/
 SHELL := bash
 # todo: do not set .ONESHELL: for now
@@ -65,7 +68,7 @@ define build_image
 		$(eval BUILD_ARGS := --build-arg BASE_IMAGE=$(BASE_IMAGE_NAME)),
 		$(eval BUILD_ARGS :=)
 	)
-	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS)  -t $(IMAGE_NAME) $(BUILD_ARGS)  $(2)
+	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) --tag $(IMAGE_NAME) --file $(2)/Dockerfile $(BUILD_ARGS) $(ROOT_DIR)/
 endef
 
 # Push function for the notebok image:

--- a/base/c9s-python-3.11/Dockerfile
+++ b/base/c9s-python-3.11/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/sclorg/python-311-c9s:c9s
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-base-centos-stream9-python-3.11" \
       summary="Python 3.11 CentOS Stream 9 base image for ODH notebooks" \
       description="Base Python 3.11 builder image based on CentOS Stream 9 for ODH notebooks" \
@@ -16,7 +18,7 @@ WORKDIR /opt/app-root/bin
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 # OS Packages needs to be installed as root
 USER root

--- a/base/c9s-python-3.11/Dockerfile
+++ b/base/c9s-python-3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/sclorg/python-311-c9s:c9s
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=base/c9s-python-3.11
 
 LABEL name="odh-notebook-base-centos-stream9-python-3.11" \
       summary="Python 3.11 CentOS Stream 9 base image for ODH notebooks" \

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/sclorg/python-39-c9s:c9s
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=base/c9s-python-3.9
 
 LABEL name="odh-notebook-base-centos-stream9-python-3.9" \
       summary="Python 3.9 CentOS Stream 9 base image for ODH notebooks" \

--- a/base/c9s-python-3.9/Dockerfile
+++ b/base/c9s-python-3.9/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/sclorg/python-39-c9s:c9s
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-base-centos-stream9-python-3.9" \
       summary="Python 3.9 CentOS Stream 9 base image for ODH notebooks" \
       description="Base Python 3.9 builder image based on CentOS Stream 9 for ODH notebooks" \
@@ -16,7 +18,7 @@ WORKDIR /opt/app-root/bin
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 # OS Packages needs to be installed as root
 USER root

--- a/base/ubi9-python-3.11/Dockerfile
+++ b/base/ubi9-python-3.11/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-311:latest
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-base-ubi9-python-3.11" \
       summary="Python 3.11 base image for ODH notebooks" \
       description="Base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -16,7 +18,7 @@ WORKDIR /opt/app-root/bin
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 

--- a/base/ubi9-python-3.11/Dockerfile
+++ b/base/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/python-311:latest
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=base/ubi9-python-3.11
 
 LABEL name="odh-notebook-base-ubi9-python-3.11" \
       summary="Python 3.11 base image for ODH notebooks" \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/python-39:latest
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=base/ubi9-python-3.9
 
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-39:latest
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \
       description="Base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -16,7 +18,7 @@ WORKDIR /opt/app-root/bin
 RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 

--- a/codeserver/ubi9-python-3.11/Dockerfile
+++ b/codeserver/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=codeserver/ubi9-python-3.11
 ARG CODESERVER_VERSION=v4.92.2
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.11" \

--- a/codeserver/ubi9-python-3.11/Dockerfile
+++ b/codeserver/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
 ARG CODESERVER_VERSION=v4.92.2
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.11" \
@@ -18,7 +19,7 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Install usefull packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
@@ -39,7 +40,7 @@ RUN yum install -y "https://github.com/coder/code-server/releases/download/${COD
 RUN chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P
 
-COPY --chown=1001:0 utils utils/
+COPY --chown=1001:0 ${SOURCE_CODE}/utils utils/
 
 # Create and intall the extensions though build-time on a temporary directory. Later this directory will copied on the `/opt/app-root/src/.local/share/code-server/extensions` via run-code-server.sh file when it starts up.
 RUN mkdir -p /opt/app-root/extensions-temp && \
@@ -64,10 +65,10 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
 
-COPY --chown=1001:0 supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY --chown=1001:0 ${SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY nginx/root/ /
+COPY ${SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model
@@ -104,12 +105,12 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
     chown -R 1001:0 /opt/app-root/src/.config/code-server
 
 ## Configure nginx
-COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
-COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
-COPY nginx/api/ /opt/app-root/api/
+COPY ${SOURCE_CODE}/nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY ${SOURCE_CODE}/nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY ${SOURCE_CODE}/nginx/api/ /opt/app-root/api/
 
 # Launcher
-COPY --chown=1001:0 run-code-server.sh run-nginx.sh ./
+COPY --chown=1001:0 ${SOURCE_CODE}/run-code-server.sh ${SOURCE_CODE}/run-nginx.sh ./
 
 ENV SHELL /bin/bash
 

--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
 ARG CODESERVER_VERSION=v4.92.2
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.9" \
@@ -18,7 +19,7 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Install usefull packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
@@ -39,7 +40,7 @@ RUN yum install -y "https://github.com/coder/code-server/releases/download/${COD
 RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P
 
-COPY --chown=1001:0 utils utils/
+COPY --chown=1001:0 ${SOURCE_CODE}/utils utils/
 
 # Create and intall the extensions though build-time on a temporary directory. Later this directory will copied on the `/opt/app-root/src/.local/share/code-server/extensions` via run-code-server.sh file when it starts up.
 RUN mkdir -p /opt/app-root/extensions-temp && \
@@ -64,10 +65,10 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
 
-COPY --chown=1001:0 supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY --chown=1001:0 ${SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY nginx/root/ /
+COPY ${SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model
@@ -104,12 +105,12 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
     chown -R 1001:0 /opt/app-root/src/.config/code-server
 
 ## Configure nginx
-COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
-COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
-COPY nginx/api/ /opt/app-root/api/
+COPY ${SOURCE_CODE}/nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY ${SOURCE_CODE}/nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY ${SOURCE_CODE}/nginx/api/ /opt/app-root/api/
 
 # Launcher
-COPY --chown=1001:0 run-code-server.sh run-nginx.sh ./
+COPY --chown=1001:0 ${SOURCE_CODE}/run-code-server.sh ${SOURCE_CODE}/run-nginx.sh ./
 
 ENV SHELL /bin/bash
 

--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=codeserver/ubi9-python-3.9
 ARG CODESERVER_VERSION=v4.92.2
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.9" \

--- a/cuda/c9s-python-3.11/Dockerfile
+++ b/cuda/c9s-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-c9s-python-3.11" \
       summary="CUDA Python 3.11 base image for ODH notebooks" \
       description="CUDA Python 3.11 builder image based on CentOS Stream 9 for ODH notebooks" \
@@ -20,7 +22,7 @@ ENV NVARCH x86_64
 ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
 ENV NV_CUDA_CUDART_VERSION 12.1.105-1
 
-COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+COPY ${SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
@@ -42,7 +44,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
-COPY NGC-DL-CONTAINER-LICENSE /
+COPY ${SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/cuda/c9s-python-3.11/Dockerfile
+++ b/cuda/c9s-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=cuda/c9s-python-3.11
 
 LABEL name="odh-notebook-cuda-c9s-python-3.11" \
       summary="CUDA Python 3.11 base image for ODH notebooks" \

--- a/cuda/c9s-python-3.9/Dockerfile
+++ b/cuda/c9s-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=cuda/c9s-python-3.9
 
 LABEL name="odh-notebook-cuda-c9s-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \

--- a/cuda/c9s-python-3.9/Dockerfile
+++ b/cuda/c9s-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-c9s-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \
       description="CUDA Python 3.9 builder image based on CentOS Stream 9 for ODH notebooks" \
@@ -20,7 +22,7 @@ ENV NVARCH x86_64
 ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
 ENV NV_CUDA_CUDART_VERSION 12.1.105-1
 
-COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+COPY ${SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
@@ -42,7 +44,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
-COPY NGC-DL-CONTAINER-LICENSE /
+COPY ${SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/cuda/ubi9-python-3.11/Dockerfile
+++ b/cuda/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=cuda/ubi9-python-3.11
 
 LABEL name="odh-notebook-cuda-ubi9-python-3.11" \
       summary="CUDA Python 3.11 base image for ODH notebooks" \

--- a/cuda/ubi9-python-3.11/Dockerfile
+++ b/cuda/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-ubi9-python-3.11" \
       summary="CUDA Python 3.11 base image for ODH notebooks" \
       description="CUDA Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -20,7 +22,7 @@ ENV NVARCH x86_64
 ENV NVIDIA_REQUIRE_CUDA "cuda>=12.4 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526 brand=tesla,driver>=535,driver<536 brand=unknown,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=geforce,driver>=535,driver<536 brand=geforcertx,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=titan,driver>=535,driver<536 brand=titanrtx,driver>=535,driver<536"
 ENV NV_CUDA_CUDART_VERSION 12.4.127-1
 
-COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+COPY ${SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
@@ -42,7 +44,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
-COPY NGC-DL-CONTAINER-LICENSE /
+COPY ${SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/cuda/ubi9-python-3.9/Dockerfile
+++ b/cuda/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-ubi9-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \
       description="CUDA Python 3.9 builder image based on UBI8 for ODH notebooks" \
@@ -20,7 +22,7 @@ ENV NVARCH x86_64
 ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
 ENV NV_CUDA_CUDART_VERSION 12.1.105-1
 
-COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+COPY ${SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
@@ -42,7 +44,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
-COPY NGC-DL-CONTAINER-LICENSE /
+COPY ${SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/cuda/ubi9-python-3.9/Dockerfile
+++ b/cuda/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=cuda/ubi9-python-3.9
 
 LABEL name="odh-notebook-cuda-ubi9-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \

--- a/intel/base/gpu/ubi9-python-3.11/Dockerfile
+++ b/intel/base/gpu/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/base/gpu/ubi9-python-3.11
 
 LABEL name="odh-notebook-intel-base-gpu-ubi9-python-3.11" \
       summary="Intel® XPU base image for ODH notebooks based on ubi9" \

--- a/intel/base/gpu/ubi9-python-3.11/Dockerfile
+++ b/intel/base/gpu/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-base-gpu-ubi9-python-3.11" \
       summary="Intel® XPU base image for ODH notebooks based on ubi9" \
       description="Base Intel® XPU base image builder image based on ubi9 for ODH notebooks" \

--- a/intel/base/gpu/ubi9-python-3.9/Dockerfile
+++ b/intel/base/gpu/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/base/gpu/ubi9-python-3.9
 
 LABEL name="odh-notebook-intel-base-gpu-ubi9-python-3.9" \
       summary="Intel® XPU base image for ODH notebooks based on ubi9" \

--- a/intel/base/gpu/ubi9-python-3.9/Dockerfile
+++ b/intel/base/gpu/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-base-gpu-ubi9-python-3.9" \
       summary="Intel® XPU base image for ODH notebooks based on ubi9" \
       description="Base Intel® XPU base image builder image based on ubi9 for ODH notebooks" \

--- a/intel/runtimes/ml/ubi9-python-3.11/Dockerfile
+++ b/intel/runtimes/ml/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/runtimes/ml/ubi9-python-3.11
 
 LABEL name="odh-notebook-intel-runtime-ml-ubi9-python-3.11" \
     summary="Runtime Intel® optimized ML notebook image for ODH notebooks" \

--- a/intel/runtimes/ml/ubi9-python-3.11/Dockerfile
+++ b/intel/runtimes/ml/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-runtime-ml-ubi9-python-3.11" \
     summary="Runtime Intel® optimized ML notebook image for ODH notebooks" \
     description="Runtime Intel® optimized ML notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,12 +16,12 @@ LABEL name="odh-notebook-intel-runtime-ml-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock Pipfile.lock
 
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils utils
+COPY ${SOURCE_CODE}/utils utils
 
-COPY --chown=1001:0 .patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
+COPY --chown=1001:0 ${SOURCE_CODE}/.patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
 ENV PYTHONSTARTUP="/opt/app-root/bin/.patch_sklearn.py"
 
 #Virtualenv creates a symlink of lib to lib64. That causes issues with importing ITEX since both locations will have ITEX library and it will conflict.

--- a/intel/runtimes/ml/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/ml/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/runtimes/ml/ubi9-python-3.9
 
 LABEL name="odh-notebook-intel-runtime-ml-ubi9-python-3.9" \
     summary="Runtime Intel® optimized ML notebook image for ODH notebooks" \

--- a/intel/runtimes/ml/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/ml/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-runtime-ml-ubi9-python-3.9" \
     summary="Runtime Intel® optimized ML notebook image for ODH notebooks" \
     description="Runtime Intel® optimized ML notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,12 +16,12 @@ LABEL name="odh-notebook-intel-runtime-ml-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock Pipfile.lock
 
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils utils
+COPY ${SOURCE_CODE}/utils utils
 
-COPY --chown=1001:0 .patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
+COPY --chown=1001:0 ${SOURCE_CODE}/.patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
 ENV PYTHONSTARTUP="/opt/app-root/bin/.patch_sklearn.py"
 
 #Virtualenv creates a symlink of lib to lib64. That causes issues with importing ITEX since both locations will have ITEX library and it will conflict.

--- a/intel/runtimes/pytorch/ubi9-python-3.11/Dockerfile
+++ b/intel/runtimes/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-runtime-pytorch-ubi9-python-3.11" \
     summary="Runtime Intel® optimized pytorch notebook image for ODH notebooks" \
     description="Runtime Intel® optimized pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-intel-runtime-pytorch-ubi9-python-3.11" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,10 +31,10 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils utils
+COPY ${SOURCE_CODE}/utils utils
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
@@ -44,7 +46,7 @@ RUN echo "Installing softwares and packages" && \
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
 
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 #CPU env
 WORKDIR ${CPU_ENV}

--- a/intel/runtimes/pytorch/ubi9-python-3.11/Dockerfile
+++ b/intel/runtimes/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/runtimes/pytorch/ubi9-python-3.11
 
 LABEL name="odh-notebook-intel-runtime-pytorch-ubi9-python-3.11" \
     summary="Runtime Intel® optimized pytorch notebook image for ODH notebooks" \

--- a/intel/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-runtime-pytorch-ubi9-python-3.9" \
     summary="Runtime Intel® optimized pytorch notebook image for ODH notebooks" \
     description="Runtime Intel® optimized pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-intel-runtime-pytorch-ubi9-python-3.9" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,10 +31,10 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils utils
+COPY ${SOURCE_CODE}/utils utils
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
@@ -44,7 +46,7 @@ RUN echo "Installing softwares and packages" && \
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
 
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 #CPU env
 WORKDIR ${CPU_ENV}

--- a/intel/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/runtimes/pytorch/ubi9-python-3.9
 
 LABEL name="odh-notebook-intel-runtime-pytorch-ubi9-python-3.9" \
     summary="Runtime Intel® optimized pytorch notebook image for ODH notebooks" \

--- a/intel/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/intel/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-runtime-tensorflow-ubi9-python-3.11" \
     summary="Runtime Intel® optimized TensorFlow notebook image for ODH notebooks" \
     description="Runtime Intel® optimized TesorFlow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-intel-runtime-tensorflow-ubi9-python-3.11" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,10 +31,10 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils utils
+COPY ${SOURCE_CODE}/utils utils
 
 #Virtualenv creates a symlink of lib to lib64. That causes issues with importing ITEX since both locations will have ITEX library and it will conflict.
 RUN unlink /opt/app-root/lib64 && \
@@ -46,7 +48,7 @@ RUN unlink /opt/app-root/lib64 && \
 
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 #CPU env
 WORKDIR ${CPU_ENV}

--- a/intel/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/intel/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/runtimes/tensorflow/ubi9-python-3.11
 
 LABEL name="odh-notebook-intel-runtime-tensorflow-ubi9-python-3.11" \
     summary="Runtime Intel® optimized TensorFlow notebook image for ODH notebooks" \

--- a/intel/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-intel-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime Intel® optimized TensorFlow notebook image for ODH notebooks" \
     description="Runtime Intel® optimized TesorFlow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-intel-runtime-tensorflow-ubi9-python-3.9" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,10 +31,10 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils utils
+COPY ${SOURCE_CODE}/utils utils
 
 #Virtualenv creates a symlink of lib to lib64. That causes issues with importing ITEX since both locations will have ITEX library and it will conflict.
 RUN unlink /opt/app-root/lib64 && \
@@ -46,7 +48,7 @@ RUN unlink /opt/app-root/lib64 && \
 
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 #CPU env
 WORKDIR ${CPU_ENV}

--- a/intel/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/intel/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=intel/runtimes/tensorflow/ubi9-python-3.9
 
 LABEL name="odh-notebook-intel-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime Intel® optimized TensorFlow notebook image for ODH notebooks" \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/datascience/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.11" \
     summary="Jupyter data science notebook image for ODH notebooks" \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.11" \
     summary="Jupyter data science notebook image for ODH notebooks" \
     description="Jupyter data science notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,10 +16,10 @@ LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 # Copy Elyra setup to utils so that it's sourced at startup
-COPY setup-elyra.sh ./utils/
+COPY ${SOURCE_CODE}/setup-elyra.sh ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
@@ -26,7 +28,7 @@ RUN echo "Installing softwares and packages" && \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P
 
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 # OS Packages needs to be installed as root
 USER root
@@ -38,12 +40,12 @@ RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile && dnf clean all &&
 RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 
 # Install MongoDB Client, We need a special repo for MongoDB as they do their own distribution
-COPY mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
+COPY ${SOURCE_CODE}/mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
 
 RUN dnf install -y mongocli && dnf clean all && rm -rf /var/cache/yum
 
 # Install MSSQL Client, We need a special repo for MSSQL as they do their own distribution
-COPY mssql-2022.repo-x86_64 /etc/yum.repos.d/mssql-2022.repo
+COPY ${SOURCE_CODE}/mssql-2022.repo-x86_64 /etc/yum.repos.d/mssql-2022.repo
 
 RUN ACCEPT_EULA=Y dnf install -y mssql-tools18 unixODBC-devel && dnf clean all && rm -rf /var/cache/yum
 
@@ -63,6 +65,6 @@ RUN mkdir /opt/app-root/runtimes && \
     fix-permissions /opt/app-root -P
 
 # Copy Elyra runtime-images definitions and set the version
-COPY runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
+COPY ${SOURCE_CODE}/runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
 
 WORKDIR /opt/app-root/src

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.9" \
     summary="Jupyter data science notebook image for ODH notebooks" \
     description="Jupyter data science notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra setup to utils so that it's sourced at startup
-COPY setup-elyra.sh ./utils/
+COPY ${SOURCE_CODE}/setup-elyra.sh ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
@@ -25,7 +27,7 @@ RUN echo "Installing softwares and packages" && \
     chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
     fix-permissions /opt/app-root -P
 
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 # OS Packages needs to be installed as root
 USER root
@@ -37,12 +39,12 @@ RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile && dnf clean all &&
 RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 
 # Install MongoDB Client, We need a special repo for MongoDB as they do their own distribution
-COPY mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
+COPY ${SOURCE_CODE}/mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
 
 RUN dnf install -y mongocli && dnf clean all && rm -rf /var/cache/yum
 
 # Install MSSQL Client, We need a special repo for MSSQL as they do their own distribution
-COPY mssql-2022.repo-x86_64 /etc/yum.repos.d/mssql-2022.repo
+COPY ${SOURCE_CODE}/mssql-2022.repo-x86_64 /etc/yum.repos.d/mssql-2022.repo
 
 RUN ACCEPT_EULA=Y dnf install -y mssql-tools18 unixODBC-devel && dnf clean all && rm -rf /var/cache/yum
 
@@ -78,6 +80,6 @@ RUN mkdir /opt/app-root/runtimes && \
     fix-permissions /opt/app-root -P
 
 # Copy Elyra runtime-images definitions and set the version
-COPY runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
+COPY ${SOURCE_CODE}/runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
 
 WORKDIR /opt/app-root/src

--- a/jupyter/datascience/ubi9-python-3.9/Dockerfile
+++ b/jupyter/datascience/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/datascience/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.9" \
     summary="Jupyter data science notebook image for ODH notebooks" \

--- a/jupyter/intel/ml/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/intel/ml/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-intel-ml-ubi9-python-3.11" \
     summary="Jupyter Intel® optimized ML notebook image for ODH notebooks." \

--- a/jupyter/intel/ml/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-intel-ml-ubi9-python-3.11" \
     summary="Jupyter Intel® optimized ML notebook image for ODH notebooks." \
     description="Jupyter Intel® ML notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-jupyter-intel-ml-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock Pipfile.lock
 
-COPY --chown=1001:0 .patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
+COPY --chown=1001:0 ${SOURCE_CODE}/.patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
 ENV PYTHONSTARTUP="/opt/app-root/bin/.patch_sklearn.py"
 
 RUN echo "Installing softwares and packages" && \
@@ -28,9 +30,9 @@ RUN echo "Installing softwares and packages" && \
     fix-permissions /opt/app-root -P
 
 #Replacing kernel manually with oneapi variable setting script
-COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
-COPY --chown=1001:0 builder /opt/app-root/builder
-COPY --chown=1001:0 utils /opt/app-root/bin/utils
+COPY --chown=1001:0 ${SOURCE_CODE}/start-notebook.sh /opt/app-root/bin
+COPY --chown=1001:0 ${SOURCE_CODE}/builder /opt/app-root/builder
+COPY --chown=1001:0 ${SOURCE_CODE}/utils /opt/app-root/bin/utils
 
 # Apply JupyterLab addons
 RUN /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-intel-ml-ubi9-python-3.9" \
     summary="Jupyter Intel® optimized ML notebook image for ODH notebooks." \
     description="Jupyter Intel® ML notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-jupyter-intel-ml-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock Pipfile.lock
 
-COPY --chown=1001:0 .patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
+COPY --chown=1001:0 ${SOURCE_CODE}/.patch_sklearn.py /opt/app-root/bin/.patch_sklearn.py
 ENV PYTHONSTARTUP="/opt/app-root/bin/.patch_sklearn.py"
 
 RUN echo "Installing softwares and packages" && \
@@ -28,9 +30,9 @@ RUN echo "Installing softwares and packages" && \
     fix-permissions /opt/app-root -P
 
 #Replacing kernel manually with oneapi variable setting script
-COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
-COPY --chown=1001:0 builder /opt/app-root/builder
-COPY --chown=1001:0 utils /opt/app-root/bin/utils
+COPY --chown=1001:0 ${SOURCE_CODE}/start-notebook.sh /opt/app-root/bin
+COPY --chown=1001:0 ${SOURCE_CODE}/builder /opt/app-root/builder
+COPY --chown=1001:0 ${SOURCE_CODE}/utils /opt/app-root/bin/utils
 
 # Apply JupyterLab addons
 RUN /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/ml/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/intel/ml/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-intel-ml-ubi9-python-3.9" \
     summary="Jupyter Intel® optimized ML notebook image for ODH notebooks." \

--- a/jupyter/intel/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.11" \
     summary="Jupyter Intel® optimized pytorch notebook image for ODH notebooks." \
     description="Jupyter Intel® pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.11" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,7 +31,7 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
@@ -41,16 +43,16 @@ RUN echo "Installing softwares and packages" && \
 
 
 #Replacing kernel manually with oneapi variable setting script
-COPY --chown=1001:0 start-kernel /opt/app-root/bin/start-kernel
-COPY --chown=1001:0 kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
-COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
-COPY --chown=1001:0 builder /opt/app-root/builder
-COPY --chown=1001:0 utils /opt/app-root/bin/utils
+COPY --chown=1001:0 ${SOURCE_CODE}/start-kernel /opt/app-root/bin/start-kernel
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/start-notebook.sh /opt/app-root/bin
+COPY --chown=1001:0 ${SOURCE_CODE}/builder /opt/app-root/builder
+COPY --chown=1001:0 ${SOURCE_CODE}/utils /opt/app-root/bin/utils
 
 #CPU env
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 WORKDIR ${CPU_ENV}
 RUN python3.11 -m venv ${CPU_ENV} && \
@@ -69,7 +71,7 @@ RUN python3.11 -m venv ${CPU_ENV} && \
     # Apply JupyterLab addons
     /opt/app-root/bin/utils/addons/apply.sh
 
-COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/pytorch-cpu/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-cpu.json /opt/app-root/share/jupyter/kernels/pytorch-cpu/kernel.json
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/intel/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/intel/pytorch/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.11" \
     summary="Jupyter Intel® optimized pytorch notebook image for ODH notebooks." \

--- a/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.9" \
     summary="Jupyter Intel® optimized pytorch notebook image for ODH notebooks." \
     description="Jupyter Intel® pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.9" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,7 +31,7 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \
@@ -40,16 +42,16 @@ RUN echo "Installing softwares and packages" && \
     fix-permissions /opt/app-root -P
 
 #Replacing kernel manually with oneapi variable setting script
-COPY --chown=1001:0 start-kernel /opt/app-root/bin/start-kernel
-COPY --chown=1001:0 kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
-COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
-COPY --chown=1001:0 builder /opt/app-root/builder
-COPY --chown=1001:0 utils /opt/app-root/bin/utils
+COPY --chown=1001:0 ${SOURCE_CODE}/start-kernel /opt/app-root/bin/start-kernel
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/start-notebook.sh /opt/app-root/bin
+COPY --chown=1001:0 ${SOURCE_CODE}/builder /opt/app-root/builder
+COPY --chown=1001:0 ${SOURCE_CODE}/utils /opt/app-root/bin/utils
 
 #CPU env
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 WORKDIR ${CPU_ENV}
 RUN python3.9 -m venv ${CPU_ENV} && \
@@ -68,7 +70,7 @@ RUN python3.9 -m venv ${CPU_ENV} && \
     # Apply JupyterLab addons
     /opt/app-root/bin/utils/addons/apply.sh
 
-COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/pytorch-cpu/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-cpu.json /opt/app-root/share/jupyter/kernels/pytorch-cpu/kernel.json
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/intel/pytorch/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-intel-pytorch-ubi9-python-3.9" \
     summary="Jupyter Intel® optimized pytorch notebook image for ODH notebooks." \

--- a/jupyter/intel/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/intel/tensorflow/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.11" \
     summary="Jupyter Intel® optimized TensorFlow notebook image for ODH notebooks." \

--- a/jupyter/intel/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.11" \
     summary="Jupyter Intel® optimized TensorFlow notebook image for ODH notebooks." \
     description="Jupyter Intel® TensorFlow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.11" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,7 +31,7 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 RUN unlink /opt/app-root/lib64 && \
     cp -r /opt/app-root/lib /opt/app-root/lib64 && \
@@ -42,16 +44,16 @@ RUN unlink /opt/app-root/lib64 && \
     fix-permissions /opt/app-root -P
 
 #Replacing kernel manually with oneapi variable setting script
-COPY --chown=1001:0 start-kernel /opt/app-root/bin/start-kernel
-COPY --chown=1001:0 kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
-COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
-COPY --chown=1001:0 builder /opt/app-root/builder
-COPY --chown=1001:0 utils /opt/app-root/bin/utils
+COPY --chown=1001:0 ${SOURCE_CODE}/start-kernel /opt/app-root/bin/start-kernel
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/start-notebook.sh /opt/app-root/bin
+COPY --chown=1001:0 ${SOURCE_CODE}/builder /opt/app-root/builder
+COPY --chown=1001:0 ${SOURCE_CODE}/utils /opt/app-root/bin/utils
 
 #CPU env
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 WORKDIR ${CPU_ENV}
 
@@ -73,7 +75,7 @@ RUN python3.11 -m venv ${CPU_ENV} && \
     # Apply JupyterLab addons
     /opt/app-root/bin/utils/addons/apply.sh
 
-COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/tensorflow-cpu/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-cpu.json /opt/app-root/share/jupyter/kernels/tensorflow-cpu/kernel.json
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/intel/tensorflow/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.9" \
     summary="Jupyter Intel® optimized TensorFlow notebook image for ODH notebooks." \

--- a/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/intel/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.9" \
     summary="Jupyter Intel® optimized TensorFlow notebook image for ODH notebooks." \
     description="Jupyter Intel® TensorFlow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,7 +16,7 @@ LABEL name="odh-notebook-jupyter-intel-tensorflow-ubi9-python-3.9" \
 USER root
 
 ARG ONEAPI_VERSION=2024.0
-COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+COPY ${SOURCE_CODE}/oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 
 RUN dnf update -y && \
     dnf install -y intel-oneapi-compiler-dpcpp-cpp-runtime-${ONEAPI_VERSION} \
@@ -29,7 +31,7 @@ USER 1001
 WORKDIR /opt/app-root/bin
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock.gpu Pipfile.lock
+COPY ${SOURCE_CODE}/Pipfile.lock.gpu Pipfile.lock
 
 RUN unlink /opt/app-root/lib64 && \
     cp -r /opt/app-root/lib /opt/app-root/lib64 && \
@@ -42,16 +44,16 @@ RUN unlink /opt/app-root/lib64 && \
     fix-permissions /opt/app-root -P
 
 #Replacing kernel manually with oneapi variable setting script
-COPY --chown=1001:0 start-kernel /opt/app-root/bin/start-kernel
-COPY --chown=1001:0 kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
-COPY --chown=1001:0 start-notebook.sh /opt/app-root/bin
-COPY --chown=1001:0 builder /opt/app-root/builder
-COPY --chown=1001:0 utils /opt/app-root/bin/utils
+COPY --chown=1001:0 ${SOURCE_CODE}/start-kernel /opt/app-root/bin/start-kernel
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-gpu.json /opt/app-root/share/jupyter/kernels/python3/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/start-notebook.sh /opt/app-root/bin
+COPY --chown=1001:0 ${SOURCE_CODE}/builder /opt/app-root/builder
+COPY --chown=1001:0 ${SOURCE_CODE}/utils /opt/app-root/bin/utils
 
 #CPU env
 ENV CPU_ENV=/opt/app-root-cpu
 ENV GPU_ENV=/opt/app-root
-COPY --chown=1001:0 Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
+COPY --chown=1001:0 ${SOURCE_CODE}/Pipfile.lock.cpu ${CPU_ENV}/Pipfile.lock
 
 WORKDIR ${CPU_ENV}
 
@@ -73,7 +75,7 @@ RUN python3.9 -m venv ${CPU_ENV} && \
     # Apply JupyterLab addons
     /opt/app-root/bin/utils/addons/apply.sh
 
-COPY --chown=1001:0 kernel-cpu.json /opt/app-root/share/jupyter/kernels/tensorflow-cpu/kernel.json
+COPY --chown=1001:0 ${SOURCE_CODE}/kernel-cpu.json /opt/app-root/share/jupyter/kernels/tensorflow-cpu/kernel.json
 
 WORKDIR /opt/app-root/src
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/minimal/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.11" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
@@ -35,4 +35,3 @@ WORKDIR /opt/app-root/src
 RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 ENTRYPOINT ["start-notebook.sh"]
-

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.11" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
     description="Minimal Jupyter notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -13,9 +15,9 @@ LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-COPY utils utils/
+COPY ${SOURCE_CODE}/utils utils/
 
-COPY Pipfile.lock start-notebook.sh ./
+COPY ${SOURCE_CODE}/Pipfile.lock ${SOURCE_CODE}/start-notebook.sh ./
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/minimal/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.9" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
@@ -35,4 +35,3 @@ WORKDIR /opt/app-root/src
 RUN sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 
 ENTRYPOINT ["start-notebook.sh"]
-

--- a/jupyter/minimal/ubi9-python-3.9/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.9" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
     description="Minimal Jupyter notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -13,9 +15,9 @@ LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.9" \
 
 WORKDIR /opt/app-root/bin
 
-COPY utils utils/
+COPY ${SOURCE_CODE}/utils utils/
 
-COPY Pipfile.lock start-notebook.sh ./
+COPY ${SOURCE_CODE}/Pipfile.lock ${SOURCE_CODE}/start-notebook.sh ./
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/pytorch/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.11" \
     summary="Jupyter pytorch notebook image for ODH notebooks" \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.11" \
     summary="Jupyter pytorch notebook image for ODH notebooks" \
     description="Jupyter pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -12,7 +14,7 @@ LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-pytorch-ubi9-python-3.11"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.9" \
     summary="Jupyter pytorch notebook image for ODH notebooks" \
     description="Jupyter pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -12,7 +14,7 @@ LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-pytorch-ubi9-python-3.9"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/jupyter/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/pytorch/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-pytorch-ubi9-python-3.9" \
     summary="Jupyter pytorch notebook image for ODH notebooks" \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
     summary="Jupyter AMD pytorch notebook image for ODH notebooks" \
     description="Jupyter AMD pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -12,9 +14,9 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.11"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy utility script
-COPY de-vendor-torch.sh ./
+COPY ${SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/rocm/pytorch/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
     summary="Jupyter AMD pytorch notebook image for ODH notebooks" \

--- a/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/rocm/pytorch/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.9" \
     summary="Jupyter AMD pytorch notebook image for ODH notebooks" \

--- a/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.9" \
     summary="Jupyter AMD pytorch notebook image for ODH notebooks" \
     description="Jupyter AMD pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -12,9 +14,9 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.9"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy utility script
-COPY de-vendor-torch.sh ./
+COPY ${SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
     summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
     description="Jupyter AMD tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -12,11 +14,11 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-tensorflow-ubi9-python-3.11"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 # Temporary:Workaround for fixing the kfp-kubernetes 1.0.0 for elyra pipeline execution
 # TODO: Remove this patch once the issue is fixed with kfp-kubernetes upgrade.
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 RUN patch /opt/app-root/lib/python3.11/site-packages/elyra/templates/kubeflow/v2/python_dsl_template.jinja2 -i utils/python_dsl_template.patch && \
     echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/rocm/tensorflow/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
     summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.9" \
     summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
     description="Jupyter AMD tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -12,7 +14,7 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-tensorflow-ubi9-python-3.9"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/rocm/tensorflow/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.9" \
     summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/tensorflow/ubi9-python-3.11
 
 LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
     summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
     summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
     description="Jupyter CUDA tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -11,9 +13,9 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11"
 
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9" \
     summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
     description="Jupyter CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -11,9 +13,9 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.9" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.9"
 
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
 

--- a/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/jupyter/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/tensorflow/ubi9-python-3.9
 
 LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9" \
     summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/trustyai/ubi9-python-3.11
 
 LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.11" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.11" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \
     description="Jupyter trustyai notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -21,7 +23,7 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 USER 1001
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=jupyter/trustyai/ubi9-python-3.9
 
 LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.9" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \

--- a/jupyter/trustyai/ubi9-python-3.9/Dockerfile
+++ b/jupyter/trustyai/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.9" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \
     description="Jupyter trustyai notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -21,7 +23,7 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 USER 1001
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/rocm/ubi9-python-3.11/Dockerfile
+++ b/rocm/ubi9-python-3.11/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=rocm/ubi9-python-3.11
 
 LABEL name="odh-notebook-rocm-python-3.11" \
       summary="ROCm Python 3.11 base image for ODH notebooks" \

--- a/rocm/ubi9-python-3.11/Dockerfile
+++ b/rocm/ubi9-python-3.11/Dockerfile
@@ -2,6 +2,9 @@
 # https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-rocm-python-3.11" \
       summary="ROCm Python 3.11 base image for ODH notebooks" \
       description="ROCm Python 3.11 builder image based on UBI9 for ODH notebooks" \

--- a/rocm/ubi9-python-3.9/Dockerfile
+++ b/rocm/ubi9-python-3.9/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=rocm/ubi9-python-3.9
 
 LABEL name="odh-notebook-rocm-python-3.9" \
       summary="ROCm Python 3.9 base image for ODH notebooks" \

--- a/rocm/ubi9-python-3.9/Dockerfile
+++ b/rocm/ubi9-python-3.9/Dockerfile
@@ -2,6 +2,9 @@
 # https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-rocm-python-3.9" \
       summary="ROCm Python 3.9 base image for ODH notebooks" \
       description="ROCm Python 3.9 builder image based on UBI9 for ODH notebooks" \

--- a/rstudio/c9s-python-3.11/Dockerfile
+++ b/rstudio/c9s-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=rstudio/c9s-python-3.11
 
 LABEL name="odh-notebook-rstudio-server-c9s-python-3.11" \
       summary="RStudio Server image with python 3.11 based on CentOS Stream 9" \

--- a/rstudio/c9s-python-3.11/Dockerfile
+++ b/rstudio/c9s-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-rstudio-server-c9s-python-3.11" \
       summary="RStudio Server image with python 3.11 based on CentOS Stream 9" \
       description="RStudio server image with python 3.11 based on CentOS Stream 9" \
@@ -45,7 +47,7 @@ RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/r
 # Specific RStudio config and fixes
 RUN chmod 1777 /var/run/rstudio-server && \
     mkdir -p /usr/share/doc/R
-COPY rsession.conf /etc/rstudio/rsession.conf
+COPY ${SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
 # package installation
 RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" \
@@ -79,10 +81,10 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     yum -y clean all --enablerepo='*'
 
-COPY --chown=1001:0 supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY --chown=1001:0 ${SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY nginx/root/ /
+COPY ${SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model
@@ -113,15 +115,15 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
     rpm-file-permissions
 
 # Configure nginx
-COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
-COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
-COPY nginx/api/ /opt/app-root/api/
+COPY ${SOURCE_CODE}/nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY ${SOURCE_CODE}/nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY ${SOURCE_CODE}/nginx/api/ /opt/app-root/api/
 
 # Launcher
 WORKDIR /opt/app-root/bin
 
-COPY utils utils/
-COPY run-rstudio.sh setup_rstudio.py rsession.sh run-nginx.sh ./
+COPY ${SOURCE_CODE}/utils utils/
+COPY ${SOURCE_CODE}/run-rstudio.sh ${SOURCE_CODE}/setup_rstudio.py ${SOURCE_CODE}/rsession.sh ${SOURCE_CODE}/run-nginx.sh ./
 
 WORKDIR /opt/app-root/src
 

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=rstudio/c9s-python-3.9
 
 LABEL name="odh-notebook-rstudio-server-c9s-python-3.9" \
       summary="RStudio Server image with python 3.9 based on CentOS Stream 9" \

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-rstudio-server-c9s-python-3.9" \
       summary="RStudio Server image with python 3.9 based on CentOS Stream 9" \
       description="RStudio server image with python 3.9 based on CentOS Stream 9" \
@@ -45,7 +47,7 @@ RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/r
 # Specific RStudio config and fixes
 RUN chmod 1777 /var/run/rstudio-server && \
     mkdir -p /usr/share/doc/R
-COPY rsession.conf /etc/rstudio/rsession.conf
+COPY ${SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
 # package installation 
 RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" \
@@ -79,10 +81,10 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     yum -y clean all --enablerepo='*'
 
-COPY --chown=1001:0 supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY --chown=1001:0 ${SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY nginx/root/ /
+COPY ${SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model
@@ -113,15 +115,15 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
     rpm-file-permissions
 
 # Configure nginx
-COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
-COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
-COPY nginx/api/ /opt/app-root/api/
+COPY ${SOURCE_CODE}/nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY ${SOURCE_CODE}/nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY ${SOURCE_CODE}/nginx/api/ /opt/app-root/api/
 
 # Launcher
 WORKDIR /opt/app-root/bin
 
-COPY utils utils/
-COPY run-rstudio.sh setup_rstudio.py rsession.sh run-nginx.sh ./
+COPY ${SOURCE_CODE}/utils utils/
+COPY ${SOURCE_CODE}/run-rstudio.sh ${SOURCE_CODE}/setup_rstudio.py ${SOURCE_CODE}/rsession.sh ${SOURCE_CODE}/run-nginx.sh ./
 
 WORKDIR /opt/app-root/src
 

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/datascience/ubi9-python-3.11
 
 LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.11" \
     summary="Runtime data science notebook image for ODH notebooks" \

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.11" \
     summary="Runtime data science notebook image for ODH notebooks" \
     description="Runtime data science notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/datascience/ubi9-python-3.9/Dockerfile
+++ b/runtimes/datascience/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/datascience/ubi9-python-3.9
 
 LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.9" \
     summary="Runtime data science notebook image for ODH notebooks" \

--- a/runtimes/datascience/ubi9-python-3.9/Dockerfile
+++ b/runtimes/datascience/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.9" \
     summary="Runtime data science notebook image for ODH notebooks" \
     description="Runtime data science notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/minimal/ubi9-python-3.11
 
 LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.11" \
     summary="Runtime minimal image for ODH notebooks" \

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.11" \
     summary="Runtime minimal image for ODH notebooks" \
     description="Runtime minimal image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/minimal/ubi9-python-3.9/Dockerfile
+++ b/runtimes/minimal/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/minimal/ubi9-python-3.9
 
 LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.9" \
     summary="Runtime minimal image for ODH notebooks" \

--- a/runtimes/minimal/ubi9-python-3.9/Dockerfile
+++ b/runtimes/minimal/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.9" \
     summary="Runtime minimal image for ODH notebooks" \
     description="Runtime minimal image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/pytorch/ubi9-python-3.11
 
 LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.11" \
     summary="Runtime pytorch notebook image for ODH notebooks" \

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.11" \
     summary="Runtime pytorch notebook image for ODH notebooks" \
     description="Runtime pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/pytorch/ubi9-python-3.9
 
 LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.9" \
     summary="Runtime pytorch notebook image for ODH notebooks" \

--- a/runtimes/pytorch/ubi9-python-3.9/Dockerfile
+++ b/runtimes/pytorch/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.9" \
     summary="Runtime pytorch notebook image for ODH notebooks" \
     description="Runtime pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/rocm-pytorch/ubi9-python-3.11
 
 LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.11" \
     summary="Runtime ROCm pytorch notebook image for ODH notebooks" \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.11" \
     summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
     description="Runtime ROCm pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,11 +16,11 @@ LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 # Copy utility script
-COPY de-vendor-torch.sh ./
+COPY ${SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.9/Dockerfile
+++ b/runtimes/rocm-pytorch/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/rocm-pytorch/ubi9-python-3.9
 
 LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.9" \
     summary="Runtime ROCm pytorch notebook image for ODH notebooks" \

--- a/runtimes/rocm-pytorch/ubi9-python-3.9/Dockerfile
+++ b/runtimes/rocm-pytorch/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.9" \
     summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
     description="Runtime ROCm pytorch notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,11 +16,11 @@ LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 # Copy utility script
-COPY de-vendor-torch.sh ./
+COPY ${SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.11" \
     summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
     description="Runtime ROCm tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/rocm-tensorflow/ubi9-python-3.11
 
 LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.11" \
     summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
     description="Runtime ROCm tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/rocm-tensorflow/ubi9-python-3.9
 
 LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/tensorflow/ubi9-python-3.11
 
 LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.11" \
     summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.11" \
     summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
     description="Runtime CUDA tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG SOURCE_CODE=.
+
 LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
     description="Runtime CUDA tensorflow notebook image with base Python 3.9 builder image based on UBI9 for ODH notebooks" \
@@ -14,9 +16,9 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY Pipfile.lock ./
+COPY ${SOURCE_CODE}/Pipfile.lock ./
 # Copy Elyra dependencies for air-gapped enviroment
-COPY utils ./utils/
+COPY ${SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install && \

--- a/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
+++ b/runtimes/tensorflow/ubi9-python-3.9/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG SOURCE_CODE=.
+ARG SOURCE_CODE=runtimes/tensorflow/ubi9-python-3.9
 
 LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.9" \
     summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-11274

## Description

```python
import glob
import pathlib

def main():
    for dockerfile in glob.glob("**/Dockerfile", recursive=True):
        print(dockerfile)
        path = pathlib.Path(dockerfile)
        lines = path.read_text().splitlines()
        idx = lines.index("ARG SOURCE_CODE=.")
        lines[idx] = f"ARG SOURCE_CODE={str(path.parent)}"
        print("\t", lines[idx])
        path.write_text("\n".join(lines) + "\n")

if __name__ == '__main__':
    main()
```

TODOs

* [ ] the next change is to manually edit the SOURCE_CODE variable to point to shared locations for workbench builds that all build from the same files that now need to be duplicated to each directory https://issues.redhat.com/browse/RHOAIENG-16518 is a pilot task for jupyterlab loading spinner
* [ ] this will break the change detection mechanism in GHA for PRs; we can't no longer so easily tell what files are used by what Dockerfile https://issues.redhat.com/browse/RHOAIENG-16517
* [ ] previous point is solvable if the GHA reads the Dockerfile and checks what it accesses in COPY and ADD instructions
* [x] update openshift/release, https://github.com/openshift/release/pull/59520

## How Has This Been Tested?

GHA on my fork

* https://github.com/jiridanek/notebooks/actions/runs/12140010357

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
