### PR TITLE
chore: add linux/amd64 default build_arch on the Makefile build command

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -43,6 +43,7 @@ jobs:
       TRIVY_VULNDB: "/home/runner/.local/share/containers/trivy_db"
       # Targets (and their folder) that should be scanned using FS instead of IMAGE scan due to resource constraints
       TRIVY_SCAN_FS_JSON: '{}'
+      BUILD_ARCH: ${{ inputs.platform }}
 
     steps:
 
@@ -326,8 +327,7 @@ jobs:
           fromJson(inputs.github).event_name == 'workflow_dispatch' }}
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
-          # Configuring `podman build --platform=` through CONTAINER_BUILD_CACHE_ARGS is a venerable hack on this project
-          CONTAINER_BUILD_CACHE_ARGS: "${{ steps.extra-podman-build-args.outputs.EXTRA_PODMAN_BUILD_ARGS }} --platform=${{ inputs.platform }} --cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
+          CONTAINER_BUILD_CACHE_ARGS: "${{ steps.extra-podman-build-args.outputs.EXTRA_PODMAN_BUILD_ARGS }} --cache-from ${{ env.CACHE }} --cache-to ${{ env.CACHE }}"
       - name: "pull_request: make ${{ inputs.target }}"
         run: |
           # print running stats on disk occupancy
@@ -338,8 +338,7 @@ jobs:
           fromJson(inputs.github).event_name == 'pull_request_target' }}"
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
-          # Configuring `podman build --platform=` through CONTAINER_BUILD_CACHE_ARGS is a venerable hack on this project
-          CONTAINER_BUILD_CACHE_ARGS: "${{ steps.extra-podman-build-args.outputs.EXTRA_PODMAN_BUILD_ARGS }} --platform=${{ inputs.platform }} --cache-from ${{ env.CACHE }}"
+          CONTAINER_BUILD_CACHE_ARGS: "${{ steps.extra-podman-build-args.outputs.EXTRA_PODMAN_BUILD_ARGS }} --cache-from ${{ env.CACHE }}"
           # We don't have access to image registry, so disable pushing
           PUSH_IMAGES: "no"
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -2,7 +2,7 @@
 name: Create release
 permissions:
   contents: write
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/notebooks-release.yaml
+++ b/.github/workflows/notebooks-release.yaml
@@ -140,4 +140,3 @@ jobs:
       release_tag: ${{ github.event.inputs.release_tag }}
       release_name: ${{ github.event.inputs.release_name }}
       branch: ${{ github.event.inputs.branch }}
-      

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ WHERE_WHICH ?= which
 
 # linux/amd64 or darwin/arm64
 OS_ARCH=$(shell go env GOOS)/$(shell go env GOARCH)
+BUILD_ARCH=linux/amd64
 
 IMAGE_TAG		 ?= $(RELEASE)_$(DATE)
 KUBECTL_BIN      ?= bin/kubectl
@@ -71,7 +72,7 @@ define build_image
 	$(info # Building $(IMAGE_NAME) image...)
 
 	$(ROOT_DIR)/scripts/sandbox.py --dockerfile '$(2)' -- \
-		$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) --label release=${RELEASE} --tag $(IMAGE_NAME) --file '$(2)' $(BUILD_ARGS) {}\;
+		$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) --platform=$(BUILD_ARCH) --label release=$(RELEASE) --tag $(IMAGE_NAME) --file '$(2)' $(BUILD_ARGS) {}\;
 endef
 
 # Push function for the notebook image:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ WHERE_WHICH ?= which
 
 # linux/amd64 or darwin/arm64
 OS_ARCH=$(shell go env GOOS)/$(shell go env GOARCH)
-BUILD_ARCH=linux/amd64
+BUILD_ARCH ?= linux/amd64
 
 IMAGE_TAG		 ?= $(RELEASE)_$(DATE)
 KUBECTL_BIN      ?= bin/kubectl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
To avoid this architecture mismatch and ensure consistent, reliable builds across environments, we explicitly set the platform with: `podman build --platform=linux/amd64 ...`

This is an example of hitting a local build via macOS: https://github.com/opendatahub-io/notebooks/pull/1151#issuecomment-3007744236 

Additionally fixed for code-static issues on GHAs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build process to specify target platform architecture for container images, enhancing build consistency.
  * Improved workflow files with linting adjustments and cleanup for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->