### PR TITLE
[RHOAIENG-26264] commit*.env references updates automatically at 11:00 UTC using cron job

### DIFF
--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -3,6 +3,8 @@ name: Update commit-latest.env on params-latest.env change
 
 "on":
   workflow_dispatch:
+  schedule:
+    - cron: '0 11 * * *'  # Daily at midnight UTC
   push:
     branches:
       - main


### PR DESCRIPTION
## Description
Update `.github/workflows/update-commit-latest-env.yaml` so it scheduled to run everyday at 11:00 UTC

## How Has This Been Tested?
I ran the GitHub action independently and waited for its scheduled execution time, confirming that both events had occurred
https://github.com/mtchoum1/notebooks/actions/runs/16351652678

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Scheduled a daily automated workflow run at 11:00 UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->