### PR TITLE
update base image references in Dockerfiles to use sha256 digests for…

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ########################
 # base                 #
 ########################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 #####################
 # base              #
 #####################
-FROM registry.redhat.io/rhel9/python-311:latest AS base
+FROM registry.access.redhat.com/rhel9/python-311:latest AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 #####################
 # base              #
 #####################
-FROM registry.redhat.io/rhel9/python-311:latest AS base
+FROM registry.access.redhat.com/rhel9/python-311:latest AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -26,7 +26,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 #######################
 # runtime-datascience #
 #######################
-FROM base AS runtime-datascience  
+FROM base AS runtime-datascience
 
 ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.11
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -26,7 +26,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 #######################
 # runtime-datascience #
 #######################
-FROM base AS runtime-datascience  
+FROM base AS runtime-datascience
 
 ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.12
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -33,7 +33,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 # runtime-minimal  #
 ####################
-FROM base AS runtime-minimal  
+FROM base AS runtime-minimal
 
 ARG MINIMAL_SOURCE_CODE=runtimes/minimal/ubi9-python-3.11
 

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -33,7 +33,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 # runtime-minimal  #
 ####################
-FROM base AS runtime-minimal  
+FROM base AS runtime-minimal
 
 ARG MINIMAL_SOURCE_CODE=runtimes/minimal/ubi9-python-3.12
 

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -135,7 +135,7 @@ RUN yum install -y \
     ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
-    
+
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -135,7 +135,7 @@ RUN yum install -y \
     ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
-    
+
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -38,7 +38,7 @@ ARG AMDGPU_VERSION=6.2.4
 # Install the ROCm rpms
 # ref: https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
 # Note: Based on 6.2 above new package mivisionx is a pre-requistes, which bring in more dependent packages
-# so we are only installing meta packages of rocm 
+# so we are only installing meta packages of rocm
 # ref: https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/package-manager-integration.html#packages-in-rocm-programming-models
 RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -38,7 +38,7 @@ ARG AMDGPU_VERSION=6.2.4
 # Install the ROCm rpms
 # ref: https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
 # Note: Based on 6.2 above new package mivisionx is a pre-requistes, which bring in more dependent packages
-# so we are only installing meta packages of rocm 
+# so we are only installing meta packages of rocm
 # ref: https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/package-manager-integration.html#packages-in-rocm-programming-models
 RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -38,7 +38,7 @@ ARG AMDGPU_VERSION=6.2.4
 # Install the ROCm rpms
 # ref: https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
 # Note: Based on 6.2 above new package mivisionx is a pre-requistes, which bring in more dependent packages
-# so we are only installing meta packages of rocm 
+# so we are only installing meta packages of rocm
 # ref: https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/package-manager-integration.html#packages-in-rocm-programming-models
 RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -38,7 +38,7 @@ ARG AMDGPU_VERSION=6.2.4
 # Install the ROCm rpms
 # ref: https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
 # Note: Based on 6.2 above new package mivisionx is a pre-requistes, which bring in more dependent packages
-# so we are only installing meta packages of rocm 
+# so we are only installing meta packages of rocm
 # ref: https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/package-manager-integration.html#packages-in-rocm-programming-models
 RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
+FROM registry.access.redhat.com/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-311:latest AS base
+FROM registry.redhat.io/ubi9/python-311@sha256:3d7217ff801658e72048ace18433f434971f64433f33e8c0f7f1e73525841ae7 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -135,7 +135,7 @@ RUN yum install -y \
     ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
-    
+
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -135,7 +135,7 @@ RUN yum install -y \
     ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
-    
+
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.redhat.io/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
+FROM registry.access.redhat.com/ubi9/python-312@sha256:9b1c6e37a36bd62815e264345ba1345f0edda83c105cf48aba72eecee1ba98d5 AS base
 
 WORKDIR /opt/app-root/bin
 


### PR DESCRIPTION
… reproducibility across various components and runtimes

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated all relevant environments to use fixed, immutable base image versions for Python 3.11 and 3.12, improving build consistency and reliability.
  * Minor whitespace cleanups in some configuration files.
  * Adjusted base image registry source for RHEL9 Python 3.11 environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->