### PR TITLE
RHOAIENG-17695: chore(ci): disable ryuk for gha runs and when it actually fails to start (most likely due to rootless podman)

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -291,16 +291,12 @@ jobs:
       - name: Run container tests (in PyTest)
         run: |
           set -Eeuxo pipefail
-          # retry to increase CI reliability
-          for i in {1..5}; do
-            if podman pull --retry 10 "${RYUK_CONTAINER_IMAGE}"; then break; fi
-          done
-          # now run the tests
           poetry run pytest --capture=fd tests/containers --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
-          RYUK_CONTAINER_IMAGE: "testcontainers/ryuk:0.8.1"
+          # pulling the Ryuk container from docker.io introduces CI flakiness
+          TESTCONTAINERS_RYUK_DISABLED: "true"
 
       # endregion Pytest image tests
 

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import Iterable, TYPE_CHECKING
 
@@ -66,6 +67,14 @@ def pytest_sessionstart(session: Session) -> None:
     # second preflight check: start the Reaper container
     if not testcontainers.core.config.testcontainers_config.ryuk_disabled:
         assert testcontainers.core.container.Reaper.get_instance() is not None, "Failed to start Reaper container"
+    if not testcontainers.core.config.testcontainers_config.ryuk_disabled:
+        try:
+            _ = testcontainers.core.container.Reaper.get_instance()
+        except RuntimeError as e:
+            # when running on rootless podman, ryuk fails to start and needs to be disabled
+            # https://java.testcontainers.org/supported_docker_environment/#podman
+            logging.warning(str(e))
+            testcontainers.core.config.testcontainers_config.ryuk_disabled = True
 
 
 # https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_sessionfinish


### PR DESCRIPTION
## Description
 Fixes #846

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/12949678360

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
