### PR TITLE
NO-JIRA: docs: update outdated internal docs after the buildchain refactoring

### DIFF
--- a/jupyter/utils/README.md
+++ b/jupyter/utils/README.md
@@ -1,5 +1,4 @@
 # Shared files for all JupyterLab workbenches we have
 
 These files were initially duplicated into many `jupyter/` subdirectories.
-In general, they are incorporated into every JupyterLab workbench,
-but sometimes that's through building `FROM` base `datascience` image and not `COPY`ed directly.
+In general, they are incorporated into every JupyterLab workbench.

--- a/jupyter/utils/addons/apply.sh
+++ b/jupyter/utils/addons/apply.sh
@@ -2,7 +2,6 @@
 
 # See https://github.com/jupyterlab/jupyterlab/issues/5463
 # This is a hack to apply partial HTML code to JupyterLab's `index.html` file
-# Look for the other duplicates in case a change is needed to this file
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
## Description

This commit updates internal documentation to reflect changes from a recent buildchain refactoring. It simplifies the explanation of how shared files are incorporated into JupyterLab workbenches. A comment regarding potential duplicates in a script was also removed, indicating it's no longer relevant after the refactoring.

## How Has This Been Tested?

Asked AI to

> Find errors in the commit: "NO-JIRA: docs: update outdated internal docs after the buildchain refactoring"

and it came back with nothing.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
