### PR TITLE
NO-JIRA: tests(gha/k8s): remove setting the `node-role.kubernetes.io/control-plane` taint

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -471,10 +471,6 @@ jobs:
           # Once you have found the failing container, you can inspect its logs with:
           # crictl --runtime-endpoint unix:///var/run/crio/crio.sock logs CONTAINERID
 
-      - name: Untaint the master
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
-        run: kubectl taint nodes --all node-role.kubernetes.io/control-plane-
-
       - name: Show nodes status and wait for readiness
         if: ${{ steps.have-tests.outputs.tests == 'true' }}
         run: |

--- a/ci/cached-builds/kubeadm.yaml
+++ b/ci/cached-builds/kubeadm.yaml
@@ -21,9 +21,7 @@ nodeRegistration:
   criSocket: unix:///var/run/crio/crio.sock
   imagePullPolicy: IfNotPresent
   imagePullSerial: true
-  taints:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/control-plane
+  taints: []
   kubeletExtraArgs:
     # Need to have enough disk space for Kubelet, so move root-dir on the LVM volume
     # Note: the internets discourage from changing the default because storage plugins may then struggle


### PR DESCRIPTION
## Description

For some reason, the `kubeadm.yaml` was setting the taint only for `build-notebooks-TEMPLATE.yaml` to immediately unset it. This became obvious after migrating to v1beta4 kubeadm.yaml

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/14928757209

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
