### PR TITLE
feat(upgrade): bi-annual RStudio package update

### DIFF
--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -46,7 +46,7 @@ LABEL name="odh-notebook-rstudio-server-c9s-python-3.11" \
 
 USER 0
 
-ENV R_VERSION=4.4.1
+ENV R_VERSION=4.4.3
 
 # Install R
 RUN yum install -y yum-utils && \
@@ -60,39 +60,38 @@ RUN yum install -y yum-utils && \
     yum -y clean all --enablerepo='*'
 
 # set R library to default (used in install.r from littler)
-RUN chmod -R a+w /usr/lib64/R/library
 ENV LIBLOC=/usr/lib64/R/library
-
-# set User R Library path
-RUN mkdir -p /opt/app-root/bin/Rpackages/4.4 && chmod -R a+w /opt/app-root/bin/Rpackages/4.4
 ENV R_LIBS_USER=/opt/app-root/bin/Rpackages/4.4
+
+RUN chmod -R a+w ${LIBLOC} && \
+    # create User R Library path
+    mkdir -p ${R_LIBS_USER} && \
+    chmod -R a+w ${R_LIBS_USER}
 
 WORKDIR /tmp/
 
 # Install RStudio
-RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum install -y rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    rm rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum -y clean all  --enablerepo='*'
+ARG RSTUDIO_RPM=rstudio-server-rhel-2024.12.1-563-x86_64.rpm
+RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel8/x86_64/${RSTUDIO_RPM} && \
+    yum install -y ${RSTUDIO_RPM} && \
+    rm ${RSTUDIO_RPM} && \
+    yum -y clean all  --enablerepo='*' && \
+    # Specific RStudio config and fixes
+    chmod 1777 /var/run/rstudio-server && \
+    mkdir -p /usr/share/doc/R && \
+    # package installation
+    # install necessary texlive-framed package to make Knit R markup to PDF rendering possible
+    dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed && \
+    dnf clean all && \
+    rm -rf /var/cache/yum
 
-# Specific RStudio config and fixes
-RUN chmod 1777 /var/run/rstudio-server && \
-    mkdir -p /usr/share/doc/R
 COPY ${RSTUDIO_SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
-# package installation
-# install necessary texlive-framed package to make Knit R markup to PDF rendering possible
-RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed \
-    && dnf clean all && rm -rf /var/cache/yum
 # Install R packages
-RUN R -e "install.packages('remotes')"
-RUN R -e "require('remotes'); \
-    remotes::install_version('Rcpp','1.0.14'); \
-    remotes::install_version('tidyverse','2.0.0'); \
-    remotes::install_version('tidymodels','1.2.0'); \
-    remotes::install_version('plumber','1.2.2'); \
-    remotes::install_version('vetiver','0.2.5'); \
-    remotes::install_version('devtools','2.4.5');"
+# https://cran.r-project.org/web/packages
+COPY ${RSTUDIO_SOURCE_CODE}/install_packages.R ./
+RUN R -f ./install_packages.R && \
+    rm ./install_packages.R
 
 # Install NGINX to proxy RStudio and pass probes check
 ENV NGINX_VERSION=1.24 \

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -137,7 +137,7 @@ RUN yum install -y \
     ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
-    
+
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
@@ -170,7 +170,7 @@ LABEL name="odh-notebook-rstudio-server-cuda-c9s-python-3.11" \
 
 USER 0
 
-ENV R_VERSION=4.4.1
+ENV R_VERSION=4.4.3
 
 # Install R
 RUN yum install -y yum-utils && \
@@ -184,39 +184,38 @@ RUN yum install -y yum-utils && \
     yum -y clean all --enablerepo='*'
 
 # set R library to default (used in install.r from littler)
-RUN chmod -R a+w /usr/lib64/R/library
 ENV LIBLOC=/usr/lib64/R/library
-
-# set User R Library path
-RUN mkdir -p /opt/app-root/bin/Rpackages/4.4 && chmod -R a+w /opt/app-root/bin/Rpackages/4.4
 ENV R_LIBS_USER=/opt/app-root/bin/Rpackages/4.4
+
+RUN chmod -R a+w ${LIBLOC} && \
+    # create User R Library path
+    mkdir -p ${R_LIBS_USER} && \
+    chmod -R a+w ${R_LIBS_USER}
 
 WORKDIR /tmp/
 
 # Install RStudio
-RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum install -y rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    rm rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum -y clean all  --enablerepo='*'
+ARG RSTUDIO_RPM=rstudio-server-rhel-2024.12.1-563-x86_64.rpm
+RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel8/x86_64/${RSTUDIO_RPM} && \
+    yum install -y ${RSTUDIO_RPM} && \
+    rm ${RSTUDIO_RPM} && \
+    yum -y clean all  --enablerepo='*' && \
+    # Specific RStudio config and fixes
+    chmod 1777 /var/run/rstudio-server && \
+    mkdir -p /usr/share/doc/R && \
+    # package installation
+    # install necessary texlive-framed package to make Knit R markup to PDF rendering possible
+    dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed && \
+    dnf clean all && \
+    rm -rf /var/cache/yum
 
-# Specific RStudio config and fixes
-RUN chmod 1777 /var/run/rstudio-server && \
-    mkdir -p /usr/share/doc/R
 COPY ${RSTUDIO_SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
-# package installation
-# install necessary texlive-framed package to make Knit R markup to PDF rendering possible
-RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed \
-    && dnf clean all && rm -rf /var/cache/yum
 # Install R packages
-RUN R -e "install.packages('remotes')"
-RUN R -e "require('remotes'); \
-    remotes::install_version('Rcpp','1.0.14'); \
-    remotes::install_version('tidyverse','2.0.0'); \
-    remotes::install_version('tidymodels','1.2.0'); \
-    remotes::install_version('plumber','1.2.2'); \
-    remotes::install_version('vetiver','0.2.5'); \
-    remotes::install_version('devtools','2.4.5');"
+# https://cran.r-project.org/web/packages
+COPY ${RSTUDIO_SOURCE_CODE}/install_packages.R ./
+RUN R -f ./install_packages.R && \
+    rm ./install_packages.R
 
 # Install NGINX to proxy RStudio and pass probes check
 ENV NGINX_VERSION=1.24 \

--- a/rstudio/c9s-python-3.11/install_packages.R
+++ b/rstudio/c9s-python-3.11/install_packages.R
@@ -1,0 +1,14 @@
+# install_packages.R
+
+# Load or install 'remotes' package
+if (!requireNamespace("remotes", quietly = TRUE)) {
+    install.packages("remotes")
+}
+
+# Install specific versions of packages
+remotes::install_version('Rcpp', '1.0.14')
+remotes::install_version('tidyverse', '2.0.0')
+remotes::install_version('tidymodels', '1.3.0')
+remotes::install_version('plumber', '1.3.0')
+remotes::install_version('vetiver', '0.2.5')
+remotes::install_version('devtools', '2.4.5')

--- a/rstudio/c9s-python-3.11/kustomize/components/accelerator/pod-patch.yaml
+++ b/rstudio/c9s-python-3.11/kustomize/components/accelerator/pod-patch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pod
 spec:
   containers:
-    - name: runtime
+    - name: rstudio
       resources:
         limits:
           memory: 6Gi

--- a/rstudio/c9s-python-3.11/kustomize/overlays/accelerator/cuda/pod-patch.yaml
+++ b/rstudio/c9s-python-3.11/kustomize/overlays/accelerator/cuda/pod-patch.yaml
@@ -7,7 +7,7 @@ spec:
   nodeSelector:
     accelerator: cuda
   containers:
-    - name: runtime
+    - name: rstudio
       resources:
         limits:
           nvidia.com/gpu: '1'


### PR DESCRIPTION
## Description

This commit is related to the ongoing work to release the `2025a` software upgrade.

Upgrades:
- `R`
	- `4.4.1` -> `4.4.3`
- `RStudio`
	- rstudio-server-rhel-2024.04.2-764-x86_64.rpm -> rstudio-server-rhel-2024.12.1-563-x86_64.rpm
- `tidymodels`
	- `1.2.0` -> `1.3.0`
- `plumber`
	- `1.2.2` -> `1.3.0`

A couple other "quality of life" improvements were included:
- Refactored `Dockerfile` to combine `RUN` statements where obvious/low-risk
- Better use of `ARG` references to reduce copy-pasta in `Dockerfile` instructions
- `install_packages.R` script externalizes the userland software installs in an external script to better "share" across `cpu` + `cuda` `Dockerfile` variants
- Fixed issue(s) with `kustomize` `cuda` `overlay` so now `kubectl apply -k overlays/accelerator/cuda` works

Related-to: https://issues.redhat.com/browse/RHOAIENG-19484

## How Has This Been Tested?

Verification was performed in the following manner:
1. [CUDA only] Acquire a CUDA-enabled ROSA cluster
    - https://docs.google.com/document/d/1OZ7vJnUg_3ei6Unb8pyPSAuYJtWQykMWgoXd2EocslA/edit?tab=t.0#heading=h.i94r0gk7mutm
2. All relevant RStudio images built locally
3. [CUDA only] Kustomize manifests used in testing updated 
    - `nodeSelector` added to ensure workload deployed on worker node with GPU
    - resources adjusted to provide more memory and also to request GPU
    - `emptyDir` volume added to mimic production usage
        - was getting `Permission Denied` errors related to `/opt/app-root/src/.cache`
4. `deploy%` target of `Makefile` used to deploy image
5. ``validate%` target used to run tests and confirmed all tests succeeded
6.  `undeploy%` target of `Makefile` used to undeploy image / prepare environment for next image

Simply to better equate myself with `R` - I also ran this simple script within the pod to confirm versions of dependencies installed:

`(app-root) bash-5.1$ cat test_versions.R `
```
# test_versions.R

# List of packages to check
packages <- c("Rcpp", "tidyverse", "tidymodels", "plumber", "vetiver", "devtools")

# Loop through each package in the list
for (package_name in packages) {
  # Check if the package is installed
  if (requireNamespace(package_name, quietly = TRUE)) {
    # Retrieve and print the version of the installed package
    package_version <- packageVersion(package_name)
    cat(sprintf("The installed version of '%s' is: %s\n", package_name, package_version))
  } else {
    cat(sprintf("The package '%s' is not installed.\n", package_name))
  }
}
```

`(app-root) bash-5.1$ Rscript test_versions.R `
```
The installed version of 'Rcpp' is: 1.0.14
The installed version of 'tidyverse' is: 2.0.0
The installed version of 'tidymodels' is: 1.3.0
The installed version of 'plumber' is: 1.3.0
The installed version of 'vetiver' is: 0.2.5
The installed version of 'devtools' is: 2.4.5
```

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
