### PR TITLE
RHOAIENG-21691: mitigate undesirable `/opt/app-root` ownership and permissions change caused by a Dockerfile `COPY`

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -81,7 +81,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
 COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY ${CODESERVER_SOURCE_CODE}/nginx/root/ /
+COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -115,7 +115,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
 COPY --chown=1001:0 ${RSTUDIO_SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY ${RSTUDIO_SOURCE_CODE}/nginx/root/ /
+COPY --chown=1001:0 ${RSTUDIO_SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -239,7 +239,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
 COPY --chown=1001:0 ${RSTUDIO_SOURCE_CODE}/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
-COPY ${RSTUDIO_SOURCE_CODE}/nginx/root/ /
+COPY --chown=1001:0 ${RSTUDIO_SOURCE_CODE}/nginx/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model


### PR DESCRIPTION
## Description

Before:

```
podman run --entrypoint /bin/bash --rm -it 7616b6ee0ff8 -c 'ls -AlFd $VIRTUAL_ENV'
drwxrwxr-x. 1 default root 40 Mar 16 09:57 /opt/app-root/
```

The Dockerfile command causing trouble:

```
USER 0
# Copy extra files to the image.
COPY ${RSTUDIO_SOURCE_CODE}/nginx/root/ /
```

After:

```
podman run --entrypoint /bin/bash --rm -it 237a5692c108 -c 'ls -AlFd $VIRTUAL_ENV'
drwxr-xr-x. 1 root root 38 Mar 14 14:16 /opt/app-root/
```

## How Has This Been Tested?

* https://github.com/opendatahub-io/notebooks/pull/968

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
