### PR TITLE
RHAIENG-568: Issue opendatahub-io/notebooks#385: decrease Python 3.11 CUDA images size by installing less

### DIFF
--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -98,49 +98,23 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/Dockerfile
-ENV NV_CUDA_CUDART_DEV_VERSION=12.6.77-1
-ENV NV_NVML_DEV_VERSION=12.6.77-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.6.4.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.3.1.54-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-6-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.23.4-1
-ENV NCCL_VERSION=2.23.4
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.6
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.6.3-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-6-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-6-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-6-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-6-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn9 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn9 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.5.1.17-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -111,49 +111,23 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/Dockerfile
-ENV NV_CUDA_CUDART_DEV_VERSION=12.6.77-1
-ENV NV_NVML_DEV_VERSION=12.6.77-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.6.4.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.3.1.54-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-6-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.23.4-1
-ENV NCCL_VERSION=2.23.4
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.6
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.6.3-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-6-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-6-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-6-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-6-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn9 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn9 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.5.1.17-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -111,49 +111,23 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/Dockerfile
-ENV NV_CUDA_CUDART_DEV_VERSION=12.6.77-1
-ENV NV_NVML_DEV_VERSION=12.6.77-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.6.4.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.3.1.54-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-6-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.23.4-1
-ENV NCCL_VERSION=2.23.4
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.6
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.6.3-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-6-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-6-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-6-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-6-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn9 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn9 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.5.1.17-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -104,49 +104,23 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/Dockerfile
-ENV NV_CUDA_CUDART_DEV_VERSION=12.6.77-1
-ENV NV_NVML_DEV_VERSION=12.6.77-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.6.4.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.3.1.54-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-6-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.23.4-1
-ENV NCCL_VERSION=2.23.4
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.6
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.6.3-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-6-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-6-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-6-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-6-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn9 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn9 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.5.1.17-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -127,50 +127,23 @@ RUN yum install -y \
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubi9/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION=12.4.1-1
-ENV NV_CUDA_CUDART_DEV_VERSION=12.4.127-1
-ENV NV_NVML_DEV_VERSION=12.4.127-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.4.5.8-1
-ENV NV_LIBNPP_DEV_VERSION=12.2.5.30-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-4-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.21.5-1
-ENV NCCL_VERSION=2.21.5
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.4
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.4.1-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-4-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-4-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-4-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-4-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-4-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-4-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-4-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn8 from:
-# hhttps://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn8 from:
+# hhttps://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.1.0.70-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -98,49 +98,23 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/Dockerfile
-ENV NV_CUDA_CUDART_DEV_VERSION=12.6.77-1
-ENV NV_NVML_DEV_VERSION=12.6.77-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.6.4.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.3.1.54-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-6-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.23.4-1
-ENV NCCL_VERSION=2.23.4
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.6
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.6.3-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-6-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-6-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-6-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-6-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn9 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn9 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.5.1.17-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -98,49 +98,23 @@ RUN yum install -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-# Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/Dockerfile
-ENV NV_CUDA_CUDART_DEV_VERSION=12.6.77-1
-ENV NV_NVML_DEV_VERSION=12.6.77-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.6.4.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.3.1.54-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-6-${NV_LIBNPP_DEV_VERSION}
-ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.23.4-1
-ENV NCCL_VERSION=2.23.4
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.6
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.6.3-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-6-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+# Install devel tools
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-6-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-6-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-6-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-6-${NV_LIBCUBLAS_DEV_VERSION} \
-    ${NV_LIBNPP_DEV_PACKAGE} \
-    ${NV_LIBNCCL_DEV_PACKAGE} \
-    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-# Install CUDA devel cudnn9 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/devel/cudnn/Dockerfile
+# Install CUDA cudnn9 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.6.3/ubi9/runtime/cudnn/Dockerfile
 ENV NV_CUDNN_VERSION=9.5.1.17-1
 ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
-    ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-568

## Description

* https://github.com/opendatahub-io/notebooks/pull/1408

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified container images by removing CUDA development libraries and tools, retaining only essential development utilities and CUDA/cuDNN runtime components.
  * Updated comments to reference runtime package sources instead of development package sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->