### PR TITLE
RHOAIENG-9707: chore(tests/containers): check shared objects with ldd

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import binascii
+import inspect
+import json
 import logging
 import pathlib
+import re
 import tempfile
-from typing import TYPE_CHECKING
+import textwrap
+from typing import TYPE_CHECKING, Any, Callable
 
+import pytest
 import testcontainers.core.container
 import testcontainers.core.waiting_utils
 
@@ -19,6 +25,84 @@ if TYPE_CHECKING:
 
 class TestBaseImage:
     """Tests that are applicable for all images we have in this repository."""
+
+    def test_elf_files_can_link_runtime_libs(self, subtests: pytest_subtests.SubTests, image):
+        container = testcontainers.core.container.DockerContainer(image=image, user=0, group_add=[0])
+        container.with_command("/bin/sh -c 'sleep infinity'")
+
+        def check_elf_file():
+            """This python function will be executed on the image itself.
+            That's why it has to have here all imports it needs."""
+            import glob
+            import os
+            import json
+            import subprocess
+            import stat
+
+            dirs = [
+                "/bin",
+                "/lib",
+                "/lib64",
+                "/opt/app-root"
+            ]
+            for path in dirs:
+                count_scanned = 0
+                unsatisfied_deps: list[tuple[str, str]] = []
+                for dlib in glob.glob(os.path.join(path, "**"), recursive=True):
+                    # we will visit all files eventually, no need to bother with symlinks
+                    s = os.stat(dlib, follow_symlinks=False)
+                    isdirectory = stat.S_ISDIR(s.st_mode)
+                    isfile = stat.S_ISREG(s.st_mode)
+                    executable = bool(s.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+                    if isdirectory or not executable or not isfile:
+                        continue
+                    with open(dlib, mode='rb') as fp:
+                        magic = fp.read(4)
+                    if magic != b'\x7fELF':
+                        continue
+
+                    count_scanned += 1
+                    ld_library_path = os.environ.get("LD_LIBRARY_PATH", "") + os.path.pathsep + os.path.dirname(dlib)
+                    output = subprocess.check_output(["ldd", dlib],
+                                                     # search the $ORIGIN, essentially; most python libs expect this
+                                                     env={**os.environ, "LD_LIBRARY_PATH": ld_library_path},
+                                                     text=True)
+                    for line in output.splitlines():
+                        if "not found" in line:
+                            unsatisfied_deps.append((dlib, line.strip()))
+                    assert output
+                print("OUTPUT>", json.dumps({"dir": path, "count_scanned": count_scanned, "unsatisfied": unsatisfied_deps}))
+
+        try:
+            container.start()
+            ecode, output = container.exec(
+                encode_python_function_execution_command_interpreter("/usr/bin/python3", check_elf_file))
+        finally:
+            docker_utils.NotebookContainer(container).stop(timeout=0)
+
+        for line in output.decode().splitlines():
+            logging.debug(line)
+            if not line.startswith("OUTPUT> "):
+                continue
+            data = json.loads(line[len("OUTPUT> "):])
+            assert data['count_scanned'] > 0
+            for dlib, deps in data["unsatisfied"]:
+                # here goes the allowlist
+                if re.search(r"^/lib64/python3.\d+/site-packages/hawkey/test/_hawkey_test.so", dlib) is not None:
+                    continue  # this is some kind of self test or what
+                if re.search(r"^/lib64/systemd/libsystemd-core-\d+.so", dlib) is not None:
+                    continue  # this is expected and we don't use systemd anyway
+                if deps.startswith("libodbc.so.2"):
+                    continue  # todo(jdanek): known issue RHOAIENG-18904
+                if deps.startswith("libcuda.so.1"):
+                    continue  # cuda magic will mount this into /usr/lib64/libcuda.so.1 and it will be found
+                if deps.startswith("libjvm.so"):
+                    continue  # it's in ../server
+                if deps.startswith("libtracker-extract.so"):
+                    continue  # it's in ../
+
+                with subtests.test(f"{dlib=}"):
+                    pytest.fail(f"{dlib=} has unsatisfied dependencies {deps=}")
 
     def test_oc_command_runs(self, image: str):
         container = testcontainers.core.container.DockerContainer(image=image, user=23456, group_add=[0])
@@ -78,3 +162,19 @@ class TestBaseImage:
                     assert ecode == 0, output.decode()
             finally:
                 docker_utils.NotebookContainer(container).stop(timeout=0)
+
+
+def encode_python_function_execution_command_interpreter(python: str, function: Callable[..., Any], *args: list[Any]) -> list[str]:
+    """Returns a cli command that will run the given Python function encoded inline.
+    All dependencies (imports, ...) must be part of function body."""
+    code = textwrap.dedent(inspect.getsource(function))
+    ccode = binascii.b2a_base64(code.encode())
+    name = function.__name__
+    parameters = ', '.join(repr(arg) for arg in args)
+    program = textwrap.dedent(f"""
+        import binascii;
+        s=binascii.a2b_base64("{ccode.decode('ascii').strip()}");
+        exec(s.decode());
+        print({name}({parameters}));""")
+    int_cmd = [python, "-c", program]
+    return int_cmd


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHOAIENG-9707
* https://issues.redhat.com/browse/RHOAIENG-18904

This sanity check will report any ELF files with dynamic linking that have unsatisfied dependencies.

* apply the `"LD_LIBRARY_PATH": os.path.dirname(dlib)` fix/workaround

cuda image already has some LD_LIBRARY_PATH, this is to be preserved

```
(app-root) sh-5.1$ echo $LD_LIBRARY_PATH
/usr/local/nvidia/lib:/usr/local/nvidia/lib64
```

* use subtests to handle multiple libs not found

* skip known issue and false positives

## Description

Running `ldd` one by one on every file is quite lengthy on macOS, due to cross-architecture emulation

```
(app-root) bash-5.1$ time bash -c 'i=0; while [[ $i -lt 100 ]]; do ldd /bin/bash >/dev/null; i=$((i+1)); done'

real    0m5.684s
user    0m4.527s
sys     0m0.795s
```

compare that with native linux vm, without this cross-arch translation

```
[jdanek@lima-default workbenches]$ time bash -c 'i=0; while [[ $i -lt 100 ]]; do ldd /bin/bash >/dev/null; i=$((i+1)); done'

real    0m0.220s
user    0m0.130s
sys     0m0.061s
```

Since there's 1000 to 2000 dynamic libs to check in each of our images, the check on a macOS when using ldd can take 70 or more seconds.

When mentioned on a daily meeting, ppl weren't very concerned, so I'm not going to optimize this now.

For the future, already tried out one approach, using the debug/elf package in Go's standard library to simply read the DT_NEEDED field out of the libraries and check that. It's quite a lot of code, but it seems to work, and work fast.  
[check_elf_file_2.go.txt](https://github.com/user-attachments/files/18584127/check_elf_file_2.go.txt)

Alternatively, it should be possible to just go around loading the dlls from the python script directly, to see if it loads or not

```python
            from ctypes import CDLL
            try:
                CDLL(lib_path)
                print(f"Successfully loaded: {lib}")
            except Exception as e:
                print(f"Error loading {lib}: {e}")
```

Question is whether binaries can be casually dlopened like this. I did this in skupper-router (dlopening the current executable ;) so it is possible sometimes, just don't know if always; worry that binary has to be compiled with some special options.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/13026586540

Checked all what it found by hand and populated an allowlist to suppress false positives.

Over all, the usefulness of this check will be best seen when we do version upgrades or some significant version upgrades for 2025.a images. Is this going to be full of false positives for trivialities, or is it going to save us from dll hell? So far it found a true positive https://issues.redhat.com/browse/RHOAIENG-18904, but I do worry that the maintenance of the allowlist is not going to be worth it.

Possibly running `import xyz` for every python package we have is more useful. Adding to that small helloworld script to check functionality would be even more powerful.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
