### PR TITLE
Include runtimes ImageStreams on manifests + gha automation

### DIFF
--- a/.github/workflows/runtimes-digest-updater-upstream-v2.yaml
+++ b/.github/workflows/runtimes-digest-updater-upstream-v2.yaml
@@ -1,0 +1,102 @@
+---
+# The aim of this GitHub workflow is to update the runtimes ImageStreams
+name: Update runtime ImageStreams SHA digests
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      branch:
+        required: true
+        description: "Which branch do you want to update?"
+      tag_version:
+        required: true
+        description: "Provide tag version: main or YYYYx"
+      user-hash:
+        required: false
+        description: "Optional: Specify a Git hash (it should exist in the provided branch's history)"
+
+env:
+  TMP_BRANCH: tmp-branch-${{ github.run_id }}
+  BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
+  TAG_VERSION: ${{ github.event.inputs.tag_version || 'main' }}
+  USER_HASH: ${{ github.event.inputs.user-hash }}
+
+jobs:
+  initialize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install Skopeo CLI
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install skopeo yq jq
+
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - name: Create a new branch
+        run: |
+         echo ${{ env.TMP_BRANCH }}
+         git checkout -b ${{ env.TMP_BRANCH }}
+         git push --set-upstream origin ${{ env.TMP_BRANCH }}
+
+  update-runtimes:
+    needs: [initialize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TMP_BRANCH }}
+          fetch-depth: 0
+
+      - name: Invoke script to handle the update
+        shell: bash
+        run: |
+          chmod +x "${GITHUB_WORKSPACE}/ci/runtimes-digest-updater.sh"
+          bash ${GITHUB_WORKSPACE}/ci/runtimes-digest-updater.sh ${{ env.TAG_VERSION }} ${{ env.USER_HASH }}
+
+      - name: Commit the changes
+        run: |
+          if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+              git fetch origin "${{ env.TMP_BRANCH }}" && \
+              git pull origin "${{ env.TMP_BRANCH }}" && \
+              git add "manifests/base/runtime-*" && \
+              git commit -m "Update file via ${{ env.TMP_BRANCH }} GitHub action" && \
+              git push origin "${{ env.TMP_BRANCH }}"
+          else
+              echo "There were no changes detected in the images for the ${{ env.BRANCH_NAME }}"
+          fi
+
+  open-pull-request:
+    needs: [update-runtimes]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ${{ env.TMP_BRANCH }}
+          destination_branch: ${{ env.BRANCH_NAME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_label: "automated pr"
+          pr_title: "[Digest Updater Action] Update Runtimes ImageStreams"
+          pr_body: |
+            :rocket: This is an automated Pull Request.
+            Created by `/.github/workflows/runtimes-digest-updater-upstream.yaml`
+
+            :exclamation: **IMPORTANT NOTE**: Remember to delete the ` ${{ env.TMP_BRANCH }}` branch after merging the changes

--- a/ci/runtimes-digest-updater.sh
+++ b/ci/runtimes-digest-updater.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+TAG_VERSION=$1
+USER_HASH=$2
+
+REPO_OWNER="opendatahub-io"
+REPO_NAME="notebooks"
+GITHUB_API_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME"
+
+if [[ -n "$USER_HASH" ]]; then
+  HASH=$USER_HASH
+  echo "Using user-provided HASH: $HASH"
+else
+  PAYLOAD=$(curl --silent -H 'Accept: application/vnd.github.v4.raw' "$GITHUB_API_URL/commits?sha=$TAG_VERSION&per_page=1")
+  HASH=$(echo "$PAYLOAD" | jq -r '.[0].sha' | cut -c1-7)
+  echo "Extracted HASH: $HASH"
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+MANIFEST_DIR="$REPO_ROOT/manifests/base"
+# Find matching files
+files=$(find "$MANIFEST_DIR" -type f -name "runtime-*.yaml")
+for file in $files; do
+  echo "PROCESSING: $file"
+
+  # Extract values
+  img=$(yq e '.spec.tags[].annotations."opendatahub.io/runtime-image-metadata" | fromjson | .[].metadata.image_name' "$file" 2>/dev/null)
+  name=$(yq e '.spec.tags[].name' "$file" 2>/dev/null)
+  ubi=$(yq e '.metadata.annotations."opendatahub.io/runtime-image-name"' "$file" 2>/dev/null | grep -oE 'UBI[0-9]+' | tr '[:upper:]' '[:lower:]')
+  py_version=$(yq e '.metadata.annotations."opendatahub.io/runtime-image-name"' "$file" 2>/dev/null | grep -oE 'Python [0-9]+\.[0-9]+' | sed 's/ /-/g' | tr '[:upper:]' '[:lower:]')
+  registry=$(echo "$img" | cut -d '@' -f1)
+
+  # Handling specific cases
+  [[ $name == tensorflow* ]] && name="cuda-$name"
+
+  if [[ $TAG_VERSION == main ]]; then
+    # This should match with the runtime-image tag name as is on quay.io registry
+    regex="^runtime-$name-$ubi-$py_version-[0-9]{8}-$HASH$"
+  else
+    # This should match with the runtime-image tag name as is on quay.io registry
+    regex="^runtime-$name-$ubi-$py_version-$TAG_VERSION-[0-9]{8}-$HASH$"
+  fi
+
+  latest_tag=$(skopeo inspect --retry-times 3 "docker://$img" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+  echo "CHECKING: ${latest_tag}"
+
+  if [[ -z "$latest_tag" || "$latest_tag" == "null" ]]; then
+    echo "No matching tag found on registry for $file. Skipping."
+    continue
+  fi
+
+  # Extract the digest sha from the latest tag
+  digest=$(skopeo inspect --retry-times 3 "docker://$registry:$latest_tag" | jq .Digest | tr -d '"')
+  output="${registry}@${digest}"
+  echo "NEW: ${output}"
+
+  # Updates the ImageStream with the new SHAs
+  yq e -i '(.spec.tags[] | .from.name) = "'"$output"'"' "$file"
+  sed -i "s|\(\"image_name\": \"\)[^\"]*|\1${output}|" "$file"
+
+done

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -14,6 +14,12 @@ resources:
   - jupyter-rocm-minimal-notebook-imagestream.yaml
   - jupyter-rocm-pytorch-notebook-imagestream.yaml
   - jupyter-rocm-tensorflow-notebook-imagestream.yaml
+  - runtime-datascience-imagestream.yaml
+  - runtime-minimal-imagestream.yaml
+  - runtime-pytorch-imagestream.yaml
+  - runtime-rocm-pytorch-imagestream.yaml
+  - runtime-rocm-tensorflow-imagestream.yaml
+  - runtime-tensorflow-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"

--- a/manifests/base/runtime-datascience-imagestream.yaml
+++ b/manifests/base/runtime-datascience-imagestream.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Datascience with Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+  name: runtime-datascience
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Datascience with Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "datascience"
+                ],
+                "display_name": "Datascience with Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:304d3b2ea846832f27312ef6776064a1bf3797c645b6fea0b292a7ef6416458e
+      name: "datascience"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-minimal-imagestream.yaml
+++ b/manifests/base/runtime-minimal-imagestream.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+  name: runtime-minimal
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "minimal"
+                ],
+                "display_name": "Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:a2b1bf59f25fd0694394ad927e5eba93e32df9c2c11d8b54412564a9fc736ab8",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:a2b1bf59f25fd0694394ad927e5eba93e32df9c2c11d8b54412564a9fc736ab8
+      name: "minimal"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-pytorch-imagestream.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Pytorch with CUDA and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Pytorch with CUDA and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "pytorch"
+                ],
+                "display_name": "Pytorch with CUDA and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:6a2806bf3cd9b00f60f3c7fe907727fb954c9776a075d9d58df26b5119d7afe6",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:6a2806bf3cd9b00f60f3c7fe907727fb954c9776a075d9d58df26b5119d7afe6
+      name: "pytorch"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-rocm-pytorch-imagestream.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Pytorch with ROCm and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-rocm-pytorch
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Pytorch with ROCm and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "rocm-pytorch"
+                ],
+                "display_name": "Pytorch with ROCm and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:c6d74d73b835d0f97040ca99bb25065a949b817b52179f239a5361c3299352ba",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:c6d74d73b835d0f97040ca99bb25065a949b817b52179f239a5361c3299352ba
+      name: "rocm-pytorch"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "TensorFlow with ROCm and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-rocm-tensorflow
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "TensorFlow with ROCm and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "rocm-tensorflow"
+                ],
+                "display_name": "TensorFlow with ROCm and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:6a2da12a8bdc9cfcda27f4189827be5fbde4b4b4c4f7d92ac694d9360e3562dc",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:6a2da12a8bdc9cfcda27f4189827be5fbde4b4b4c4f7d92ac694d9360e3562dc
+      name: "rocm-tensorflow"
+      referencePolicy:
+        type: Source

--- a/manifests/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-tensorflow-imagestream.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "TensorFlow with CUDA and Python 3.11 (UBI9)"
+    opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-tensorflow
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "TensorFlow with CUDA and Python 3.11 (UBI9)",
+              "metadata": {
+                "tags": [
+                  "tensorflow"
+                ],
+                "display_name": "TensorFlow with CUDA and Python 3.11 (UBI9)",
+                "image_name": "quay.io/opendatahub/workbench-images@sha256:5d695b2e5dc76fc07a138644e2cd507c73eb9b26a47596734169c0b313e733f9",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/workbench-images@sha256:5d695b2e5dc76fc07a138644e2cd507c73eb9b26a47596734169c0b313e733f9
+      name: "tensorflow"
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Related to: https://issues.redhat.com/browse/RHOAIENG-19050

## Description
<!--- Describe your changes in detail -->

This PR includes the following changes:

 - Introduces six newly created ImageStreams to utilize runtime images via manifests.
The .json with its metadata incorporated under the imagestream using the `opendatahub.io/runtime-image-metadata` annotation.

 - And a new GHA that updates these files upon user's request. 

**NOTES**:
1. The gha named (temporary) as runtimes-digest-updater-upstream-v2.yaml.  This (-v2) is there in order don't break the functionality of the current runtimes-digest-updater-upstream.yaml until fully switch to these un-wiring strategy. A follow up PR will be open to update this.
 2. I didn't use .env and its correspondence vars on the imagestreams because it does not function as expected with the multi-line json. So the parameter inside the json does not updated updated properly this way. IIf we want it this way it increase a lot the complexity on the manifests files as it needs to add these jsons as configmaps an patch them. Personally, I wouldn't prefer that.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use as `DevFlag`  on RHOAI DSC the following in order to inspect the ImageStreams.

```
     workbenches:
       devFlags:
         manifests:
           - contextDir: manifests
             sourcePath: ''
             uri: 'https://github.com/atheo89/notebooks/archive/runtimes-imagestreams.tar.gz'
       managementState: Managed
```

2.  GHA updater run: https://github.com/atheo89/notebooks/actions/runs/13571562492, and the generated PR: https://github.com/atheo89/notebooks/pull/23


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
