### PR TITLE
NO-JIRA: tests(gha): fix podman.sock cleanup in system reset for build workflow

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -186,6 +186,10 @@ jobs:
           # remote (CONTAINER_HOST) podman does not do reset (and refuses --force option)
           sudo /home/linuxbrew/.linuxbrew/opt/podman/bin/podman system reset --force
 
+          # https://github.com/containers/podman/pull/25504
+          # podman 5.5.0: The podman system reset command no longer removes the user's podman.sock API socket
+          sudo rm -rf /var/run/podman
+
           # https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md
           # since `brew services start podman` is buggy, let's do our own brew-compatible service
           # Regarding directory paths, see https://unix.stackexchange.com/questions/224992/where-do-i-put-my-systemd-unit-file
@@ -204,7 +208,12 @@ jobs:
 
       - name: Show error logs (on failure)
         if: ${{ failure() }}
-        run: journalctl -xe
+        run: |
+          set -Eeuxo pipefail
+
+          journalctl -xe
+          ls -AlF /var/run/podman/podman.sock || echo "Socket /var/run/podman/podman.sock not found"
+          sudo ss -xlpn | grep 'podman.sock' || echo "No active listener found for podman.sock via ss"
 
       - name: Calculate image name and tag
         id: calculated_vars

--- a/ci/cached-builds/podman.service
+++ b/ci/cached-builds/podman.service
@@ -1,3 +1,4 @@
+# https://github.com/containers/podman/blob/main/contrib/systemd/system/podman.service.in
 # https://docs.podman.io/en/latest/markdown/podman-system-service.1.html
 # cat /usr/lib/systemd/system/podman.socket
 

--- a/ci/cached-builds/podman.socket
+++ b/ci/cached-builds/podman.socket
@@ -1,3 +1,4 @@
+# https://github.com/containers/podman/blob/main/contrib/systemd/system/podman.socket
 # cat /usr/lib/systemd/system/podman.socket
 
 [Unit]


### PR DESCRIPTION
Fixes #1120

## Description

* https://github.com/containers/podman/pull/25504

The `podman system reset` command in version 5.5.0 no longer removes the API socket and its containing directory, leading to stale permissions on the directory. Added a manual step to delete the podman.sock containing directory to ensure a clean environment. This change enhances reliability in the build workflow.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/15122544399

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
