### PR TITLE
RHOAIENG-19388: fix the transformers version in manifests

### DIFF
--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -26,7 +26,7 @@ spec:
           [
             {"name": "JupyterLab","version": "4.2"},
             {"name": "TrustyAI", "version": "0.6"},
-            {"name": "Transformers", "version": "4.36"},
+            {"name": "Transformers", "version": "4.38"},
             {"name": "Datasets", "version": "2.21"},
             {"name": "Accelerate", "version": "0.34"},
             {"name": "Torch", "version": "2.2"},


### PR DESCRIPTION
The TrustyAI package has wrong version of transformers package in the ImageStream manifest file compared to what is actually installed on the image.

This fixes https://issues.redhat.com/browse/RHOAIENG-19388.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
