### PR TITLE
NO-JIRA: fix(ci): update the way we check for the rocm version

### DIFF
--- a/ci/check-software-versions.py
+++ b/ci/check-software-versions.py
@@ -148,7 +148,7 @@ def process_dependency_item(item, container_id, annotation_type):
 
     command_mapping = {
         "PyTorch": ["/bin/bash", "-c", f"pip show torch | grep 'Version: '"],
-        "ROCm": ["/bin/bash", "-c", "rpm -q --queryformat '%{VERSION}\n' rocm"],
+        "ROCm": ["/bin/bash", "-c", "rpm -q --queryformat '%{VERSION}\n' rocm-core"],
         "ROCm-PyTorch": ["/bin/bash", "-c", "pip show torch | grep 'Version: ' | grep rocm"],
         "ROCm-TensorFlow": ["/bin/bash", "-c", "pip show tensorflow-rocm | grep 'Version: '"],
         "TensorFlow": ["/bin/bash", "-c", "pip show tensorflow | grep 'Version: '"],


### PR DESCRIPTION
With the introduction of the 2025.1 images, we changed the way we install the ROCm on our images. Instead of installing the main `rocm` metapackage, we install directly just it's subpackages ecluding the installation of the `migraphx` and `mivisionx` packages to reduce the size of the result ROCm images. This was a deliberate decision and so we need to amend the way how to check the ROCm version on our images.

For the record:
* https://github.com/opendatahub-io/notebooks/pull/956/commits/0d262e27b599349f3f33e129f934584860ba4e24#diff-8ddc31b6fcd6307008d6abf6aef98768f83a7a94cb09a2eee2b3e1ff04788f20R40-R42

## How Has This Been Tested?
```
./ci/check-software-versions.py
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
