### PR TITLE
Include script on workbench to copy runtime-image json to relevant path

### DIFF
--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -91,6 +91,7 @@ RUN echo "Installing softwares and packages" && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
+    mkdir /opt/app-root/pipeline-runtimes && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
@@ -102,8 +103,5 @@ RUN echo "Installing softwares and packages" && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P
-
-# Copy Elyra runtime-images definitions and set the version
-COPY ${DATASCIENCE_SOURCE_CODE}/runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
 
 WORKDIR /opt/app-root/src

--- a/jupyter/datascience/ubi9-python-3.11/setup-elyra.sh
+++ b/jupyter/datascience/ubi9-python-3.11/setup-elyra.sh
@@ -14,6 +14,11 @@ if [ "$(ls -A /opt/app-root/runtimes/)" ]; then
   cp -r /opt/app-root/runtimes/..data/*.json $(jupyter --data-dir)/metadata/runtimes/
 fi
 
+# Set elyra runtime images json from volume mount
+if [ "$(ls -A /opt/app-root/pipeline-runtimes/)" ]; then
+  cp -r /opt/app-root/pipeline-runtimes/..data/*.json /opt/app-root/share/jupyter/metadata/runtime-images/
+fi
+
 # Environment vars set for accessing ssl_sa_certs and sa_token
 # export PIPELINES_SSL_SA_CERTS="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 export KF_PIPELINES_SA_TOKEN_ENV="/var/run/secrets/kubernetes.io/serviceaccount/token"


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-20241

## Description
<!--- Describe your changes in detail -->
This PR include the following changes:
- Modifies the `elyra.sh` script to copy the content from mount path `/opt/app-root/pipeline-runtimes/` to elyra path `/opt/app-root/share/jupyter/metadata/runtime-images/` this take place when the DS notebook starts up. The reason is to avoid override the runtime images that the user may have import by himself. 

(`quay.io/rh_ee_atheodor/workbench-images@sha256:f2bc105afab97575007a5743e39cc4c045fa276ba8612b6a8241758d48711913`) `custom_v3`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This changes have been tested along with notebook controller (PR soon)  by importing the new data science image generated by this PR 

These are the logs when the datachience notebook when it get spin up on cluster.
The list of .json comes from the mount assigned on the notebook from the notebook-controller 
![image](https://github.com/user-attachments/assets/be54cc27-15db-4d53-8b99-5e3b1e7a6ad7)



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
