### PR TITLE
NO-JIRA: scripts(.tekton): remove unused script `konflux_generate_component_build_pipelines.py` from CI

### DIFF
--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -2,4 +2,3 @@
 set -Eeuxo pipefail
 
 bash scripts/sync-requirements-txt.sh
-PYTHONPATH=. python3 ci/cached-builds/konflux_generate_component_build_pipelines.py


### PR DESCRIPTION
## Description

The call to `konflux_generate_component_build_pipelines.py` was removed as it is no longer in use. This cleanup reduces unnecessary overhead from dealing with failed CI execution.

## How Has This Been Tested?

* 

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
