### PR TITLE
(case 2) Add the runtime-images COPY cmd back on DS notebook

### DIFF
--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -104,4 +104,7 @@ RUN echo "Installing softwares and packages" && \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P
 
+# Copy Elyra runtime-images definitions and set the version
+COPY ${DATASCIENCE_SOURCE_CODE}/runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
+
 WORKDIR /opt/app-root/src

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -14,12 +14,6 @@ resources:
   - jupyter-rocm-minimal-notebook-imagestream.yaml
   - jupyter-rocm-pytorch-notebook-imagestream.yaml
   - jupyter-rocm-tensorflow-notebook-imagestream.yaml
-  - runtime-datascience-imagestream.yaml
-  - runtime-minimal-imagestream.yaml
-  - runtime-pytorch-imagestream.yaml
-  - runtime-rocm-pytorch-imagestream.yaml
-  - runtime-rocm-tensorflow-imagestream.yaml
-  - runtime-tensorflow-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix this comment: https://github.com/opendatahub-io/notebooks/pull/909#issuecomment-2702112750 

## Description
<!--- Describe your changes in detail -->
This line removed while I was working on the https://issues.redhat.com/browse/RHOAIENG-20241. 
So in case that we are not ready to incorporate the generation of pipeline-runtime-images config map via the odh-notebook-controller, we should keep still funtional the old logic of the runtimes, if not we are fine without this PR as a follow up is been created to clean up the notebooks from the old structure: https://github.com/opendatahub-io/notebooks/pull/943. 

❗ SUPER IMPORTANT NOTE: ❗
Case 1: If the corresponding PR: https://github.com/opendatahub-io/kubeflow/pull/513 on notebook-controller is been merged, this PR should be merged as well https://github.com/opendatahub-io/notebooks/pull/943 
Case 2: If the PR on notebook-controller is not merged, should revert the COPY cmd on DS dockerfile deleted by mistake by this PR. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
GHA builds 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
