### PR TITLE
Disable PDF export for s390x architecture in Jupyter Minimal images

### DIFF
--- a/tests/containers/architecture_support.py
+++ b/tests/containers/architecture_support.py
@@ -1,0 +1,11 @@
+"""Centralized configuration for architecture-specific feature limitations."""
+
+ARCHITECTURE_LIMITATIONS = {
+    "s390x": {"pdf_export": False, "pdf_export_reason": "TexLive and Pandoc dependencies not available on s390x"},
+    "x86_64": {"pdf_export": True, "pdf_export_reason": "Full support available"},
+    "aarch64": {"pdf_export": True, "pdf_export_reason": "Full support available"},
+    "ppc64le": {"pdf_export": True, "pdf_export_reason": "Full support available"},
+}
+
+# Architecture mapping from uname -m to common names
+ARCHITECTURE_NAMES = {"x86_64": "x86_64", "aarch64": "arm64", "ppc64le": "ppc64le", "s390x": "s390x"}

--- a/tests/containers/architecture_utils.py
+++ b/tests/containers/architecture_utils.py
@@ -1,0 +1,31 @@
+"""Architecture detection utilities for container tests."""
+
+import pytest
+
+from tests.containers import docker_utils
+from tests.containers.architecture_support import ARCHITECTURE_LIMITATIONS
+from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
+
+
+@pytest.fixture(scope="function")
+def container_architecture(jupyterlab_image):
+    """Cache architecture detection per test function."""
+    container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
+    container.start(wait_for_readiness=False)
+    try:
+        exit_code, arch_output = container.exec(["uname", "-m"])
+        if exit_code == 0:
+            return arch_output.decode().strip()
+        return None
+    finally:
+        docker_utils.NotebookContainer(container).stop(timeout=0)
+
+
+def is_feature_supported(architecture: str, feature: str) -> bool:
+    """Check if a feature is supported on the given architecture."""
+    return ARCHITECTURE_LIMITATIONS.get(architecture, {}).get(feature, True)
+
+
+def get_architecture_limitation_reason(architecture: str, feature: str) -> str:
+    """Get the reason why a feature is not supported on the given architecture."""
+    return ARCHITECTURE_LIMITATIONS.get(architecture, {}).get(f"{feature}_reason", "Unknown limitation")

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -8,6 +8,10 @@ import pytest
 import requests
 
 from tests.containers import conftest, docker_utils
+from tests.containers.architecture_utils import (
+    get_architecture_limitation_reason,
+    is_feature_supported,
+)
 from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
 
 
@@ -56,16 +60,12 @@ class TestJupyterLabImage:
 
     @allure.issue("RHOAIENG-16568")
     @allure.description("Check that PDF export is working correctly")
-    def test_pdf_export(self, jupyterlab_image: conftest.Image) -> None:
+    def test_pdf_export(self, jupyterlab_image: conftest.Image, container_architecture) -> None:
+        # Skip if PDF export is not supported on this architecture
+        if not is_feature_supported(container_architecture, "pdf_export"):
+            reason = get_architecture_limitation_reason(container_architecture, "pdf_export")
+            pytest.skip(f"PDF export functionality is not supported on {container_architecture} architecture: {reason}")
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
-        # Skip if we're running on s390x architecture
-        container.start(wait_for_readiness=False)
-        try:
-            exit_code, arch_output = container.exec(["uname", "-m"])
-            if exit_code == 0 and arch_output.decode().strip() == "s390x":
-                pytest.skip("PDF export functionality is not supported on s390x architecture")
-        finally:
-            docker_utils.NotebookContainer(container).stop(timeout=0)
         test_file_name = "test.ipybn"
         test_file_content = """{
                 "cells": [


### PR DESCRIPTION
@jiridanek: The _enhanced_ tests in the second commit don't pass. I've split out the core of the work (first commit) into a separate PR that I'm looking into merging

* https://github.com/opendatahub-io/notebooks/pull/1751

## Summary
This PR disables PDF export functionality for s390x (IBM Z) architecture in Jupyter Minimal images for both Python 3.11 and 3.12 versions due to known compatibility issues with this feature on s390x.

## Changes Made

### 1. Modified `jupyter/utils/install_pdf_deps.sh`
- Added early exit for s390x architecture detection using `uname -m`
- PDF export dependencies (TexLive and Pandoc) are now skipped for s390x
-
### 2. Updated `ci/cached-builds/gen_gha_matrix_jobs.py`
- Added `jupyter-minimal-ubi9-python-3.11` and `jupyter-minimal-ubi9-python-3.12` to `S390X_COMPATIBLE` set
- Enables s390x builds for these minimal Jupyter images in CI pipeline

### 3. Modified `tests/containers/workbenches/jupyterlab/jupyterlab_test.py`
- Added architecture detection to `test_pdf_export` test
- Test now skips PDF export functionality for s390x architecture
- Prevents test failures on s390x where PDF export is intentionally disabled

## Testing
- Local testing completed for both Python 3.11 and 3.12 versions
- Images build successfully on s390x without PDF export dependencies
- PDF export continues to work on other architectures (x86_64, arm64)
- Test suite passes with architecture-aware PDF export test

## Impact
- **s390x**: PDF export functionality is disabled (as intended)
- **Other architectures**: No change - PDF export continues to work normally
- **CI/CD**: s390x builds are now enabled for Jupyter Minimal images

## Validation
- Github CI Validation
1. Version(3.11)
<img width="1540" height="556" alt="image" src="https://github.com/user-attachments/assets/4483d765-6a75-49a0-a7b9-99367671100f" />
2. Version(3.12)
<img width="1634" height="770" alt="image" src="https://github.com/user-attachments/assets/75738165-afca-4201-8358-7bafe5a511db" />

-  Local Testing on s390x Cluster(3.11/3.12)
<img width="967" height="443" alt="image" src="https://github.com/user-attachments/assets/07455ef3-304f-4510-8720-6956f1d16867" />
<img width="1199" height="555" alt="image" src="https://github.com/user-attachments/assets/62517e80-598b-4bce-a33d-60bea361f08d" />
<img width="1639" height="421" alt="image" src="https://github.com/user-attachments/assets/0849f177-96e7-41d3-b0b6-07ae7a9e316f" />
<img width="1647" height="1006" alt="image" src="https://github.com/user-attachments/assets/9ae1e2c0-3cd1-4fc1-9449-c41997d7a466" />

- Precommit-validation
<img width="1278" height="304" alt="image" src="https://github.com/user-attachments/assets/984df8fa-f8fb-404d-977b-366e12433eb9" />

c.c:- @jiridanek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF export installation and testing are now properly skipped on s390x architecture, preventing unsupported operations and related errors.

* **Chores**
  * Updated compatibility lists to include additional jupyter-minimal images for s390x support.
  * Improved architecture detection and feature support checks for containerized environments to enhance test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->