### PR TITLE
Reapply "RHOAIENG-17306, RHOAIENG-17307, RHOAIENG-17308: feat(workbenches): tolerate IPv6 environments in codeserver, jupyterlab and rstudio"

### DIFF
--- a/2024b/codeserver/ubi9-python-3.11/nginx/api/kernels/access.cgi
+++ b/2024b/codeserver/ubi9-python-3.11/nginx/api/kernels/access.cgi
@@ -3,7 +3,7 @@ echo "Status: 200"
 echo "Content-type: application/json"
 echo
 # Query the heartbeat endpoint
-HEALTHZ=$(curl -s http://127.0.0.1:8888/codeserver/healthz)
+HEALTHZ=$(curl -s http://localhost:8888/codeserver/healthz)
 # Extract last_activity | remove milliseconds
 LAST_ACTIVITY_EPOCH=$(echo $HEALTHZ | grep -Po 'lastHeartbeat":\K.*?(?=})' | awk '{ print substr( $0, 1, length($0)-3 ) }')
 # Convert to ISO8601 date format

--- a/2024b/codeserver/ubi9-python-3.11/nginx/root/opt/app-root/nginxconf.sed
+++ b/2024b/codeserver/ubi9-python-3.11/nginx/root/opt/app-root/nginxconf.sed
@@ -1,9 +1,6 @@
 # Change port
 /listen/s%80%8888 default_server%
 
-# Remove listening on IPv6
-/\[::\]/d
-
 # One worker only
 /worker_processes/s%auto%1%
 

--- a/2024b/codeserver/ubi9-python-3.11/nginx/serverconf/proxy.conf.template
+++ b/2024b/codeserver/ubi9-python-3.11/nginx/serverconf/proxy.conf.template
@@ -45,7 +45,7 @@ location = /codeserver {
 
 location /codeserver/ {
     # Standard code-server/NGINX configuration
-    proxy_pass http://127.0.0.1:8787/;
+    proxy_pass http://localhost:8787/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;

--- a/2024b/codeserver/ubi9-python-3.11/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/2024b/codeserver/ubi9-python-3.11/nginx/serverconf/proxy.conf.template_nbprefix
@@ -59,7 +59,7 @@ location = / {
 location /codeserver/ {
     rewrite ^/codeserver/(.*)$ /$1 break;
     # Standard RStudio/NGINX configuration
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://localhost:8787;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;

--- a/2024b/codeserver/ubi9-python-3.11/run-code-server.sh
+++ b/2024b/codeserver/ubi9-python-3.11/run-code-server.sh
@@ -110,10 +110,20 @@ if [ ! -d "$logs_dir" ]; then
   mkdir -p "$logs_dir"
 fi
 
+# IPv6 support
+echo "Checking IPv6 support..."
+if [ -f /proc/net/if_inet6 ]; then
+    BIND_ADDR="[::]:8787"  # IPv6/dual-stack
+    echo "IPv6 detected: binding to all interfaces (IPv4 + IPv6)"
+else
+    BIND_ADDR="0.0.0.0:8787"  # IPv4 only
+    echo "IPv6 not detected: falling back to IPv4 only"
+fi
+
 # Start server
 start_process /usr/bin/code-server \
-  --bind-addr 0.0.0.0:8787 \
-  --disable-telemetry \
-  --auth none \
-  --disable-update-check \
-  /opt/app-root/src
+    --bind-addr "${BIND_ADDR}" \
+    --disable-telemetry \
+    --auth none \
+    --disable-update-check \
+    /opt/app-root/src

--- a/2024b/jupyter/minimal/ubi9-python-3.11/start-notebook.sh
+++ b/2024b/jupyter/minimal/ubi9-python-3.11/start-notebook.sh
@@ -35,6 +35,6 @@ fi
 
 # Start the JupyterLab notebook
 start_process jupyter lab ${NOTEBOOK_PROGRAM_ARGS} \
-    --ServerApp.ip=0.0.0.0 \
+    --ServerApp.ip="" \
     --ServerApp.allow_origin="*" \
     --ServerApp.open_browser=False

--- a/2024b/rstudio/c9s-python-3.11/nginx/serverconf/proxy.conf.template
+++ b/2024b/rstudio/c9s-python-3.11/nginx/serverconf/proxy.conf.template
@@ -50,7 +50,7 @@ location = /rstudio {
 location /rstudio/ {
     rewrite ^/rstudio/(.*)$ /$1 break;
     # Standard RStudio/NGINX configuration
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://localhost:8787;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;

--- a/2024b/rstudio/c9s-python-3.11/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/2024b/rstudio/c9s-python-3.11/nginx/serverconf/proxy.conf.template_nbprefix
@@ -77,7 +77,7 @@ location = / {
 location /rstudio/ {
     rewrite ^/rstudio/(.*)$ /$1 break;
     # Standard RStudio/NGINX configuration
-    proxy_pass http://127.0.0.1:8787;
+    proxy_pass http://localhost:8787;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;

--- a/2024b/rstudio/c9s-python-3.11/setup_rstudio.py
+++ b/2024b/rstudio/c9s-python-3.11/setup_rstudio.py
@@ -46,6 +46,30 @@ def _support_arg(arg):
     ret = subprocess.check_output([get_rstudio_executable('rserver'), '--help'])
     return ret.decode().find(arg) != -1
 
+def detect_env():
+    import socket
+    supports_ipv4 = supports_ipv6 = False
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', 0))
+            supports_ipv4 = True
+    except OSError:
+        pass
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(('::1', 0))
+            supports_ipv6 = True
+    except OSError:
+        pass
+    if supports_ipv4 and supports_ipv6:
+        return '::'  # Dual-stack
+    elif supports_ipv6:
+        return '::'
+    elif supports_ipv4:
+        return '0.0.0.0'
+    else:
+        raise EnvironmentError('No IPv4 or IPv6 support detected.')
+
 def _get_cmd(port):
     ntf = tempfile.NamedTemporaryFile()
 
@@ -60,7 +84,7 @@ def _get_cmd(port):
         '--server-working-dir=' + os.getenv('HOME'),
         '--auth-none=1',
         '--www-frame-origin=same',
-        #'--www-address=0.0.0.0',
+        '--www-address='+ detect_env(),
         '--www-port=' + str(port),
         '--www-verify-user-agent=0',
         '--rsession-which-r=' + get_rstudio_executable('R'),

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -49,7 +49,6 @@ class TestWorkbenchImage:
         finally:
             docker_utils.NotebookContainer(container).stop(timeout=0)
 
-    @pytest.mark.skip(reason="RHOAIENG-17305: currently our Workbench images don't tolerate IPv6")
     def test_ipv6_only(self, image: str, test_frame):
         """Test that workbench image is accessible via IPv6.
         Workarounds for macOS will be needed, so that's why it's a separate test."""


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17305

Reverts opendatahub-io/notebooks#877
* https://github.com/opendatahub-io/notebooks/pull/877

Which means it's to reapply opendatahub-io/notebooks#827
* https://github.com/opendatahub-io/notebooks/pull/827