### PR TITLE
RHOAIENG-16604: feat(RStudio): grab proxy-related env vars from container env context and set them in R default environment

### DIFF
--- a/rstudio/c9s-python-3.11/run-rstudio.sh
+++ b/rstudio/c9s-python-3.11/run-rstudio.sh
@@ -25,7 +25,11 @@ do
 done  
 # rstudio terminal cant see environment variables set by the container runtime
 # (which breaks kubectl, to fix this we store the KUBERNETES_* env vars in Renviron.site)
-env | grep KUBERNETES_ >> /usr/lib64/R/etc/Renviron.site
+# Also, we store proxy-related env vars lowercased by key so RStudio projects work with proxy by default
+env | grep "^KUBERNETES_" >> /usr/lib64/R/etc/Renviron.site
+env | grep "^HTTP_PROXY=" | tr '[:upper:]' '[:lower:]' >> /usr/lib64/R/etc/Renviron.site
+env | grep "^HTTPS_PROXY=" | tr '[:upper:]' '[:lower:]' >> /usr/lib64/R/etc/Renviron.site
+env | grep "^NO_PROXY=" | tr '[:upper:]' '[:lower:]' >> /usr/lib64/R/etc/Renviron.site
 
 export USER=$(whoami)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16604

* fixes #795 

<!--- Provide a general summary of your changes in the Title above -->
@guimou Needed so that R proxy settings do not need to be done at user-home level, instead globally, if the information is already present in notebook container env vars.
https://support.posit.co/hc/en-us/articles/200488488-Configuring-R-to-Use-an-HTTP-or-HTTPS-Proxy
## Description
added one more line to startup script, similar to the already-existing KUBERNETES_ env variables.
Only difference in R Studio is, key needs to be lowercased.

## How Has This Been Tested?
command-line tested, tested in ~/.Renviron
Created a new project in R studio with version control.
Url of Git used required use of proxy cause it is not directly accessible.
Worked fine.

If this PR can create a PR- labeled notebook image R studio, I can test, too.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
