### PR TITLE
RHOAIENG-19051: chore(Makefile): remove dependency on `bin/buildinputs` for running image tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endef
 #######################################        Build helpers                 #######################################
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
-skip-init-for := all-images deploy% undeploy% test% scan-image-vulnerabilities
+skip-init-for := all-images deploy% undeploy% test% validate% refresh-pipfilelock-files scan-image-vulnerabilities
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
 $(SELF): bin/buildinputs
 endif


### PR DESCRIPTION
Found when enabling hypershift in

* https://github.com/openshift/release/pull/62392

in support of https://issues.redhat.com//browse/RHOAIENG-19051
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some CI jobs would fail when go is not present on the machine running the `make validate%` targets. This change avoids needing go just to run tests.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/13873545184
* [ci/prow/codeserver-notebook-e2e-tests](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_notebooks/948/pull-ci-opendatahub-io-notebooks-main-codeserver-notebook-e2e-tests/1900970141944909824) — Job succeeded.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
