### PR TITLE
Set py3.12 imagestream name based on naming convention

### DIFF
--- a/manifests/base/README.md
+++ b/manifests/base/README.md
@@ -4,24 +4,24 @@ Listing the order in which each imagestreams are introduced.
 NOTE: In overlays/additional there are new set of Python 3.12 images, they are also included in this ordering
 
 1. jupyter-minimal-notebook-imagestream.yaml
-2. jupyter-minimal-notebook-imagestream-beta.yaml
+2. jupyter-minimal-cpu-py312-ubi9-imagestream.yaml
 3. jupyter-minimal-gpu-notebook-imagestream.yaml
-4. jupyter-minimal-gpu-notebook-imagestream-beta.yaml
+4. jupyter-minimal-cuda-py312-ubi9-imagestream.yaml
 5. jupyter-rocm-minimal-notebook-imagestream.yaml
-6. jupyter-rocm-minimal-notebook-imagestream-beta.yaml
+6. jupyter-minimal-rocm-py312-ubi9-imagestream.yaml
 7. jupyter-datascience-notebook-imagestream.yaml
-8. jupyter-datascience-notebook-imagestream-beta.yaml
+8. jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
 9. jupyter-pytorch-notebook-imagestream.yaml
-10. jupyter-pytorch-notebook-imagestream-beta.yaml
+10. jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
 11. jupyter-rocm-pytorch-notebook-imagestream.yaml
-12. jupyter-rocm-pytorch-notebook-imagestream-beta.yaml
+12. jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
 13. jupyter-tensorflow-notebook-imagestream.yaml
-14. jupyter-tensorflow-notebook-imagestream-beta.yaml
+14. jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
 15. jupyter-rocm-tensorflow-notebook-imagestream.yaml
 16. jupyter-trustyai-notebook-imagestream.yaml
-17. jupyter-trustyai-notebook-imagestream-beta.yaml
+17. jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
 18. code-server-notebook-imagestream.yaml
-19. code-server-notebook-imagestream-beta.yaml
+19. codeserver-datascience-cpu-py312-ubi9-imagestream.yaml
 20. rstudio-notebook-imagestream.yaml
 21. rstudio-gpu-notebook-imagestream.yaml
 

--- a/manifests/overlays/additional/codeserver-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/codeserver-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
     opendatahub.io/notebook-image-order: "19"
-  name: code-server-notebook-beta
+  name: codeserver-datascience-cpu-py312-ubi9
 spec:
   lookupPolicy:
     local: true

--- a/manifests/overlays/additional/jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -5,12 +5,11 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch"
-    opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
-    opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "10"
-    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-  name: jupyter-pytorch-notebook-beta
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience"
+    opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
+    opendatahub.io/notebook-image-order: "8"
+  name: jupyter-datascience-cpu-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -19,16 +18,12 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.6"},
-            {"name": "Python", "version": "v3.12"},
-            {"name": "PyTorch", "version": "2.6"}
+            {"name": "Python", "version": "v3.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab","version": "4.2"},
-            {"name": "PyTorch", "version": "2.6"},
-            {"name": "Tensorboard", "version": "2.19"},
             {"name": "Boto3", "version": "1.37"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Kfp", "version": "2.12"},
@@ -48,10 +43,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-n_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
+        name: odh-workbench-jupyter-datascience-cpu-py312-ubi9-n_PLACEHOLDER
       name: "2025.1"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/jupyter-minimal-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-cpu-py312-ubi9-imagestream.yaml
@@ -6,11 +6,10 @@ metadata:
     opendatahub.io/notebook-image: "true"
   annotations:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
-    opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
-    opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "4"
-    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-  name: jupyter-minimal-gpu-notebook-beta
+    opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
+    opendatahub.io/notebook-image-order: "2"
+  name: jupyter-minimal-cpu-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -19,20 +18,19 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.6"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab", "version": "4.2"}
+            {"name": "JupyterLab","version": "4.2"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-n_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-n_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cuda-py312-ubi9-n_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cpu-py312-ubi9-n_PLACEHOLDER
       name: "2025.1"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/jupyter-minimal-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-cuda-py312-ubi9-imagestream.yaml
@@ -6,10 +6,11 @@ metadata:
     opendatahub.io/notebook-image: "true"
   annotations:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
-    opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
-    opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "2"
-  name: jupyter-minimal-notebook-beta
+    opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
+    opendatahub.io/notebook-image-order: "4"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+  name: jupyter-minimal-cuda-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -18,19 +19,20 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
+            {"name": "CUDA", "version": "12.6"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.2"}
+            {"name": "JupyterLab", "version": "4.2"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-n_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-n_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cpu-py312-ubi9-n_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cuda-py312-ubi9-n_PLACEHOLDER
       name: "2025.1"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/jupyter-minimal-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-rocm-py312-ubi9-imagestream.yaml
@@ -10,7 +10,7 @@ metadata:
     opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "6"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
-  name: jupyter-rocm-minimal-beta
+  name: jupyter-minimal-rocm-py312-ubi9
 spec:
   lookupPolicy:
     local: true

--- a/manifests/overlays/additional/jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
@@ -5,11 +5,12 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience"
-    opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.12"
-    opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
-    opendatahub.io/notebook-image-order: "8"
-  name: jupyter-datascience-notebook-beta
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch"
+    opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+    opendatahub.io/notebook-image-order: "10"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+  name: jupyter-pytorch-cuda-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -18,12 +19,16 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "Python", "version": "v3.12"}
+            {"name": "CUDA", "version": "12.6"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.6"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab","version": "4.2"},
+            {"name": "PyTorch", "version": "2.6"},
+            {"name": "Tensorboard", "version": "2.19"},
             {"name": "Boto3", "version": "1.37"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Kfp", "version": "2.12"},
@@ -43,10 +48,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-n_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-datascience-cpu-py312-ubi9-n_PLACEHOLDER
+        name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
       name: "2025.1"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
@@ -10,7 +10,7 @@ metadata:
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "12"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
-  name: jupyter-rocm-pytorch-beta
+  name: jupyter-pytorch-rocm-py312-ubi9
 spec:
   lookupPolicy:
     local: true

--- a/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
@@ -10,7 +10,7 @@ metadata:
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "14"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-  name: jupyter-tensorflow-notebook-beta
+  name: jupyter-tensorflow-cuda-py312-ubi9
 spec:
   lookupPolicy:
     local: true

--- a/manifests/overlays/additional/jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
     opendatahub.io/notebook-image-order: "17"
-  name: jupyter-trustyai-notebook-beta
+  name: jupyter-trustyai-cpu-py312-ubi9
 spec:
   lookupPolicy:
     local: true

--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -4,20 +4,20 @@ kind: Kustomization
 
 resources:
   - ../../base
-  - jupyter-minimal-notebook-imagestream-beta.yaml
-  - jupyter-minimal-gpu-notebook-imagestream-beta.yaml
-  - jupyter-datascience-notebook-imagestream-beta.yaml
-  - jupyter-pytorch-notebook-imagestream-beta.yaml
-  - jupyter-rocm-minimal-notebook-imagestream-beta.yaml
-  - jupyter-rocm-pytorch-notebook-imagestream-beta.yaml
-  - jupyter-tensorflow-notebook-imagestream-beta.yaml
-  - jupyter-trustyai-notebook-imagestream-beta.yaml
-  - code-server-notebook-imagestream-beta.yaml
-  - runtime-datascience-imagestream-beta.yaml
-  - runtime-minimal-imagestream-beta.yaml
-  - runtime-pytorch-imagestream-beta.yaml
-  - runtime-rocm-pytorch-imagestream-beta.yaml
-  - runtime-tensorflow-imagestream-beta.yaml
+  - codeserver-datascience-cpu-py312-ubi9-imagestream.yaml
+  - jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
+  - jupyter-minimal-cpu-py312-ubi9-imagestream.yaml
+  - jupyter-minimal-cuda-py312-ubi9-imagestream.yaml
+  - jupyter-minimal-rocm-py312-ubi9-imagestream.yaml
+  - jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
+  - jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
+  - jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
+  - jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
+  - runtime-datascience-cpu-py312-ubi9-imagestream.yaml
+  - runtime-minimal-cpu-py312-ubi9-imagestream.yaml
+  - runtime-pytorch-cuda-py312-ubi9-imagestream.yaml
+  - runtime-pytorch-rocm-py312-ubi9-imagestream.yaml
+  - runtime-tensorflow-cuda-py312-ubi9-imagestream.yaml
 
 labels:
   - includeSelectors: true
@@ -36,7 +36,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-minimal-notebook-beta
+          name: jupyter-minimal-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-n
@@ -49,7 +49,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-datascience-notebook-beta
+          name: jupyter-datascience-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-n
@@ -62,7 +62,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-minimal-gpu-notebook-beta
+          name: jupyter-minimal-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n
@@ -75,7 +75,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-pytorch-notebook-beta
+          name: jupyter-pytorch-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n
@@ -88,7 +88,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-tensorflow-notebook-beta
+          name: jupyter-tensorflow-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n
@@ -101,7 +101,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-trustyai-notebook-beta
+          name: jupyter-trustyai-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-n
@@ -114,7 +114,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: code-server-notebook-beta
+          name: codeserver-datascience-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-n
@@ -127,7 +127,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-rocm-minimal-beta
+          name: jupyter-minimal-rocm-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n
@@ -140,7 +140,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-rocm-pytorch-beta
+          name: jupyter-pytorch-rocm-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-n
@@ -153,7 +153,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-minimal-notebook-beta
+          name: jupyter-minimal-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-n
@@ -166,7 +166,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-datascience-notebook-beta
+          name: jupyter-datascience-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-n
@@ -179,7 +179,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-minimal-gpu-notebook-beta
+          name: jupyter-minimal-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n
@@ -192,7 +192,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-pytorch-notebook-beta
+          name: jupyter-pytorch-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-n
@@ -205,7 +205,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-tensorflow-notebook-beta
+          name: jupyter-tensorflow-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-n
@@ -218,7 +218,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-trustyai-notebook-beta
+          name: jupyter-trustyai-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-n
@@ -231,7 +231,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: code-server-notebook-beta
+          name: codeserver-datascience-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-n
@@ -244,7 +244,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-rocm-minimal-beta
+          name: jupyter-minimal-rocm-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-n
@@ -257,7 +257,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: jupyter-rocm-pytorch-beta
+          name: jupyter-pytorch-rocm-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-minimal-cpu-py312-ubi9-n
@@ -270,7 +270,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: runtime-minimal-beta
+          name: runtime-minimal-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-datascience-cpu-py312-ubi9-n
@@ -283,7 +283,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: runtime-datascience-beta
+          name: runtime-datascience-cpu-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n
@@ -296,7 +296,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: runtime-pytorch-beta
+          name: runtime-pytorch-cuda-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n
@@ -309,7 +309,7 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: runtime-rocm-pytorch-beta
+          name: runtime-pytorch-rocm-py312-ubi9
           version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n
@@ -322,5 +322,5 @@ replacements:
         select:
           group: image.openshift.io
           kind: ImageStream
-          name: runtime-tensorflow-beta
+          name: runtime-tensorflow-cuda-py312-ubi9
           version: v1

--- a/manifests/overlays/additional/runtime-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -6,9 +6,9 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12"
-    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
-  name: runtime-pytorch-beta
+    opendatahub.io/runtime-image-name: "Runtime | Data Science | CPU | Python 3.12"
+    opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+  name: runtime-datascience-cpu-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | PyTorch | CUDA | Python 3.12",
+              "display_name": "Runtime | Data Science | CPU | Python 3.12",
               "metadata": {
                 "tags": [
-                  "pytorch"
+                  "datascience"
                 ],
-                "display_name": "Runtime | PyTorch | CUDA | Python 3.12",
+                "display_name": "Runtime | Data Science | CPU | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
       from:
         kind: DockerImage
-        name: odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
-      name: "pytorch"
+        name: odh-pipeline-runtime-datascience-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "datascience"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/runtime-minimal-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-minimal-cpu-py312-ubi9-imagestream.yaml
@@ -5,11 +5,10 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
-    # TODO: once the restraction takes a final shape need to update that url
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
-    opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
-  name: runtime-tensorflow-beta
+    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
+    opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+  name: runtime-minimal-cpu-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -19,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+              "display_name": "Runtime | Minimal | CPU | Python 3.12",
               "metadata": {
                 "tags": [
-                  "tensorflow"
+                  "minimal"
                 ],
-                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+                "display_name": "Runtime | Minimal | CPU | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"
@@ -33,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
       from:
         kind: DockerImage
-        name: odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n_PLACEHOLDER
-      name: "tensorflow"
+        name: odh-pipeline-runtime-minimal-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "minimal"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/runtime-pytorch-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-pytorch-cuda-py312-ubi9-imagestream.yaml
@@ -6,9 +6,9 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12"
-    opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
-  name: runtime-rocm-pytorch-beta
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-cuda-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | PyTorch | ROCm | Python 3.12",
+              "display_name": "Runtime | PyTorch | CUDA | Python 3.12",
               "metadata": {
                 "tags": [
-                  "rocm-pytorch"
+                  "pytorch"
                 ],
-                "display_name": "Runtime | PyTorch | ROCm | Python 3.12",
+                "display_name": "Runtime | PyTorch | CUDA | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
       from:
         kind: DockerImage
-        name: odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n_PLACEHOLDER
-      name: "rocm-pytorch"
+        name: odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "pytorch"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/runtime-pytorch-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-pytorch-rocm-py312-ubi9-imagestream.yaml
@@ -6,9 +6,9 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
-    opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
-  name: runtime-minimal-beta
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12"
+    opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-rocm-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Minimal | CPU | Python 3.12",
+              "display_name": "Runtime | PyTorch | ROCm | Python 3.12",
               "metadata": {
                 "tags": [
-                  "minimal"
+                  "rocm-pytorch"
                 ],
-                "display_name": "Runtime | Minimal | CPU | Python 3.12",
+                "display_name": "Runtime | PyTorch | ROCm | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
       from:
         kind: DockerImage
-        name: odh-pipeline-runtime-minimal-cpu-py312-ubi9-n_PLACEHOLDER
-      name: "minimal"
+        name: odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n_PLACEHOLDER
+      name: "rocm-pytorch"
       referencePolicy:
         type: Source

--- a/manifests/overlays/additional/runtime-tensorflow-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-tensorflow-cuda-py312-ubi9-imagestream.yaml
@@ -5,10 +5,11 @@ metadata:
   labels:
     opendatahub.io/runtime-image: "true"
   annotations:
+    # TODO: once the restraction takes a final shape need to update that url
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Data Science | CPU | Python 3.12"
-    opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
-  name: runtime-datascience-beta
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-tensorflow-cuda-py312-ubi9
 spec:
   lookupPolicy:
     local: true
@@ -18,12 +19,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Data Science | CPU | Python 3.12",
+              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
               "metadata": {
                 "tags": [
-                  "datascience"
+                  "tensorflow"
                 ],
-                "display_name": "Runtime | Data Science | CPU | Python 3.12",
+                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"
@@ -32,7 +33,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
       from:
         kind: DockerImage
-        name: odh-pipeline-runtime-datascience-cpu-py312-ubi9-n_PLACEHOLDER
-      name: "datascience"
+        name: odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "tensorflow"
       referencePolicy:
         type: Source


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Set py3.12 imagestream name based on naming convention

## Description
<!--- Describe your changes in detail -->
Related-to: https://issues.redhat.com/browse/RHOAIENG-28515

The imagestream name, is immutable field
keep it as per naming convention , mark it life for long term

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
kustomize build manifests/overlays/additional | oc apply -n opendatahub -f -
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated image stream and resource names to use detailed naming conventions reflecting CPU/GPU type, Python version, and base image version across all manifests and configuration files.
  * Replaced older beta image stream references with new, descriptive names for Jupyter notebooks, code-server, and runtime images, ensuring consistency throughout overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->