### PR TITLE
RHOAIENG-18400: chore(.tekton/): implement computation of `"pipelinesascode.tekton.dev/on-cel-expression"` values

### DIFF
--- a/.tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml
@@ -10,7 +10,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && has(body.repository) && body.repository.full_name == "opendatahub-io/notebooks"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "jupyter/minimal/ubi9-python-3.11/Pipfile.lock".pathChanged()
+      || "jupyter/minimal/ubi9-python-3.11/start-notebook.sh".pathChanged() || "jupyter/utils/***".pathChanged()
+      || ".tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml".pathChanged()
+      || "jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu".pathChanged() ) && has(body.repository)
+      && body.repository.full_name == "opendatahub-io/notebooks"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: notebooks

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -38,12 +38,7 @@ def main() -> int:
         print("must give a `{};` parameter that will be replaced with new build context")
         return 1
 
-    if not (ROOT_DIR / "bin/buildinputs").exists():
-        subprocess.check_call([MAKE, "bin/buildinputs"], cwd=ROOT_DIR)
-    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs", str(args.dockerfile)],
-                                     text=True, cwd=ROOT_DIR)
-    prereqs = [pathlib.Path(file) for file in json.loads(stdout)] if stdout != "\n" else []
-    print(f"{prereqs=}")
+    prereqs = buildinputs(dockerfile=args.dockerfile)
 
     with tempfile.TemporaryDirectory(delete=True) as tmpdir:
         setup_sandbox(prereqs, pathlib.Path(tmpdir))
@@ -55,6 +50,16 @@ def main() -> int:
             logging.error("Failed to execute process, see errors logged above ^^^")
             return err.returncode
     return 0
+
+
+def buildinputs(dockerfile: pathlib.Path | str) -> list[pathlib.Path]:
+    if not (ROOT_DIR / "bin/buildinputs").exists():
+        subprocess.check_call([MAKE, "bin/buildinputs"], cwd=ROOT_DIR)
+    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs", str(dockerfile)],
+                                     text=True, cwd=ROOT_DIR)
+    prereqs = [pathlib.Path(file) for file in json.loads(stdout)] if stdout != "\n" else []
+    print(f"{prereqs=}")
+    return prereqs
 
 
 def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-18400

## Description

This is necessary so that our `-pull-request.yaml` pipelines are run every time build inputs are changed, but not when build inputs have not changed.

The next step is to let the script generate pipelines for all our images, and I don't want to do that carelessly, otherwise we'd be rebuilding every image on Konflux with every PR update.

We should also consider running this when the tests change, similarly as we don't yet do (but want to) with Github Actions

* https://github.com/opendatahub-io/notebooks/issues/951

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/13928049662

```
PYTHONPATH=. python3 ci/cached-builds/konflux_generate_component_build_pipelines.py
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
