### PR TITLE
Issue opendatahub-io/notebooks#1598: RHAIENG-337: add support for `pytorch+llmcompressor` variants to Makefile for jupyter and runtime CUDA images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ cuda-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
 cuda-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
 	$(call image,$@,jupyter/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
 
+.PHONY: cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION)
+cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION):
+	$(call image,$@,jupyter/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+
 .PHONY: jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION):
 	$(call image,$@,jupyter/trustyai/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
@@ -149,6 +153,10 @@ runtime-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION):
 .PHONY: runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
 	$(call image,$@,runtimes/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+
+.PHONY: runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION)
+runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION):
+	$(call image,$@,runtimes/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
 
 .PHONY: runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
@@ -399,6 +407,7 @@ ifeq ($(PYTHON_VERSION), 3.11)
 		jupyter/pytorch/ubi9-python-$(PYTHON_VERSION) \
 		jupyter/tensorflow/ubi9-python-$(PYTHON_VERSION) \
 		jupyter/trustyai/ubi9-python-$(PYTHON_VERSION) \
+		jupyter/pytorch+llmcompressor/ubi9-python-$(PYTHON_VERSION) \
 		jupyter/rocm/tensorflow/ubi9-python-$(PYTHON_VERSION) \
 		jupyter/rocm/pytorch/ubi9-python-$(PYTHON_VERSION) \
 		codeserver/ubi9-python-$(PYTHON_VERSION) \
@@ -484,10 +493,12 @@ all-images: \
 	cuda-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	cuda-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	cuda-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
+	cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	runtime-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	runtime-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION) \
+	runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	codeserver-ubi9-python-$(RELEASE_PYTHON_VERSION) \
 	rstudio-c9s-python-$(RELEASE_PYTHON_VERSION) \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -28,6 +28,8 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base
 
+ARG TARGETARCH
+
 ARG CUDA_SOURCE_CODE=cuda
 
 # Install CUDA base from:
@@ -39,7 +41,7 @@ ENV NVARCH=x86_64
 ENV NVIDIA_REQUIRE_CUDA "cuda>=12.4 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526 brand=tesla,driver>=535,driver<536 brand=unknown,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=geforce,driver>=535,driver<536 brand=geforcertx,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=titan,driver>=535,driver<536 brand=titanrtx,driver>=535,driver<536"
 ENV NV_CUDA_CUDART_VERSION 12.4.127-1
 
-COPY ${CUDA_SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+COPY ${CUDA_SOURCE_CODE}/cuda.repo-${TARGETARCH} /etc/yum.repos.d/cuda.repo
 COPY ${CUDA_SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
@@ -137,7 +139,7 @@ RUN yum install -y \
 #     ${NV_CUDNN_PACKAGE_DEV} \
 #     && yum clean all \
 #     && rm -rf /var/cache/yum/*
-    
+
 # # Set this flag so that libraries can find the location of CUDA
 # ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
@@ -148,7 +150,7 @@ WORKDIR /opt/app-root/src
 #########################
 # cuda-jupyter-minimal  #
 #########################
-FROM cuda-base AS cuda-jupyter-minimal  
+FROM cuda-base AS cuda-jupyter-minimal
 
 ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.11
@@ -158,7 +160,7 @@ WORKDIR /opt/app-root/bin
 COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
-    
+
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -230,11 +232,11 @@ RUN echo "Installing softwares and packages" && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \    
+    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
     # Disable announcement plugin of jupyterlab \
-    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \    
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Apply JupyterLab addons \
-    /opt/app-root/bin/utils/addons/apply.sh && \    
+    /opt/app-root/bin/utils/addons/apply.sh && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -1,3 +1,16 @@
+######################################################
+# mongocli-builder (build stage only, not published) #
+######################################################
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+
+ARG MONGOCLI_VERSION=2.0.3
+
+WORKDIR /tmp/
+RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip
+RUN unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
+RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
+    CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
+
 ####################
 # base             #
 ####################
@@ -47,7 +60,6 @@ COPY ${CUDA_SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
-
 
 ENV CUDA_VERSION 12.4.
 
@@ -161,6 +173,14 @@ COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
+USER 0
+
+# Dependencies for PDF export
+RUN ./utils/install_pdf_deps.sh
+ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
+
+USER 1001
+
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
@@ -180,13 +200,11 @@ USER root
 # Install useful OS packages
 RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
 
-# Install MongoDB Client, We need a special repo for MongoDB as they do their own distribution
-COPY ${DATASCIENCE_SOURCE_CODE}/mongodb-org-6.0.repo-x86_64 /etc/yum.repos.d/mongodb-org-6.0.repo
-
-RUN dnf install -y mongocli && dnf clean all && rm -rf /var/cache/yum
+# Copy dynamically-linked mongocli built in earlier build stage
+COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
 
 # Install MSSQL Client, We need a special repo for MSSQL as they do their own distribution
-COPY ${DATASCIENCE_SOURCE_CODE}/mssql-2022.repo-x86_64 /etc/yum.repos.d/mssql-2022.repo
+COPY ${DATASCIENCE_SOURCE_CODE}/mssql-2022.repo /etc/yum.repos.d/mssql-2022.repo
 
 RUN ACCEPT_EULA=Y dnf install -y mssql-tools18 unixODBC-devel && dnf clean all && rm -rf /var/cache/yum
 
@@ -207,7 +225,6 @@ FROM cuda-jupyter-datascience AS cuda-jupyter-pytorch
 
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.11
 ARG PYTORCH_SOURCE_CODE=jupyter/pytorch+llmcompressor/ubi9-python-3.11
-
 
 WORKDIR /opt/app-root/bin
 
@@ -233,6 +250,8 @@ RUN echo "Installing softwares and packages" && \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
     sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
+    # copy jupyter configuration
+    cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Apply JupyterLab addons \
@@ -246,4 +265,3 @@ COPY ${DATASCIENCE_SOURCE_CODE}/runtime-images/ /opt/app-root/share/jupyter/meta
 COPY ${PYTORCH_SOURCE_CODE}/runtime-images/ /opt/app-root/share/jupyter/metadata/runtime-images/
 
 WORKDIR /opt/app-root/src
-

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -61,8 +61,7 @@ RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION 12.4.
-
+ENV CUDA_VERSION 12.4.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -48,9 +48,7 @@ RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-
-ENV CUDA_VERSION 12.4.
-
+ENV CUDA_VERSION 12.4.1
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -28,6 +28,8 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base
 
+ARG TARGETARCH
+
 ARG CUDA_SOURCE_CODE=cuda
 
 # Install CUDA base from:
@@ -39,7 +41,7 @@ ENV NVARCH=x86_64
 ENV NVIDIA_REQUIRE_CUDA "cuda>=12.4 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526 brand=tesla,driver>=535,driver<536 brand=unknown,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=geforce,driver>=535,driver<536 brand=geforcertx,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=titan,driver>=535,driver<536 brand=titanrtx,driver>=535,driver<536"
 ENV NV_CUDA_CUDART_VERSION 12.4.127-1
 
-COPY ${CUDA_SOURCE_CODE}/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+COPY ${CUDA_SOURCE_CODE}/cuda.repo-${TARGETARCH} /etc/yum.repos.d/cuda.repo
 COPY ${CUDA_SOURCE_CODE}/NGC-DL-CONTAINER-LICENSE /
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
@@ -137,7 +139,7 @@ RUN yum install -y \
 #     ${NV_CUDNN_PACKAGE_DEV} \
 #     && yum clean all \
 #     && rm -rf /var/cache/yum/*
-    
+
 # # Set this flag so that libraries can find the location of CUDA
 # ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-337

## Description
* https://github.com/opendatahub-io/notebooks/pull/1519

## How Has This Been Tested?
* https://github.com/jiridanek/notebooks/actions/runs/16686256890/job/47236206073
* https://github.com/jiridanek/notebooks/actions/runs/16687017839

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for building new "pytorch+llmcompressor" Jupyter and runtime CUDA Python images.
  * Included these new image variants in the full build process for Python 3.11.
  * Improved build flexibility by enabling dynamic selection of CUDA repository files based on target architecture.
  * Enhanced PDF export capabilities and Jupyter server configuration in the new image variants.
  * Updated CUDA version to 12.4.1 and optimized MongoDB CLI installation in Jupyter images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->