### PR TITLE
fix: add '=' to ENV directives in Dockerfiles 

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile
+++ b/codeserver/ubi9-python-3.11/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /opt/app-root/extensions-temp && \
     code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2024.7.0.vsix --extensions-dir /opt/app-root/extensions-temp
 
 # Install NGINX to proxy code-server and pass probes check
-ENV NGINX_VERSION=1.24 \
+ENV NGINX_VERSION=1.24=\
     NGINX_SHORT_VER=124 \
     NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/nginx/nginx.conf \
@@ -112,7 +112,7 @@ COPY ${SOURCE_CODE}/nginx/api/ /opt/app-root/api/
 # Launcher
 COPY --chown=1001:0 ${SOURCE_CODE}/run-code-server.sh ${SOURCE_CODE}/run-nginx.sh ./
 
-ENV SHELL /bin/bash
+ENV SHELL=/bin/bash
 
 ENV PYTHONPATH=/opt/app-root/bin/python3
 

--- a/cuda/c9s-python-3.11/Dockerfile
+++ b/cuda/c9s-python-3.11/Dockerfile
@@ -18,9 +18,9 @@ LABEL name="odh-notebook-cuda-c9s-python-3.11" \
 USER 0
 WORKDIR /opt/app-root/bin
 
-ENV NVARCH x86_64
-ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
-ENV NV_CUDA_CUDART_VERSION 12.1.105-1
+ENV NVARCH=x86_64
+ENV NVIDIA_REQUIRE_CUDA="cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
+ENV NV_CUDA_CUDART_VERSION=12.1.105-1
 
 COPY ${SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
@@ -28,7 +28,7 @@ RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION 12.1.1
+ENV CUDA_VERSION=12.1.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \
@@ -41,27 +41,27 @@ RUN yum upgrade -y && yum install -y \
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 COPY ${SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 # nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Install CUDA runtime from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/runtime/Dockerfile
-ENV NV_CUDA_LIB_VERSION 12.1.1-1
-ENV NV_NVTX_VERSION 12.1.105-1
-ENV NV_LIBNPP_VERSION 12.1.0.40-1
-ENV NV_LIBNPP_PACKAGE libnpp-12-1-${NV_LIBNPP_VERSION}
-ENV NV_LIBCUBLAS_VERSION 12.1.3.1-1
-ENV NV_LIBNCCL_PACKAGE_NAME libnccl
-ENV NV_LIBNCCL_PACKAGE_VERSION 2.17.1-1
-ENV NV_LIBNCCL_VERSION 2.17.1
-ENV NCCL_VERSION 2.17.1
-ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
+ENV NV_CUDA_LIB_VERSION=12.1.1-1
+ENV NV_NVTX_VERSION=12.1.105-1
+ENV NV_LIBNPP_VERSION=12.1.0.40-1
+ENV NV_LIBNPP_PACKAGE=libnpp-12-1-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION=12.1.3.1-1
+ENV NV_LIBNCCL_PACKAGE_NAME=libnccl
+ENV NV_LIBNCCL_PACKAGE_VERSION=2.17.1-1
+ENV NV_LIBNCCL_VERSION=2.17.1
+ENV NCCL_VERSION=2.17.1
+ENV NV_LIBNCCL_PACKAGE=${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
 
 RUN yum install -y \
     cuda-libraries-12-1-${NV_CUDA_LIB_VERSION} \
@@ -77,20 +77,20 @@ ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
 # Install CUDA devel from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION 12.1.1-1
-ENV NV_NVPROF_VERSION 12.1.105-1
-ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-12-1-${NV_NVPROF_VERSION}
-ENV NV_CUDA_CUDART_DEV_VERSION 12.1.105-1
-ENV NV_NVML_DEV_VERSION 12.1.105-1
-ENV NV_LIBCUBLAS_DEV_VERSION 12.1.3.1-1
-ENV NV_LIBNPP_DEV_VERSION 12.1.0.40-1
-ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.17.1-1
-ENV NCCL_VERSION 2.17.1
-ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION 12.1.1-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+ENV NV_CUDA_LIB_VERSION=12.1.1-1
+ENV NV_NVPROF_VERSION=12.1.105-1
+ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-1-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION=12.1.105-1
+ENV NV_NVML_DEV_VERSION=12.1.105-1
+ENV NV_LIBCUBLAS_DEV_VERSION=12.1.3.1-1
+ENV NV_LIBNPP_DEV_VERSION=12.1.0.40-1
+ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
+ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.17.1-1
+ENV NCCL_VERSION=2.17.1
+ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.1.1-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
 
 RUN yum install -y \
     make \
@@ -108,13 +108,13 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 # Install CUDA devel cudnn8 from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/cudnn8/Dockerfile
-ENV NV_CUDNN_VERSION 8.9.0.131-1
-ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
-ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
+ENV NV_CUDNN_VERSION=8.9.0.131-1
+ENV NV_CUDNN_PACKAGE=libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
+ENV NV_CUDNN_PACKAGE_DEV=libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 

--- a/cuda/ubi9-python-3.11/Dockerfile
+++ b/cuda/ubi9-python-3.11/Dockerfile
@@ -18,9 +18,9 @@ LABEL name="odh-notebook-cuda-ubi9-python-3.11" \
 USER 0
 WORKDIR /opt/app-root/bin
 
-ENV NVARCH x86_64
-ENV NVIDIA_REQUIRE_CUDA "cuda>=12.4 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526 brand=tesla,driver>=535,driver<536 brand=unknown,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=geforce,driver>=535,driver<536 brand=geforcertx,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=titan,driver>=535,driver<536 brand=titanrtx,driver>=535,driver<536"
-ENV NV_CUDA_CUDART_VERSION 12.4.127-1
+ENV NVARCH=x86_64
+ENV NVIDIA_REQUIRE_CUDA="cuda>=12.4 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526 brand=tesla,driver>=535,driver<536 brand=unknown,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=geforce,driver>=535,driver<536 brand=geforcertx,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=titan,driver>=535,driver<536 brand=titanrtx,driver>=535,driver<536"
+ENV NV_CUDA_CUDART_VERSION=12.4.127-1
 
 COPY ${SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
@@ -28,7 +28,7 @@ RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION 12.4.1
+ENV CUDA_VERSION=12.4.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \
@@ -41,27 +41,27 @@ RUN yum upgrade -y && yum install -y \
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 COPY ${SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 # nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Install CUDA runtime from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubi9/runtime/Dockerfile
-ENV NV_CUDA_LIB_VERSION 12.4.1-1
-ENV NV_NVTX_VERSION 12.4.127-1
-ENV NV_LIBNPP_VERSION 12.2.5.30-1
-ENV NV_LIBNPP_PACKAGE libnpp-12-4-${NV_LIBNPP_VERSION}
-ENV NV_LIBCUBLAS_VERSION 12.4.5.8-1
-ENV NV_LIBNCCL_PACKAGE_NAME libnccl
-ENV NV_LIBNCCL_PACKAGE_VERSION 2.21.5-1
-ENV NV_LIBNCCL_VERSION 2.21.5
-ENV NCCL_VERSION 2.21.5
-ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.4
+ENV NV_CUDA_LIB_VERSION=12.4.1-1
+ENV NV_NVTX_VERSION=12.4.127-1
+ENV NV_LIBNPP_VERSION=12.2.5.30-1
+ENV NV_LIBNPP_PACKAGE=libnpp-12-4-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION=12.4.5.8-1
+ENV NV_LIBNCCL_PACKAGE_NAME=libnccl
+ENV NV_LIBNCCL_PACKAGE_VERSION=2.21.5-1
+ENV NV_LIBNCCL_VERSION=2.21.5
+ENV NCCL_VERSION=2.21.5
+ENV NV_LIBNCCL_PACKAGE=${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.4
 
 RUN yum install -y \
     cuda-libraries-12-4-${NV_CUDA_LIB_VERSION} \
@@ -77,20 +77,20 @@ ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
 # Install CUDA devel from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubi9/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION 12.4.1-1
-ENV NV_NVPROF_VERSION 12.4.127-1
-ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-12-4-${NV_NVPROF_VERSION}
-ENV NV_CUDA_CUDART_DEV_VERSION 12.4.127-1
-ENV NV_NVML_DEV_VERSION 12.4.127-1
-ENV NV_LIBCUBLAS_DEV_VERSION 12.4.5.8-1
-ENV NV_LIBNPP_DEV_VERSION 12.2.5.30-1
-ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-12-4-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.21.5-1
-ENV NCCL_VERSION 2.21.5
-ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.4
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION 12.4.1-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE cuda-nsight-compute-12-4-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+ENV NV_CUDA_LIB_VERSION=12.4.1-1
+ENV NV_NVPROF_VERSION=12.4.127-1
+ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-4-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION=12.4.127-1
+ENV NV_NVML_DEV_VERSION=12.4.127-1
+ENV NV_LIBCUBLAS_DEV_VERSION=12.4.5.8-1
+ENV NV_LIBNPP_DEV_VERSION=12.2.5.30-1
+ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-4-${NV_LIBNPP_DEV_VERSION}
+ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.21.5-1
+ENV NCCL_VERSION=2.21.5
+ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.4
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.4.1-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-4-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
 
 RUN yum install -y \
     make \
@@ -108,13 +108,13 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 # Install CUDA devel cudnn8 from:
 # hhttps://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubi9/devel/cudnn/Dockerfile
-ENV NV_CUDNN_VERSION 9.1.0.70-1
-ENV NV_CUDNN_PACKAGE libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
+ENV NV_CUDNN_VERSION=9.1.0.70-1
+ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
+ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 

--- a/rstudio/c9s-python-3.11/Dockerfile
+++ b/rstudio/c9s-python-3.11/Dockerfile
@@ -30,11 +30,11 @@ RUN yum install -y yum-utils && \
 
 # set R library to default (used in install.r from littler)
 RUN chmod -R a+w /usr/lib64/R/library
-ENV LIBLOC /usr/lib64/R/library
+ENV LIBLOC=/usr/lib64/R/library
 
 # set User R Library path
 RUN mkdir -p /opt/app-root/bin/Rpackages/4.4 && chmod -R a+w /opt/app-root/bin/Rpackages/4.4
-ENV R_LIBS_USER /opt/app-root/bin/Rpackages/4.4
+ENV R_LIBS_USER=/opt/app-root/bin/Rpackages/4.4
 
 WORKDIR /tmp/
 
@@ -64,7 +64,7 @@ RUN R -e "require('remotes'); \
     remotes::install_version('devtools','2.4.5');"
 
 # Install NGINX to proxy RStudio and pass probes check
-ENV NGINX_VERSION=1.24 \
+ENV NGINX_VERSION=1.24=\
     NGINX_SHORT_VER=124 \
     NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/nginx/nginx.conf \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #804 

Add '=' to  env variable directives in dockerfiles 

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using command: 
`docker buildx build --check -f cuda/ubi9-python-3.11/Dockerfile .  --build-arg BASE_IMAGE=ubuntu`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
