### PR TITLE
RHOAIENG-17695: chore(ci): capture logs in pytest tests so that we don't have too many debug logs there from passing tests

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -296,7 +296,7 @@ jobs:
             if podman pull --retry 10 "${RYUK_CONTAINER_IMAGE}"; then break; fi
           done
           # now run the tests
-          poetry run pytest tests/containers --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
+          poetry run pytest --capture=fd tests/containers --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17695

## Description

This way full logs are only printed for failing tests, see https://docs.pytest.org/en/stable/how-to/logging.html

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/12884645067

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
