### PR TITLE
RHOAIENG-21740: Perform filesystem permission check on images

### DIFF
--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -16,6 +16,7 @@ import docker.models.images
 import docker.types
 
 from tests.containers import docker_utils
+from tests.containers import utils
 
 if TYPE_CHECKING:
     from pytest import ExitCode, Session, Parser, Metafunc
@@ -92,7 +93,7 @@ def jupyterlab_image(image: str) -> docker.models.images.Image:
 @pytest.fixture(scope="function")
 def rstudio_image(image: str) -> docker.models.images.Image:
     image_metadata = skip_if_not_workbench_image(image)
-    if "-rstudio-" not in image_metadata.labels['name']:
+    if not utils.is_rstudio_image(image):
         pytest.skip(
             f"Image {image} does not have '-rstudio-' in {image_metadata.labels['name']=}'")
 

--- a/tests/containers/utils.py
+++ b/tests/containers/utils.py
@@ -1,0 +1,15 @@
+import docker.errors
+import docker.models.images
+import testcontainers.core.container
+
+def is_rstudio_image(my_image: str) -> bool:
+    label = "-rstudio-"
+
+    client = testcontainers.core.container.DockerClient()
+    try:
+        image_metadata = client.client.images.get(my_image)
+    except docker.errors.ImageNotFound:
+        image_metadata = client.client.images.pull(my_image)
+        assert isinstance(image_metadata, docker.models.images.Image)
+
+    return label in image_metadata.labels['name']


### PR DESCRIPTION
This adds a simple test to scan our final images for the crucial directories for their ownership and permissions configuration.

## Description
https://issues.redhat.com/browse/RHOAIENG-21740

## How Has This Been Tested?
```
for image_ref in $(cat manifests/base/params.env | grep "\-n=" | cut -d "=" -f 2); do DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock poetry run pytest tests/containers --image "${image_ref}" -k test_file_permissions; done
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
