### PR TITLE
feat(kustomize): use LabelTransformer instead of deprecated commonLabels

### DIFF
--- a/codeserver/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/codeserver/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: codeserver-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: codeserver-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/codeserver/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/codeserver/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: codeserver-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/codeserver/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/codeserver/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: codeserver-image
 spec:
   containers:
     - name: codeserver

--- a/jupyter/datascience/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/datascience/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-datascience-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-datascience-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/datascience/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/datascience/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-datascience-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/datascience/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/datascience/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/jupyter/minimal/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/minimal/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-minimal-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-minimal-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/minimal/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/minimal/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-minimal-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/minimal/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/minimal/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/jupyter/pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-pytorch-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-pytorch-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-pytorch-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/pytorch/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/pytorch/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-rocm-pytorch-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-rocm-pytorch-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-rocm-pytorch-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-rocm-tensorflow-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-rocm-tensorflow-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-rocm-tensorflow-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/jupyter/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-tensorflow-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-tensorflow-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-tensorflow-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/tensorflow/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/tensorflow/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/jupyter/trustyai/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/trustyai/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-trustyai-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-trustyai-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml
+transformers:
+  - labels.yaml
 images:
   - name: quay.io/opendatahub/workbench-images
     newName: quay.io/opendatahub/workbench-images

--- a/jupyter/trustyai/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/jupyter/trustyai/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: jupyter-trustyai-ubi9-python-3-11
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/jupyter/trustyai/ubi9-python-3.11/kustomize/base/statefulset.yaml
+++ b/jupyter/trustyai/ubi9-python-3.11/kustomize/base/statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     opendatahub.io/user: jovyan
 spec:
   replicas: 1
-  selector: {}
+  selector:
+    matchLabels: {}
   serviceName: notebook
   template:
     metadata:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -21,9 +21,8 @@ resources:
   - runtime-rocm-tensorflow-imagestream.yaml
   - runtime-tensorflow-imagestream.yaml
 
-commonLabels:
-  opendatahub.io/component: "true"
-  component.opendatahub.io/name: notebooks
+transformers:
+  - labels.yaml
 
 configMapGenerator:
   - name: notebooks-parameters

--- a/manifests/base/labels.yaml
+++ b/manifests/base/labels.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: notebooks
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -5,6 +5,5 @@ kind: Kustomization
 resources:
   - ../../base
 
-commonLabels:
-  opendatahub.io/component: "true"
-  component.opendatahub.io/name: notebooks
+transformers:
+  - labels.yaml

--- a/manifests/overlays/additional/labels.yaml
+++ b/manifests/overlays/additional/labels.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: notebooks
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/rstudio/c9s-python-3.11/kustomize/base/kustomization.yaml
+++ b/rstudio/c9s-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: rstudio-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: rstudio-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/rstudio/c9s-python-3.11/kustomize/base/labels.yaml
+++ b/rstudio/c9s-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: rstudio-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/rstudio/c9s-python-3.11/kustomize/base/pod.yaml
+++ b/rstudio/c9s-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: rstudio-image
 spec:
   containers:
     - name: rstudio

--- a/rstudio/rhel9-python-3.11/kustomize/base/kustomization.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: rstudio-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: rstudio-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/rstudio/rhel9-python-3.11/kustomize/base/labels.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: rstudio-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/rstudio/rhel9-python-3.11/kustomize/base/pod.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: rstudio-image
 spec:
   containers:
     - name: rstudio

--- a/runtimes/datascience/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/runtimes/datascience/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: runtime-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: runtime-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/runtimes/datascience/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/runtimes/datascience/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: runtime-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/runtimes/datascience/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/runtimes/datascience/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: runtime-image
 spec:
   containers:
     - name: runtime

--- a/runtimes/minimal/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/runtimes/minimal/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: runtime-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: runtime-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/runtimes/minimal/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/runtimes/minimal/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: runtime-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/runtimes/minimal/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/runtimes/minimal/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: runtime-image
 spec:
   containers:
     - name: runtime

--- a/runtimes/pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/runtimes/pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: runtime-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: runtime-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/runtimes/pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/runtimes/pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: runtime-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/runtimes/pytorch/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/runtimes/pytorch/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: runtime-image
 spec:
   containers:
     - name: runtime

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: runtime-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: runtime-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: runtime-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: runtime-image
 spec:
   containers:
     - name: runtime

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: runtime-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: runtime-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: runtime-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: runtime-image
 spec:
   containers:
     - name: runtime

--- a/runtimes/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/runtimes/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namePrefix: runtime-
 resources:
   - pod.yaml
+transformers:
+  - labels.yaml
 images:
   - name: runtime-workbench
     newName: quay.io/opendatahub/workbench-images

--- a/runtimes/tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
+++ b/runtimes/tensorflow/ubi9-python-3.11/kustomize/base/labels.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  app: runtime-image
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+  - path: spec/template/metadata/labels
+    create: false
+  - path: spec/selector
+    kind: Service
+    create: true
+  - path: spec/selector/matchLabels
+    create: false

--- a/runtimes/tensorflow/ubi9-python-3.11/kustomize/base/pod.yaml
+++ b/runtimes/tensorflow/ubi9-python-3.11/kustomize/base/pod.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod
-  labels:
-    app: runtime-image
 spec:
   containers:
     - name: runtime


### PR DESCRIPTION
## Description
This is a "piece" of a more comprehensive/interesting PR:
- https://github.com/opendatahub-io/notebooks/pull/1015

Unfortunately, that PR has grown wildly unwieldy in its size - and immediate feedback received was to try to break it into smaller pieces - so consider this one piece!

The ulitmate goal here on this targetted PR is two-fold:
- standardization irrespective of image build "flavour" our kustomize labelling
- get rid of following warning:

```
$ kubectl kustomize jupyter/minimal/ubi9-python-3.11/kustomize/base
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
...
```

No actual changes are introduced in this PR - simply leveraging the `LabelTransformer` to accomplish what `commonLabels` was previously doing.

Related-to: https://issues.redhat.com/browse/RHOAIENG-23291

## How Has This Been Tested?
The following command (replacing the directory as appropriate) can be used to have `kustomize` process our manifests:
- `kubectl kustomize jupyter/minimal/ubi9-python-3.11/kustomize/base`

For verification purposes - one can then simply compare the output of `kustomize` on **this branch** with that of `main`.

Here is a simple script that can do the verifications **FOR YOU**
[labeltransformer-verify.sh.txt](https://github.com/user-attachments/files/19743292/labeltransformer-verify.sh.txt)
- remove `.txt` extension and make sure file executable
- run file in its own directory
    - the script creates a couple transient directories... easier to keep this file in its own folder to then just safely blow away/clean everything up
- do note that a **specific** version of `kustomize` (`5.0.3`) is downloaded and used by this script as later versions have a more strict parser
- rudimentary support provided for MacOS Silicone and Linux AMD64 - albeit the Linux support was not actually tested.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
