### PR TITLE
docs(examples): hadolint insists on --no-cache-dir, even though we already take care of this in s2i env variables

### DIFF
--- a/examples/jupyterlab-with-elyra/Dockerfile
+++ b/examples/jupyterlab-with-elyra/Dockerfile
@@ -68,7 +68,7 @@ numpy~=2.2.3
 EOF
 
 RUN echo "Installing software and packages" && \
-    pip install -r requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt && \
     rm -f ./Pipfile.lock && \
     # Prepare directories for elyra runtime configuration
     mkdir /opt/app-root/runtimes && \


### PR DESCRIPTION
## Description

```
Starting Hadolint
./examples/jupyterlab-with-elyra/Dockerfile:70 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
Error: Process completed with exit code 123.
```

https://github.com/opendatahub-io/notebooks/actions/runs/16781558093/job/47521315676?pr=1686

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Python package installation by disabling pip cache during setup, reducing disk space usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->