### PR TITLE
Change RHOAI version from 2.21 to 2.22

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -42,7 +42,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.21
+      ref: rhoai-2.22
   strategy:
     type: Docker
     dockerStrategy:

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -39,7 +39,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.21
+      ref: rhoai-2.22
   strategy:
     type: Docker
     dockerStrategy:


### PR DESCRIPTION
Change RStudio and CUDA versions of RHOAI from 2.21 to 2.22

## Merge criteria:

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source repository reference for build configurations to use the latest version. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->