### PR TITLE
[2024b] RHOAIENG-28774: update the 2024b GitHub Action so that it does not end up pulling the wrong cache

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -106,10 +106,12 @@ jobs:
         run: sudo apt-get -qq remove podman crun
 
       - uses: actions/cache@v4
+        # https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
+        # https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
         id: cached-linuxbrew
         with:
           path: /home/linuxbrew/.linuxbrew
-          key: linuxbrew
+          key: linuxbrew-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install podman
         if: steps.cached-linuxbrew.outputs.cache-hit != 'true'


### PR DESCRIPTION
This is a selective cherry-pick from the

* https://github.com/opendatahub-io/notebooks/pull/1330

because otherwise the x86-64 build may end up fetching arm64 cache and things then would not work.

First, the arm64 cache is too big to fit (2024b partitions disk differently, less space on /) and second, even if it did unpack the cache, it would not be able to run arm64 binaries.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache management in the build workflow for better compatibility across different operating systems and architectures.
  * Added documentation comments to clarify environment variable usage in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->