### PR TITLE
Ignore yamllint in konflux insta-merge.yaml file

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -69,8 +69,8 @@ jobs:
         id: validate-yaml-files
         run: |
           type yamllint || sudo apt-get -y install yamllint
-          # We ignore the .tekton directory with the konflux pipelines definitions as it's managed by devops (and usually violates rules...).
-          find . -name "*.yaml" | grep -v "./.tekton/" | xargs yamllint --strict --config-file ./ci/yamllint-config.yaml
+          # We ignore the insta-merge.yaml and .tekton directory with the konflux pipelines definitions as it's managed by devops (and usually violates rules...).
+          find . -name "*.yaml" | grep -v "./.tekton/" | grep -v "./.github/workflows/insta-merge.yaml" | xargs yamllint --strict --config-file ./ci/yamllint-config.yaml
           find . -name "*.yml" | grep -v "./.tekton/" | xargs yamllint --strict --config-file ./ci/yamllint-config.yaml
 
       # In some YAML files we use JSON strings, let's check these


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Trying to fix the following job failure:
<img width="830" height="265" alt="image" src="https://github.com/user-attachments/assets/ab0d0d64-7145-4f9b-9c7f-1d8a3691b58d" />

Given that konflux automation will just revert any fixes that we put in there, this change adds the file to the list of files that are ignored for this check.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Old command fails, new command passes.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to exclude an additional workflow file from YAML linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->