### PR TITLE
NO-JIRA: tests(containers): Add GPU support and pod exec functionality in tests

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -335,7 +335,7 @@ jobs:
       - name: Run Testcontainers container tests (in PyTest)
         run: |
           set -Eeuxo pipefail
-          uv run pytest --capture=fd tests/containers -m 'not openshift' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
+          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
@@ -508,7 +508,7 @@ jobs:
         if: ${{ steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
-          uv run pytest --capture=fd tests/containers -m 'openshift' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
+          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           # TODO(jdanek): this Testcontainers stuff should not be necessary but currently it has to be there
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sudo dnf install podman
 systemctl --user start podman.service
 systemctl --user status podman.service
 systemctl --user status podman.socket
-DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock uv run pytest tests/containers -m 'not openshift' --image quay.io/opendatahub/workbench-images@sha256:e98d19df346e7abb1fa3053f6d41f0d1fa9bab39e49b4cb90b510ca33452c2e4
+DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock uv run pytest tests/containers -m 'not openshift and not cuda and not rocm' --image quay.io/opendatahub/workbench-images@sha256:e98d19df346e7abb1fa3053f6d41f0d1fa9bab39e49b4cb90b510ca33452c2e4
 
 # Mac OS
 brew install podman

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,4 +16,8 @@ log_cli_level = INFO
 log_file = logs/pytest-logs.txt
 log_file_level = DEBUG
 
-markers = openshift
+# https://docs.pytest.org/en/stable/example/markers.html#registering-markers
+markers =
+    openshift: requires openshift to run,
+    cuda: requires cuda to run,
+    rocm: requires rocm to run,

--- a/tests/containers/workbenches/accelerator_image_test.py
+++ b/tests/containers/workbenches/accelerator_image_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shlex
+
+import pytest
+
+from tests.containers import conftest, kubernetes_utils
+
+code = """
+import torch; device = "cuda" if torch.cuda.is_available() else "cpu"; print(f"Using {device} device")
+"""
+
+
+# This is from ods-ci,
+# https://github.com/red-hat-data-services/ods-ci/blob/ab7237d899c053b0f5b0ff0a2074ac4cdde3543e/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource#L13-L12
+class TestAccelerator:
+    @pytest.mark.cuda
+    @pytest.mark.openshift
+    # image must be both jupyterlab image and cuda workbench image
+    def test_cuda_run_on_openshift(self, jupyterlab_image, cuda_workbench_image):
+        client = kubernetes_utils.get_client()
+        print(client)
+
+        image_metadata = conftest.get_image_metadata(cuda_workbench_image)
+        library = None
+        if "-pytorch-" in image_metadata.labels.get("name"):
+            library = "torch"
+        if "-tensorflow-" in image_metadata.labels.get("name"):
+            library = "tensorflow"
+
+        # language=python
+        torch_check = (
+            """import torch; device = "cuda" if torch.cuda.is_available() else "cpu"; print(f"Using {device} device")"""
+        )
+        # language=python
+        tensorflow_check = """import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; print(tf.config.list_physical_devices('GPU'))"""
+
+        with kubernetes_utils.ImageDeployment(client, cuda_workbench_image) as image:
+            image.deploy(container_name="notebook-tests-pod", accelerator="nvidia.com/gpu")
+            if library == "torch":
+                result = image.exec(shlex.join(["python", "-c", torch_check]))
+                assert "Using cuda device" in result.stdout
+            elif library == "tensorflow":
+                result = image.exec(shlex.join(["python", "-c", tensorflow_check]))
+                assert "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]" in result.stdout
+            else:
+                raise ValueError(f"Unknown library {library}")


### PR DESCRIPTION
Enhance `ImageDeployment` to support GPU accelerators (AMD/NVIDIA) during pod deployment and introduce a method to execute commands inside pods. Additionally, add tests for ensuring CUDA compatibility on OpenShift using a PyTorch or Tensorflow notebook image.

## Description
This commit enhances containerized testing capabilities. It introduces support for deploying pods with GPU accelerators (like AMD or NVIDIA) and adds a new function to execute commands directly inside these running pods.

Additionally, new markers and fixtures were added to pytest to better categorize and manage tests based on image capabilities, such as CUDA or ROCm.

The documentation and CI workflows were updated to reflect these new testing options.

These changes enable more comprehensive testing of GPU-accelerated applications.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/14970894551

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
