### PR TITLE
refactor(gha, makefile): improve piplock renewal process log printout

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -65,9 +65,12 @@ jobs:
         run: pip install pipenv
 
       # Run makefile recipe to refresh Pipfile.lock and push changes back to the branch
-      - name: Run make refresh-pipfilelock-files and push the changes back to the branch
+      - name: Run `make refresh-pipfilelock-files`
         run: |
           make refresh-pipfilelock-files PYTHON_VERSION=${{ env.PYTHON_VERSION }} INCLUDE_OPT_DIRS=${{ env.INCLUDE_OPT_DIRS }}
+
+      - name: Push the changes back to the branch
+        run: |
           git add .
           git commit -m "Update Pipfile.lock files by piplock-renewal.yaml action"
           git push origin ${{ env.BRANCH }}

--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,7 @@ refresh-pipfilelock-files:
 			echo "Updating $(PYTHON_VERSION) Pipfile.lock in $$dir"
 			cd $$dir
 			if [ -f "Pipfile" ]; then
-				pipenv lock --verbose
+				pipenv lock || pipenv lock --verbose
 			else
 				echo "No Pipfile found in $$dir, skipping."
 			fi


### PR DESCRIPTION
## Description

- Split `make refresh-pipfilelock-files` and branch push steps in piplock-renewal workflow for clarity.
- Enhanced `pipenv lock` verbosity control in `Makefile`, added failure handling with detailed error logging.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/16218997637

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved error handling and logging when updating dependency lock files.
  * Enhanced workflow automation by separating the update and push steps for dependency lock files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->