### PR TITLE
Issue #953: add `MAKEFLAGS="-j4"` to RStudio Dockerfiles for parallel compilation

### DIFF
--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -47,7 +47,7 @@ LABEL name="odh-notebook-rstudio-server-c9s-python-3.11" \
 USER 0
 
 ENV R_VERSION=4.4.3
-ENV MAKEFLAGS="-j2"
+ENV MAKEFLAGS="-j4"
 
 # Install R
 RUN yum install -y yum-utils && \

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -179,7 +179,7 @@ LABEL name="odh-notebook-rstudio-server-cuda-c9s-python-3.11" \
 USER 0
 
 ENV R_VERSION=4.4.3
-ENV MAKEFLAGS="-j2"
+ENV MAKEFLAGS="-j4"
 
 # Install R
 RUN yum install -y yum-utils && \

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -67,7 +67,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
   fi
 
 ENV R_VERSION=4.4.3
-ENV MAKEFLAGS="-j2"
+ENV MAKEFLAGS="-j4"
 
 # Install R
 RUN yum install -y yum-utils && \

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -225,7 +225,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
   fi
 
 ENV R_VERSION=4.4.3
-ENV MAKEFLAGS="-j2"
+ENV MAKEFLAGS="-j4"
 
 # Install R
 RUN yum install -y yum-utils && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replacement for CodeRabbitAI-created
* https://github.com/opendatahub-io/notebooks/pull/1391

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized build performance for all RStudio Python 3.11 Docker images by increasing parallel jobs during package compilation. No changes to user-facing features or configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->