### PR TITLE
NO-JIRA: chore(gha): run code-server playwright tests for pushes (and scheduled run) as well

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -457,7 +457,7 @@ jobs:
       # we leave little free disk space after we mount LVM for podman storage
       # not enough to install playwright; running playwright in podman uses the space we have
       - name: Run Playwright tests
-        if: ${{ fromJson(inputs.github).event_name == 'pull_request' && contains(inputs.target, 'codeserver') }}
+        if: ${{ contains(inputs.target, 'codeserver') }}
         # --ipc=host because Microsoft says so in Playwright docs
         # --net=host because testcontainers connects to the Reaper container's exposed port
         # we need to pass through the relevant environment variables


### PR DESCRIPTION
## Description

Originally the image name was different for PR check and for the other events, and I was lazy and did not want to be solving that at the moment. It was solved in the meantime and now the test can be simply run and the image will be found and all is well.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/12399015193

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
