### PR TITLE
RHOAIENG-18459: chore(tests/containers/workbenches): make the ipv6 listening test work on macOS

### DIFF
--- a/tests/containers/podman_machine_utils.py
+++ b/tests/containers/podman_machine_utils.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import socket
+import subprocess
+from tests.containers.schemas import PodmanMachineInspect
+
+logging.basicConfig(level=logging.DEBUG)
+
+def open_ssh_tunnel(machine_name: str, local_port: int, remote_port: int, remote_interface: str = "localhost") -> subprocess.Popen:
+    # Load and parse the Podman machine data
+    json_data = subprocess.check_output(["podman", "machine", "inspect", machine_name], text=True)
+    inspect = PodmanMachineInspect(machines=json.loads(json_data))
+    machines = inspect.machines
+
+    machine = next((m for m in machines if m.Name == machine_name), None)
+    if not machine:
+        raise ValueError(f"Machine '{machine_name}' not found")
+
+    ssh_command = [
+        "ssh",
+        "-i", machine.SSHConfig.IdentityPath,
+        "-p", str(machine.SSHConfig.Port),
+        "-L", f"{local_port}:{remote_interface}:{remote_port}",
+        "-N",  # Do not execute a remote command
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "StrictHostKeyChecking=no",
+        f"{machine.SSHConfig.RemoteUsername}@localhost"
+    ]
+
+    # Open the SSH tunnel
+    process = subprocess.Popen(ssh_command)
+
+    logging.info(f"SSH tunnel opened for {machine_name}: {remote_interface}:{local_port} -> localhost:{remote_port}")
+    return process
+
+def find_free_port() -> int:
+    """Find a free port on the local machine.
+    :return: A port number that is currently free and available for use.
+    """
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))  # Bind to a free port provided by the system
+        s.listen(1)
+        port = s.getsockname()[1]
+    return port
+
+# Usage example
+if __name__ == "__main__":
+    tunnel_process = open_ssh_tunnel(
+        "podman-machine-default",
+        8080, 8080,
+        remote_interface="[fc00::2]"
+    )
+
+    # Keep the tunnel open until user interrupts
+    try:
+        tunnel_process.wait()
+    except KeyboardInterrupt:
+        tunnel_process.terminate()
+        print("SSH tunnel closed")

--- a/tests/containers/schemas.py
+++ b/tests/containers/schemas.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+
+class ConfigDir(BaseModel):
+    Path: str
+
+class PodmanSocket(BaseModel):
+    Path: str
+
+class ConnectionInfo(BaseModel):
+    PodmanSocket: PodmanSocket
+    PodmanPipe: Optional[str] = None
+
+class Resources(BaseModel):
+    CPUs: int
+    DiskSize: int
+    Memory: int
+    USBs: list[str] = []
+
+class SSHConfig(BaseModel):
+    IdentityPath: str
+    Port: int
+    RemoteUsername: str
+
+class PodmanMachine(BaseModel):
+    ConfigDir: ConfigDir
+    ConnectionInfo: ConnectionInfo
+    Created: datetime
+    LastUp: datetime
+    Name: str
+    Resources: Resources
+    SSHConfig: SSHConfig
+    State: str
+    UserModeNetworking: bool
+    Rootful: bool
+    Rosetta: bool
+
+# generated from `podman machine inspect` output by smart tooling
+class PodmanMachineInspect(BaseModel):
+    machines: list[PodmanMachine]

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import http.cookiejar
 import logging
+import os
 import platform
 import urllib.error
 import urllib.request
@@ -87,9 +88,11 @@ class TestWorkbenchImage:
                         # the container host is a podman machine, we need to expose port on podman machine first
                         host = "localhost"
                         port = podman_machine_utils.find_free_port()
-                        process = podman_machine_utils.open_ssh_tunnel("podman-machine-default",
-                                                                       local_port=port, remote_port=container.port,
-                                                                       remote_interface=f"[{ipv6_address}]")
+                        socket_path = os.path.realpath(docker_utils.get_socket_path(client.client))
+                        process = podman_machine_utils.open_ssh_tunnel(
+                            machine_predicate=lambda m: os.path.realpath(m.ConnectionInfo.PodmanSocket.Path) == socket_path,
+                            local_port=port, remote_port=container.port,
+                            remote_interface=f"[{ipv6_address}]")
                         test_frame.append(process, lambda p: p.kill())
                     else:
                         host = ipv6_address


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHOAIENG-9707
* https://issues.redhat.com/browse/RHOAIENG-18459

follow-up for
* https://github.com/opendatahub-io/notebooks/pull/866

## Description

Uses the pydantic library to load output from `podman machine info` and sets-up a ssh tunnel from the podman machine vm to the machine running the test.

This is a workaround for macOS/rootful issues in Podman
* https://github.com/containers/podman/issues/14491
* https://github.com/containers/podman/issues/15140

## How Has This Been Tested?

* works on my macOS
* https://github.com/jiridanek/notebooks/actions/runs/12986604939

```
poetry run pytest tests/containers \
    -k 'TestWorkbenchImage and test_ipv6_only' \
    --image=quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.11-20250124-6a93e34
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
