### PR TITLE
NO-ISSUE: fix the manifest definitions software versions for images

### DIFF
--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -46,8 +46,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "3.6"},
-            {"name": "Notebook","version": "6.5"}
+            {"name": "JupyterLab","version": "4.2"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
         opendatahub.io/notebook-software: |
           [
             {"name": "R", "version": "v4.4"},
-            {"name": "Python", "version": "v3.9"}
+            {"name": "Python", "version": "v3.11"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |


### PR DESCRIPTION
After recent updates, there were some small glitches in the announced versions of the linked images.

## How Has This Been Tested?
```
./ci/check-software-versions.py
```

There is still one failure regarding `rocm` vs `rocm-core` rpm package check. This is being discussed on Slack right now.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
