### PR TITLE
[RHOAIENG-26066] bump TrustyAI image transformers in manifests too

### DIFF
--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -26,7 +26,7 @@ spec:
           [
             {"name": "JupyterLab","version": "4.2"},
             {"name": "TrustyAI", "version": "0.6"},
-            {"name": "Transformers", "version": "4.49"},
+            {"name": "Transformers", "version": "4.50"},
             {"name": "Datasets", "version": "3.4"},
             {"name": "Accelerate", "version": "1.5"},
             {"name": "Torch", "version": "2.6"},


### PR DESCRIPTION
This is a followup of the recent image update to propagate this upgrade also into the image manifest metadata.

This is a followup of this #1127.

https://issues.redhat.com/browse/RHOAIENG-26066

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "Transformers" Python package version in the notebook image metadata from 4.49 to 4.50 for the "2025.1" image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->