### PR TITLE
Pin `jupyterlab` package to version `4.2.6`

### DIFF
--- a/jupyter/datascience/ubi9-python-3.11/Pipfile
+++ b/jupyter/datascience/ubi9-python-3.11/Pipfile
@@ -30,7 +30,7 @@ mysql-connector-python = "~=9.0.0"
 
 odh-elyra = "==4.2.0"
 
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-bokeh = "~=4.0.5"
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"

--- a/jupyter/minimal/ubi9-python-3.11/Pipfile
+++ b/jupyter/minimal/ubi9-python-3.11/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 
 [packages]
 # JupyterLab packages
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"
 jupyter-server-terminals = "~=0.5.3"

--- a/jupyter/pytorch/ubi9-python-3.11/Pipfile
+++ b/jupyter/pytorch/ubi9-python-3.11/Pipfile
@@ -40,7 +40,7 @@ mysql-connector-python = "~=9.0.0"
 
 odh-elyra = "==4.2.0"
 
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-bokeh = "~=4.0.5"
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Pipfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Pipfile
@@ -42,7 +42,7 @@ mysql-connector-python = "~=9.0.0"
 
 odh-elyra = "==4.2.0"
 
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-bokeh = "~=4.0.5"
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Pipfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Pipfile
@@ -35,7 +35,7 @@ mysql-connector-python = "~=9.0.0"
 
 odh-elyra = "==4.2.0"
 
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-bokeh = "~=4.0.5"
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"

--- a/jupyter/tensorflow/ubi9-python-3.11/Pipfile
+++ b/jupyter/tensorflow/ubi9-python-3.11/Pipfile
@@ -34,7 +34,7 @@ mysql-connector-python = "~=9.0.0"
 # JupyterLab packages
 odh-elyra = "==4.2.0"
 
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-bokeh = "~=4.0.5"
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"

--- a/jupyter/trustyai/ubi9-python-3.11/Pipfile
+++ b/jupyter/trustyai/ubi9-python-3.11/Pipfile
@@ -41,7 +41,7 @@ mysql-connector-python = "~=9.0.0"
 # JupyterLab packages
 odh-elyra = "==4.2.0"
 
-jupyterlab = "~=4.2.4"
+jupyterlab = "==4.2.6"
 jupyter-bokeh = "~=3.0.5" # Should be pinned down to this version in order to be compatible with trustyai
 jupyter-server = "~=2.14.2"
 jupyter-server-proxy = "~=4.3.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to https://issues.redhat.com/browse/RHOAIENG-11156

## Description
<!--- Describe your changes in detail -->
Pin `jupyterlab` package to version `4.2.6` to avoid changes made on the base images being overridden due to JL upgrades. No need to update the Pipfile.lock files since they are already using the target version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
