### PR TITLE
update runtime-minimal-python312 image for ppc64le

### DIFF
--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -12,7 +12,7 @@ USER 0
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \
     PACKAGES="mesa-libGL skopeo" && \
-    if [ "$ARCH" = "s390x" ]; then \
+    if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then \
         PACKAGES="$PACKAGES gcc g++ make openssl-devel autoconf automake libtool cmake"; \
     fi && \
     dnf install -y $PACKAGES && \


### PR DESCRIPTION
This PR adds additional packages in minimal runtime Dockerfile.cpu for ppc64le as pyzmq require them. Without these changes, image is failing to build on ppc64le with following error:

```
127.3   note: This error originates from a subprocess, and is likely not a problem with pip.
127.3   ERROR: Failed building wheel for pyzmq
127.3 Failed to build pyzmq
127.3 ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (pyzmq)
127.6 Failed to install requirements, dependency 'pyzmq' could not be installed
```

This change ensures notebook runtime minimal builds are successfull on IBM Power (ppc64le) and it will not impact to x86_64 builds.

Tested on: ppc64le

Able to build runtime-minimal image for python3.12 with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved support for additional architectures during installation by updating the package installation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->