### PR TITLE
ISSUE #631: lowercase the image repository name in github actions

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -46,6 +46,11 @@ jobs:
 
       - run: mkdir -p $TMPDIR
 
+      - name: downcase IMAGE_REGISTRY and CACHE
+        run: |
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >>${GITHUB_ENV}
+          echo "CACHE=${CACHE,,}" >>${GITHUB_ENV}
+
       # for bin/buildinputs in scripts/sandbox.py
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -42,14 +42,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
-
-      - run: mkdir -p $TMPDIR
-
       - name: downcase IMAGE_REGISTRY and CACHE
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >>${GITHUB_ENV}
           echo "CACHE=${CACHE,,}" >>${GITHUB_ENV}
+      
+      - uses: actions/checkout@v4
+
+      - run: mkdir -p $TMPDIR
 
       # for bin/buildinputs in scripts/sandbox.py
       - uses: actions/setup-go@v5

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -42,11 +42,12 @@ jobs:
 
     steps:
 
+      # image repository name must be lowercase
       - name: downcase IMAGE_REGISTRY and CACHE
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >>${GITHUB_ENV}
           echo "CACHE=${CACHE,,}" >>${GITHUB_ENV}
-      
+
       - uses: actions/checkout@v4
 
       - run: mkdir -p $TMPDIR


### PR DESCRIPTION
Fixes opendatahub-io/notebooks#631

## Description
 >Error: unable to parse value provided [ghcr.io/RomanFilip/notebooks-fork/workbench-images/build-cache] to --cache-to: invalid repo "ghcr.io/RomanFilip/notebooks-fork/workbench-images/build-cache": must contain registry and repository: invalid reference format: repository name must be lowercase

https://github.com/RomanFilip/notebooks-fork/actions/runs/13499383840/job/37713825404#step:17:95

## How Has This Been Tested?
* https://github.com/RomanFilip/notebooks-fork/actions/runs/13502100423


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
