### PR TITLE
Exiting PDF install script with error code if commands fail

### DIFF
--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -2,6 +2,8 @@
 
 # Install dependencies required for Notebooks PDF exports
 
+set -e
+
 # tex live installation
 echo "Installing TexLive to allow PDf export from Notebooks" 
 curl -L https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -o install-tl-unx.tar.gz 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This forces the script to exit with error if some of the commands fail. closes #1147 

## How Has This Been Tested?
Tested locally making sure that the image is not built when the script fails

