### PR TITLE
RHOAIENG-20569: Fix the ImageStream manifests with the correct software versions

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -63,7 +63,7 @@ spec:
           [
             {"name": "Boto3", "version": "1.34"},
             {"name": "Kafka-Python", "version": "2.0"},
-            {"name": "Kfp", "version": "2.8"},
+            {"name": "Kfp", "version": "2.11"},
             {"name": "Matplotlib", "version": "3.8"},
             {"name": "Numpy", "version": "1.26"},
             {"name": "Pandas", "version": "2.2"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -72,7 +72,7 @@ spec:
             {"name": "Tensorboard", "version": "2.16"},
             {"name": "Boto3", "version": "1.34"},
             {"name": "Kafka-Python", "version": "2.0"},
-            {"name": "Kfp", "version": "2.8"},
+            {"name": "Kfp", "version": "2.11"},
             {"name": "Matplotlib", "version": "3.8"},
             {"name": "Numpy", "version": "1.26"},
             {"name": "Pandas", "version": "2.2"},

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -69,7 +69,7 @@ spec:
             {"name": "TrustyAI", "version": "0.6"},
             {"name": "Boto3", "version": "1.34"},
             {"name": "Kafka-Python", "version": "2.0"},
-            {"name": "Kfp", "version": "2.8"},
+            {"name": "Kfp", "version": "2.11"},
             {"name": "Matplotlib", "version": "3.6"},
             {"name": "Numpy", "version": "1.24"},
             {"name": "Pandas", "version": "1.5"},

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -20,14 +20,14 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.4"},
+            {"name": "CUDA", "version": "12.1"},
             {"name": "R", "version": "v4.4"},
             {"name": "Python", "version": "v3.11"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "rstudio-server", "version": "4.4"}
+            {"name": "rstudio-server", "version": "2024.04"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
@@ -38,19 +38,19 @@ spec:
       name: "2024.2"
       referencePolicy:
         type: Source
-    # N Version of the image
+    # N-1 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |
           [
             {"name": "CUDA", "version": "12.1"},
-            {"name": "R", "version": "v4.3"},
+            {"name": "R", "version": "v4.4"},
             {"name": "Python", "version": "v3.9"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "rstudio-server", "version": "4.3"}
+            {"name": "rstudio-server", "version": "2023.12"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -25,7 +25,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "rstudio-server", "version": "4.4"}
+            {"name": "rstudio-server", "version": "2024.04"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
@@ -36,18 +36,18 @@ spec:
       name: "2024.2"
       referencePolicy:
         type: Source
-    # N - 1 Version of the image
+    # N-1 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "R", "version": "v4.3"},
+            {"name": "R", "version": "v4.4"},
             {"name": "Python", "version": "v3.9"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "rstudio-server", "version": "4.3"}
+            {"name": "rstudio-server", "version": "2023.12"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'


### PR DESCRIPTION
This was caught by the demo PR implementation check in #923 for the 
https://issues.redhat.com/browse/RHOAIENG-20569.

Please check thoroughly - maybe I misunderstood what we want to show e.g. for the `rstudio-server`. Also, what is suspicious is the R studio version of the N-1 images and Cuda version in R studio version N.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
