### PR TITLE
RHOAIENG-28509: release new version of odh-elyra to get fix for RHOAIENG-25809

### DIFF
--- a/jupyter/datascience/ubi9-python-3.11/Pipfile
+++ b/jupyter/datascience/ubi9-python-3.11/Pipfile
@@ -29,7 +29,7 @@ mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/datascience/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/datascience/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "feafcb8e308ba3ab88d5533d5a0fdef21271265aa479a0778b390843039fec63"
+            "sha256": "50c36472693a2be1965055f295341c6cec7cb16e2a616848e5725865039a2390"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -564,11 +564,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2205,12 +2205,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/datascience/ubi9-python-3.11/requirements.txt
+++ b/jupyter/datascience/ubi9-python-3.11/requirements.txt
@@ -412,9 +412,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1505,9 +1505,9 @@ numpy==2.2.6; python_version >= '3.10' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/datascience/ubi9-python-3.12/Pipfile
+++ b/jupyter/datascience/ubi9-python-3.12/Pipfile
@@ -29,7 +29,7 @@ mysql-connector-python = "~=9.2.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/datascience/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/datascience/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "83cc5a99445fdc0d2004bac919a6b9bc31d3ffe41f33a3d6585047328e646291"
+            "sha256": "e0005153468f317cd2593c3e66c16f36bacaec846a93542392a538eee168c341"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -564,11 +564,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2204,12 +2204,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/datascience/ubi9-python-3.12/requirements.txt
+++ b/jupyter/datascience/ubi9-python-3.12/requirements.txt
@@ -412,9 +412,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1504,9 +1504,9 @@ numpy==2.2.6; python_version >= '3.10' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/pytorch/ubi9-python-3.11/Pipfile
+++ b/jupyter/pytorch/ubi9-python-3.11/Pipfile
@@ -39,7 +39,7 @@ mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/pytorch/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/pytorch/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9d210921b8122a7db54f7da4dbf6f0825e01601c742840a35a2e21584bc0de14"
+            "sha256": "cce004e8725e9a1b8fd62f0a5b047878d5fb9dd65277edaaa2e510f0207a4e34"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -577,11 +577,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2362,12 +2362,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/pytorch/ubi9-python-3.11/requirements.txt
+++ b/jupyter/pytorch/ubi9-python-3.11/requirements.txt
@@ -416,9 +416,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1579,9 +1579,9 @@ nvidia-nvtx-cu12==12.6.77; python_version >= '3' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/pytorch/ubi9-python-3.12/Pipfile
+++ b/jupyter/pytorch/ubi9-python-3.12/Pipfile
@@ -39,7 +39,7 @@ mysql-connector-python = "~=9.2.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/pytorch/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/pytorch/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3ccaefb497458bf7a22d3abac6e7acb89cfe5496979661b9af44827fdd7a145c"
+            "sha256": "d2311f32833b34d7ec70837fb5d059b2472434d8b514dc17e91d7c86f4653434"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -577,11 +577,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2361,12 +2361,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/pytorch/ubi9-python-3.12/requirements.txt
+++ b/jupyter/pytorch/ubi9-python-3.12/requirements.txt
@@ -416,9 +416,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1578,9 +1578,9 @@ nvidia-nvtx-cu12==12.6.77; python_version >= '3' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Pipfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Pipfile
@@ -41,7 +41,7 @@ mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7dec436ed0da992e3532cba3bbb8f17311f19371016e8cf3e7e5f3ac3931811d"
+            "sha256": "a53eec165cb13f3e281394350ea82d45c0de27a4fa9cc7cf26abf4c79b44d1fb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -577,11 +577,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2233,12 +2233,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/requirements.txt
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/requirements.txt
@@ -416,9 +416,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1515,9 +1515,9 @@ numpy==2.2.6; python_version >= '3.10' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Pipfile
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Pipfile
@@ -41,7 +41,7 @@ mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e72df5e25a253268e244dbfb4a431f992f280dde9f1162c04fc2bf5dd1ab8c60"
+            "sha256": "2c7a661d0f66726075cc6248984ef8d6ac2ae5be3abcddc6e034f071b66e946c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -577,11 +577,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2233,12 +2233,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.txt
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.txt
@@ -416,9 +416,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1515,9 +1515,9 @@ numpy==2.2.6; python_version >= '3.10' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Pipfile
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Pipfile
@@ -36,7 +36,7 @@ mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
 
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "72227d82cd9bd3d97b6574c3db802c3ae7be7ffd0d05d827befbf64c1c2327d3"
+            "sha256": "a110938befa26070dafced8574b255957b7d3a86f8d9d691fdd4394d3dd9b4b3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -579,11 +579,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2318,12 +2318,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/requirements.txt
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/requirements.txt
@@ -418,9 +418,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1567,9 +1567,9 @@ numpy==1.26.4; python_version >= '3.9' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/tensorflow/ubi9-python-3.11/Pipfile
+++ b/jupyter/tensorflow/ubi9-python-3.11/Pipfile
@@ -34,7 +34,7 @@ pyodbc = "~=5.2.0"
 mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/tensorflow/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/tensorflow/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e3554f61aef069e4a34893a7e4bed7578bff01c4398d24b8d5109d6b14d8f878"
+            "sha256": "f1b2d704c52abbba242eb11a0639e2749bc7b955f88b762013582f7f198ccaa7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -579,11 +579,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2422,12 +2422,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/tensorflow/ubi9-python-3.11/requirements.txt
+++ b/jupyter/tensorflow/ubi9-python-3.11/requirements.txt
@@ -418,9 +418,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1617,9 +1617,9 @@ nvidia-nvjitlink-cu12==12.5.82; python_version >= '3' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/tensorflow/ubi9-python-3.12/Pipfile
+++ b/jupyter/tensorflow/ubi9-python-3.12/Pipfile
@@ -34,7 +34,7 @@ pyodbc = "~=5.2.0"
 mysql-connector-python = "~=9.2.0"
 
 # JupyterLab packages
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=4.0.5"

--- a/jupyter/tensorflow/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/tensorflow/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "67137422d0e43ab99d6d9c341e9c2b598a0765d155867d010efd8668b8016347"
+            "sha256": "911003bf536ca85c22fd84427e0d17a1bda783a3203dfce516302ceafc1519f6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -579,11 +579,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2421,12 +2421,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/tensorflow/ubi9-python-3.12/requirements.txt
+++ b/jupyter/tensorflow/ubi9-python-3.12/requirements.txt
@@ -418,9 +418,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1616,9 +1616,9 @@ nvidia-nvjitlink-cu12==12.5.82; python_version >= '3' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/trustyai/ubi9-python-3.11/Pipfile
+++ b/jupyter/trustyai/ubi9-python-3.11/Pipfile
@@ -43,7 +43,7 @@ pyodbc = "~=5.2.0"
 mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=3.0.5" # Should be pinned down to this version in order to be compatible with trustyai

--- a/jupyter/trustyai/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/trustyai/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "44f9e0afd96fdde620a951df7fbd6f4c7cb12bd6956c86d51b39e84547331ba4"
+            "sha256": "86a81a0f859093c63922720cda050c5a4329fbd6a441aaa4855e58bcb5bc9a72"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -578,11 +578,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2416,12 +2416,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/trustyai/ubi9-python-3.11/requirements.txt
+++ b/jupyter/trustyai/ubi9-python-3.11/requirements.txt
@@ -416,9 +416,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.30.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:79923eddea43476c65b743c4341d613a39891a04a519720c015a9c28eb0d4b0d \
     --hash=sha256:d7cb1e1d83da104701e5a72124b3545b5a62e3b3e29e1a11edbbc66893f3b645
@@ -1608,9 +1608,9 @@ nvidia-nvtx-cu12==12.6.77; python_version >= '3' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/jupyter/trustyai/ubi9-python-3.12/Pipfile
+++ b/jupyter/trustyai/ubi9-python-3.12/Pipfile
@@ -43,7 +43,7 @@ pyodbc = "~=5.2.0"
 mysql-connector-python = "~=9.3.0"
 
 # JupyterLab packages
-odh-elyra = "==4.2.1"
+odh-elyra = "==4.2.2"
 
 jupyterlab = "==4.2.7"
 jupyter-bokeh = "~=3.0.5" # Should be pinned down to this version in order to be compatible with trustyai

--- a/jupyter/trustyai/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/trustyai/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b2503e78ab3ee23b675d963c5e45b417f0ddc18b16636403da422e202e217e26"
+            "sha256": "ed24b1cb33ad941c75a42aa8c83f141cc60cd78f6f75c5eedec5ef247dd3d84a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -399,11 +399,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "cffi": {
             "hashes": [
@@ -578,11 +578,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
         },
         "codeflare-sdk": {
             "hashes": [
@@ -2417,12 +2417,12 @@
         },
         "odh-elyra": {
             "hashes": [
-                "sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689",
-                "sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78"
+                "sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d",
+                "sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.2"
         },
         "onnx": {
             "hashes": [

--- a/jupyter/trustyai/ubi9-python-3.12/requirements.txt
+++ b/jupyter/trustyai/ubi9-python-3.12/requirements.txt
@@ -252,9 +252,9 @@ botocore==1.37.38; python_version >= '3.8' \
 cachetools==5.5.2; python_version >= '3.7' \
     --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-certifi==2025.6.15; python_version >= '3.7' \
-    --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
-    --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
+certifi==2025.7.9; python_version >= '3.7' \
+    --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
+    --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
 cffi==1.17.1; python_version >= '3.8' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \
@@ -416,9 +416,9 @@ charset-normalizer==3.4.2; python_version >= '3.7' \
     --hash=sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
-click==8.2.1; python_version >= '3.10' \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.1.8; python_version >= '3.7' \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
 codeflare-sdk==0.29.0; python_version >= '3.11' and python_version < '4.0' \
     --hash=sha256:a8fac9a83bac1511dcf060d253eac31d161c9e371f472cb24987ff94b8aec366 \
     --hash=sha256:c196018f2c71b796ede2c0a1046aedd42ee4b53fb4ceeb88ecaaa5dfdc900eab
@@ -1609,9 +1609,9 @@ nvidia-nvtx-cu12==12.6.77; python_version >= '3' \
 oauthlib==3.3.1; python_version >= '3.8' \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
-odh-elyra==4.2.1; python_version >= '3.8' \
-    --hash=sha256:255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689 \
-    --hash=sha256:a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78
+odh-elyra==4.2.2; python_version >= '3.9' \
+    --hash=sha256:7710dbc07c58a52b24bbae554b8ddc3dc1d8e2fe0c6f37bf8500b9626e23877d \
+    --hash=sha256:7a230292b28da5c55426eb57ca042076f4d702cb027ae2a7d238fde1cb4dfdd2
 onnx==1.18.0; python_version >= '3.9' \
     --hash=sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95 \
     --hash=sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05 \

--- a/runtimes/datascience/ubi9-python-3.12/Pipfile.lock
+++ b/runtimes/datascience/ubi9-python-3.12/Pipfile.lock
@@ -293,11 +293,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "cffi": {
             "hashes": [

--- a/runtimes/datascience/ubi9-python-3.12/requirements.txt
+++ b/runtimes/datascience/ubi9-python-3.12/requirements.txt
@@ -201,9 +201,9 @@ botocore==1.37.38; python_version >= '3.8' \
 cachetools==5.5.2; python_version >= '3.7' \
     --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-certifi==2025.6.15; python_version >= '3.7' \
-    --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
-    --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
+certifi==2025.7.9; python_version >= '3.7' \
+    --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
+    --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
 cffi==1.17.1; python_version >= '3.8' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \

--- a/runtimes/minimal/ubi9-python-3.12/Pipfile.lock
+++ b/runtimes/minimal/ubi9-python-3.12/Pipfile.lock
@@ -203,11 +203,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "cffi": {
             "hashes": [

--- a/runtimes/minimal/ubi9-python-3.12/requirements.txt
+++ b/runtimes/minimal/ubi9-python-3.12/requirements.txt
@@ -137,9 +137,9 @@ beautifulsoup4==4.13.4; python_full_version >= '3.7.0' \
 bleach[css]==6.2.0; python_version >= '3.9' \
     --hash=sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e \
     --hash=sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f
-certifi==2025.6.15; python_version >= '3.7' \
-    --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
-    --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
+certifi==2025.7.9; python_version >= '3.7' \
+    --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
+    --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
 cffi==1.17.1; python_version >= '3.8' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \

--- a/runtimes/pytorch/ubi9-python-3.12/Pipfile.lock
+++ b/runtimes/pytorch/ubi9-python-3.12/Pipfile.lock
@@ -306,11 +306,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "cffi": {
             "hashes": [

--- a/runtimes/pytorch/ubi9-python-3.12/requirements.txt
+++ b/runtimes/pytorch/ubi9-python-3.12/requirements.txt
@@ -205,9 +205,9 @@ botocore==1.37.38; python_version >= '3.8' \
 cachetools==5.5.2; python_version >= '3.7' \
     --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-certifi==2025.6.15; python_version >= '3.7' \
-    --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
-    --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
+certifi==2025.7.9; python_version >= '3.7' \
+    --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
+    --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
 cffi==1.17.1; python_version >= '3.8' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Pipfile.lock
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Pipfile.lock
@@ -306,11 +306,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "cffi": {
             "hashes": [

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.txt
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.txt
@@ -205,9 +205,9 @@ botocore==1.37.38; python_version >= '3.8' \
 cachetools==5.5.2; python_version >= '3.7' \
     --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-certifi==2025.6.15; python_version >= '3.7' \
-    --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
-    --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
+certifi==2025.7.9; python_version >= '3.7' \
+    --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
+    --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
 cffi==1.17.1; python_version >= '3.8' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \

--- a/runtimes/tensorflow/ubi9-python-3.12/Pipfile.lock
+++ b/runtimes/tensorflow/ubi9-python-3.12/Pipfile.lock
@@ -308,11 +308,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "cffi": {
             "hashes": [
@@ -3748,11 +3748,11 @@
     "develop": {
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+                "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.9"
         },
         "charset-normalizer": {
             "hashes": [

--- a/runtimes/tensorflow/ubi9-python-3.12/requirements.txt
+++ b/runtimes/tensorflow/ubi9-python-3.12/requirements.txt
@@ -207,9 +207,9 @@ botocore==1.37.38; python_version >= '3.8' \
 cachetools==5.5.2; python_version >= '3.7' \
     --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-certifi==2025.6.15; python_version >= '3.7' \
-    --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
-    --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
+certifi==2025.7.9; python_version >= '3.7' \
+    --hash=sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079 \
+    --hash=sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39
 cffi==1.17.1; python_version >= '3.8' \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \


### PR DESCRIPTION
## Description

ODH-Elyra `4.2.2` includes:

* [Add support to Python 3.12 and 3.13 #115](https://github.com/opendatahub-io/elyra/pull/115)
* [RHOAIENG-11446: Add task-level cache control #116 ](https://github.com/opendatahub-io/elyra/pull/116)

## How Has This Been Tested?

Through sanity checks on the generated images

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple Python package versions and integrity hashes across various environments.
  * Upgraded `odh-elyra` to version 4.2.2 with adjusted Python version requirements.
  * Downgraded `click` to 8.1.8, broadening Python compatibility.
  * Updated `certifi` to version 2025.7.9.
  * Modified Python version constraints for `click` and `odh-elyra` packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->