### PR TITLE
RHOAIENG-8388: rm(intel): fixup to remove one forgotten intel case that's now causing the script to fail

### DIFF
--- a/scripts/test_jupyter_with_papermill.sh
+++ b/scripts/test_jupyter_with_papermill.sh
@@ -352,9 +352,6 @@ function _handle_test()
         *-${jupyter_trustyai_notebook_id}-*)
             notebook_id="${jupyter_trustyai_notebook_id}"
             ;;
-        *-${jupyter_ml_notebook_id}-*)
-            notebook_id="${accelerator_flavor:+$accelerator_flavor/}${jupyter_ml_notebook_id}"
-            ;;
         *${jupyter_tensorflow_notebook_id}-*)
             notebook_id="${accelerator_flavor:+$accelerator_flavor/}${jupyter_tensorflow_notebook_id}"
             ;;


### PR DESCRIPTION
## Description

```
./scripts/test_jupyter_with_papermill.sh: line 345: jupyter_ml_notebook_id: unbound variable
```

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/12892921325

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
