### PR TITLE
NO-JIRA: tests(containers): use Skopeo for remote image inspection in tests

### DIFF
--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import platform
@@ -13,7 +14,7 @@ import testcontainers.core.config
 import testcontainers.core.container
 import testcontainers.core.docker_client
 
-from tests.containers import docker_utils, utils
+from tests.containers import docker_utils, skopeo_utils, utils
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -38,6 +39,18 @@ SHUTDOWN_RYUK = False
 testcontainers.core.config.testcontainers_config.ryuk_privileged = True
 
 
+@dataclasses.dataclass
+class Image:
+    # only pulled images have an id
+    id: str | None
+    name: str
+    labels: dict[str, str]
+
+    @classmethod
+    def from_docker(cls, image: docker.models.images.Image, name: str):
+        return Image(id=image.id, name=name, labels=image.labels)
+
+
 # https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_addoption
 def pytest_addoption(parser: Parser) -> None:
     parser.addoption("--image", action="append", default=[], help="Image to use, can be specified multiple times")
@@ -49,20 +62,24 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
         metafunc.parametrize(image.__name__, metafunc.config.getoption("--image"))
 
 
-def get_image_metadata(image: str) -> docker.models.images.Image:
+def get_image_metadata(image: str) -> Image:
     client = testcontainers.core.container.DockerClient()
     try:
+        # docker inspect
         image_metadata = client.client.images.get(image)
     except docker.errors.ImageNotFound:
-        # todo(jdanek): this means that even when image is to be run remotely (on openshift),
-        #  it has to be pulled locally first so that we can check its metadata
+        # skopeo inspect
+        labels = skopeo_utils.get_image_labels(image)
+        if labels is not None:
+            return Image(id=None, name=image, labels=labels)
+        # pull & docker inspect
         image_metadata = client.client.images.pull(image)
         assert isinstance(image_metadata, docker.models.images.Image)
 
-    return image_metadata
+    return Image.from_docker(image_metadata, name=image)
 
 
-def skip_if_not_workbench_image(image: str) -> docker.models.images.Image:
+def skip_if_not_workbench_image(image: str) -> Image:
     image_metadata = get_image_metadata(image)
 
     ide_server_label_fragments = ("-code-server-", "-jupyter-", "-rstudio-")
@@ -74,7 +91,7 @@ def skip_if_not_workbench_image(image: str) -> docker.models.images.Image:
     return image_metadata
 
 
-def skip_if_not_cuda_image(image: str) -> docker.models.images.Image:
+def skip_if_not_cuda_image(image: str) -> Image:
     image_metadata = get_image_metadata(image)
 
     if "-cuda-" not in image_metadata.labels["name"]:
@@ -83,7 +100,7 @@ def skip_if_not_cuda_image(image: str) -> docker.models.images.Image:
     return image_metadata
 
 
-def skip_if_not_rocm_image(image: str) -> docker.models.images.Image:
+def skip_if_not_rocm_image(image: str) -> Image:
     image_metadata = get_image_metadata(image)
     if "-rocm-" not in image_metadata.labels["name"]:
         pytest.skip(f"Image {image} does not have any of '-rocm-' in {image_metadata.labels['name']=}")
@@ -117,7 +134,7 @@ def rocm_workbench_image(workbench_image: str):
 
 
 @pytest.fixture(scope="function")
-def jupyterlab_image(image: str) -> docker.models.images.Image:
+def jupyterlab_image(image: str) -> Image:
     image_metadata = skip_if_not_workbench_image(image)
     if "-jupyter-" not in image_metadata.labels["name"]:
         pytest.skip(f"Image {image} does not have '-jupyter-' in {image_metadata.labels['name']=}'")
@@ -126,7 +143,7 @@ def jupyterlab_image(image: str) -> docker.models.images.Image:
 
 
 @pytest.fixture(scope="function")
-def rstudio_image(image: str) -> docker.models.images.Image:
+def rstudio_image(image: str) -> Image:
     image_metadata = skip_if_not_workbench_image(image)
     if not utils.is_rstudio_image(image):
         pytest.skip(f"Image {image} does not have '-rstudio-' in {image_metadata.labels['name']=}'")
@@ -135,7 +152,7 @@ def rstudio_image(image: str) -> docker.models.images.Image:
 
 
 @pytest.fixture(scope="function")
-def codeserver_image(image: str) -> docker.models.images.Image:
+def codeserver_image(image: str) -> Image:
     image_metadata = skip_if_not_workbench_image(image)
     if "-code-server-" not in image_metadata.labels["name"]:
         pytest.skip(f"Image {image} does not have '-code-server-' in {image_metadata.labels['name']=}'")

--- a/tests/containers/skopeo_utils.py
+++ b/tests/containers/skopeo_utils.py
@@ -1,0 +1,43 @@
+import json
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+type JSON = dict[str, JSON] | list[JSON] | str | int | float | bool | None
+
+
+def get_image_labels(image_name: str) -> JSON | None:
+    try:
+        skopeo_command = [
+            "skopeo",
+            # "--override-os=linux", "--override-arch=amd64",
+            "inspect",
+            "--config",
+            f"docker://{image_name}",
+        ]
+        logger.info(f"Attempting remote inspection for {image_name} using skopeo: {' '.join(skopeo_command)}")
+        result = subprocess.run(skopeo_command, capture_output=True, text=True, check=True, timeout=60)
+        image_config_json = json.loads(result.stdout)
+
+        # Labels can be in image_config_json.config.Labels or image_config_json.Labels (older formats)
+        labels = image_config_json.get("config", {}).get("Labels")
+        if labels is None:
+            labels = image_config_json.get("Labels")
+
+        if labels is not None:  # Explicitly check for None, as {} is a valid (empty) set of labels
+            logger.info(f"Skopeo successfully inspected {image_name}. Labels: {labels}")
+            return labels
+        else:
+            logger.warning(f"Skopeo inspection for {image_name} found config but no 'Labels' field.")
+            return None
+
+    except FileNotFoundError:
+        logger.warning("skopeo command not found. Cannot inspect remote image labels without pulling.")
+    except subprocess.TimeoutExpired:
+        logger.warning(f"skopeo inspect for {image_name} timed out.")
+    except subprocess.CalledProcessError as e:
+        logger.warning(f"skopeo inspect for {image_name} failed. Command: '{' '.join(e.cmd)}'. Error: {e.stderr}")
+    except json.JSONDecodeError as e:
+        logger.warning(f"Failed to parse skopeo JSON output for {image_name}: {e}")
+    return None

--- a/tests/containers/utils.py
+++ b/tests/containers/utils.py
@@ -1,16 +1,9 @@
-import docker.errors
-import docker.models.images
-import testcontainers.core.container
+from tests.containers import conftest
 
 
 def is_rstudio_image(my_image: str) -> bool:
     label = "-rstudio-"
 
-    client = testcontainers.core.container.DockerClient()
-    try:
-        image_metadata = client.client.images.get(my_image)
-    except docker.errors.ImageNotFound:
-        image_metadata = client.client.images.pull(my_image)
-        assert isinstance(image_metadata, docker.models.images.Image)
+    image_metadata = conftest.get_image_metadata(my_image)
 
     return label in image_metadata.labels["name"]

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import allure
 import requests
 
-from tests.containers import docker_utils
+from tests.containers import conftest, docker_utils
 from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
-
-if TYPE_CHECKING:
-    import docker.models.images
 
 
 class TestJupyterLabImage:
@@ -19,8 +14,8 @@ class TestJupyterLabImage:
 
     @allure.issue("RHOAIENG-11156")
     @allure.description("Check that the HTML for the spinner is contained in the initial page.")
-    def test_spinner_html_loaded(self, jupyterlab_image: docker.models.images.Image) -> None:
-        container = WorkbenchContainer(image=jupyterlab_image, user=4321, group_add=[0])
+    def test_spinner_html_loaded(self, jupyterlab_image: conftest.Image) -> None:
+        container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
         # if no env is specified, the image will run
         # > 4321        3334    3319  0 10:36 pts/0    00:00:01 /mnt/rosetta /opt/app-root/bin/python3.11 /opt/app-root/bin/jupyter-lab
         # > --ServerApp.root_dir=/opt/app-root/src --ServerApp.ip= --ServerApp.allow_origin=* --ServerApp.open_browser=False

--- a/tests/containers/workbenches/rstudio/rstudio_test.py
+++ b/tests/containers/workbenches/rstudio/rstudio_test.py
@@ -11,11 +11,10 @@ from typing import TYPE_CHECKING, NamedTuple
 import allure
 import pytest
 
-from tests.containers import docker_utils
+from tests.containers import conftest, docker_utils
 from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
 
 if TYPE_CHECKING:
-    import docker.models.images
     import pytest_subtests
 
 
@@ -25,7 +24,7 @@ class TestRStudioImage:
     APP_ROOT_HOME = "/opt/app-root/src"
 
     @allure.issue("RHOAIENG-17256")
-    def test_rmd_to_pdf_rendering(self, rstudio_image: docker.models.images.Image) -> None:
+    def test_rmd_to_pdf_rendering(self, rstudio_image: conftest.Image) -> None:
         """
         References:
             https://stackoverflow.com/questions/40563479/relationship-between-r-markdown-knitr-pandoc-and-bookdown
@@ -36,7 +35,7 @@ class TestRStudioImage:
                 "ISSUE-957, RHOAIENG-17256(comments): RStudio workbench on RHEL does not come with knitr preinstalled"
             )
 
-        container = WorkbenchContainer(image=rstudio_image, user=1000, group_add=[0])
+        container = WorkbenchContainer(image=rstudio_image.name, user=1000, group_add=[0])
         try:
             container.start(wait_for_readiness=False)
 
@@ -108,12 +107,12 @@ class TestRStudioImage:
             docker_utils.NotebookContainer(container).stop(timeout=0)
 
     @allure.issue("RHOAIENG-23584")
-    def test_arbitrary_env_propagates_unchanged(self, rstudio_image: str) -> None:
+    def test_arbitrary_env_propagates_unchanged(self, rstudio_image: conftest.Image) -> None:
         """
         Checks that environment variables are propagated into the RStudio environment.
         """
 
-        container = WorkbenchContainer(image=rstudio_image, user=1000, group_add=[0])
+        container = WorkbenchContainer(image=rstudio_image.name, user=1000, group_add=[0])
         container.with_env("SOME_VARIABLE", "Some Value")
 
         try:
@@ -127,7 +126,9 @@ class TestRStudioImage:
             docker_utils.NotebookContainer(container).stop(timeout=0)
 
     @allure.issue("RHOAIENG-16604")
-    def test_http_proxy_env_propagates(self, rstudio_image: str, subtests: pytest_subtests.plugin.SubTests) -> None:
+    def test_http_proxy_env_propagates(
+        self, rstudio_image: conftest.Image, subtests: pytest_subtests.plugin.SubTests
+    ) -> None:
         """
         This checks that the lowercased proxy configuration is propagated into the RStudio
         environment so that the appropriate values are then accepted and followed.
@@ -144,7 +145,7 @@ class TestRStudioImage:
             TestCase("NO_PROXY", "no_proxy", "google.com"),
         ]
 
-        container = WorkbenchContainer(image=rstudio_image, user=1000, group_add=[0])
+        container = WorkbenchContainer(image=rstudio_image.name, user=1000, group_add=[0])
         for tc in test_cases:
             container.with_env(tc.name, tc.value)
 

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -11,7 +11,6 @@ import urllib.request
 from typing import TYPE_CHECKING
 
 import docker.errors
-import docker.models.images
 import docker.types
 import pytest
 import testcontainers.core.container


### PR DESCRIPTION
## Description

This commit adds support for remote image inspection using Skopeo, enabling retrieval of image labels without pulling the image locally.

Refactored image handling to use a new `Image` dataclass, simplifying metadata storage and access across test functions.

## How Has This Been Tested?

* ~~https://github.com/jiridanek/notebooks/actions/runs/14971548102~~
* ~~https://github.com/jiridanek/notebooks/actions/runs/14971684030~~
* https://github.com/jiridanek/notebooks/actions/runs/14972575816

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
