### PR TITLE
RHOAIENG-22439: fix(manifests/rstudio): dismantle the broken RStudio BuildConfig chain and build the image directly

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -2,18 +2,6 @@
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
-  name: cuda-rhel9
-spec:
-  lookupPolicy:
-    local: true
-  tags:
-    - name: latest
-      referencePolicy:
-        type: Source
----
-kind: ImageStream
-apiVersion: image.openshift.io/v1
-metadata:
   annotations:
     opendatahub.io/notebook-image-creator: RHOAI
     opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/rstudio"
@@ -45,51 +33,6 @@ spec:
 kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
-  name: cuda-rhel9
-  labels:
-    app: buildchain
-    component: cuda-rhel9
-spec:
-  source:
-    type: Git
-    git:
-      uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.19
-  strategy:
-    type: Docker
-    dockerStrategy:
-      dockerfilePath: "rstudio/rhel9-python-3.11/Dockerfile.cuda"
-      noCache: true
-      volumes:
-        - name: secret-mvn
-          source:
-            type: Secret
-            secret:
-              secretName: rhel-subscription-secret
-              defaultMode: 420
-          mounts:
-            - destinationPath: /opt/app-root/src/.sec
-  output:
-    to:
-      kind: ImageStreamTag
-      name: "cuda-rhel9:latest"
-  resources:
-    limits:
-      cpu: "1"
-      memory: 8Gi
-    requests:
-      cpu: "1"
-      memory: 8Gi
-  successfulBuildsHistoryLimit: 2
-  failedBuildsHistoryLimit: 2
-  runPolicy: Serial
-  triggers:
-    - imageChange: {}
-      type: ImageChange
----
-kind: BuildConfig
-apiVersion: build.openshift.io/v1
-metadata:
   name: cuda-rstudio-server-rhel9
   labels:
     app: buildchain
@@ -105,9 +48,6 @@ spec:
     dockerStrategy:
       dockerfilePath: "rstudio/rhel9-python-3.11/Dockerfile.cuda"
       noCache: true
-      from:
-        kind: "ImageStreamTag"
-        name: "cuda-rhel9:latest"
       volumes:
         - name: secret-mvn
           source:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-22439

## Description

The way it was, the second (dependent) build would always fail on

```
[3/3] STEP 33/37: RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && chmod -R g+w /opt/app-root/lib/python3.11/site-packages && fix-permissions /opt/app-root -P
Installing softwares and packages
/bin/sh: line 1: micropipenv: command not found
error: build error: building at STEP "RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && chmod -R g+w /opt/app-root/lib/python3.11/site-packages && fix-permissions /opt/app-root -P": while running runtime: exit status 127
```

This is because both BuildConfigs were building the same `Dockerfile.cuda` (that's obviously wasteful) and the Dockerfile was not idempotent (and still is not).

## How Has This Been Tested?

```
    workbenches:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/jiridanek/notebooks/archive/jd_sync_rhds_main_again.tar.gz'
      managementState: Managed
```



## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
