### PR TITLE
NO-JIRA: fix(pydantic_schemas): new podman version changed output of `podman info`

### DIFF
--- a/tests/containers/pydantic_schemas/podman_info.py
+++ b/tests/containers/pydantic_schemas/podman_info.py
@@ -129,6 +129,12 @@ class ContainerStore(BaseModel):
     stopped: int
 
 
+class GraphOptions(BaseModel, extra="allow"):
+    overlay_additional_image_stores: list[str] | None = Field(None, alias="overlay.additionalImageStores")
+    overlay_imagestore: str | None = Field(None, alias="overlay.imagestore")
+    overlay_mountopt: str | None = Field(None, alias="overlay.mountopt")
+
+
 class GraphStatus(BaseModel):
     backing_filesystem: str = Field(..., alias="Backing Filesystem")
     native_overlay_diff: str = Field(..., alias="Native Overlay Diff")
@@ -146,7 +152,7 @@ class Store(BaseModel):
     configFile: str
     containerStore: ContainerStore
     graphDriverName: str
-    graphOptions: dict[str, str]
+    graphOptions: GraphOptions
     graphRoot: str
     graphRootAllocated: int
     graphRootUsed: int
@@ -284,6 +290,7 @@ def test_podman_info():
                 "containerStore": {"number": 0, "paused": 0, "running": 0, "stopped": 0},
                 "graphDriverName": "overlay",
                 "graphOptions": {
+                    "overlay.additionalImageStores": ["/usr/lib/containers/storage"],
                     "overlay.imagestore": "/usr/lib/containers/storage",
                     "overlay.mountopt": "nodev,metacopy=on",
                 },


### PR DESCRIPTION
Schema needs to be updated to also handle a `list[str]` value that may now be present.

## Description

```
❯ podman version
Client:        Podman Engine
Version:       5.4.2
API Version:   5.4.2
Go Version:    go1.24.2
Built:         Wed Apr  2 15:43:09 2025
Build Origin:  brew
OS/Arch:       darwin/arm64

Server:       Podman Engine
Version:      5.4.1
API Version:  5.4.1
Go Version:   go1.23.7
Git Commit:   b79bc8afe796cba51dd906270a7e1056ccdfcf9e
Built:        Tue Mar 11 01:00:00 2025
OS/Arch:      linux/arm64
```

## How Has This Been Tested?

Pytest tests work on my machine now whereas before they would fail with pydantic validation error.

```
INTERNALERROR>     info = tests.containers.pydantic_schemas.PodmanInfo.model_validate(podman_client.info())
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/jdanek/IdeaProjects/notebooks/.venv/lib/python3.12/site-packages/pydantic/main.py", line 627, in model_validate
INTERNALERROR>     return cls.__pydantic_validator__.validate_python(
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR> pydantic_core._pydantic_core.ValidationError: 1 validation error for PodmanInfo
INTERNALERROR> store.graphOptions.`overlay.additionalImageStores`
INTERNALERROR>   Input should be a valid string [type=string_type, input_value=['/usr/lib/containers/storage'], input_type=list]
INTERNALERROR>     For further information visit https://errors.pydantic.dev/2.10/v/string_type

Process finished with exit code 3
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
