### PR TITLE
RHOAIENG-26513: tests(containers): skip torchaudio test

### DIFF
--- a/tests/containers/workbenches/jupyterlab/libraries_testunits.py
+++ b/tests/containers/workbenches/jupyterlab/libraries_testunits.py
@@ -108,7 +108,11 @@ class TestDataScienceLibs(unittest.TestCase):
         """🧪 Tests torchaudio waveform generation."""
         if "-pytorch-" not in self.image:
             self.skipTest("Not a Torch image")
-        import torchaudio  # pyright: ignore[reportMissingImports]
+        try:
+            import torchaudio  # pyright: ignore[reportMissingImports]
+        except ImportError:
+            # TODO: determine if having torchaudio installed is a requirement
+            self.skipTest("Torchaudio is not installed.")
 
         sample_rate = 16000
         waveform = torchaudio.functional.generate_sine(440, sample_rate=sample_rate, duration=0.5)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-26513

## Description

* https://github.com/opendatahub-io/notebooks/pull/1421

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/16690731388

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by skipping the torchaudio-related test if the module is not installed, instead of causing a failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->