### PR TITLE
RHOAIENG-21690: chore(Dockerfiles): augument `micropipenv` with `uv` for faster package installs

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -139,7 +139,7 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -141,7 +141,7 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -134,7 +134,7 @@ ENV PYTHONPATH=/opt/app-root/bin/python3
 
 USER 1001
 
-# Install useful packages from Pipfile.lock
+# Install useful packages from requirements.txt
 COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -135,11 +135,11 @@ ENV PYTHONPATH=/opt/app-root/bin/python3
 USER 1001
 
 # Install useful packages from Pipfile.lock
-COPY ${CODESERVER_SOURCE_CODE}/Pipfile.lock ./
+COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -140,7 +140,6 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -139,7 +139,9 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -139,7 +139,7 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -139,7 +139,7 @@ COPY ${CODESERVER_SOURCE_CODE}/Pipfile.lock ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -141,7 +141,7 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -139,7 +139,9 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -135,11 +135,11 @@ ENV PYTHONPATH=/opt/app-root/bin/python3
 USER 1001
 
 # Install useful packages from Pipfile.lock
-COPY ${CODESERVER_SOURCE_CODE}/Pipfile.lock ./
+COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -134,7 +134,7 @@ ENV PYTHONPATH=/opt/app-root/bin/python3
 
 USER 1001
 
-# Install useful packages from Pipfile.lock
+# Install useful packages from requirements.txt
 COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -140,7 +140,6 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -139,7 +139,7 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -139,7 +139,7 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.txt ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -107,7 +107,9 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -102,12 +102,12 @@ ENV PATH="$PATH:/opt/mssql-tools18/bin"
 USER 1001
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
+COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra setup to utils so that it's sourced at startup
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -107,7 +107,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -101,7 +101,7 @@ ENV PATH="$PATH:/opt/mssql-tools18/bin"
 # Other apps and tools installed as default user
 USER 1001
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra setup to utils so that it's sourced at startup
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -108,7 +108,6 @@ COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils 
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -109,7 +109,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils 
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -107,7 +107,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -107,7 +107,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -107,7 +107,9 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -102,12 +102,12 @@ ENV PATH="$PATH:/opt/mssql-tools18/bin"
 USER 1001
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
+COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra setup to utils so that it's sourced at startup
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -101,7 +101,7 @@ ENV PATH="$PATH:/opt/mssql-tools18/bin"
 # Other apps and tools installed as default user
 USER 1001
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra setup to utils so that it's sourced at startup
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -108,7 +108,6 @@ COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils 
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -109,7 +109,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils 
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -107,7 +107,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -107,7 +107,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -58,7 +58,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -60,7 +60,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -59,7 +59,6 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -54,9 +54,9 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -188,7 +188,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -186,7 +186,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -186,7 +186,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -186,7 +186,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -187,7 +187,6 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -186,7 +186,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -182,9 +182,9 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -186,7 +186,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -94,7 +94,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -93,7 +93,6 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -88,9 +88,9 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -92,7 +92,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -58,7 +58,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -60,7 +60,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -59,7 +59,6 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -54,9 +54,9 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -160,7 +160,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -160,7 +160,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -161,7 +161,6 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -162,7 +162,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -156,9 +156,9 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -160,7 +160,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -160,7 +160,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -88,7 +88,7 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -94,7 +94,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -93,7 +93,6 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.s
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -92,7 +92,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -92,7 +92,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ${MINIMAL_SOURCE_CODE}/start-notebo
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Disable announcement plugin of jupyterlab \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -185,6 +185,7 @@ RUN ./utils/install_pdf_deps.sh
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
+
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -252,7 +253,8 @@ RUN echo "Installing softwares and packages" && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \# copy jupyter configuration
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # copy jupyter configuration
     cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -178,7 +178,6 @@ WORKDIR /opt/app-root/bin
 COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
-
 USER 0
 
 # Dependencies for PDF export
@@ -186,7 +185,6 @@ RUN ./utils/install_pdf_deps.sh
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
-
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -248,15 +246,14 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # copy jupyter configuration
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \# copy jupyter configuration
     cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,6 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -243,10 +243,10 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.11"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,7 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,7 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -249,7 +249,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,9 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -243,7 +243,7 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch/ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.11"
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -224,7 +224,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -219,10 +219,10 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.12"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -223,7 +223,6 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -222,7 +222,9 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -222,7 +222,7 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -222,7 +222,7 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -218,7 +218,7 @@ LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch/ubi9-python-3.12" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.12"
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -152,7 +152,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -152,7 +152,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -152,7 +152,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -152,7 +152,9 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -154,7 +154,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-to
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -84,7 +84,6 @@ WORKDIR /opt/app-root/bin
 COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
-
 USER 0
 
 # Dependencies for PDF export
@@ -92,7 +91,6 @@ RUN ./utils/install_pdf_deps.sh
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
-
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -154,7 +152,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
 COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -149,7 +149,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/pytorch/ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.11"
 
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -153,7 +153,6 @@ COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -154,7 +154,9 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -155,7 +155,6 @@ COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -151,7 +151,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/pytorch/ubi9-python-3.12" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.12"
 
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
 COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -156,7 +156,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ${PYTORCH_SOURCE_CODE}/de-vendor-to
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -154,7 +154,9 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -156,7 +156,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock  ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -155,7 +155,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock  ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock  ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install --dev && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -154,7 +154,7 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -151,7 +151,7 @@ LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/tensorflow/ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-tensorflow-ubi9-python-3.11"
 
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock  ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -249,7 +249,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -242,7 +242,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11"
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -185,6 +185,7 @@ RUN ./utils/install_pdf_deps.sh
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
+
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -252,7 +253,8 @@ RUN echo "Installing softwares and packages" && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \# copy jupyter configuration
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # copy jupyter configuration
     cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -178,7 +178,6 @@ WORKDIR /opt/app-root/bin
 COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
-
 USER 0
 
 # Dependencies for PDF export
@@ -186,7 +185,6 @@ RUN ./utils/install_pdf_deps.sh
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
-
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -248,15 +246,14 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install --dev && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # copy jupyter configuration
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \# copy jupyter configuration
     cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,9 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -247,7 +247,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -243,10 +243,10 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -227,7 +227,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -227,7 +227,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install --dev && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -228,7 +228,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install --dev && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -229,7 +229,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -223,7 +223,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
     io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.12" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.12"
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -224,7 +224,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
     io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.12"
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     micropipenv install --dev && \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -227,7 +227,9 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -227,7 +227,7 @@ LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -127,7 +127,7 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -127,7 +127,7 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -124,10 +124,10 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 USER 1001
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${TRUSTYAI_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -128,7 +128,6 @@ COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -129,7 +129,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -127,7 +127,7 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -127,7 +127,9 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -123,7 +123,7 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 
 USER 1001
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -127,7 +127,7 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -27,7 +27,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -128,7 +128,6 @@ COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -129,7 +129,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -27,8 +27,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -124,10 +124,10 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 USER 1001
 
 # Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${TRUSTYAI_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -127,7 +127,7 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -127,7 +127,9 @@ USER 1001
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -123,7 +123,7 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 
 USER 1001
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
+# Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -166,7 +166,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -166,7 +166,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -166,7 +166,9 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -5,7 +5,7 @@ FROM quay.io/sclorg/python-311-c9s:c9s AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -167,7 +167,6 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -5,8 +5,8 @@ FROM quay.io/sclorg/python-311-c9s:c9s AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root
 USER root
@@ -166,7 +166,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -163,10 +163,10 @@ COPY ${RSTUDIO_SOURCE_CODE}/run-rstudio.sh ${RSTUDIO_SOURCE_CODE}/setup_rstudio.
 
 USER 1001
 
-COPY ${RSTUDIO_SOURCE_CODE}/Pipfile.lock ./
+COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -168,7 +168,7 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -298,7 +298,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -298,7 +298,9 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -5,8 +5,8 @@ FROM quay.io/sclorg/python-311-c9s:c9s AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root
 USER root
@@ -298,7 +298,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/Pipfile.lock ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -299,7 +299,6 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -5,7 +5,7 @@ FROM quay.io/sclorg/python-311-c9s:c9s AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -295,10 +295,10 @@ COPY ${RSTUDIO_SOURCE_CODE}/run-rstudio.sh ${RSTUDIO_SOURCE_CODE}/setup_rstudio.
 
 USER 1001
 
-COPY ${RSTUDIO_SOURCE_CODE}/Pipfile.lock ./
+COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -298,7 +298,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -300,7 +300,7 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -189,7 +189,6 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -188,7 +188,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -190,7 +190,7 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -188,7 +188,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -5,8 +5,8 @@ FROM registry.redhat.io/rhel9/python-311:latest AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root
 USER root
@@ -185,10 +185,10 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
 
 USER 1001
 
-COPY ${RSTUDIO_SOURCE_CODE}/Pipfile.lock ./
+COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -5,7 +5,7 @@ FROM registry.redhat.io/rhel9/python-311:latest AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -188,7 +188,9 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -346,7 +346,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -346,7 +346,7 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -5,8 +5,8 @@ FROM registry.redhat.io/rhel9/python-311:latest AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root
 USER root
@@ -343,10 +343,10 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
 
 USER 1001
 
-COPY ${RSTUDIO_SOURCE_CODE}/Pipfile.lock ./
+COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -347,7 +347,6 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -346,7 +346,9 @@ USER 1001
 COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -348,7 +348,7 @@ COPY ${RSTUDIO_SOURCE_CODE}/requirements.txt ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -5,7 +5,7 @@ FROM registry.redhat.io/rhel9/python-311:latest AS base
 
 WORKDIR /opt/app-root/bin
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # OS Packages needs to be installed as root

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -43,7 +43,7 @@ LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -50,7 +50,6 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -49,7 +49,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -49,7 +49,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -51,7 +51,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -49,7 +49,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -49,7 +49,9 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -44,12 +44,12 @@ LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
+COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -51,7 +51,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -49,7 +49,9 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -49,7 +49,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -44,12 +44,12 @@ LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.12" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
+COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -43,7 +43,7 @@ LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -50,7 +50,6 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -49,7 +49,7 @@ COPY ${DATASCIENCE_SOURCE_CODE}/requirements.txt ./
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -56,7 +56,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -51,12 +51,12 @@ LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -50,7 +50,7 @@ LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -21,8 +21,8 @@ RUN ARCH=$(uname -m) && \
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -56,7 +56,7 @@ COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -56,7 +56,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -21,7 +21,7 @@ RUN ARCH=$(uname -m) && \
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -56,7 +56,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -57,7 +57,6 @@ COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -50,7 +50,7 @@ LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -56,7 +56,9 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -57,7 +57,6 @@ COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -21,8 +21,8 @@ RUN ARCH=$(uname -m) && \
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -51,12 +51,12 @@ LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.12" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ./
+COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -21,7 +21,7 @@ RUN ARCH=$(uname -m) && \
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -56,7 +56,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -56,7 +56,7 @@ COPY ${MINIMAL_SOURCE_CODE}/requirements.txt ./
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -171,7 +171,7 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -177,7 +177,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -177,7 +177,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -178,7 +178,6 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -177,7 +177,9 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -177,7 +177,7 @@ COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -172,12 +172,12 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -179,7 +179,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -151,7 +151,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -146,12 +146,12 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.12" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -151,7 +151,7 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -151,7 +151,9 @@ COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -145,7 +145,7 @@ LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -153,7 +153,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -152,7 +152,6 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -77,7 +77,7 @@ LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -85,7 +85,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -85,7 +85,9 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -85,7 +85,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -86,7 +86,6 @@ COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -85,7 +85,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -87,7 +87,7 @@ COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -78,14 +78,14 @@ LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 # Copy utility script
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -77,7 +77,7 @@ LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -78,14 +78,14 @@ LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+COPY ${PYTORCH_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 # Copy utility script
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -85,7 +85,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -85,7 +85,9 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -85,7 +85,7 @@ COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -86,7 +86,6 @@ COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -87,7 +87,7 @@ COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -85,7 +85,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -83,7 +83,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -83,7 +83,9 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -83,7 +83,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -83,7 +83,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -84,7 +84,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -77,7 +77,7 @@ LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -78,12 +78,12 @@ LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -77,7 +77,7 @@ LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -78,12 +78,12 @@ LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -83,7 +83,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -84,7 +84,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -83,7 +83,9 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -85,7 +85,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -83,7 +83,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -177,7 +177,9 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -177,7 +177,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -179,7 +179,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -172,12 +172,12 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.11" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -171,7 +171,7 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.11" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -178,7 +178,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -177,7 +177,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    micropipenv requirements | uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy unsafe-best-match --requirements - && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -177,7 +177,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -156,7 +156,9 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -156,7 +156,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    # First run may download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -14,8 +14,8 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install --no-cache-dir -U "micropipenv[toml]"
+# Install micropipenv and uv to deploy packages from Pipfile.lock
+RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
@@ -151,12 +151,12 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12" \
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -158,7 +158,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf
 # Other apps and tools installed as default user
 USER 1001
 
-# Install micropipenv and uv to deploy packages from Pipfile.lock
+# Install micropipenv and uv to deploy packages from requirements.txt
 RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 
 # Install the oc client begin

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -150,7 +150,7 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
+# Install Python packages from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -156,7 +156,7 @@ COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt --build-constraints=./requirements.txt && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -157,7 +157,6 @@ COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --require-hashes --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
-    rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-21690

This change depends upon

* https://github.com/opendatahub-io/notebooks/pull/986
* https://github.com/opendatahub-io/notebooks/pull/987

## Description

In our Dockerfile builds, micropipenv is used to read Pipfile.lock and run pip install to install everything in there.

it works by first creating a temporary requirement.txt with hashes, and then it runs pip install -r to install from that generated file

```
Collecting scikit-learn==1.5.2 (from -r /tmp/requirements_micropipenv-rti6r8e5.txt (line 2))
Downloading scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.3 MB)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.3/13.3 MB 172.2 MB/s eta 0:00:00
Installing collected packages: scikit-learn
Successfully installed scikit-learn-1.5.2
```

In enhancement

* https://github.com/opendatahub-io/notebooks/pull/875

we added generating requirements.txt with hashes and committing them into our repository directly. That means we now can install from the requirements.txt without needing micropipenv. Turns out that uv is very fast requirements.txt installer that can be a drop-in replacement https://astral.sh/blog/uv

## How Has This Been Tested?

This change still keeps micropipenv around, it uses it to generate requirements.txt, and then it uses uv to install the requirements.

Checking the install logs, it still prints the desirable warning

```
warning: The package `tf2onnx` requires `protobuf~=3.20`, but `4.25.6` is installed
```

* https://github.com/opendatahub-io/notebooks/actions/runs/16692234762/job/47251953764?pr=968#step:25:2703

Checking (comparing) image sizes

```
ghcr.io/opendatahub-io/notebooks/workbench-images              codeserver-ubi9-python-3.12-_03b3da89870cbd0a348161003ac5850d121f3517  sha256:e0246a3ad347cc1ce012bc7916094f97b967366be0e5d0ead4820378f59389bc  07a655595049  10 seconds ago  3.23 GB
```

```
ghcr.io/opendatahub-io/notebooks/workbench-images              codeserver-ubi9-python-3.12-_cb6dd669204361d83197dd7c958e71a5fd56f321  sha256:e1f79cccc76d0375ad58682cc57a3ee3de5d4f3af1faeb8c7979fe63242590dd  79c3a6cc80a0  18 minutes ago  3.36 GB
```

* https://github.com/opendatahub-io/notebooks/actions/runs/16781310093/job/47520892024?pr=968#step:26:16
* https://github.com/opendatahub-io/notebooks/actions/runs/16766953674/job/47474040678#step:26:17

after also adding `--compile-bytecode`

```
ghcr.io/opendatahub-io/notebooks/workbench-images              codeserver-ubi9-python-3.12-_a2a1b1d96820eb01baff50723912006cb768764b  sha256:3eb9bfca60922b71029467eee4dd00653d3efa209c3028a4c6e0f8f29c346232  cd8ae3dfefd8  11 seconds ago  3.45 GB
```

* https://github.com/opendatahub-io/notebooks/actions/runs/16785925669/job/47565308883?pr=968#step:26:16

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added the "uv" package alongside "micropipenv[toml]" in Python package installations across multiple images.
  * Transitioned from using Pipfile.lock to requirements.txt for specifying Python dependencies in various images.

* **Refactor**
  * Updated Python package installation commands to use `uv pip install` with strict flags, enhancing dependency management and hash verification.
  * Removed cleanup steps related to Pipfile.lock due to the switch to requirements.txt.

* **Style**
  * Applied minor formatting and whitespace adjustments in Dockerfiles for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->