### PR TITLE
RHOAIENG-20553 - CSS is broken when loading the TensorBoard extension

### DIFF
--- a/jupyter/utils/addons/apply.sh
+++ b/jupyter/utils/addons/apply.sh
@@ -6,7 +6,7 @@
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly.min.css"
+pf_url="https://unpkg.com/@patternfly/patternfly@6.0.0/patternfly-no-globals.css"
 
 static_dir="/opt/app-root/share/jupyter/lab/static"
 index_file="$static_dir/index.html"
@@ -30,12 +30,6 @@ if [ ! -f "$body_file" ]; then
 fi
 
 curl -o "$static_dir/pf.css" "$pf_url"
-
-# Patternfly implemented some changes, setting the default height on iframe objects to "auto", which
-# excluded the default 800px height of Tensorboard's IFrame object. This stylesheet will simply search
-# for all IFrames that contain `tensorboard` on its URL and add a default height of 800px to it, and only
-# on it.
-echo "iframe[id*=\"tensorboard\"] { height: 800px !important }" >> "$static_dir/pf.css"
 
 head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
 body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')

--- a/jupyter/utils/addons/apply.sh
+++ b/jupyter/utils/addons/apply.sh
@@ -31,6 +31,12 @@ fi
 
 curl -o "$static_dir/pf.css" "$pf_url"
 
+# Patternfly implemented some changes, setting the default height on iframe objects to "auto", which
+# excluded the default 800px height of Tensorboard's IFrame object. This stylesheet will simply search
+# for all IFrames that contain `tensorboard` on its URL and add a default height of 800px to it, and only
+# on it.
+echo "iframe[id*=\"tensorboard\"] { height: 800px !important }" >> "$static_dir/pf.css"
+
 head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
 body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')
 


### PR DESCRIPTION
This will fix [RHOAIENG-20553 - CSS is broken when loading the TensorBoard extension](https://issues.redhat.com/browse/RHOAIENG-20553)

Tensorboard provides an IFrame element inside Jupyter Notebooks so it can display all the visualization toolkit properly. Patternfly did implement some changes that affected the IFrame from Tensorboard, making it smaller. This fix aims to provide a clean solution without affecting any other components and styling.

## Description
Tensorboard provides a visualization toolkit for TensorFlow and it provides its functionality [through the use of an IFrame](https://github.com/tensorflow/tensorboard/blob/aebdc82a3e4ec282a21dc6bfc7806e8ea2c42246/tensorboard/notebook.py#L365-L368) inside Jupyter Notebook, as follows:

```python
    frame_id = "tensorboard-frame-{:08x}".format(random.getrandbits(64))
    shell = """
      <iframe id="%HTML_ID%" width="100%" height="%HEIGHT%" frameborder="0">
      </iframe>
```
https://github.com/tensorflow/tensorboard/blob/aebdc82a3e4ec282a21dc6bfc7806e8ea2c42246/tensorboard/notebook.py#L365-L368

The main issue here lies on the use of reset CSS for global elements, where elements like iframe will receive normal state, in our case it will receive a `height: auto` attribute, which will break the default `height: 800px` of the IFrame element.

Since the PatternFly in our case is only being used to load the spinner at the start of the Jupyter Notebooks, we will simply replace the CSS used, going from the `minimal` to the `no-reset` option.


## References:
- [patternfly/patternfly: fix(global): remove woff, use where with globals, cleanup #5435](https://github.com/patternfly/patternfly/pull/5435)
- [patternfly/src/patternfly/base/normalize.scss](https://github.com/patternfly/patternfly/blob/e31a56f8c8994136026dab6fc74f72be5d00e7d3/src/patternfly/base/normalize.scss#L72-L82)
- [tensorboard/notebook.py](https://github.com/tensorflow/tensorboard/blob/aebdc82a3e4ec282a21dc6bfc7806e8ea2c42246/tensorboard/notebook.py#L365-L368)
- [notebooks/jupyter/utils/addons/apply.sh](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/utils/addons/apply.sh#L32)

## Building
To build the images properly with the changes, the following command has been executed:

```bash
make cuda-jupyter-tensorflow-ubi9-python-3.11 \
    -e IMAGE_REGISTRY="quay.io/dlutz/workbench-images" \
    -e RELEASE="2025a" \
    -e CONTAINER_BUILD_CACHE_ARGS="" \
    -e PUSH_IMAGES="yes"
```

The following image is available for testing on Quay.io:
[quay.io/dlutz/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11-2025a_20250415](https://quay.io/repository/dlutz/workbench-images?tab=tags&tag=cuda-jupyter-tensorflow-ubi9-python-3.11-2025a_20250415)

## How Has This Been Tested?
This has been tested in an OpenShift Local cluster.

### Testing on Cluster
To test in your cluster you should:

- the build process did take place and completed;
- the image on Quay.io is available;
- you are connected to your OpenShift cluster through the `oc login` command;

1. Now you can run the `make deploy9-` command to deploy the TensorFlow image:

```bash
$ make deploy9-cuda-jupyter-tensorflow-ubi9-python-3.11 \
     -e IMAGE_REGISTRY="quay.io/dlutz/workbench-images" \
     -e RELEASE="2025a" \
     -e CONTAINER_BUILD_CACHE_ARGS="" \
     -e PUSH_IMAGES="yes"
```

2. Create a port-forward mapping in your system:

```bash
$ kubectl port-forward jupyter-tensorflow-ubi9-python-3-11-notebook-0 8888:8888
```

3. Open your browser, pointing to `localhost`, on port `8888` and with the `jovyan` controller:

- [http://localhost:8888/notebook/opendatahub/jovyan/](http://localhost:8888/notebook/opendatahub/jovyan/)

4. Now run each of the following commands in a Jupyter Notebook cell (if you are running on a different scenario, please, adjust the `TENSORBOARD_PROXY_URL` accordingly)

```python
import os
```
```python
os.environ["TENSORBOARD_PROXY_URL"] = "/notebook/opendatahub/jovyan/proxy/6006/"
```
```python
%load_ext tensorboard
```
```python
%tensorboard --logdir /opt/app-root/src/shared
```

Note: originally, on the Jira ticket, the description uses the NB_PREFIX variable, [that is available through the Dashboard deployment](https://github.com/search?q=repo%3Aopendatahub-io%2Fodh-dashboard%20NB_PREFIX&type=code), but not available on the make deploy commands, this is why we have used the direct reference to the controller here.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
