### PR TITLE
RHOAIENG-28774: update Python 3.12 codeserver image Dockerfile for using TARGETARCH

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -29,6 +29,8 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS codeserver
 
+ARG TARGETOS TARGETARCH
+
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.98.0
 
@@ -50,7 +52,7 @@ WORKDIR /opt/app-root/bin
 RUN dnf install -y jq git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
 
 # Install code-server
-RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-amd64.rpm" && \
+RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm" && \
     yum -y clean all --enablerepo='*'
 
 COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-28774
* https://github.com/opendatahub-io/notebooks/pull/1258

<div _ngcontent-ng-c2383589868="" class="mat-typography markdown typography ng-star-inserted"><h2>Description</h2>
<p>This PR updates the Dockerfile for the Python 3.12 image to support different architectures by using the <code>TARGETARCH</code> build argument. This aligns it with the changes made for the Python 3.11 image in PR #1258.</p>
<p>Specifically, the following changes were made:</p>
<ul>
<li>Added <code>ARG TARGETOS TARGETARCH</code> to the Dockerfile.</li>
<li>Modified the code-server installation URL to use the <code>${TARGETARCH}</code> variable, allowing it to fetch the correct binary for the target architecture.</li>
</ul>
<h2>How Has This Been Tested?</h2>
<p>These changes were based on the existing, tested changes in PR #1258 for the Python 3.11 image. The Dockerfile syntax is standard and the variable substitution is a common pattern.</p>
<h2>Merge criteria:</h2>
<ul>
<li> The commits are squashed in a cohesive manner and have meaningful messages.</li>
<li> Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).</li>
<li> The developer has manually tested the changes and verified that the changes work</li>
</ul>
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build process to support multiple architectures by dynamically selecting the appropriate code-server package based on build arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->