### PR TITLE
Update rsession.sh to preserve environment variables

### DIFF
--- a/rstudio/rhel9-python-3.11/rsession.sh
+++ b/rstudio/rhel9-python-3.11/rsession.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
+# Copy environment variables from PID 1, the container's root process
+# This is to undo RStudio's purging of environment variables prior to launching rsession
+# The idea of using `--rsession-path=rsession.sh` was suggested at
+#  https://github.com/jupyterhub/jupyter-rsession-proxy/issues/135
+# The command to clone (startup) environment variables from another process using Bash comes from
+#  https://unix.stackexchange.com/questions/125110/how-do-i-source-another-processs-environment-variables
+source <(xargs -0 bash -c 'printf "export %q\n" "$@"' -- < /proc/1/environ)
+
 /usr/lib/rstudio-server/bin/rsession "$@"


### PR DESCRIPTION
The way things usually end up, we run out of time at the end of the sprint and we put up, polish, and merge whatever can be made ready quickly, instead of being able to consider entirely alternative designs. So, here you have an alternate design inspired by

* https://github.com/jupyterhub/jupyter-rsession-proxy/issues/135#issuecomment-1302526034

## Description

Modify the rsession.sh script to clone environment variables from the container's root process (PID 1), addressing issues caused by RStudio's purging of variables. This approach was inspired by community discussions and ensures proper variable propagation during R session startup.

## How Has This Been Tested?

Looking at what I have running in the RStudio image

```
1001       67686   67637  0 20:57 pts/0    00:00:03 /mnt/rosetta /usr/lib/rstudio-server/bin/rserver --server-daemonize=0 --server-working-dir=/opt/app-root/src --auth-none=1 --www-frame-origin=same --www-address=:: --www-port=8787 -
1001       67705   67657  0 20:57 pts/0    00:00:00 /mnt/rosetta /usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket
1001       67716   67686  0 20:57 pts/0    00:00:00 /mnt/rosetta /bin/bash /opt/app-root/bin/rsession.sh -u default --session-use-secure-cookies 0 --session-root-path / --session-same-site 0 --session-use-file-storage 1 --launcher-to
1001       67717   67716  1 20:57 pts/0    00:00:13 /mnt/rosetta /usr/lib/rstudio-server/bin/rsession -u default --session-use-secure-cookies 0 --session-root-path / --session-same-site 0 --session-use-file-storage 1 --launcher-token
1001       67747   67717  0 20:58 pts/1    00:00:00 /mnt/rosetta /usr/bin/bash --login --posix
```

The rserver process still has full env, but rsession.sh and rsession don't.

RStudio has quite a lot of env variable handling code

* 
https://github.com/rstudio/rstudio/blob/9844bdaa84bdda19b23f00032211c48b3379978c/src/cpp/server/ServerEnvVars.cpp#L95
* https://github.com/rstudio/rstudio/blob/9844bdaa84bdda19b23f00032211c48b3379978c/src/cpp/core/system/PosixSystem.cpp#L2397
* 
https://github.com/rstudio/rstudio/blob/9844bdaa84bdda19b23f00032211c48b3379978c/src/cpp/session/modules/SessionTerminalShell.cpp#L365

Obviously somebody put lot of effort into wiping the env clean.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
