### PR TITLE
Enhance Pipfile.lock GitHub Action: Multi-version Matrix Support

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -18,11 +18,11 @@ on:  # yamllint disable-line rule:truthy
         default: '["3.11", "3.12"]'
         type: choice
         options:
-            - '["3.11", "3.12"]'
-            - '["3.12"]'
-            - '["3.11"]'
-            - '["3.9"]'
-            - '["3.8"]'
+          - '["3.11", "3.12"]'
+          - '["3.12"]'
+          - '["3.11"]'
+          - '["3.9"]'
+          - '["3.8"]'
       update_optional_dirs:
         description: 'Include optional directories in update'
         required: false

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -13,16 +13,16 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 'main'
       python_version:
-        description: 'Select Python version to update Pipfile.lock'
+        description: 'Select a Python version to update Pipfile.lock'
         required: false
-        default: 'all'
+        default: "['3.11', '3.12']"
         type: choice
         options:
-          - 'all'
-          - '3.12'
-          - '3.11'
-          - '3.9'
-          - '3.8'
+          - "['3.11', '3.12']"
+          - "['3.12']"
+          - "['3.11']"
+          - "['3.9']"
+          - "['3.8']"
       update_optional_dirs:
         description: 'Include optional directories in update'
         required: false
@@ -42,12 +42,7 @@ jobs:
       max-parallel: 1
       matrix:
         python-version: >-
-          ${{ fromJSON(
-              (github.event_name == 'schedule' ||
-               github.event.inputs.python_version == 'all') &&
-               '["3.11","3.12"]' ||
-               format('["{0}"]', github.event.inputs.python_version)
-          ) }}
+          ${{ fromJSON( github.event.inputs.python_version || '["3.11", "3.12"]' ) }}
     permissions:
       contents: write
     env:

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -78,9 +78,8 @@ jobs:
         run: |
           make refresh-pipfilelock-files PYTHON_VERSION=${{ matrix.python-version }} INCLUDE_OPT_DIRS=${{ env.INCLUDE_OPT_DIRS }}
 
-      - name: Commit and push changes (if any)
+      - name: Push the changes back to the branch
         run: |
           git add .
-          git diff --cached --quiet || git commit -m "Update Pipfile.lock for Python ${{ matrix.python-version }}"
-          git pull --rebase origin ${{ env.BRANCH }}
+          git commit -m "Update Pipfile.lock files by piplock-renewal.yaml action"
           git push origin ${{ env.BRANCH }}

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -37,7 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ fromJSON((github.event_name == 'schedule' || github.event.inputs.python_version == 'all') && '["3.11", "3.12"]' || format('["{0}"]', github.event.inputs.python_version)) }}
+        python-version: >-
+          ${{ fromJSON(
+              (github.event_name == 'schedule' ||
+               github.event.inputs.python_version == 'all') &&
+               '["3.11","3.12"]' ||
+               format('["{0}"]', github.event.inputs.python_version)
+          ) }}
     permissions:
       contents: write
     env:

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -18,6 +18,7 @@ on:  # yamllint disable-line rule:truthy
         default: '3.11'
         type: choice
         options:
+          - 'all'
           - '3.12'
           - '3.11'
           - '3.9'
@@ -32,14 +33,59 @@ on:  # yamllint disable-line rule:truthy
           - 'false'
 
 jobs:
-  build:
+  # Matrix job for multiple Python versions
+  refresh-multiple-versions:
+    if: github.event_name == 'schedule' || github.event.inputs.python_version == 'all'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+    permissions:
+      contents: write
+    env:
+      BRANCH: ${{ github.event.inputs.branch || 'main' }}
+      INCLUDE_OPT_DIRS: ${{ github.event.inputs.update_optional_dirs || 'false' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Run make refresh-pipfilelock-files
+        run: |
+          make refresh-pipfilelock-files PYTHON_VERSION=${{ matrix.python-version }} INCLUDE_OPT_DIRS=${{ env.INCLUDE_OPT_DIRS }}
+
+      - name: Commit and push changes (if any)
+        run: |
+          git add .
+          git diff --cached --quiet || git commit -m "Update Pipfile.lock for Python ${{ matrix.python-version }}"
+          git pull --rebase origin ${{ env.BRANCH }}
+          git push origin ${{ env.BRANCH }}
+
+  # Single Python version job for manual runs
+  refresh-single-version:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.python_version != 'all'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       BRANCH: ${{ github.event.inputs.branch || 'main' }}
-      PYTHON_VERSION: ${{ github.event.inputs.python_version || '3.11' }}
-      INCLUDE_OPT_DIRS: ${{ github.event.inputs.update_optional_dirs || 'false' }}
+      PYTHON_VERSION: ${{ github.event.inputs.python_version }}
+      INCLUDE_OPT_DIRS: ${{ github.event.inputs.update_optional_dirs }}
     steps:
       # Checkout the specified branch from the specified organization
       - name: Checkout code from the specified branch

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -35,7 +35,11 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   refresh-pipfile-locks:
     runs-on: ubuntu-latest
+    concurrency:
+      group: refresh-pipfile-locks-${{ github.ref }}
+      cancel-in-progress: false
     strategy:
+      max-parallel: 1
       matrix:
         python-version: >-
           ${{ fromJSON(

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -39,6 +39,7 @@ jobs:
       group: refresh-pipfile-locks-${{ github.ref }}
       cancel-in-progress: false
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         python-version: >-

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -15,14 +15,14 @@ on:  # yamllint disable-line rule:truthy
       python_version:
         description: 'Select a Python version to update Pipfile.lock'
         required: false
-        default: "['3.11', '3.12']"
+        default: '["3.11", "3.12"]'
         type: choice
         options:
-          - "['3.11', '3.12']"
-          - "['3.12']"
-          - "['3.11']"
-          - "['3.9']"
-          - "['3.8']"
+            - '["3.11", "3.12"]'
+            - '["3.12"]'
+            - '["3.11"]'
+            - '["3.9"]'
+            - '["3.8"]'
       update_optional_dirs:
         description: 'Include optional directories in update'
         required: false

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
       python_version:
         description: 'Select Python version to update Pipfile.lock'
         required: false
-        default: '3.11'
+        default: 'all'
         type: choice
         options:
           - 'all'

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -33,18 +33,17 @@ on:  # yamllint disable-line rule:truthy
           - 'false'
 
 jobs:
-  # Matrix job for multiple Python versions
-  refresh-multiple-versions:
-    if: github.event_name == 'schedule' || github.event.inputs.python_version == 'all'
+  refresh-pipfile-locks:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11, 3.12]
+        python-version: ${{ fromJSON((github.event_name == 'schedule' || github.event.inputs.python_version == 'all') && '["3.11", "3.12"]' || format('["{0}"]', github.event.inputs.python_version)) }}
     permissions:
       contents: write
     env:
       BRANCH: ${{ github.event.inputs.branch || 'main' }}
       INCLUDE_OPT_DIRS: ${{ github.event.inputs.update_optional_dirs || 'false' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,49 +73,4 @@ jobs:
           git add .
           git diff --cached --quiet || git commit -m "Update Pipfile.lock for Python ${{ matrix.python-version }}"
           git pull --rebase origin ${{ env.BRANCH }}
-          git push origin ${{ env.BRANCH }}
-
-  # Single Python version job for manual runs
-  refresh-single-version:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.python_version != 'all'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      BRANCH: ${{ github.event.inputs.branch || 'main' }}
-      PYTHON_VERSION: ${{ github.event.inputs.python_version }}
-      INCLUDE_OPT_DIRS: ${{ github.event.inputs.update_optional_dirs }}
-    steps:
-      # Checkout the specified branch from the specified organization
-      - name: Checkout code from the specified branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.BRANCH }}
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-
-      # Configure Git
-      - name: Configure Git
-        run: |
-         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-         git config --global user.name "GitHub Actions"
-
-      # Setup Python environment with the specified version (or default to '3.11')
-      - name: Setup Python environment
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      # Install pipenv
-      - name: Install pipenv
-        run: pip install pipenv
-
-      # Run makefile recipe to refresh Pipfile.lock and push changes back to the branch
-      - name: Run `make refresh-pipfilelock-files`
-        run: |
-          make refresh-pipfilelock-files PYTHON_VERSION=${{ env.PYTHON_VERSION }} INCLUDE_OPT_DIRS=${{ env.INCLUDE_OPT_DIRS }}
-
-      - name: Push the changes back to the branch
-        run: |
-          git add .
-          git commit -m "Update Pipfile.lock files by piplock-renewal.yaml action"
           git push origin ${{ env.BRANCH }}

--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ else ifeq ($(PYTHON_VERSION), 3.12)
 		runtimes/pytorch/ubi9-python-$(PYTHON_VERSION) \
 		runtimes/tensorflow/ubi9-python-$(PYTHON_VERSION) \
 		runtimes/rocm-pytorch/ubi9-python-$(PYTHON_VERSION) \
-		runtimes/rocm-tensorflow/ubi9-python-$(PYTHON_VERSION)
+		# runtimes/rocm-tensorflow/ubi9-python-$(PYTHON_VERSION)
 		# jupyter/rocm/tensorflow/ubi9-python-$(PYTHON_VERSION)
 		# rstudio/rhel9-python-$(PYTHON_VERSION)
 		# rstudio/c9s-python-$(PYTHON_VERSION)
@@ -515,7 +515,7 @@ all-images: \
 	rocm-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION) \
  	rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
-	rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
+# rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 # rstudio-c9s-python-$(RELEASE_PYTHON_VERSION)
 # cuda-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION)
 # rstudio-rhel9-python-$(RELEASE_PYTHON_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ else ifeq ($(PYTHON_VERSION), 3.12)
 		runtimes/datascience/ubi9-python-$(PYTHON_VERSION) \
 		runtimes/pytorch/ubi9-python-$(PYTHON_VERSION) \
 		runtimes/tensorflow/ubi9-python-$(PYTHON_VERSION) \
-		runtimes/rocm-pytorch/ubi9-python-$(PYTHON_VERSION) \
+		runtimes/rocm-pytorch/ubi9-python-$(PYTHON_VERSION)
 		# runtimes/rocm-tensorflow/ubi9-python-$(PYTHON_VERSION)
 		# jupyter/rocm/tensorflow/ubi9-python-$(PYTHON_VERSION)
 		# rstudio/rhel9-python-$(PYTHON_VERSION)
@@ -514,7 +514,7 @@ all-images: \
 	runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	rocm-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION) \
  	rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
-	rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
+	rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 # rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 # rstudio-c9s-python-$(RELEASE_PYTHON_VERSION)
 # cuda-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the `piplock-renewal.yaml` GitHub Action to improve flexibility, automation, and reliability.
(Also removes the `rocm-tensorflow-runtime` from the makefile as it is not ready yet and has resolution issues, this change is added on a separated commit)

What's Changed: 
- Enables matrix support for multiple Python versions (3.11, 3.12)
- Preserved the old functionality with workflow_dispatch inputs.
- Skips commits when there are no actual changes using git diff --cached --quiet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run successfully on my local fork: on dispatch using "all": https://github.com/atheo89/notebooks/actions/runs/16292499147

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for updating dependencies across multiple Python versions (3.11 and 3.12) in the workflow, with a new input option to trigger updates for all supported versions at once.
  * Introduced separate workflow jobs for updating a single Python version or multiple versions in parallel.

* **Chores**
  * Disabled building and inclusion of the ROCm TensorFlow runtime for Python 3.12 in the image build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->