### PR TITLE
RHOAIENG-17257: chore(tests): add testcontainers test to check Rmd to PDF rendering in RStudio

### DIFF
--- a/tests/containers/docker_utils.py
+++ b/tests/containers/docker_utils.py
@@ -66,6 +66,20 @@ def container_cp(container: Container, src: str, dst: str,
     container.put_archive(dst, fh)
 
 
+def from_container_cp(container: Container, src: str, dst: str) -> None:
+    fh = io.BytesIO()
+    bits, stat = container.get_archive(src, encode_stream=True)
+    for chunk in bits:
+        fh.write(chunk)
+    fh.seek(0)
+    tar = tarfile.open(fileobj=fh, mode="r")
+    try:
+        tar.extractall(path=dst, filter=tarfile.data_filter)
+    finally:
+        tar.close()
+        fh.close()
+
+
 def container_exec(
         container: Container,
         cmd: str | list[str],

--- a/tests/containers/workbenches/rstudio/rstudio_tests.py
+++ b/tests/containers/workbenches/rstudio/rstudio_tests.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+from typing import TYPE_CHECKING
+
+import allure
+import pytest
+
+from tests.containers import docker_utils
+from tests.containers.workbenches.workbench_image_test import WorkbenchContainer, skip_if_not_workbench_image
+
+if TYPE_CHECKING:
+    import docker.models.images
+
+
+class TestRStudioImage:
+    """Tests for RStudio Workbench images in this repository."""
+
+    @allure.issue("RHOAIENG-17256")
+    def test_rmd_to_pdf_rendering(self, image: str) -> None:
+        """
+        References:
+            https://stackoverflow.com/questions/40563479/relationship-between-r-markdown-knitr-pandoc-and-bookdown
+            https://www.earthdatascience.org/courses/earth-analytics/document-your-science/knit-rmarkdown-document-to-pdf/
+        """
+        skip_if_not_rstudio_image(image)
+
+        container = WorkbenchContainer(image=image, user=1000, group_add=[0])
+        try:
+            container.start(wait_for_readiness=False)
+
+            # language=R
+            script = textwrap.dedent("""
+                library(knitr)
+                library(rmarkdown)
+                render("document.Rmd", output_format = "pdf_document")
+                """)
+            # language=markdown
+            document = textwrap.dedent("""
+                ---
+                title: "Untitled"
+                output: pdf_document
+                date: "2025-01-22"
+                ---
+
+                ```{r setup, include=FALSE}
+                knitr::opts_chunk$set(echo = TRUE)
+                ```
+
+                ## R Markdown
+
+                This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
+
+                When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
+
+                ```{r cars}
+                summary(cars)
+                ```
+
+                ## Including Plots
+
+                You can also embed plots, for example:
+
+                ```{r pressure, echo=FALSE}
+                plot(pressure)
+                ```
+
+                Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code that generated the plot.
+                """)
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmpdir = pathlib.Path(tmpdir)
+                (tmpdir / "script.R").write_text(script)
+                docker_utils.container_cp(container.get_wrapped_container(), src=str(tmpdir / "script.R"),
+                                          dst="/scripts")
+                (tmpdir / "document.Rmd").write_text(document)
+                docker_utils.container_cp(container.get_wrapped_container(), src=str(tmpdir / "document.Rmd"),
+                                          dst="/scripts")
+
+            # copy to a (writable) working directory
+            check_call(container, "bash -c 'cp /scripts/document.Rmd ./'")
+            # https://stackoverflow.com/questions/28432607/pandoc-version-1-12-3-or-higher-is-required-and-was-not-found-r-shiny
+            check_call(container,
+                         "bash -c 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64 Rscript /scripts/script.R'")
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                docker_utils.from_container_cp(container.get_wrapped_container(), src="/opt/app-root/src/", dst=tmpdir)
+                allure.attach.file(
+                    pathlib.Path(tmpdir) / "src/document.pdf",
+                    name="rendered-pdf",
+                    attachment_type=allure.attachment_type.PDF
+                )
+
+        finally:
+            docker_utils.NotebookContainer(container).stop(timeout=0)
+
+
+def check_call(container: WorkbenchContainer, cmd: str) -> int:
+    """Like subprocess.check_output, but in a container."""
+    logging.debug(_("Running command", cmd=cmd))
+    rc, result = container.exec(cmd)
+    result = result.decode("utf-8")
+    logging.debug(_("Command execution finished", rc=rc, result=result))
+    if rc != 0:
+        raise subprocess.CalledProcessError(rc, cmd, output=result)
+    return rc
+
+
+def check_output(container: WorkbenchContainer, cmd: str) -> str:
+    """Like subprocess.check_output, but in a container."""
+    logging.debug(_("Running command", cmd=cmd))
+    rc, result = container.exec(cmd)
+    result = result.decode("utf-8")
+    logging.debug(_("Command execution finished", rc=rc, result=result))
+    if rc != 0:
+        raise subprocess.CalledProcessError(rc, cmd, output=result)
+    return result
+
+
+def skip_if_not_rstudio_image(image: str) -> docker.models.images.Image:
+    image_metadata = skip_if_not_workbench_image(image)
+    if "-rstudio-" not in image_metadata.labels['name']:
+        pytest.skip(
+            f"Image {image} does not have '-rstudio-' in {image_metadata.labels['name']=}'")
+
+    return image_metadata
+
+
+class StructuredMessage:
+    """https://docs.python.org/3/howto/logging-cookbook.html#implementing-structured-logging"""
+
+    def __init__(self, message, /, **kwargs):
+        self.message = message
+        self.kwargs = kwargs
+
+    def __str__(self):
+        s = Encoder().encode(self.kwargs)
+        return '%s >>> %s' % (self.message, s)
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, set):
+            return tuple(o)
+        elif isinstance(o, str):
+            return o.encode('unicode_escape').decode('ascii')
+        return super().default(o)
+
+
+_ = StructuredMessage  # optional shortcut, to improve readability


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17257

## Description

## How Has This Been Tested?

This passes with

```
--image=ghcr.io/jiridanek/notebooks/workbench-images:rstudio-c9s-python-3.11-jd_ipv6_test_512e959935af50afde2c1fa49706207190fb5e8d
```

and fails with

```
--image=ghcr.io/jiridanek/notebooks/workbench-images:rstudio-c9s-python-3.11-main_fe3641a01ac9e1e8f694f1a8bce3b34cacf9ae57
```

with error that's beginning the same as what's in the screenshot that @shalberd reported in
* https://github.com/opendatahub-io/notebooks/issues/794

```
DEBUG:root:Command execution finished >>> {"rc": 1, "result": "

processing file: document.Rmd
1/7           
2/7 [setup]   
3/7           
4/7 [cars]    
5/7           
6/7 [pressure]
7/7           
output file: document.knit.md

/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/pandoc +RTS -K512m -RTS document.knit.md --to latex --from markdown+autolink_bare_uris+tex_math_single_backslash --output document.tex --lua-filter /opt/app-root/bin/Rpackages/4.4/rmarkdown/rmarkdown/lua/pagebreak.lua --lua-filter /opt/app-root/bin/Rpackages/4.4/rmarkdown/rmarkdown/lua/latex-div.lua --embed-resources --standalone --highlight-style tango --pdf-engine pdflatex --variable graphics --variable 'geometry:margin=1in' 
! LaTeX Error: File `framed.sty' not found.

! Emergency stop.
<read *> 

! kpathsea: Running mktexfmt pdflatex.fmt
! mktexfmt: mktexfmt is using the following fmtutil.cnf files (in precedence order):
! mktexfmt:   /usr/share/texlive/texmf-dist/web2c/fmtutil.cnf
! mktexfmt: mktexfmt is using the following fmtutil.cnf file for writing changes:
! mktexfmt:   /opt/app-root/src/.texlive2020/texmf-config/web2c/fmtutil.cnf
! mktexfmt [INFO]: writing formats under /opt/app-root/src/.texlive2020/texmf-var/web2c
! mktexfmt [INFO]: --- remaking pdflatex with pdftex
! mktexfmt: running `pdftex -ini   -jobname=pdflatex -progname=pdflatex -translate-file=cp227.tcx *pdflatex.ini' ...
! This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020) (INITEX)
!  restricted \\write18 enabled.
!  (/usr/share/texlive/texmf-dist/web2c/cp227.tcx)
! entering extended mode
! (/usr/share/texlive/texmf-dist/tex/latex/latexconfig/pdflatex.ini
! (/usr/share/texlive/texmf-dist/tex/generic/tex-ini-files/pdftexconfig.tex)
! (/usr/share/texlive/texmf-dist/tex/latex/base/latex.ltx
! (/usr/share/texlive/texmf-dist/tex/latex/base/texsys.cfg)
! ./texsys.aux found

[...]

! 17292 multiletter control sequences

! \\font\
ullfont=nullfont

! \\font\\c__fp_exp_intarray=cmr10 at 0.00002pt

! \\font\\c__fp_trig_intarray=cmr10 at 0.00003pt

! \\font\\c_initex_cctab=cmr10 at 0.00005pt

! \\font\\c_other_cctab=cmr10 at 0.00006pt

! \\font\\c_str_cctab=cmr10 at 0.00008pt

! \\font\\g__regex_state_active_intarray=cmr10 at 0.00009pt

! \\font\\g__regex_thread_info_intarray=cmr10 at 0.0001pt

! \\font\\g__regex_submatch_prev_intarray=cmr10 at 0.00012pt

! \\font\\g__regex_submatch_begin_intarray=cmr10 at 0.00014pt

! \\font\\g__regex_submatch_end_intarray=cmr10 at 0.00015pt

! \\font\\g__regex_balance_intarray=cmr10 at 0.00017pt

! \\font\\OMX/cmex/m/n/10=cmex10

! \\font\\tenln=line10

! \\font\\tenlnw=linew10

! \\font\\tencirc=lcircle10

! \\font\\tencircw=lcirclew10

! \\font\\OT1/cmr/m/n/5=cmr5

! \\font\\OT1/cmr/m/n/7=cmr7

! \\font\\OT1/cmr/m/n/10=cmr10

! \\font\\OML/cmm/m/it/5=cmmi5

! \\font\\OML/cmm/m/it/7=cmmi7

! \\font\\OML/cmm/m/it/10=cmmi10

! \\font\\OMS/cmsy/m/n/5=cmsy5

! \\font\\OMS/cmsy/m/n/7=cmsy7

! \\font\\OMS/cmsy/m/n/10=cmsy10

! \\font\\c_code_cctab=cmr10 at 0.00018pt

! \\font\\c_document_cctab=cmr10 at 0.0002pt

! 403423 words of font info for 27 preloaded fonts

! 14 hyphenation exceptions

! Hyphenation trie of length 6081 has 183 ops out of 35111

!   2 for language 1

!   181 for language 0

! 0 words of pdfTeX memory

! 0 indirect objects

! No pages of output.

! Transcript written on pdflatex.log.

! mktexfmt [INFO]: log file copied to: /opt/app-root/src/.texlive2020/texmf-var/web2c/pdftex/pdflatex.log

! mktexfmt [INFO]: /opt/app-root/src/.texlive2020/texmf-var/web2c/pdftex/pdflatex.fmt installed.

! mktexfmt [INFO]: successfully rebuilt formats: 1

! mktexfmt [INFO]: not selected formats: 19

! mktexfmt [INFO]: total formats: 20

! mktexfmt [INFO]: exiting with status 0

Error: LaTeX failed to compile document.tex. See https://yihui.org/tinytex/r/#debugging for debugging tips. See document.log for more info.
Execution halted
```

![image](https://github.com/user-attachments/assets/d364155b-8c6a-43ec-aba4-aa6d2b24c9d1)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
