### PR TITLE
RHOAIENG-28774: allow ODH codeserver image to be built for arm64

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -29,6 +29,8 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS codeserver
 
+ARG TARGETOS TARGETARCH
+
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.11
 ARG CODESERVER_VERSION=v4.98.0
 
@@ -50,7 +52,7 @@ WORKDIR /opt/app-root/bin
 RUN dnf install -y jq git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
 
 # Install code-server
-RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-amd64.rpm" && \
+RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm" && \
     yum -y clean all --enablerepo='*'
 
 COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-28774

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has only been tested by verifying that the image can be built for both amd64 and arm64. The changes here shouldn't have any impact on the existing amd64 image.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build process to support multiple architectures when building the image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->