### PR TITLE
NO-JIRA: configure kubelet to disable image garbage collection in kubeadm CI config

### DIFF
--- a/ci/cached-builds/kubeadm.yaml
+++ b/ci/cached-builds/kubeadm.yaml
@@ -59,3 +59,16 @@ controllerManager: {}
 dns: {}
 proxy: {}
 scheduler: {}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# ISSUE #1326: disable gc, otherwise kubelet would GC Pytorch images causing later tests to fail
+# The low threshold must be strictly less than the high threshold
+imageGCHighThresholdPercent: 100
+imageGCLowThresholdPercent: 99
+# https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#minimum-eviction-reclaim
+evictionHard:
+  # eviction threshold nodefs.available must be positive
+  nodefs.available: "1Mi"
+  # eviction threshold imagefs.available must be positive
+  imagefs.available: "1Mi"


### PR DESCRIPTION
## Description

This should hopefully solve the case of disappearing pytorch images after kubernetes tests are done but before a Trivy scan is performed.

## How Has This Been Tested?

### PyTorch ROCm (demonstrates fix works)

* with fix https://github.com/opendatahub-io/notebooks/actions/runs/16102997548/job/45434573463?pr=1327
* without fix https://github.com/opendatahub-io/notebooks/actions/runs/16101815643

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes configuration to disable image garbage collection and set stricter eviction thresholds for node and image filesystem availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->