### PR TITLE
NO-JIRA: tests(gha): fix `check-payload` to work with PRs and without `podman login` for root user

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -561,7 +561,7 @@ jobs:
 
       # endregion
 
-      # region Trivy vulnerability scan
+      # region check-payload for FIPS compliance
 
       - id: check-payload-vars
         run: |
@@ -584,6 +584,11 @@ jobs:
           rm -f /tmp/openshift-client-linux.tar.gz
           sudo mv ./oc /usr/local/bin
 
+      # perform `podman image mount` ourselves, and then follow the scenario from
+      # https://github.com/openshift/check-payload/pull/154, that is because
+      # `check-payload scan image --spec` insists on pulling the image, even if already present,
+      #  that causes trouble when checking PRs (image not pushed) and requires `podman login` as root
+      #  (we run podman as root in the GHA to reuse container storage in Kubernetes)
       # use sudo to avoid
       #  podman error (args=[image mount ghcr.io/...])
       #  (stderr=Error: cannot use command "podman image mount" with the remote podman client
@@ -592,7 +597,14 @@ jobs:
       - name: Check image with check-payload for FIPS compliance
         run: |
           set -Eeuxo pipefail
-          sudo --preserve-env=PATH go run github.com/openshift/check-payload scan image --spec "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
+          # resolve podman under current user, not under sudo/root
+          PODMAN="$(which podman)"
+          # mount the image
+          IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}")
+          # run the check-payload scan
+          sudo --preserve-env=PATH go run github.com/openshift/check-payload scan local --path "${IMAGE_MOUNT_DIR}"
+          # unmount the image
+          sudo "${PODMAN}" image unmount --all
         working-directory: scripts/check-payload
         env:
           GOPATH: ${{ steps.check-payload-vars.outputs.GOPATH }}

--- a/scripts/check-payload/config.toml
+++ b/scripts/check-payload/config.toml
@@ -234,7 +234,15 @@ files = [
 
 # https://issues.redhat.com/browse/RHOAIENG-24290
 
+# when scanning with `scan image --spec`
 [[payload.python-311-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+    # executable is not dynamically linked
+    "/opt/app-root/bin/py-spy",
+]
+# when scanning with `scan local --path`, the above does not apply
+[[ignore]]
 error = "ErrNotDynLinked"
 files = [
     # executable is not dynamically linked


### PR DESCRIPTION
## Description

Turns out, there were two problems with previous implementation, that were only revealed when

* the action was running on a push to a repository that has private github container registry
* the action was running on a pull request that modified some image

In the first case, action was unable to pull from repository that requires authentication.

In the second case, the image is not pushed anywhere, so attempts to pull are futile.

The solution appears to be what was implemented in

* https://github.com/openshift/check-payload/pull/154

That way we can run against a locally present image.

## How Has This Been Tested?

* The GHAs that runs on the PR, note that PR branch is in this repo, not on my fork, that is intentional

my fork

* https://github.com/jiridanek/notebooks/actions/runs/14992177148

tried running without the valgrind ignores to check that it will be picked up

* https://github.com/jiridanek/notebooks/actions/runs/14992549084 (failed as intended)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
