### PR TITLE
NO-JIRA: chore(Makefile): remove `BUILD_DEPENDENT_IMAGES` option

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -254,8 +254,6 @@ jobs:
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
           CONTAINER_BUILD_CACHE_ARGS: "--cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
-          # dependent images were already built and pushed, so just let podman pull it
-          BUILD_DEPENDENT_IMAGES: "no"
       - name: "pull_request: make ${{ inputs.target }}"
         run: |
           make ${{ inputs.target }}

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ RELEASE	 		 ?= 2024b
 RELEASE_PYTHON_VERSION	 ?= 3.11
 # additional user-specified caching parameters for $(CONTAINER_ENGINE) build
 CONTAINER_BUILD_CACHE_ARGS ?= --no-cache
-# whether to build all dependent images or just the one specified
-BUILD_DEPENDENT_IMAGES ?= yes
 # whether to push the images to a registry as they are built
 PUSH_IMAGES ?= yes
 
@@ -94,18 +92,15 @@ endef
 #   ARG 1: Image tag name.
 #   ARG 2: Path of Dockerfile we want to build.
 #
-# BUILD_DEPENDENT_IMAGES: only build images that were explicitly given as a goal on command line
 # PUSH_IMAGES: allows skipping podman push
 define image
 	$(eval BUILD_DIRECTORY := $(shell echo $(2) | sed 's/\/Dockerfile.*//'))
 	$(info #*# Image build directory: <$(BUILD_DIRECTORY)> #(MACHINE-PARSED LINE)#*#...)
 
-	$(if $(or $(BUILD_DEPENDENT_IMAGES:no=), $(filter $@,$(MAKECMDGOALS))),
-		$(call build_image,$(1),$(2))
+	$(call build_image,$(1),$(2))
 
-		$(if $(PUSH_IMAGES:no=),
-			$(call push_image,$(1))
-		)
+	$(if $(PUSH_IMAGES:no=),
+		$(call push_image,$(1))
 	)
 endef
 
@@ -170,11 +165,11 @@ codeserver-ubi9-python-$(RELEASE_PYTHON_VERSION):
 ####################################### Buildchain for Python using C9S #######################################
 
 .PHONY: rstudio-c9s-python-$(RELEASE_PYTHON_VERSION)
-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION): 
+rstudio-c9s-python-$(RELEASE_PYTHON_VERSION):
 	$(call image,$@,rstudio/c9s-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
 
 .PHONY: cuda-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION)
-cuda-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION): 
+cuda-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION):
 	$(call image,$@,rstudio/c9s-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
 
 ####################################### Buildchain for AMD Python using UBI9 #######################################

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make ${WORKBENCH_NAME} -e  IMAGE_REGISTRY=quay.io/${YOUR_USER}/workbench-images 
 
 Using  `IMAGE_REGISTRY` and `RELEASE` variables you can overwrite the default values and use a different registry or release tag
 
-Using `CONTAINER_BUILD_CACHE_ARGS` (default: `--no-cache`), `BUILD_DEPENDENT_IMAGES`, and `PUSH_IMAGES` variables you can further customize the build process.
+Using `CONTAINER_BUILD_CACHE_ARGS` (default: `--no-cache`), and `PUSH_IMAGES` variables you can further customize the build process.
 
 ### Local Execution
 


### PR DESCRIPTION
## Description

The recent change [RHOAIENG-19048](https://issues.redhat.com//browse/RHOAIENG-19048) that removed build chains made the option obsolete

* https://github.com/opendatahub-io/notebooks/pull/924

This modifies the Makefile customization feature as implemented in [RHOAIENG-9822](https://issues.redhat.com//browse/RHOAIENG-9822)

* https://github.com/opendatahub-io/notebooks/pull/657

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
