### PR TITLE
RHOAIENG-24342: scripts(fips): remove outdated ignore rule for `bin/oc`

### DIFF
--- a/scripts/check-payload/config.toml
+++ b/scripts/check-payload/config.toml
@@ -285,10 +285,3 @@ files = [
     # go binary does not contain required symbol(s)
     "/usr/bin/mongocli",
 ]
-
-[[payload.openshift-ai-workbenches.ignore]]
-error = "ErrLibcryptoSoMissing"
-files = [
-    # could not find dependent openssl version within container image: libcrypto.so.1.1
-    "/opt/app-root/bin/oc",
-]


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-24342

## Description


The ignore rule for "ErrLibcryptoSoMissing" for bin/oc is no longer applicable and has been removed from the configuration file. This cleans up unused entries and ensures the config remains relevant.

## How Has This Been Tested?

* xxx

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
