### PR TITLE
RHOAIENG-22425: chore(konflux): implement nudging to keep a (separate) manifests repo up-to-date

### DIFF
--- a/.tekton/codeserver-ubi9-python-3-11-push.yaml
+++ b/.tekton/codeserver-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cuda-jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/cuda-jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cuda-jupyter-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/cuda-jupyter-pytorch-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cuda-jupyter-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/cuda-jupyter-tensorflow-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cuda-rstudio-c9s-python-3-11-push.yaml
+++ b/.tekton/cuda-rstudio-c9s-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cuda-rstudio-rhel9-python-3-11-push.yaml
+++ b/.tekton/cuda-rstudio-rhel9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/jupyter-datascience-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-datascience-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/jupyter-trustyai-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-trustyai-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rocm-jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rocm-jupyter-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-jupyter-pytorch-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rocm-jupyter-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-jupyter-tensorflow-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rocm-runtime-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-runtime-pytorch-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rocm-runtime-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-runtime-tensorflow-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rstudio-c9s-python-3-11-push.yaml
+++ b/.tekton/rstudio-c9s-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/rstudio-rhel9-python-3-11-push.yaml
+++ b/.tekton/rstudio-rhel9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/runtime-cuda-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-cuda-pytorch-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/runtime-cuda-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-cuda-tensorflow-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/runtime-datascience-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-datascience-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/runtime-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-minimal-ubi9-python-3-11-push.yaml
@@ -4,6 +4,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: manifests/base/params.env
     build.appstudio.openshift.io/repo: 'https://github.com/opendatahub-io/notebooks?rev={{revision}}'
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/ci/cached-builds/konflux_generate_component_build_pipelines.py
+++ b/ci/cached-builds/konflux_generate_component_build_pipelines.py
@@ -83,6 +83,9 @@ def component_build_pipeline(component_name, dockerfile_path, is_pr: bool = True
                         + (' && ( ' + files_changed_cel_expression + ' )' if files_changed_cel_expression else "")
                         + ' && has(body.repository) && body.repository.full_name == "opendatahub-io/notebooks"'
                 ),
+                # https://konflux-ci.dev/docs/building/component-nudges/#customizing-nudging-prs
+                # https://docs.renovatebot.com/string-pattern-matching/
+                **when(is_pr, {}, {"build.appstudio.openshift.io/build-nudge-files": "manifests/base/params.env"}),
             },
             "creationTimestamp": None,
             "labels": {

--- a/ci/cached-builds/konflux_generate_component_definitions.py
+++ b/ci/cached-builds/konflux_generate_component_definitions.py
@@ -35,6 +35,9 @@ def konflux_component(component_name, dockerfile_path) -> dict:
                 # this annotation will create imagerepository in quay,
                 # https://redhat-internal.slack.com/archives/C07S8637ELR/p1736436093726049?thread_ts=1736420157.217379&cid=C07S8637ELR
                 "image.redhat.com/generate": '{"visibility": "public"}',
+                # this annotation looks useful, but I don't know what it does
+                # https://github.com/openshift-knative/hack/blob/a3a641238bab181b48e8cd8957f499402071d163/pkg/konfluxgen/dockerfile-component.template.yaml#L6
+                # "build.appstudio.openshift.io/request": "configure-pac-no-mr",
 
                 "build.appstudio.openshift.io/status": '{"pac":{"state":"enabled","merge-url":"https://github.com/opendatahub-io/notebooks/pull/903","configuration-time":"Tue, 18 Feb 2025 12:39:27 UTC"},"message":"done"}',
                 "build.appstudio.openshift.io/pipeline": '{"name":"docker-build-oci-ta","bundle":"latest"}',
@@ -58,6 +61,7 @@ def konflux_component(component_name, dockerfile_path) -> dict:
         },
         "spec": {
             "application": application_name,
+            "build-nudges-ref": [ "manifests" ],
             "componentName": component_name,
             "containerImage": "quay.io/redhat-user-workloads/"
                               + workspace_name


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-22425

## Description

This is a proof-of-concept of how things may be done. I do not insist on keeping manifests separate, although it seems to me that's the only sensible way of doing things.

```
PYTHONPATH=. uv run ci/cached-builds/konflux_generate_component_build_pipelines.py

oc get component --output jsonpath="{.items[*].status.lastPromotedImage}"
```

The repo to be nudged is https://github.com/rhoai-ide-konflux/notebooks/tree/manifests, that's in order not to mess up this one repo here with automated PRs.

## How Has This Been Tested?

Played with nudging with two test repos in

* https://github.com/rhoai-ide-konflux/trynudgefirst/tree/main
* https://github.com/rhoai-ide-konflux/trynudgesecond

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
