### PR TITLE
Make PDF export dependencies optional for s390x architecture

### DIFF
--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -48,8 +48,15 @@ COPY ${JUPYTER_REUSABLE_UTILS} utils/
 USER 0
 
 # Dependencies for PDF export
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/x86_64-linux:/usr/local/pandoc/bin:$PATH"
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" != "s390x" ]; then \
+  echo "Installing PDF export deps for $TARGETARCH" && \
+  ./utils/install_pdf_deps.sh; \
+else \
+  echo "Skipping PDF export deps for $TARGETARCH"; \
+fi
+
+ENV PATH="/usr/local/texlive/bin/${TARGETARCH}-linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 


### PR DESCRIPTION
This PR conditionally disables the installation of PDF export dependencies (`texlive`, `pandoc`) on `s390x` architecture, since precompiled binaries for these are currently not available.

### Details

- Uses `ARG TARGETARCH` to skip the installation step on `s390x`
- Sets the PATH variable unconditionally (safe on all archs)
- Ensures build does not break on `s390x` while preserving full PDF export functionality on supported platforms like `x86_64`

### Why this change needed for s390x ?

- Builds on `s390x` currently fail due to missing binaries for TeX Live and Pandoc.
- This is a **temporary workaround** for the upcoming release.
- We will revisit and address this in future releases to enable PDF export support on `s390x`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved compatibility for different system architectures by conditionally installing PDF export dependencies. PDF export support will be skipped on certain architectures where it is not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->