### PR TITLE
RHOAIENG-18459: chore(tests/containers): handle multiple podman machines and improve debugging output when podman machine is not found

### DIFF
--- a/tests/containers/podman_machine_utils.py
+++ b/tests/containers/podman_machine_utils.py
@@ -11,11 +11,10 @@ logging.basicConfig(level=logging.DEBUG)
 def open_ssh_tunnel(machine_predicate: Callable[[tests.containers.schemas.PodmanMachine], bool],
                     local_port: int, remote_port: int, remote_interface: str = "localhost") -> subprocess.Popen:
     # Load and parse the Podman machine data
-    machines = []
-    for machine_name in subprocess.check_output(["podman", "machine", "list", "--quiet"], text=True).splitlines():
-        json_data = subprocess.check_output(["podman", "machine", "inspect", machine_name], text=True)
-        inspect = tests.containers.schemas.PodmanMachineInspect(machines=json.loads(json_data))
-        machines.extend(inspect.machines)
+    machine_names = subprocess.check_output(["podman", "machine", "list", "--quiet"], text=True).splitlines()
+    json_data = subprocess.check_output(["podman", "machine", "inspect", *machine_names], text=True)
+    inspect = tests.containers.schemas.PodmanMachineInspect(machines=json.loads(json_data))
+    machines = inspect.machines
 
     machine = next((m for m in machines if machine_predicate(m)), None)
     if not machine:

--- a/tests/containers/podman_machine_utils.py
+++ b/tests/containers/podman_machine_utils.py
@@ -11,13 +11,16 @@ logging.basicConfig(level=logging.DEBUG)
 def open_ssh_tunnel(machine_predicate: Callable[[tests.containers.schemas.PodmanMachine], bool],
                     local_port: int, remote_port: int, remote_interface: str = "localhost") -> subprocess.Popen:
     # Load and parse the Podman machine data
-    json_data = subprocess.check_output(["podman", "machine", "inspect"], text=True)
-    inspect = tests.containers.schemas.PodmanMachineInspect(machines=json.loads(json_data))
-    machines = inspect.machines
+    machines = []
+    for machine_name in subprocess.check_output(["podman", "machine", "list", "--quiet"], text=True).splitlines():
+        json_data = subprocess.check_output(["podman", "machine", "inspect", machine_name], text=True)
+        inspect = tests.containers.schemas.PodmanMachineInspect(machines=json.loads(json_data))
+        machines.extend(inspect.machines)
 
     machine = next((m for m in machines if machine_predicate(m)), None)
     if not machine:
-        raise ValueError(f"Machine matching given predicate not found")
+        raise ValueError(f"Machine matching given predicate not found:"
+                         f" the available machines are: {machines}")
 
     ssh_command = [
         "ssh",

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -89,6 +89,7 @@ class TestWorkbenchImage:
                         host = "localhost"
                         port = podman_machine_utils.find_free_port()
                         socket_path = os.path.realpath(docker_utils.get_socket_path(client.client))
+                        logging.debug(f"{socket_path=}")
                         process = podman_machine_utils.open_ssh_tunnel(
                             machine_predicate=lambda m: os.path.realpath(m.ConnectionInfo.PodmanSocket.Path) == socket_path,
                             local_port=port, remote_port=container.port,


### PR DESCRIPTION
Followup on
* https://github.com/opendatahub-io/notebooks/pull/868

## Description

Thanks @andyatmiami for help figuring this out. `podman machine inspect` replies with a json list, but it's always a json list of one element! `podman machine list` does give all machines, but it does not have access to their socket paths.

```shell
# From screwing around with a Go template string.. i'm not sure we can use the ls command of machine list - i'm beginning to think the information is moreso high level there.. and PodmanSocket is just literally not exposed :confused:

$ podman machine ls --format '{{range .}}{{.}}{{end -}}'  <-- doesn't contain what we actually care about
```

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/12994087373
* https://github.com/jiridanek/notebooks/actions/runs/12994274960

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
