### PR TITLE
RHOAIENG-18535, RHOAIENG-11812, RHOAIENG-18601, RHOAIENG-18613: bump …

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -39,7 +39,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -44,7 +44,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -41,7 +41,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -41,7 +41,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.17"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.2"}
+            {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -45,7 +45,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.2"}
+            {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -44,7 +44,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images


### PR DESCRIPTION
…mysql-connector-python

This is a followup of the previous PR that bumped this version in Pipfiles only. This change is for manifests to the relevant images so it's then properly grabbed by UI etc.

Followup of the #1210.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MySQL Connector/Python dependency to version 9.3 for multiple Jupyter notebook images (including datascience, pytorch, rocm-pytorch, rocm-tensorflow, tensorflow, and trustyai) for the 2025.1 release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->