### PR TITLE
NO-JIRA: chore(tests/containers): report on nginx error messages in logs

### DIFF
--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -149,7 +149,7 @@ class WorkbenchContainer(testcontainers.core.container.DockerContainer):
         host = container_host or self.get_container_host_ip()
         port = container_port or self.get_exposed_port(self.port)
         try:
-            # if we did not enable cookies support here, with RStudio we'd end up looping and getting
+            # if we did not enable cookie support here, with RStudio we'd end up looping and getting
             # HTTP 302 (i.e. `except urllib.error.HTTPError as e: assert e.code == 302`) every time
             cookie_jar = http.cookiejar.CookieJar()
             opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
@@ -194,8 +194,15 @@ def skip_if_not_workbench_image(image: str) -> docker.models.images.Image:
 
 def grab_and_check_logs(subtests: pytest_subtests.SubTests, container: WorkbenchContainer) -> None:
     # Here is a list of blocked keywords we don't want to see in the log messages during the container/workbench
-    # startup (e.g. log messages from Jupyter IDE, code-server IDE or RStudio IDE).
-    blocked_keywords = ["Error", "error", "Warning", "warning", "Failed", "failed", "[W ", "[E ", "Traceback"]
+    # startup (e.g., log messages from Jupyter IDE, code-server IDE or RStudio IDE).
+    blocked_keywords = [
+        "Error", "error", "Warning", "warning", "Failed", "failed",
+        "[W ", "[E ",
+        # https://docs.nginx.com/nginx/admin-guide/monitoring/logging/
+        "[warn] ", "[error] ", "[crit] ", "[alert] ", "[emerg] ",
+        # https://docs.python.org/3/tutorial/errors.html#exceptions
+        "Traceback",
+    ]
     # Here is a list of allowed messages that match some block keyword from the list above, but we allow them
     # for some reason.
     allowed_messages = [
@@ -205,8 +212,8 @@ def grab_and_check_logs(subtests: pytest_subtests.SubTests, container: Workbench
         "connect() failed (111: Connection refused) while connecting to upstream, client",
     ]
 
-    # Let's wait couple of seconds to give a chance to log eventual extra startup messages just to be sure we don't
-    # miss anytihng important in this test.
+    # Let's wait a couple of seconds to give a chance to log eventual extra startup messages just to be sure we don't
+    # miss anything important in this test.
     time.sleep(3)
 
     stdout, stderr = container.get_logs()


### PR DESCRIPTION
## Description

Add a check for NGINX log messages in tests/containers.

## How Has This Been Tested?

Added this at the end of `codeserver/ubi9-python-3.11/nginx/httpconf/http.conf`

```
#redirect port 80 http to 443 https
server{
    listen 8000;
    listen [::]:8000;
    #just for external access
    server_name hostname.external_domain;
    return 301 https://$host$request_uri;
}

# serve both http and https internally
server {
    listen 8000;
    listen 4430;
    listen [::]:8000;
    listen [::]:4430;

    server_name hostname hostname.internal_domain hostname.external_domain;
}
```

and started

```
poetry run pytest tests/containers --image quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.11-2024b_20250222 -k test_image_entrypoint_starts
```

```
ERROR:root:Unexpected keyword in the following message: '2025/02/22 20:53:42 [warn] 17#17: conflicting server name "hostname.external_domain" on 0.0.0.0:8000, ignored'
--------------------------------------------------------------------------------------------- live log logreport ---------------------------------------------------------------------------------------------
2025-02-22 21:53:48 ERROR Unexpected keyword in the following message: '2025/02/22 20:53:42 [warn] 17#17: conflicting server name "hostname.external_domain" on 0.0.0.0:8000, ignored'
ERROR:root:Unexpected keyword in the following message: 'nginx: [warn] conflicting server name "hostname.external_domain" on 0.0.0.0:8000, ignored'
2025-02-22 21:53:48 ERROR Unexpected keyword in the following message: 'nginx: [warn] conflicting server name "hostname.external_domain" on 0.0.0.0:8000, ignored'
ERROR:root:Unexpected keyword in the following message: '2025/02/22 20:53:42 [warn] 17#17: conflicting server name "hostname.external_domain" on [::]:8000, ignored'
2025-02-22 21:53:48 ERROR Unexpected keyword in the following message: '2025/02/22 20:53:42 [warn] 17#17: conflicting server name "hostname.external_domain" on [::]:8000, ignored'
ERROR:root:Unexpected keyword in the following message: 'nginx: [warn] conflicting server name "hostname.external_domain" on [::]:8000, ignored'
2025-02-22 21:53:48 ERROR Unexpected keyword in the following message: 'nginx: [warn] conflicting server name "hostname.external_domain" on [::]:8000, ignored'
DEBUG:root:Waived message: '2025/02/22 20:53:42 [error] 21#21: *2 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.127.1, server: ${base_url}, request: "GET /codeserver/ HTTP/1.1", upstream: "http://127.0.0.1:8787/", host: "localhost:36321"'
DEBUG:root:Waived message: '2025/02/22 20:53:43 [error] 21#21: *5 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.127.1, server: ${base_url}, request: "GET /codeserver/ HTTP/1.1", upstream: "http://127.0.0.1:8787/", host: "localhost:36321"'

tests/containers/workbenches/workbench_image_test.py::TestWorkbenchImage::test_image_entrypoint_starts[quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.11-2024b_20250222-sysctls0] [Checking the log in the workbench...] SUBFAILDEBUG:urllib3.connectionpool:http://localhost:None "POST /v1.41/containers/4cfbe5fc51add0605a2add12e2bed95634a406e491452ff8fb01d112396f9325/stop?t=0 HTTP/1.1" 204 0 
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
