### PR TITLE
Create ImageStream objects for the runtime images

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -14,6 +14,12 @@ resources:
   - jupyter-rocm-minimal-notebook-imagestream.yaml
   - jupyter-rocm-pytorch-notebook-imagestream.yaml
   - jupyter-rocm-tensorflow-notebook-imagestream.yaml
+  - runtime-datascience-imagestream.yaml
+  - runtime-minimal-imagestream.yaml
+  - runtime-pytorch-imagestream.yaml
+  - runtime-rocm-pytorch-imagestream.yaml
+  - runtime-rocm-tensorflow-imagestream.yaml
+  - runtime-tensorflow-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"

--- a/manifests/base/runtime-datascience-imagestream.yaml
+++ b/manifests/base/runtime-datascience-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Datascience with Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+  name: runtime-datascience
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Datascience with Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "datascience"
+                ],
+                "display_name": "Datascience with Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e
+      name: "datascience"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-minimal-imagestream.yaml
+++ b/manifests/base/runtime-minimal-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+  name: runtime-minimal
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "minimal"
+                ],
+                "display_name": "Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:a2b1bf59f25fd0694394ad927e5eba93e32df9c2c11d8b54412564a9fc736ab8",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:a2b1bf59f25fd0694394ad927e5eba93e32df9c2c11d8b54412564a9fc736ab8
+      name: "minimal"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-pytorch-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Pytorch with CUDA and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Pytorch with CUDA and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "pytorch"
+                ],
+                "display_name": "Pytorch with CUDA and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:6a2806bf3cd9b00f60f3c7fe907727fb954c9776a075d9d58df26b5119d7afe6",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:6a2806bf3cd9b00f60f3c7fe907727fb954c9776a075d9d58df26b5119d7afe6
+      name: "pytorch"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-rocm-pytorch-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Pytorch with ROCm and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-rocm-pytorch
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Pytorch with ROCm and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "rocm-pytorch"
+                ],
+                "display_name": "Pytorch with ROCm and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:c6d74d73b835d0f97040ca99bb25065a949b817b52179f239a5361c3299352ba",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:c6d74d73b835d0f97040ca99bb25065a949b817b52179f239a5361c3299352ba
+      name: "rocm-pytorch"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "TensorFlow with ROCm and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-rocm-tensorflow
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "TensorFlow with ROCm and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "rocm-tensorflow"
+                ],
+                "display_name": "TensorFlow with ROCm and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:6a2da12a8bdc9cfcda27f4189827be5fbde4b4b4c4f7d92ac694d9360e3562dc",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:6a2da12a8bdc9cfcda27f4189827be5fbde4b4b4c4f7d92ac694d9360e3562dc
+      name: "rocm-tensorflow"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-tensorflow-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "TensorFlow with CUDA and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-tensorflow
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "TensorFlow with CUDA and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "tensorflow"
+                ],
+                "display_name": "TensorFlow with CUDA and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:5d695b2e5dc76fc07a138644e2cd507c73eb9b26a47596734169c0b313e733f9",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:5d695b2e5dc76fc07a138644e2cd507c73eb9b26a47596734169c0b313e733f9
+      name: "tensorflow"
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-19050 [part 1/x]

## Description
<!--- Describe your changes in detail -->
This PR introduces six newly created ImageStreams to utilize runtime images via manifests.

The .json with its metadata incorporated under the imagestream using the ` opendatahub.io/runtime-image-metadata` annotation.

:bangbang: NOTE: Please review the annotation fields carefully 🙂 and provide feedback on whether they meet our requirements. I will update later on with thir inclusion on N and N-1 directories

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Used `DevFlags` on the RHOAI DSC 

```
    workbenches:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/atheo89/notebooks/archive/rhoaieng-19050.tar.gz'
      managementState: Managed
```

![image](https://github.com/user-attachments/assets/3de1d486-ae96-4c89-8247-d81fcbcd1ebe)


This is what the runtime ImageStream looks like when generated by the RHOAI operator:

```
kind: ImageStream
apiVersion: image.openshift.io/v1
metadata:
  annotations:
    platform.opendatahub.io/instance.name: default-workbenches
    internal.config.kubernetes.io/previousNamespaces: default
    opendatahub.io/runtime-image-url: 'https://github.com//opendatahub-io/notebooks/tree/main/runtimes'
    internal.config.kubernetes.io/previousKinds: ImageStream
    opendatahub.io/runtime-image-name: Datascience with Python 3.11 (UBI9)
    platform.opendatahub.io/instance.generation: '1'
    opendatahub.io/runtime-image-desc: 'Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes.'
    internal.config.kubernetes.io/previousNames: runtime-datascience
    platform.opendatahub.io/version: 2.18.0
    openshift.io/image.dockerRepositoryCheck: '2025-02-05T10:33:49Z'
    platform.opendatahub.io/instance.uid: d373a9b1-54b5-4bb3-8f78-86b435e2288b
    platform.opendatahub.io/type: OpenShift AI Self-Managed
  resourceVersion: '66395157'
  name: runtime-datascience
  uid: 6c973fd7-e08f-4b9c-9de9-0ccfe53709c8
  creationTimestamp: '2025-02-05T10:33:38Z'
  generation: 2
  namespace: redhat-ods-applications
  labels:
    app.kubernetes.io/part-of: workbenches
    app.opendatahub.io/workbenches: 'true'
    component.opendatahub.io/name: notebooks
    opendatahub.io/component: 'true'
    opendatahub.io/runtime-image: 'true'
    platform.opendatahub.io/part-of: workbenches
spec:
  lookupPolicy:
    local: true
  tags:
    - name: datascience
      annotations:
        opendatahub.io/runtime-image-metadata: |
          [
            {
              "display_name": "Datascience with Python 3.11 (UBI9)",
              "metadata": {
                "tags": [
                  "datascience"
                ],
                "display_name": "Datascience with Python 3.11 (UBI9)",
                "image_name": "quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e",
                "pull_policy": "IfNotPresent"
              },
              "schema_name": "runtime-image"
            }
          ]
        openshift.io/imported-from: quay.io/opendatahub/workbench-images
      from:
        kind: DockerImage
        name: 'quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e'
      generation: 2
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Source
status:
  dockerImageRepository: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/runtime-datascience'
  tags:
    - tag: datascience
      items:
        - created: '2025-02-05T10:33:49Z'
          dockerImageReference: 'quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e'
          image: 'sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e'
          generation: 2
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
