### PR TITLE
NO-JIRA: add `--verbose` flag to `pipenv lock` command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ refresh-pipfilelock-files:
 			echo "Updating $(PYTHON_VERSION) Pipfile.lock in $$dir"
 			cd $$dir
 			if [ -f "Pipfile" ]; then
-				pipenv lock
+				pipenv lock --verbose
 			else
 				echo "No Pipfile found in $$dir, skipping."
 			fi


### PR DESCRIPTION
## Description

There is one good reason to not run `pipfile lock` with the `--verbose` flag. It makes the output very verbose.

There is one excellent reason to do run with `--verbose`. It will not tell you why actually locking the `Pipfile` failed otherwise.

## How Has This Been Tested?

Locking without `--verbose`:

https://github.com/opendatahub-io/notebooks/actions/runs/15942107529/job/44971526485#step:6:92

```
Successfully created virtual environment!
Virtualenv location: /home/runner/.local/share/virtualenvs/ubi9-python-3.11-QhO6oaV8
Locking  dependencies...
Building requirements...
Resolving dependencies...
Locking Failed!
CRITICAL:pipenv.patched.pip._internal.resolution.resolvelib.factory:Cannot 
install -r /tmp/pipenv-s5jjgure-requirements/pipenv-436spfan-constraints.txt 
(line 28) and jupyterlab-git~=0.51.1 because these package versions have 
conflicting dependencies.
[ResolutionFailure]:   File 
"/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/pipenv/res
olver.py", line 451, in main
[ResolutionFailure]:       _main(
[ResolutionFailure]:   File 
"/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/pipenv/res
olver.py", line 436, in _main
[ResolutionFailure]:       resolve_packages(
[ResolutionFailure]:   File 
"/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/pipenv/res
olver.py", line 400, in resolve_packages
[ResolutionFailure]:       results, resolver = resolve_deps(
[ResolutionFailure]:       ^^^^^^^^^^^^^
[ResolutionFailure]:   File 
"/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/pipenv/uti
ls/resolver.py", line [97](https://github.com/opendatahub-io/notebooks/actions/runs/15942107529/job/44971526485#step:6:98)9, in resolve_deps
[ResolutionFailure]:       results, hashes, internal_resolver = 
actually_resolve_deps(
[ResolutionFailure]:       ^^^^^^^^^^^^^^^^^^^^^^
[ResolutionFailure]:   File 
"/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/pipenv/uti
ls/resolver.py", line 747, in actually_resolve_deps
[ResolutionFailure]:       resolver.resolve()
[ResolutionFailure]:   File 
"/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/pipenv/uti
ls/resolver.py", line 474, in resolve
[ResolutionFailure]:       raise ResolutionFailure(message=e)
Your dependencies could not be resolved. You likely have a mismatch in your 
sub-dependencies.
You can use $ pipenv run pip install <requirement_name> to bypass this 
mechanism, then run $ pipenv graph to inspect the versions actually installed in
the virtualenv.
Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: ResolutionImpossible: for help visit 
https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-depende
ncy-conflicts

Your dependencies could not be resolved. You likely have a mismatch in your 
sub-dependencies.
You can use $ pipenv run pip install <requirement_name> to bypass this 
mechanism, then run $ pipenv graph to inspect the versions actually installed in
the virtualenv.
Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: Failed to lock Pipfile.lock!
make: *** [Makefile:420: refresh-pipfilelock-files] Error 1
```

Compare that with locking in `--verbose` mode of operation

https://github.com/opendatahub-io/notebooks/actions/runs/15942296313/job/44971972670#step:6:4761

```
CRITICAL:pipenv.patched.pip._internal.resolution.resolvelib.factory:Cannot 
install -r /tmp/pipenv-opnn3y_e-requirements/pipenv-f9p263g3-constraints.txt 
(line 32) and jupyterlab-git~=0.51.1 because these package versions have 
conflicting dependencies.
INFO:pipenv.patched.pip._internal.resolution.resolvelib.factory:
The conflict is caused by:
    The user requested jupyterlab-git~=0.51.1
    odh-elyra 4.2.1 depends on jupyterlab-git~=0.50.0
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency 
conflict
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
