### PR TITLE
NO-JIRA: chore(gha): switch image build to ubuntu-24.04 as there is more disk space available

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -18,10 +18,7 @@ name: Build & Publish Notebook Servers (TEMPLATE)
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-24.04
     env:
       # Some pieces of code (image pulls for example) in podman consult TMPDIR or default to /var/tmp
       TMPDIR: /home/runner/.local/share/containers/tmpdir


### PR DESCRIPTION
## Description

There is less stuff preinstalled now

* https://github.com/actions/runner-images
* https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

The changes themselves were highlighted in

* https://github.com/actions/runner-images/issues/10636

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/13952851356

### Before

https://github.com/jiridanek/notebooks/actions/runs/13950814007/job/39049648105#step:8:57

```
Filesystem                   Size  Used Avail Use% Mounted on
/dev/root                     73G   69G  4.1G  95% /
tmpfs                        7.9G  172K  7.9G   1% /dev/shm
tmpfs                        3.2G  1.2M  3.2G   1% /run
tmpfs                        5.0M     0  5.0M   0% /run/lock
/dev/sdb15                   105M  6.1M   99M   6% /boot/efi
/dev/sda1                     74G   70G  100M 100% /mnt
tmpfs                        1.6G   12K  1.6G   1% /run/user/1001
/dev/mapper/buildvg-buildlv  105G   24K  105G   1% /home/runner/.local/share/containers
               total        used        free      shared  buff/cache   available
Mem:            15Gi       630Mi        11Gi        [62](https://github.com/jiridanek/notebooks/actions/runs/13950814007/job/39049648105#step:8:63)Mi       3.2Gi        14Gi
Swap:          4.0Gi          0B       4.0Gi
```

### With this change

https://github.com/jiridanek/notebooks/actions/runs/13952851356/job/39056607887#step:8:57

```
Filesystem                   Size  Used Avail Use% Mounted on
/dev/root                     72G   68G  4.1G  95% /
tmpfs                        7.9G   84K  7.9G   1% /dev/shm
tmpfs                        3.2G  1.1M  3.2G   1% /run
tmpfs                        5.0M     0  5.0M   0% /run/lock
/dev/sda16                   881M   [59](https://github.com/jiridanek/notebooks/actions/runs/13952851356/job/39056607887#step:8:60)M  761M   8% /boot
/dev/sda15                   105M  6.1M   99M   6% /boot/efi
/dev/sdb1                     74G   70G  100M 100% /mnt
tmpfs                        1.6G   12K  1.6G   1% /run/user/1001
/dev/mapper/buildvg-buildlv  107G   24K  107G   1% /home/runner/.local/share/containers
               total        used        free      shared  buff/cache   available
Mem:            15Gi       995Mi        12Gi        [61](https://github.com/jiridanek/notebooks/actions/runs/13952851356/job/39056607887#step:8:62)Mi       2.3Gi        14Gi
Swap:          4.0Gi          0B       4.0Gi
```

This is +2G of disk space! Hmm, meh.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
