### PR TITLE
RHOAIENG-717: fix `image-tag-outdated` annotation description in `workbench-imagestreams.md`

### DIFF
--- a/docs/workbench-imagestreams.md
+++ b/docs/workbench-imagestreams.md
@@ -41,7 +41,7 @@ spec:
   - **`opendatahub.io/notebook-python-dependencies:`** -  a string that represents the list of Python libraries included within the workbench image. Each library is described by its name and currently used version (e.g. `'[{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"}]'`)
   - **`openshift.io/imported-from:`** - a reference to the image repository where the workbench image was obtained (e.g. `quay.io/repository/opendatahub/workbench-images`)
   - **`opendatahub.io/workbench-image-recommended:`** - a flag that allows the ImageStream tag to be marked as Recommended (used by the UI to distinguish which tags are recommended for use, e.g., when the workbench image offers multiple tags to choose from)
-  - **`opendatahub.io/image-tag-outdated:`** - a flag to mark the ImageStream tag as outdated and out of regular maintenance cycle. The image tag would be eventually removed.
+  - **`opendatahub.io/image-tag-outdated:`** - a flag to mark the ImageStream tag as outdated and out of regular maintenance cycle. The image tag will eventually be removed.
   - **`opendatahub.io/notebook-build-commit:`** - a reference to the build commit with the ID to look at the updated information.
 
 ### **ImageStream definitions for the supported out-of-the-box images in ODH**  

--- a/docs/workbench-imagestreams.md
+++ b/docs/workbench-imagestreams.md
@@ -41,7 +41,7 @@ spec:
   - **`opendatahub.io/notebook-python-dependencies:`** -  a string that represents the list of Python libraries included within the workbench image. Each library is described by its name and currently used version (e.g. `'[{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"}]'`)
   - **`openshift.io/imported-from:`** - a reference to the image repository where the workbench image was obtained (e.g. `quay.io/repository/opendatahub/workbench-images`)
   - **`opendatahub.io/workbench-image-recommended:`** - a flag that allows the ImageStream tag to be marked as Recommended (used by the UI to distinguish which tags are recommended for use, e.g., when the workbench image offers multiple tags to choose from)
-  - **`opendatahub.io/image-tag-outdated:`** - a reference to the image version Tags that are outdated and out of regular maintaince cycle. The image tag would be eventually removed.
+  - **`opendatahub.io/image-tag-outdated:`** - a flag to mark the ImageStream tag as outdated and out of regular maintaince cycle. The image tag would be eventually removed.
   - **`opendatahub.io/notebook-build-commit:`** - a reference to the build commit with the ID to look at the updated information.
 
 ### **ImageStream definitions for the supported out-of-the-box images in ODH**  

--- a/docs/workbench-imagestreams.md
+++ b/docs/workbench-imagestreams.md
@@ -41,7 +41,7 @@ spec:
   - **`opendatahub.io/notebook-python-dependencies:`** -  a string that represents the list of Python libraries included within the workbench image. Each library is described by its name and currently used version (e.g. `'[{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"}]'`)
   - **`openshift.io/imported-from:`** - a reference to the image repository where the workbench image was obtained (e.g. `quay.io/repository/opendatahub/workbench-images`)
   - **`opendatahub.io/workbench-image-recommended:`** - a flag that allows the ImageStream tag to be marked as Recommended (used by the UI to distinguish which tags are recommended for use, e.g., when the workbench image offers multiple tags to choose from)
-  - **`opendatahub.io/image-tag-outdated:`** - a flag to mark the ImageStream tag as outdated and out of regular maintaince cycle. The image tag would be eventually removed.
+  - **`opendatahub.io/image-tag-outdated:`** - a flag to mark the ImageStream tag as outdated and out of regular maintenance cycle. The image tag would be eventually removed.
   - **`opendatahub.io/notebook-build-commit:`** - a reference to the build commit with the ID to look at the updated information.
 
 ### **ImageStream definitions for the supported out-of-the-box images in ODH**  


### PR DESCRIPTION
* https://github.com/opendatahub-io/opendatahub-documentation/pull/813

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of the annotation for marking ImageStream tags as outdated, specifying it as a boolean flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->