### PR TITLE
RHOAISTRAT-169: add conditional package install in minimal Dockerfile.cpu for s390x

### DIFF
--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -9,7 +9,14 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 # Install useful OS packages
-RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
+RUN ARCH=$(uname -m) && \
+    echo "Detected architecture: $ARCH" && \
+    if [ "$ARCH" = "s390x" ]; then \
+        dnf install -y mesa-libGL skopeo gcc g++ make openssl-devel autoconf automake libtool cmake; \
+    else \
+        dnf install -y mesa-libGL skopeo; \
+    fi && \
+    dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user
 USER 1001


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAISTRAT-169

This PR enhances the `Dockerfile.cpu` for the minimal runtime to conditionally install additional OS packages when building on the `s390x` architecture.

This python package `pyzmq` require native compilation and thus depend on development tools and libraries such as `gcc`, `g++`, `make`, `openssl-devel`, `autoconf`, `automake`, `libtool`, and `cmake`. These are typically not needed on x86_64 but are essential for s390x.

### Changes
- Added an `ARCH=$(uname -m)` check to detect the architecture.
- Installed the additional packages only when `ARCH == "s390x"`.

### Impact
This change ensures:
- notebook runtime minimal builds are successfull on IBM Z (s390x).
- No impact to x86_64 builds.

Tested on: s390x 

c.c: @modassarrana89 @vibhaKulka

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved compatibility for s390x architecture by conditionally installing additional development tools during the build process. No changes for other architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->