### PR TITLE
NO-JIRA: tests(gha/k8s): install contrack and address kubernetes version compatibility issues

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -379,20 +379,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y software-properties-common curl
 
+          # https://github.com/cri-o/packaging?tab=readme-ov-file#distributions-using-deb-packages
+
           curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | \
             sudo gpg --dearmor --batch --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
           echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | \
             sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-          curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key | \
+          curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key | \
             sudo gpg --dearmor --batch --yes -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
 
-          echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/ /" | \
+          echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/cri-o:/stable:/$CRIO_VERSION/deb/ /" | \
             sudo tee /etc/apt/sources.list.d/cri-o.list
 
           sudo apt-get update
-          sudo apt-get install -y cri-o kubelet kubeadm kubectl
+          # [ERROR FileExisting-conntrack]: conntrack not found in system path
+          sudo apt-get install -y cri-o kubelet kubeadm kubectl conntrack
 
           # make use of /etc/cni/net.d/11-crio-ipv4-bridge.conflist so we don't
           # need a pod network and just use the default bridge
@@ -406,8 +409,12 @@ jobs:
 
           sudo systemctl start crio.service
         env:
-          CRIO_VERSION: v1.30
-          KUBERNETES_VERSION: v1.30
+          CRIO_VERSION: v1.32
+          # This has to be kept in sync with the packages above, otherwise
+          # [ERROR KubeletVersion]: the kubelet version is higher than the control plane version.
+          #  This is not a supported version skew and may lead to a malfunctional cluster.
+          #  Kubelet version: "1.33.0" Control plane version: "1.30.12"
+          KUBERNETES_VERSION: v1.33
 
       - name: Show crio debug data (on failure)
         if: ${{ failure() && steps.have-tests.outputs.tests == 'true' }}


### PR DESCRIPTION
Fixes
* https://github.com/opendatahub-io/notebooks/issues/1042

## Description

* Added `conntrack` installation to resolve missing dependency error.
* Updated CRI-O to v1.32 and Kubernetes to v1.33 to maintain compatibility and prevent version skew issues.
* Changed CRI-O repository URL to use openSUSE source because the project migrated to the openSUSE Build Service.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/14890647327/job/41821601178

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
