### PR TITLE
RHOAIENG-19036: chore(gha): fix workflow_dispatch invocation

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -237,17 +237,19 @@ jobs:
       # region Image build
 
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
-      - name: "push|schedule: make ${{ inputs.target }}"
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+
+      - name: "push|schedule|workflow_dispatch: make ${{ inputs.target }}"
         run: |
           make ${{ inputs.target }}
-        if: ${{ fromJson(inputs.github).event_name == 'push' || fromJson(inputs.github).event_name == 'schedule' }}
+        if: ${{ fromJson(inputs.github).event_name == 'push' ||
+          fromJson(inputs.github).event_name == 'schedule' ||
+          fromJson(inputs.github).event_name == 'workflow_dispatch' }}
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
           CONTAINER_BUILD_CACHE_ARGS: "--cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
           # dependent images were already built and pushed, so just let podman pull it
           BUILD_DEPENDENT_IMAGES: "no"
-
-      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
       - name: "pull_request: make ${{ inputs.target }}"
         run: |
           make ${{ inputs.target }}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-19036

## Description

Previously, triggering the GitHub action manually would not build the image, and so the tests would then fail.

The cause is that we do different build commands depending whether it's builting on push, on pr, or on schedule, and for manual trigger nothing was defined.

![image](https://github.com/user-attachments/assets/49bcebd3-c48c-4fe2-bb43-0d53857a5ef9)

This PR should resolve the first problem that @andyatmiami pointed out in https://issues.redhat.com/browse/RHOAIENG-19036?focusedId=26504453&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26504453 that's regarding the manually triggered run at https://github.com/red-hat-data-services/notebooks/actions/runs/13056808219

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/13087476156

the first failure there

```
Error: creating build container: initializing source docker://registry.access.redhat.com/ubi9/python-311:latest: reading manifest latest in registry.access.redhat.com/ubi9/python-311: received unexpected HTTP status: 503 Service Unavailable
```

was an infra issue and it fixed itself in a rerun

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
