### PR TITLE
NO-ISSUE: chore(GHA): update expected image size for 2025.1 version

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -106,7 +106,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="jupyter-minimal-ubi9-python-3.11-amd64"
-            expected_img_size=520
+            expected_img_size=624
             ;;
         odh-minimal-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.11"
@@ -118,7 +118,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="cuda-jupyter-minimal-ubi9-python-3.11-amd64"
-            expected_img_size=5157
+            expected_img_size=5025
             ;;
         odh-minimal-gpu-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.11"
@@ -142,7 +142,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="jupyter-datascience-ubi9-python-3.11-amd64"
-            expected_img_size=961
+            expected_img_size=1067
             ;;
         odh-generic-data-science-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.11"
@@ -154,7 +154,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="cuda-jupyter-tensorflow-ubi9-python-3.11-amd64"
-            expected_img_size=8211
+            expected_img_size=8037
             ;;
         odh-tensorflow-gpu-notebook-image-n-1)
             expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.11"
@@ -166,7 +166,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="jupyter-trustyai-ubi9-python-3.11-amd64"
-            expected_img_size=4197
+            expected_img_size=4369
             ;;
         odh-trustyai-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.11"
@@ -190,7 +190,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-rstudio-server-c9s-python-3.11"
             expected_commitref="main"
             expected_build_name="rstudio-c9s-python-3.11-amd64"
-            expected_img_size=1242
+            expected_img_size=1349
             ;;
         odh-rstudio-notebook-image-n-1)
             expected_name="odh-notebook-rstudio-server-c9s-python-3.11"
@@ -205,7 +205,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-rstudio-server-cuda-c9s-python-3.11"
             expected_commitref="main"
             expected_build_name="cuda-rstudio-c9s-python-3.11-amd64"
-            expected_img_size=7184
+            expected_img_size=6473
             ;;
         odh-rstudio-gpu-notebook-image-n-1)
             expected_name="odh-notebook-rstudio-server-c9s-python-3.11"
@@ -217,7 +217,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="rocm-jupyter-minimal-ubi9-python-3.11-amd64"
-            expected_img_size=4830
+            expected_img_size=5891
             ;;
         odh-rocm-minimal-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.11"
@@ -229,7 +229,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="rocm-jupyter-pytorch-ubi9-python-3.11-amd64"
-            expected_img_size=6571
+            expected_img_size=7531
             ;;
         odh-rocm-pytorch-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.11"
@@ -241,7 +241,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11"
             expected_commitref="main"
             expected_build_name="rocm-jupyter-tensorflow-ubi9-python-3.11-amd64"
-            expected_img_size=5782
+            expected_img_size=6828
             ;;
         odh-rocm-tensorflow-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.11"

--- a/ci/check-runtime-images.sh
+++ b/ci/check-runtime-images.sh
@@ -19,7 +19,7 @@
 # ---------------------------- DEFINED FUNCTIONS ----------------------------- #
 
 # Expected commit reference for the runtime images
-EXPECTED_COMMIT_REF="2024b"
+EXPECTED_COMMIT_REF="main"
 
 # Number of attempts for the skopeo tool to gather data from the repository.
 SKOPEO_RETRY=3
@@ -38,22 +38,22 @@ function check_image_size() {
 
     case "${img_name}" in
         odh-notebook-runtime-datascience-ubi9-python-3.11)
-            expected_img_size=866
+            expected_img_size=973
             ;;
         odh-notebook-runtime-pytorch-ubi9-python-3.11)
-            expected_img_size=3829
+            expected_img_size=8530
             ;;
         odh-notebook-runtime-rocm-pytorch-ubi9-python-3.11)
-            expected_img_size=6477
+            expected_img_size=7439
             ;;
         odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.11)
-            expected_img_size=5660
+            expected_img_size=6731
             ;;
         odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.11)
             expected_img_size=7992
             ;;
         odh-notebook-runtime-minimal-ubi9-python-3.11)
-            expected_img_size=494
+            expected_img_size=589
             ;;
         *)
             echo "Unimplemented image name: '${img_name}'"
@@ -131,6 +131,11 @@ function check_image() {
     echo "Image name: '${img_name}'"
 
     local expected_string="runtime-${img_tag}-ubi"
+    # workaround as we have a mismatch in the naming in the dockerfile:
+    # https://github.com/opendatahub-io/notebooks/blob/6d0d410abfcf91b42962acce15fe2c80d056912d/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm#L67
+    if test "${expected_string}" == "runtime-rocm-tensorflow-ubi"; then
+        expected_string="rocm-runtime-tensorflow-ubi"
+    fi
     echo "Checking that '${expected_string}' is present in the image metadata"
     echo "${img_metadata_config}" | grep --quiet "${expected_string}" || {
         echo "ERROR: The string '${expected_string}' isn't present in the image metadata at all. Please check that the referenced image '${img_url}' is the correct one!"


### PR DESCRIPTION
With the introduction of the 2025.1 image version, there were some changes in the expected image size for some of our images. Basically:

1. We included the `skopeo` tool in our images which bumped image size by cca 100MB.
2. PyTorch and TensorFlow images now contain the additional CUDA package which increase the image size by 1GB roughly.

## Description
I haven't checked deeply each image size bump, but here is some script that I used for couple of them:
https://github.com/jstourac/notebooks/blob/compareImages/ci/compare-images.sh

## How Has This Been Tested?
```
./ci/check-params.env
./ci/check-runtime-images.sh
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
