### PR TITLE
chore: Update Image name retrieved field to fix the params-validator

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -242,7 +242,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
         odh-workbench-rstudio-minimal-cpu-py311-c9s-n)
             expected_name="odh-notebook-rstudio-server-c9s-python-3.11"
             expected_commitref="main"
-            expected_build_name="rstudio-c9s-python-3.11-amd64"
+            expected_build_name="konflux"
             expected_img_size=1377
             ;;
         odh-workbench-rstudio-minimal-cpu-py311-c9s-n-1)
@@ -257,7 +257,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
         odh-workbench-rstudio-minimal-cuda-py311-c9s-n)
             expected_name="odh-notebook-rstudio-server-cuda-c9s-python-3.11"
             expected_commitref="main"
-            expected_build_name="cuda-rstudio-c9s-python-3.11-amd64"
+            expected_build_name="konflux"
             expected_img_size=6541
             ;;
         odh-workbench-rstudio-minimal-cuda-py311-c9s-n-1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Check params validator fails because wasn't updated based the latest changes (Onboard RStudio to konflux as well): https://github.com/opendatahub-io/notebooks/actions/runs/16630011060/job/47056679708?pr=1570#logs


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Now GHA is green: https://github.com/atheo89/notebooks/actions/runs/16645240481/job/47104233706 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build name references for specific image variables to use a generic value. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->