### PR TITLE
Run the pipfile.lock update github action in parallel over Python versions

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -40,7 +40,6 @@ jobs:
       cancel-in-progress: false
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         python-version: >-
           ${{ fromJSON( github.event.inputs.python_version || '["3.11", "3.12"]' ) }}
@@ -74,8 +73,15 @@ jobs:
         run: |
           make refresh-pipfilelock-files PYTHON_VERSION=${{ matrix.python-version }} INCLUDE_OPT_DIRS=${{ env.INCLUDE_OPT_DIRS }}
 
-      - name: Push the changes back to the branch
+      - name: Pull latest changes safely
         run: |
           git add .
-          git commit -m "Update Pipfile.lock files by piplock-renewal.yaml action"
+          git stash push -m "pre-pull-stash" || true
+          git pull --rebase origin ${{ env.BRANCH }}
+          git stash pop || true
+
+      - name: Commit and push changes (if any)
+        run: |
+          git add .
+          git diff --cached --quiet && echo "No changes to commit." || git commit -m "Update Pipfile.lock for Python ${{ matrix.python-version }}"
           git push origin ${{ env.BRANCH }}


### PR DESCRIPTION
## Description

Contains the more advanced changes by @atheo89 originally in
* https://github.com/opendatahub-io/notebooks/pull/1397

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workflow steps for updating and pushing changes, ensuring safer integration of remote updates and more reliable commit handling.
  * Enhanced parallel execution by removing previous job concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->