### PR TITLE
Remove double references of the runtime-pytorch-rocm-py312-ubi9-n on params-latest and commits-latest files

### DIFF
--- a/manifests/base/commit-latest.env
+++ b/manifests/base/commit-latest.env
@@ -24,7 +24,6 @@ odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n=6cfdd8b
 odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-n=7c26b6b
 odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-n=3d24448
 odh-pipeline-runtime-datascience-cpu-py312-ubi9-commit-n=6cfdd8b
-odh-pipeline-runtime-pytorch-rocm-py312-ubi9-commit-n=02f637a
 odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-n=6cfdd8b
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-n=6cfdd8b
 odh-pipeline-runtime-minimal-cpu-py312-ubi9-commit-n=6cfdd8b

--- a/manifests/base/params-latest.env
+++ b/manifests/base/params-latest.env
@@ -24,11 +24,9 @@ odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbenc
 odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9@sha256:8566550f04ea79a95a714c396d981fc9603d86f825494717141b0f6c1e0a6397
 odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9@sha256:2a8cd5c581db355aec24fe5524c22d7f40680b86146952b7564d81a9e8fba106
 odh-pipeline-runtime-datascience-cpu-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9@sha256:1be1c4f7a6ad912b338a49ff6a5dfa88c004c565767bfc86ca895ba20d235b93
-odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9@sha256:9e6df01d7ffc0c3ba8ab45c1c41598c0a018a2a696d886fce003cdf973c73cd4
 odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9@sha256:4d616960c6394f5df6b6aff1181940a3640fac2ecc21bfa038b0b43078434f60
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-n=quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9@sha256:6678033b39a3bc52af6fdc06bd9ab4cdc195eb001cb57f45b955a5645df125ef
 odh-pipeline-runtime-minimal-cpu-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9@sha256:f91b6d74a0330fdfd292a635a84017f9e6ee1cf2e40998b653c89fbc420b9480
 odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9@sha256:a2d0daf5af0ff3fc010561a4acb08d794571072b95962e68c3b4b165683fd08f
 odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9@sha256:6b16319d239c3fca398e371756075be830860a3f76946af3749b0d913cbb5060
 odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9@sha256:9e6df01d7ffc0c3ba8ab45c1c41598c0a018a2a696d886fce003cdf973c73cd4
-


### PR DESCRIPTION

Related to: https://redhat-internal.slack.com/archives/C060A5FJEAD/p1753883746335659 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove double references of the `runtime-pytorch-rocm-py312-ubi9-n` on params-latest and commits-latest files, it was added accidentally two times in there which is not correct. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No test needed but you can do `kustomize build manifests/base > output.yaml` 


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate entries for a specific image in environment configuration files to ensure each appears only once. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->