### PR TITLE
RHOAIENG-17256: install necessary base OS package to make Knit rendering of R markup to PDF possible

### DIFF
--- a/rstudio/c9s-python-3.11/Dockerfile
+++ b/rstudio/c9s-python-3.11/Dockerfile
@@ -50,7 +50,8 @@ RUN chmod 1777 /var/run/rstudio-server && \
 COPY ${SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
 # package installation
-RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" \
+# install necessary texlive-framed package to make Knit R markup to PDF rendering possible
+RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed \
     && dnf clean all && rm -rf /var/cache/yum
 # Install R packages
 RUN R -e "install.packages('remotes')"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17256

fixes #794 

<!--- Provide a general summary of your changes in the Title above -->
A coworker pointed me to problems he was having converting R markup code to PDF with RStudio.

## Description
install needed OS package

## How Has This Been Tested?
I took a recent notebooks R Studio image, built a custom image installing the package with yum, then ran
the new workbench image in ODH and was able to produce the PDF rendered from Rmd markup with Knit, it showed up in a popup window.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
