### PR TITLE
NO-JIRA: chore(konflux): introduce image retention on pushed images

### DIFF
--- a/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-minimal-ubi9-python-3-11:{{revision}}
+  - name: image-expires-after
+    value: 28d
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
Until we decide to release on Konflux in upstream, it doesn't make much sense to store the result images in the quay.io repository wasting the disk resources there. Let's introduce the retention similarly as we do for the PR builds. For PR we delete images after 5 days, let's have 28 days for the pushed builds just in case.

Once we decide to perform release in upstream from Konflux, this decision needs to be revisited to avoid deletion of the released artifacts.

See the quay.io repo in question: https://quay.io/repository/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-minimal-ubi9-python-3-11

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
