### PR TITLE
RHOAIENG-17257: chore(tests): make the wait for readiness optional

### DIFF
--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import http.cookiejar
 import logging
@@ -92,12 +94,13 @@ class WorkbenchContainer(testcontainers.core.container.DockerContainer):
         finally:
             result.close()
 
-    def start(self):
+    def start(self, wait_for_readiness: bool = True) -> WorkbenchContainer:
         super().start()
         container_id = self.get_wrapped_container().id
         docker_client = testcontainers.core.container.DockerClient().client
         logging.debug(docker_client.api.inspect_container(container_id)['HostConfig'])
-        self._connect()
+        if wait_for_readiness:
+            self._connect()
         return self
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17257

## Description

This is useful in some tests when it's not necessary to actually start the IDE to test something.

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
