### PR TITLE
Issue opendatahub-io/notebooks#631: cut the ref name to avoid going over 128 character limit for Docker image tag

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -209,7 +209,10 @@ jobs:
       - name: Calculate image name and tag
         id: calculated_vars
         run: |
-          SANITIZED_REF_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/_/g')
+          # Need for sanitization explained in https://github.com/opendatahub-io/notebooks/issues/631
+          # For length, Docker image tags have 128-character limit, and we form them as <inputs.target>-<ref_name>_<sha>
+          # therefore since sha is 40 characters, and our target names are <40 chars, we should cut ref_name at 40
+          SANITIZED_REF_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/_/g') | cut -c 1-40
           IMAGE_TAG="${SANITIZED_REF_NAME}_${{ github.sha }}"
 
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

* https://github.com/opendatahub-io/notebooks/issues/631

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/14642835456
* https://github.com/jiridanek/notebooks/actions/runs/14643403904

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
