### PR TITLE
ISSUE #971: chore(gha): switch from ext4 to btrfs with compression and add log printing for the future

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -54,6 +54,8 @@ jobs:
         with:
           cache-dependency-path: "**/*.sum"
 
+      - run: sudo apt-get update
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -92,6 +94,8 @@ jobs:
           wait
 
           df -h
+
+      - run: sudo apt-get install -y btrfs-compsize
 
       - name: Mount lvm overlay for podman builds
         run: |
@@ -244,6 +248,9 @@ jobs:
 
       - name: "push|schedule|workflow_dispatch: make ${{ inputs.target }}"
         run: |
+          # print running stats on disk occupancy
+          (while true; do df -h | grep "${HOME}/.local/share/containers"; sleep 30; done) &
+
           make ${{ inputs.target }}
         if: ${{ fromJson(inputs.github).event_name == 'push' ||
           fromJson(inputs.github).event_name == 'schedule' ||
@@ -253,6 +260,9 @@ jobs:
           CONTAINER_BUILD_CACHE_ARGS: "--cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
       - name: "pull_request: make ${{ inputs.target }}"
         run: |
+          # print running stats on disk occupancy
+          (while true; do df -h | grep "${HOME}/.local/share/containers"; sleep 30; done) &
+
           make ${{ inputs.target }}
         if: "${{ fromJson(inputs.github).event_name == 'pull_request' }}"
         env:
@@ -567,4 +577,7 @@ jobs:
       # endregion
 
       - run: df -h
+        if: "${{ !cancelled() }}"
+
+      - run: sudo compsize -x "${HOME}/.local/share/containers"
         if: "${{ !cancelled() }}"

--- a/ci/cached-builds/gha_lvm_overlay.sh
+++ b/ci/cached-builds/gha_lvm_overlay.sh
@@ -10,7 +10,7 @@ set -Eeuo pipefail
 # root_reserve_mb=2048 was running out of disk space building cuda images
 root_reserve_mb=4096
 temp_reserve_mb=100
-swap_size_mb=4096
+swap_size_mb=256
 
 build_mount_path="${HOME}/.local/share/containers"
 build_mount_path_ownership="runner:runner"


### PR DESCRIPTION
Fixes #971

/label tide/merge-method-rebase

## Description

```
$ sudo compsize -x "${HOME}/.local/share/containers"
zstd        18%      5.1G          27G          27G   
```

zstd compression is mighty!, 27G of data takes only 5G on the physical disk

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/13968301883

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
