### PR TITLE
ISSUE #883: feat: add `data-testid` attribute for loading spinner 

### DIFF
--- a/2024b/jupyter/utils/addons/partial-body.html
+++ b/2024b/jupyter/utils/addons/partial-body.html
@@ -8,7 +8,7 @@
     <circle
       class="pf-v6-c-spinner__path"
       data-testid="loading-spinner-initial"
-      ="50"
+      cx="50"
       cy="50"
       r="45"
       fill="none"

--- a/2024b/jupyter/utils/addons/partial-body.html
+++ b/2024b/jupyter/utils/addons/partial-body.html
@@ -5,7 +5,14 @@
     viewBox="0 0 100 100"
     aria-label="Loading..."
   >
-    <circle class="pf-v6-c-spinner__path" cx="50" cy="50" r="45" fill="none" />
+    <circle
+      class="pf-v6-c-spinner__path"
+      data-testid="loading-spinner-initial"
+      ="50"
+      cy="50"
+      r="45"
+      fill="none"
+    />
   </svg>
 </div>
 

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -8,10 +8,7 @@ import allure
 import pytest
 
 from tests.containers import docker_utils
-from tests.containers.workbenches.workbench_image_test import (
-    WorkbenchContainer,
-    skip_if_not_workbench_image,
-)
+from tests.containers.workbenches.workbench_image_test import WorkbenchContainer, skip_if_not_workbench_image
 
 if TYPE_CHECKING:
     import docker.models.images
@@ -23,9 +20,7 @@ class TestJupyterLabImage:
     APP_ROOT_HOME = "/opt/app-root/src"
 
     @allure.issue("RHOAIENG-11156")
-    @allure.description(
-        "Check that the HTML for the spinner is contained in the initial page."
-    )
+    @allure.description("Check that the HTML for the spinner is contained in the initial page.")
     def test_spinner_html_loaded(self, image: str) -> None:
         skip_if_not_jupyterlab_image(image)
 
@@ -37,19 +32,13 @@ class TestJupyterLabImage:
 
         # These NOTEBOOK_ARGS are what ODH Dashboard uses,
         # and we also have them in the Kustomize test files for Makefile tests
-        container.with_env(
-            "NOTEBOOK_ARGS",
-            "\n".join(
-                [
-                    "--ServerApp.port=8888",
-                    "--ServerApp.token=''",
-                    "--ServerApp.password=''",
-                    "--ServerApp.base_url=/notebook/opendatahub/jovyan",
-                    "--ServerApp.quit_button=False",
-                    """--ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}""",
-                ]
-            ),
-        )
+        container.with_env("NOTEBOOK_ARGS", "\n".join([
+            "--ServerApp.port=8888",
+            "--ServerApp.token=''",
+            "--ServerApp.password=''",
+            "--ServerApp.base_url=/notebook/opendatahub/jovyan",
+            "--ServerApp.quit_button=False",
+            """--ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}"""]))
         try:
             # we changed base_url, and wait_for_readiness=True would attempt connections to /
             container.start(wait_for_readiness=False)
@@ -57,9 +46,7 @@ class TestJupyterLabImage:
 
             host_ip = container.get_container_host_ip()
             host_port = container.get_exposed_port(container.port)
-            response = requests.get(
-                f"http://{host_ip}:{host_port}/notebook/opendatahub/jovyan"
-            )
+            response = requests.get(f"http://{host_ip}:{host_port}/notebook/opendatahub/jovyan")
             assert response.status_code == 200
             assert "text/html" in response.headers["content-type"]
             assert 'data-testid="loading-spinner-initial"' in response.text
@@ -69,9 +56,8 @@ class TestJupyterLabImage:
 
 def skip_if_not_jupyterlab_image(image: str) -> docker.models.images.Image:
     image_metadata = skip_if_not_workbench_image(image)
-    if "-jupyter-" not in image_metadata.labels["name"]:
+    if "-jupyter-" not in image_metadata.labels['name']:
         pytest.skip(
-            f"Image {image} does not have '-jupyter-' in {image_metadata.labels['name']=}'"
-        )
+            f"Image {image} does not have '-jupyter-' in {image_metadata.labels['name']=}'")
 
     return image_metadata


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #883 
* https://github.com/opendatahub-io/notebooks/issues/883
## Description

Add data-testid attribute to a initial loading spinner element
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
