### PR TITLE
[2024b] RHOAIENG-19051: chore(Makefile): remove dependency on `bin/buildinputs` for running image tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ endef
 #######################################        Build helpers                 #######################################
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
-skip-init-for := deploy% undeploy% test% scan-image-vulnerabilities
+skip-init-for := deploy% undeploy% test% validate% refresh-pipfilelock-files scan-image-vulnerabilities
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
 $(SELF): bin/buildinputs
 endif


### PR DESCRIPTION
Cherry-pick of

* https://github.com/opendatahub-io/notebooks/pull/948#issuecomment-3106961922

## Description

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process by skipping certain initialization steps for additional targets, specifically those related to validation and pipfile lock file refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->