### PR TITLE
NO-ISSUE: chore(tests/containers): fix fake fips tests for macOS rootless podman machine

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import pathlib
+import platform
 import re
 import tempfile
 import textwrap
@@ -135,16 +136,24 @@ class TestBaseImage:
             tmp_crypto.chmod(0o777)
 
             container = testcontainers.core.container.DockerContainer(image=image, user=54321, group_add=[0])
-            container.with_volume_mapping(str(tmp_crypto), "/proc/sys", mode="ro,z")
+
+            # if /proc/sys/crypto/fips_enabled exists, only replace this file,
+            # otherwise (Ubuntu case), assume entire /proc/sys/crypto does not exist
+            if platform.system().lower() == "darwin" or pathlib.Path("/proc/sys/crypto/fips_enabled").exists():
+                container.with_volume_mapping(str(tmp_crypto / 'crypto' / 'fips_enabled'), "/proc/sys/crypto/fips_enabled", mode="ro,z")
+            else:
+                container.with_volume_mapping(str(tmp_crypto), "/proc/sys", mode="ro,z")
+
             container.with_command("/bin/sh -c 'sleep infinity'")
 
             try:
                 container.start()
 
                 with subtests.test("/proc/sys/crypto/fips_enabled is 1"):
-                    ecode, output = container.exec(["/bin/sh", "-c", "sysctl crypto.fips_enabled"])
+                    # sysctl here works too, but it may not be present in image
+                    ecode, output = container.exec(["/bin/sh", "-c", "cat /proc/sys/crypto/fips_enabled"])
                     assert ecode == 0, output.decode()
-                    assert "crypto.fips_enabled = 1\n" == output.decode(), output.decode()
+                    assert "1\n" == output.decode(), f"Unexpected crypto/fips_enabled content: {output.decode()}"
 
                 # 0: enabled, 1: partial success, 2: not enabled
                 with subtests.test("/fips-mode-setup --is-enabled reports 1"):


### PR DESCRIPTION
This is to fix this problem I have on macOS with rootless podman machine

```
base_image_test.py:146: in test_oc_command_runs_fake_fips
    assert ecode == 0, output.decode()
E   AssertionError: assertion failed [!result.is_error]: Unable to open /proc/sys/vm/mmap_min_addr
E     (VMAllocationTracker.cpp:317 init)
E
E   assert 137 == 0
```

Normally, there is `/proc/sys/vm/mmap_min_addr` file

```
lima cat /proc/sys/vm/mmap_min_addr
65536
```

```
podman machine ssh cat /proc/sys/vm/mmap_min_addr
65536
```

```
podman run --entrypoint /bin/bash --rm -it ghcr.io/jiridanek/notebooks/workbench-images:base-ubi9-python-3.11-jd_ubi_base_1e8dd3140d980ff573d56d3ae746959f31825d8a
WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)
bash-5.1$ cat /proc/sys/vm/mmap_min_addr
65536
```

but in the tests when mounting iinto /proc/sys, we end up making /proc/sys/vm inaccessible. The broad mount is required for GitHub Actions on Ubuntu.

## Description

Solution is conditional, to mount differently on ubuntu and in a different way elsewhere. Checking whether /proc/sys/crypto is present on macOS is harder (podman machine) so assume on macOS ppl are using Fedora in podman machine so it works.

## How Has This Been Tested?

```
helpers/pycharm/_jb_pytest_runner.py --target base_image_test.py::TestBaseImage.test_oc_command_runs_fake_fips -- --image=ghcr.io/jiridanek/notebooks/workbench-images:base-ubi9-python-3.11-jd_ubi_base_1e8dd3140d980ff573d56d3ae746959f31825d8a 
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
