### PR TITLE
NO-JIRA: chore(tests/): fix running rstudio rhel9 Makefile image tests

### DIFF
--- a/ci/cached-builds/make_test.py
+++ b/ci/cached-builds/make_test.py
@@ -141,7 +141,8 @@ def wait_for_stability(pod: str) -> None:
     timeout = 100
     for _ in range(3):
         call(
-            f"timeout {timeout}s bash -c 'until kubectl wait --for=condition=Ready pods --all --timeout 5s; do sleep 1; done'", shell=True)
+            f"timeout {timeout}s bash -c 'until kubectl wait --for=condition=Ready pods --all --timeout 5s; do sleep 1; done'",
+            shell=True)
         timeout = 50
         time.sleep(3)
 
@@ -199,6 +200,15 @@ class TestMakeTest(unittest.TestCase):
         assert "make undeploy-c9s-rstudio-c9s-python-3.11" in commands
 
     @unittest.mock.patch("make_test.execute")
+    def test_make_commands_rsudio_rhel(self, mock_execute: unittest.mock.Mock) -> None:
+        """Compares the commands with what we had in the openshift/release yaml"""
+        run_tests("rstudio-rhel9-python-3.11")
+        commands: list[str] = [c[0][1][0] for c in mock_execute.call_args_list]
+        assert "make deploy-rhel9-rstudio-rhel9-python-3.11" in commands
+        assert "make validate-rstudio-image image=rstudio-rhel9-python-3.11" in commands
+        assert "make undeploy-rhel9-rstudio-rhel9-python-3.11" in commands
+
+    @unittest.mock.patch("make_test.execute")
     def test_make_commands_cuda_rstudio(self, mock_execute: unittest.mock.Mock) -> None:
         """Compares the commands with what we had in the openshift/release yaml"""
         run_tests("cuda-rstudio-c9s-python-3.11")
@@ -206,6 +216,15 @@ class TestMakeTest(unittest.TestCase):
         assert "make deploy-c9s-rstudio-c9s-python-3.11" in commands
         assert "make validate-rstudio-image image=cuda-rstudio-c9s-python-3.11" in commands
         assert "make undeploy-c9s-rstudio-c9s-python-3.11" in commands
+
+    @unittest.mock.patch("make_test.execute")
+    def test_make_commands_cuda_rstudio_rhel(self, mock_execute: unittest.mock.Mock) -> None:
+        """Compares the commands with what we had in the openshift/release yaml"""
+        run_tests("cuda-rstudio-rhel9-python-3.11")
+        commands: list[str] = [c[0][1][0] for c in mock_execute.call_args_list]
+        assert "make deploy-rhel9-rstudio-rhel9-python-3.11" in commands
+        assert "make validate-rstudio-image image=cuda-rstudio-rhel9-python-3.11" in commands
+        assert "make undeploy-rhel9-rstudio-rhel9-python-3.11" in commands
 
     @unittest.mock.patch("make_test.execute")
     def test_make_commands_runtime(self, mock_execute: unittest.mock.Mock) -> None:


### PR DESCRIPTION
Fixes

```
make: *** No rule to make target 'deploy-rhel9-rstudio-rhel9-python-3.11'.  Stop.
```

## Description

Define make targets necessary to run rstudio rhel9 images in tests.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/14082671917/job/39439025035

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
