### PR TITLE
RHOAIENG-18400: chore(konflux): restrict triggering only for the opendatahub-io/notebooks repository

### DIFF
--- a/.tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && has(body.repository) && body.repository.full_name == "opendatahub-io/notebooks"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notebooks

--- a/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && has(body.repository) && body.repository.full_name == "opendatahub-io/notebooks"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notebooks


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-18400

## Description

Without this, we'd have a failed pipeline on red-hat-data-services/notebooks fork

> There was an error creating the PipelineRun: *jupyter-minimal-ubi9-python-3-11-on-pull-request-*
>
> creating pipelinerun jupyter-minimal-ubi9-python-3-11-on-pull-request- in namespace rhoai-tenant has failed.
>
> Tekton Controller has reported this error: `the namespace of the provided object does not match the namespace sent on the request`

https://github.com/red-hat-data-services/notebooks/pull/518/checks?check_run_id=38404699272

## How Has This Been Tested?

PR with the fix did not trigger Konflux in rhds

* https://github.com/red-hat-data-services/notebooks/pull/519

PR without the fix did

* https://github.com/red-hat-data-services/notebooks/pull/518

## Supplemental information

The complete list of all available variables should be https://pipelinesascode.com/docs/guide/authoringprs/#dynamic-variables

Provided to me in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1741551722332819?thread_ts=1741549247.946459&cid=C04PZ7H0VA8

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
