### PR TITLE
NO-JIRA: fix(manifests/): torch version in `jupyter-rocm-pytorch-notebook-imagestream.yaml`

### DIFF
--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -21,13 +21,13 @@ spec:
         opendatahub.io/notebook-software: |
           [
             {"name": "Python", "version": "v3.11"},
-            {"name": "ROCm-PyTorch", "version": "2.4"}
+            {"name": "ROCm-PyTorch", "version": "2.6"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab","version": "4.2"},
-            {"name": "ROCm-PyTorch", "version": "2.4"},
+            {"name": "ROCm-PyTorch", "version": "2.6"},
             {"name": "Tensorboard", "version": "2.18"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.10"},


### PR DESCRIPTION
* https://github.com/jiridanek/notebooks/actions/runs/14086099329

## Fix for

```
======================================================================
FAIL: test_torch_version (__main__.TestPytorchNotebook.test_torch_version)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/ipykernel_58/3114923626.py", line 41, in test_torch_version
    self.assertEqual(actual_major_minor, expected_major_minor, "incorrect version")
AssertionError: '2.6' != '2.4'
- 2.6
?   ^
+ 2.4
?   ^
 : incorrect version

----------------------------------------------------------------------
Ran 9 tests in 3.004s
```