### PR TITLE
RHOAIENG-24684: fix(jupyter/utils/addon) fix vertical centering of the PatternFly spinner

### DIFF
--- a/jupyter/utils/addons/partial-head.html
+++ b/jupyter/utils/addons/partial-head.html
@@ -3,7 +3,11 @@
   type="text/css"
   href="{{page_config.fullStaticUrl}}/pf.css"
 />
+<!-- set height to 100% so that vertical centering works -->
 <style>
+  :where(html, body) {
+    height: 100%;
+  }
   #loading-container {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-24684

Follows up on

* https://github.com/opendatahub-io/notebooks/pull/1018

## Description

After we switched to the css without global css reset, we no longer have the rule

```
  :where(html, body) {
    height: 100%;
  }
```

present, and it causes the spinner to be tucked to the top edge of screen.

![image](https://github.com/user-attachments/assets/d0da2711-2e2b-4c95-b562-69e190aa8e8a)

## How Has This Been Tested?

Played with it a while.

I've checked that setting this does not visibly change how JupyterLab (with TensorBoard open) displays.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
