### PR TITLE
NO-JIRA: add a 'release' label to our images

### DIFF
--- a/.tekton/codeserver-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/codeserver-ubi9-python-3-11-pull-request.yaml
@@ -35,6 +35,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/codeserver-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -101,6 +104,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -228,6 +235,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/codeserver-ubi9-python-3-11-push.yaml
+++ b/.tekton/codeserver-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/codeserver-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-jupyter-minimal-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/cuda-jupyter-minimal-ubi9-python-3-11-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-jupyter-minimal-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -99,6 +102,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -226,6 +233,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/cuda-jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-jupyter-minimal-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-jupyter-pytorch-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/cuda-jupyter-pytorch-ubi9-python-3-11-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-jupyter-pytorch-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -102,6 +105,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -229,6 +236,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-jupyter-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/cuda-jupyter-pytorch-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-jupyter-pytorch-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-jupyter-tensorflow-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/cuda-jupyter-tensorflow-ubi9-python-3-11-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-jupyter-tensorflow-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -102,6 +105,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -229,6 +236,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-jupyter-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/cuda-jupyter-tensorflow-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-jupyter-tensorflow-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-rstudio-c9s-python-3-11-pull-request.yaml
+++ b/.tekton/cuda-rstudio-c9s-python-3-11-pull-request.yaml
@@ -38,6 +38,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-rstudio-c9s-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -104,6 +107,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -231,6 +238,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-rstudio-c9s-python-3-11-push.yaml
+++ b/.tekton/cuda-rstudio-c9s-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-rstudio-c9s-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-rstudio-rhel9-python-3-11-pull-request.yaml
+++ b/.tekton/cuda-rstudio-rhel9-python-3-11-pull-request.yaml
@@ -38,6 +38,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-rstudio-rhel9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -104,6 +107,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -231,6 +238,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/cuda-rstudio-rhel9-python-3-11-push.yaml
+++ b/.tekton/cuda-rstudio-rhel9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/cuda-rstudio-rhel9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/jupyter-datascience-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/jupyter-datascience-ubi9-python-3-11-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-datascience-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -102,6 +105,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -229,6 +236,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/jupyter-datascience-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-datascience-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-datascience-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-minimal-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -99,6 +102,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -226,6 +233,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-minimal-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/jupyter-trustyai-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/jupyter-trustyai-ubi9-python-3-11-pull-request.yaml
@@ -35,6 +35,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-trustyai-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -101,6 +104,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -228,6 +235,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/jupyter-trustyai-ubi9-python-3-11-push.yaml
+++ b/.tekton/jupyter-trustyai-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/jupyter-trustyai-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-jupyter-minimal-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/rocm-jupyter-minimal-ubi9-python-3-11-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-jupyter-minimal-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -99,6 +102,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -226,6 +233,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-jupyter-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-jupyter-minimal-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-jupyter-minimal-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-jupyter-pytorch-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/rocm-jupyter-pytorch-ubi9-python-3-11-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-jupyter-pytorch-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -102,6 +105,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -229,6 +236,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-jupyter-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-jupyter-pytorch-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-jupyter-pytorch-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-jupyter-tensorflow-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/rocm-jupyter-tensorflow-ubi9-python-3-11-pull-request.yaml
@@ -35,6 +35,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-jupyter-tensorflow-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -101,6 +104,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -228,6 +235,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-jupyter-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-jupyter-tensorflow-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-jupyter-tensorflow-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-runtime-pytorch-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/rocm-runtime-pytorch-ubi9-python-3-11-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-runtime-pytorch-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -99,6 +102,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -226,6 +233,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-runtime-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-runtime-pytorch-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-runtime-pytorch-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-runtime-tensorflow-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/rocm-runtime-tensorflow-ubi9-python-3-11-pull-request.yaml
@@ -32,6 +32,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-runtime-tensorflow-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -98,6 +101,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -225,6 +232,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rocm-runtime-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/rocm-runtime-tensorflow-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rocm-runtime-tensorflow-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rstudio-c9s-python-3-11-pull-request.yaml
+++ b/.tekton/rstudio-c9s-python-3-11-pull-request.yaml
@@ -37,6 +37,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rstudio-c9s-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -103,6 +106,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -230,6 +237,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rstudio-c9s-python-3-11-push.yaml
+++ b/.tekton/rstudio-c9s-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rstudio-c9s-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rstudio-rhel9-python-3-11-pull-request.yaml
+++ b/.tekton/rstudio-rhel9-python-3-11-pull-request.yaml
@@ -37,6 +37,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rstudio-rhel9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -103,6 +106,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -230,6 +237,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/rstudio-rhel9-python-3-11-push.yaml
+++ b/.tekton/rstudio-rhel9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/rstudio-rhel9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-cuda-pytorch-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/runtime-cuda-pytorch-ubi9-python-3-11-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-cuda-pytorch-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -99,6 +102,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -226,6 +233,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-cuda-pytorch-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-cuda-pytorch-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-cuda-pytorch-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-cuda-tensorflow-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/runtime-cuda-tensorflow-ubi9-python-3-11-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-cuda-tensorflow-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -99,6 +102,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -226,6 +233,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-cuda-tensorflow-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-cuda-tensorflow-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-cuda-tensorflow-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-datascience-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/runtime-datascience-ubi9-python-3-11-pull-request.yaml
@@ -32,6 +32,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-datascience-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -98,6 +101,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -225,6 +232,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-datascience-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-datascience-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-datascience-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-minimal-ubi9-python-3-11-pull-request.yaml
+++ b/.tekton/runtime-minimal-ubi9-python-3-11-pull-request.yaml
@@ -32,6 +32,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-minimal-ubi9-python-3-11:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -98,6 +101,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -225,6 +232,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/.tekton/runtime-minimal-ubi9-python-3-11-push.yaml
+++ b/.tekton/runtime-minimal-ubi9-python-3-11-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: 'quay.io/redhat-user-workloads/rhoai-ide-konflux-tenant/runtime-minimal-ubi9-python-3-11:{{revision}}'
   - name: image-expires-after
     value: 28d
+  - name: image-labels
+    value:
+    - release=2025a
   - name: build-platforms
     value:
     - linux/x86_64
@@ -95,6 +98,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: []
+      description: Array of --labels values ("label=value" strings) for buildah.
+      name: image-labels
+      type: array
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -222,6 +229,9 @@ spec:
         value: $(params.prefetch-input)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
+      - name: LABELS
+        value:
+        - $(params.image-labels[*])
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ define build_image
 	$(info # Building $(IMAGE_NAME) image...)
 
 	$(ROOT_DIR)/scripts/sandbox.py --dockerfile '$(2)' -- \
-		$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) --tag $(IMAGE_NAME) --file '$(2)' $(BUILD_ARGS) {}\;
+		$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) --label release=${RELEASE} --tag $(IMAGE_NAME) --file '$(2)' $(BUILD_ARGS) {}\;
 endef
 
 # Push function for the notebook image:
@@ -102,7 +102,7 @@ endef
 #######################################        Build helpers                 #######################################
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
-skip-init-for := all-images deploy% undeploy% test% validate% refresh-pipfilelock-files scan-image-vulnerabilities
+skip-init-for := all-images deploy% undeploy% test% validate% refresh-pipfilelock-files scan-image-vulnerabilities print-release
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
 $(SELF): bin/buildinputs
 endif
@@ -471,3 +471,8 @@ all-images: jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
+
+# This is used primarly for konflux_generate_component_build_pipelines.py to we know the build release version
+.PHONY: print-release
+print-release:
+	@echo "$(RELEASE)"

--- a/ci/cached-builds/makefile_helper.py
+++ b/ci/cached-builds/makefile_helper.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import pathlib
+import platform
+import subprocess
+import sys
+
+
+def exec_makefile(target: str, makefile_dir: pathlib.Path | str, options: list[str] = []) -> str:
+    # Check if the operating system is macOS
+    if platform.system() == "Darwin":
+        make_command = "gmake"
+    else:
+        make_command = "make"
+
+    try:
+        # Run the make (or gmake) command and capture the output
+        result = subprocess.run(
+            [make_command, *options, target],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=makefile_dir,
+        )
+    except subprocess.CalledProcessError as e:
+        # Handle errors if the make command fails
+        print(f"{make_command} failed with return code: {e.returncode}:\n{e.stderr}", file=sys.stderr)
+        raise
+    except Exception as e:
+        # Handle any other exceptions
+        print(f"Error occurred attempting to parse Makefile:\n{e!s}", file=sys.stderr)
+        raise
+
+    return result.stdout
+
+
+def dry_run_makefile(target: str, makefile_dir: pathlib.Path | str) -> str:
+    return exec_makefile(
+        target=target, makefile_dir=makefile_dir, options=["--dry-run", "--print-data-base", "--quiet"]
+    )


### PR DESCRIPTION
Let's have a 'release' label in our images we build so that we can
easily filter them out. This change includes this update for the:
* local build via Makefile
* konflux build via .tekton pipeline definitions

There is a third place we should update - the openshift-ci job
definitions.

## Description
Note that in the end I used key `release` instead of the originally on the call announced `version`. Reason is to become compliant to the name of the variable we have there already.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
