### PR TITLE
NO-JIRA: fix(gha): validate-dockerfiles more permissive

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -118,7 +118,7 @@ jobs:
                              && wget --output-document=hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 \
                              && chmod a+x hadolint
           echo "Starting Hadolint"
-          find . -name "Dockerfile" | xargs ./hadolint --config ./ci/hadolint-config.yaml
+          find . -name "Dockerfile*" | xargs ./hadolint --config ./ci/hadolint-config.yaml
           echo "Hadolint done"
 
       # This simply checks that the manifests and respective kustomization.yaml finishes without an error.


### PR DESCRIPTION
## Description
Presently, we use a `find . -name Dockerfile` to find files to lint with `Hadolint`.  With the [move to remove chained builds ](https://github.com/opendatahub-io/notebooks/pull/924)- our Dockerfiles now have extensions that help differentiate what (if any) accelerator they are built for.

As a result, all of our Dockerfiles now have file extensions - which means the current code doesn't find them.

A simple `find . -name "Dockerfile*"` (adding a `*`) resolves this problem.

Note: Once we onboard into Konflux - we will also have `Dockerfile.konflux` files.  I have made the decision to **include** them in our linting (as they are part of our repo).  However, if that causes issue in the future - the following command could be used:
- `find . -name "Dockerfile*" -not -name "Dockerfile.konflux"`

Related-to: https://issues.redhat.com/browse/RHOAIENG-19048

## How Has This Been Tested?
Confirmed backwards compatibility of this change (i.e. reading files named literally `Dockerfile`) locally against the repo:

```
➜ notebooks/ git:(fix/gha-find-dockerfiles) $ find . -name "Dockerfile*"
./cuda/ubi9-python-3.11/Dockerfile
./cuda/c9s-python-3.11/Dockerfile
./runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile
./runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile
./runtimes/minimal/ubi9-python-3.11/Dockerfile
./runtimes/tensorflow/ubi9-python-3.11/Dockerfile
./runtimes/pytorch/ubi9-python-3.11/Dockerfile
./runtimes/datascience/ubi9-python-3.11/Dockerfile
./rstudio/c9s-python-3.11/Dockerfile
./codeserver/ubi9-python-3.11/Dockerfile
./rocm/ubi9-python-3.11/Dockerfile
./jupyter/trustyai/ubi9-python-3.11/Dockerfile
./jupyter/minimal/ubi9-python-3.11/Dockerfile
./jupyter/tensorflow/ubi9-python-3.11/Dockerfile
./jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile
./jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile
./jupyter/pytorch/ubi9-python-3.11/Dockerfile
./jupyter/datascience/ubi9-python-3.11/Dockerfile
./base/ubi9-python-3.11/Dockerfile
./base/c9s-python-3.11/Dockerfile
```

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
