### PR TITLE
RHOAIENG-28514, RHOAIENG-28513: ci(gha): remove Python 3.12 exclusion for .ipynb testing

### DIFF
--- a/ci/cached-builds/has_tests.py
+++ b/ci/cached-builds/has_tests.py
@@ -38,9 +38,6 @@ def check_tests(target: str) -> bool:
     if target.startswith(("rocm-jupyter-minimal-", "rocm-jupyter-datascience-")):
         return False  # we don't have specific tests for -minimal-, ... in ci-operator/config
 
-    if target.endswith("-python-3.12"):
-        return False  # we haven't yet enabled on-cluster testing because that needs valid manifests
-
     build_directory = gha_pr_changed_files.get_build_directory(target)
     kustomization = (
         pathlib.Path(gha_pr_changed_files.PROJECT_ROOT) / build_directory / "kustomize/base/kustomization.yaml"


### PR DESCRIPTION
## Description

Follows up on
* https://github.com/opendatahub-io/notebooks/pull/1247

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/16377150190

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test detection logic to include targets ending with `-python-3.12`, ensuring they are no longer automatically excluded from test checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->