### PR TITLE
NO-ISSUE: chore(owners): add myself as reviewer/approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+  - andyatmiami
   - atheo89
   - caponetto
   - daniellutz
@@ -8,6 +9,7 @@ approvers:
   - paulovmr
 
 reviewers:
+  - andyatmiami  
   - atheo89
   - caponetto
   - daniellutz


### PR DESCRIPTION
## Description
Adding my own GH handle (`andyatmiami`) to the `approvers` and `reviewers` section of `OWNERS`, honor alphanumeric sorting, so I can be more self-sufficient in working issues alongside the team.

## How Has This Been Tested?
n/a

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
