### PR TITLE
NO-ISSUE: chore(ci): fix expected image names in params.env check

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -112,7 +112,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=503
             ;;
         odh-minimal-gpu-notebook-image-n)
-            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.11"
+            expected_name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="cuda-jupyter-minimal-ubi9-python-3.11-amd64"
             expected_img_size=5157
@@ -124,9 +124,9 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=5157
             ;;
         odh-pytorch-gpu-notebook-image-n)
-            expected_name="odh-notebook-jupyter-pytorch-ubi9-python-3.11"
+            expected_name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.11"
             expected_commitref="main"
-            expected_build_name="jupyter-pytorch-ubi9-python-3.11-amd64"
+            expected_build_name="cuda-jupyter-pytorch-ubi9-python-3.11-amd64"
             expected_img_size=8571
             ;;
         odh-pytorch-gpu-notebook-image-n-1)
@@ -199,7 +199,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
         # This is because the very same RStudio Dockerfile is used but different base images in both cases
         # We should consider what to do with this - in ideal case, we should have different labels for these cases.
         odh-rstudio-gpu-notebook-image-n)
-            expected_name="odh-notebook-rstudio-server-c9s-python-3.11"
+            expected_name="odh-notebook-rstudio-server-cuda-c9s-python-3.11"
             expected_commitref="main"
             expected_build_name="cuda-rstudio-c9s-python-3.11-amd64"
             expected_img_size=7184
@@ -211,7 +211,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=7184
             ;;
         odh-rocm-minimal-notebook-image-n)
-            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.11"
+            expected_name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="rocm-jupyter-minimal-ubi9-python-3.11-amd64"
             expected_img_size=4830


### PR DESCRIPTION
With recent 2025a image version introduced, we fixed some image build names annotations and these need to be reflected in this check now.

For older images, the fixes weren't applied as they weren't rebuild, so no fix is done for these N-1 image version checks.

## How Has This Been Tested?
```
./ci/check-params-env.sh
```

Note: there are still failures in this script due to the image size changes. These will be investigated first and then fixed with a followup PR eventually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
