### PR TITLE
Set the new ordering of the imagestreams on UI

### DIFF
--- a/ci/package_versions_selftestdata.py
+++ b/ci/package_versions_selftestdata.py
@@ -6,7 +6,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/minimal"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Minimal Python"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "1"

--- a/manifests/base/README.md
+++ b/manifests/base/README.md
@@ -1,19 +1,29 @@
 # IDE Imagestreams
 
 Listing the order in which each imagestreams are introduced.
+NOTE: In overlays/additional there are new set of Python 3.12 images, they are also included in this ordering
 
 1. jupyter-minimal-notebook-imagestream.yaml
-2. jupyter-datascience-notebook-imagestream.yaml
+2. jupyter-minimal-notebook-imagestream-beta.yaml
 3. jupyter-minimal-gpu-notebook-imagestream.yaml
-4. jupyter-pytorch-notebook-imagestream.yaml
-5. jupyter-tensorflow-notebook-imagestream.yaml
-6. jupyter-trustyai-notebook-imagestream.yaml
-8. code-server-notebook-imagestream.yaml
-9. rstudio-notebook-imagestream.yaml
-10. rstudio-gpu-notebook-imagestream.yaml
-11. jupyter-rocm-minimal-notebook-imagestream.yaml
-12. jupyter-rocm-pytorch-notebook-imagestream.yaml
-13. jupyter-rocm-tensorflow-notebook-imagestream.yaml
+4. jupyter-minimal-gpu-notebook-imagestream-beta.yaml
+5. jupyter-rocm-minimal-notebook-imagestream.yaml
+6. jupyter-rocm-minimal-notebook-imagestream-beta.yaml
+7. jupyter-datascience-notebook-imagestream.yaml
+8. jupyter-datascience-notebook-imagestream-beta.yaml
+9. jupyter-pytorch-notebook-imagestream.yaml
+10. jupyter-pytorch-notebook-imagestream-beta.yaml
+11. jupyter-rocm-pytorch-notebook-imagestream.yaml
+12. jupyter-rocm-pytorch-notebook-imagestream-beta.yaml
+13. jupyter-tensorflow-notebook-imagestream.yaml
+14. jupyter-tensorflow-notebook-imagestream-beta.yaml
+15. jupyter-rocm-tensorflow-notebook-imagestream.yaml
+16. jupyter-trustyai-notebook-imagestream.yaml
+17. jupyter-trustyai-notebook-imagestream-beta.yaml
+18. code-server-notebook-imagestream.yaml
+19. code-server-notebook-imagestream-beta.yaml
+20. rstudio-notebook-imagestream.yaml
+21. rstudio-gpu-notebook-imagestream.yaml
 
 The order would also be same as `opendatahub.io/notebook-image-order` listed in each imagestreams.  
 _Note_: On deprecation/removal of imagestream, the index of that image is retired with it.

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/codeserver"
     opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.11"
     opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
-    opendatahub.io/notebook-image-order: "8"
+    opendatahub.io/notebook-image-order: "18"
   name: code-server-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/datascience"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience"
     opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
-    opendatahub.io/notebook-image-order: "2"
+    opendatahub.io/notebook-image-order: "7"
   name: jupyter-datascience-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/minimal"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "1"

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "4"
+    opendatahub.io/notebook-image-order: "9"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-notebook
 spec:

--- a/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | ROCm | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "11"
+    opendatahub.io/notebook-image-order: "5"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-minimal
 spec:

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm/pytorch"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | ROCm | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "12"
+    opendatahub.io/notebook-image-order: "11"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-pytorch
 spec:

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm/tensorflow"
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | ROCm | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized TensorFlow notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "13"
+    opendatahub.io/notebook-image-order: "15"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-tensorflow
 spec:

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/tensorflow"
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | CUDA | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "5"
+    opendatahub.io/notebook-image-order: "13"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-tensorflow-notebook
 spec:

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/trustyai"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai"
     opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.11"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
-    opendatahub.io/notebook-image-order: "6"
+    opendatahub.io/notebook-image-order: "16"
   name: jupyter-trustyai-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
     opendatahub.io/notebook-image-name: "RStudio | Minimal | CUDA | R 4.4"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
-    opendatahub.io/notebook-image-order: "10"
+    opendatahub.io/notebook-image-order: "21"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: rstudio-gpu-notebook
 spec:

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
     opendatahub.io/notebook-image-name: "RStudio | Minimal | CPU | R 4.4"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
-    opendatahub.io/notebook-image-order: "9"
+    opendatahub.io/notebook-image-order: "20"
   name: rstudio-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/runtime-datascience-imagestream.yaml
+++ b/manifests/base/runtime-datascience-imagestream.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Datascience with Python 3.11 (UBI9)"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
   name: runtime-datascience

--- a/manifests/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-pytorch-imagestream.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "PyTorch with CUDA and Python 3.11 (UBI9)"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch

--- a/manifests/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-rocm-pytorch-imagestream.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "PyTorch with ROCm and Python 3.11 (UBI9)"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-pytorch

--- a/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     # TODO: once the restraction takes a final shape need to update that url
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "TensorFlow with ROCm and Python 3.11 (UBI9)"
     opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-tensorflow

--- a/manifests/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-tensorflow-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     # TODO: once the restraction takes a final shape need to update that url
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "TensorFlow with CUDA and Python 3.11 (UBI9)"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-tensorflow

--- a/manifests/overlays/additional/code-server-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/code-server-notebook-imagestream-beta.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/codeserver"
     opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
-    opendatahub.io/notebook-image-order: "23"
+    opendatahub.io/notebook-image-order: "19"
   name: code-server-notebook-beta
 spec:
   lookupPolicy:

--- a/manifests/overlays/additional/jupyter-datascience-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-datascience-notebook-imagestream-beta.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/datascience"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience"
     opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
-    opendatahub.io/notebook-image-order: "16"
+    opendatahub.io/notebook-image-order: "8"
   name: jupyter-datascience-notebook-beta
 spec:
   lookupPolicy:

--- a/manifests/overlays/additional/jupyter-minimal-gpu-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-gpu-notebook-imagestream-beta.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "15"
+    opendatahub.io/notebook-image-order: "4"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-minimal-gpu-notebook-beta
 spec:

--- a/manifests/overlays/additional/jupyter-minimal-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-notebook-imagestream-beta.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/minimal"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "14"
+    opendatahub.io/notebook-image-order: "2"
   name: jupyter-minimal-notebook-beta
 spec:
   lookupPolicy:

--- a/manifests/overlays/additional/jupyter-pytorch-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-notebook-imagestream-beta.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "17"
+    opendatahub.io/notebook-image-order: "10"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-notebook-beta
 spec:

--- a/manifests/overlays/additional/jupyter-rocm-minimal-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-rocm-minimal-notebook-imagestream-beta.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "18"
+    opendatahub.io/notebook-image-order: "6"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-minimal-beta
 spec:

--- a/manifests/overlays/additional/jupyter-rocm-pytorch-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-rocm-pytorch-notebook-imagestream-beta.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm/pytorch"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "19"
+    opendatahub.io/notebook-image-order: "12"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-pytorch-beta
 spec:

--- a/manifests/overlays/additional/jupyter-tensorflow-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-tensorflow-notebook-imagestream-beta.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/tensorflow"
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "21"
+    opendatahub.io/notebook-image-order: "14"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-tensorflow-notebook-beta
 spec:

--- a/manifests/overlays/additional/jupyter-trustyai-notebook-imagestream-beta.yaml
+++ b/manifests/overlays/additional/jupyter-trustyai-notebook-imagestream-beta.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/trustyai"
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai"
     opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
-    opendatahub.io/notebook-image-order: "22"
+    opendatahub.io/notebook-image-order: "17"
   name: jupyter-trustyai-notebook-beta
 spec:
   lookupPolicy:

--- a/manifests/overlays/additional/runtime-datascience-imagestream-beta.yaml
+++ b/manifests/overlays/additional/runtime-datascience-imagestream-beta.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | Data Science | CPU | Python 3.12"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
   name: runtime-datascience-beta

--- a/manifests/overlays/additional/runtime-minimal-imagestream-beta.yaml
+++ b/manifests/overlays/additional/runtime-minimal-imagestream-beta.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
     opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
   name: runtime-minimal-beta

--- a/manifests/overlays/additional/runtime-pytorch-imagestream-beta.yaml
+++ b/manifests/overlays/additional/runtime-pytorch-imagestream-beta.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch-beta

--- a/manifests/overlays/additional/runtime-rocm-pytorch-imagestream-beta.yaml
+++ b/manifests/overlays/additional/runtime-rocm-pytorch-imagestream-beta.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-pytorch-beta

--- a/manifests/overlays/additional/runtime-tensorflow-imagestream-beta.yaml
+++ b/manifests/overlays/additional/runtime-tensorflow-imagestream-beta.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     # TODO: once the restraction takes a final shape need to update that url
-    opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-tensorflow-beta


### PR DESCRIPTION
Set the new ordering of the imagestreams on UI
  - order follows: 
     - Minimal, Data Science, Pytorch, TensorFlow, Trustyai, CodeServer, RStudio 
     - Along with that order, they each are sorted based on Accelerator and Python version

<!--- Provide a general summary of your changes in the Title above -->

Related-to: https://issues.redhat.com/browse/RHOAIENG-28515

## Description
<!--- Describe your changes in detail -->
<img width="1011" height="1150" alt="Screenshot from 2025-07-16 12-27-21" src="https://github.com/user-attachments/assets/0cc7b625-926a-40cf-a069-5357a16ba74b" />

Further details about ordering can be found here:
https://redhat-internal.slack.com/archives/C05TTTYG599/p1746800790811959
https://docs.google.com/document/d/1iQE681Kjhgy8NDY_Yn5DDPpir8JJZhMIi99w0tHeKlo/edit?tab=t.oqwiradeog37

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NA
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a longer, reordered list of notebook image streams, adding new beta and ROCm-enabled variants and noting Python 3.12 images.
* **Style**
  * Improved catalog organization by adjusting the display order of multiple notebook images and their beta variants.
* **Bug Fixes**
  * Corrected malformed URLs in image annotations to ensure accurate linking to GitHub repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->