### PR TITLE
Make the pipfile renewal to work when cron firing

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -3,9 +3,9 @@
 name: Pipfile.locks Renewal Action
 
 on:  # yamllint disable-line rule:truthy
-  # Triggers the workflow every Monday at 22pm UTC am 0 22 * * 1
+  # Triggers the workflow every Wednesday at 1am UTC
   schedule:
-    - cron: "0 22 * * 1"
+    - cron: "0 1 * * 3"
   workflow_dispatch:  # for manual trigger workflow from GH Web UI
     inputs:
       branch:
@@ -35,12 +35,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      BRANCH: ${{ github.event.inputs.branch || 'main' }}
+      PYTHON_VERSION: ${{ github.event.inputs.python_version || '3.11' }}
+      INCLUDE_OPT_DIRS: ${{ github.event.inputs.update_optional_dirs || 'false' }}
     steps:
       # Checkout the specified branch from the specified organization
       - name: Checkout code from the specified branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ env.BRANCH }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       # Configure Git
@@ -53,7 +57,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ github.event.inputs.python_version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       # Install pipenv
       - name: Install pipenv
@@ -62,7 +66,7 @@ jobs:
       # Run makefile recipe to refresh Pipfile.lock and push changes back to the branch
       - name: Run make refresh-pipfilelock-files and push the changes back to the branch
         run: |
-          make refresh-pipfilelock-files PYTHON_VERSION=${{ github.event.inputs.python_version }} INCLUDE_OPT_DIRS=${{ github.event.inputs.update_optional_dirs }}
+          make refresh-pipfilelock-files PYTHON_VERSION=${{ env.PYTHON_VERSION }} INCLUDE_OPT_DIRS=${{ env.INCLUDE_OPT_DIRS }}
           git add .
           git commit -m "Update Pipfile.lock files by piplock-renewal.yaml action"
-          git push origin ${{ github.event.inputs.branch }}
+          git push origin ${{ env.BRANCH }}


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-15393

## Description
<!--- Describe your changes in detail -->
Didn't specify what the gha should do in case of scheduled firing and that's why we got that failure: https://github.com/opendatahub-io/notebooks/actions/runs/12362324472/job/34501399571#step:6:65 

Also changed the cron to Wenesday to be closer to release day. 

With this update now it works as expected. 

## How Has This Been Tested?
Tested localy: https://github.com/atheo89/notebooks/actions/runs/12374398338 
![image](https://github.com/user-attachments/assets/e6806059-25a7-4772-8a1e-36327159b08f)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
