### PR TITLE
RHOAIENG-11679: update kustomization.yaml to replace deprecated `commonLabels` with `labels` using `includeSelectors` structure

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/kustomize/base/kustomization.yaml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/kustomize/base/kustomization.yaml
@@ -2,8 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: jupyter-pytorch-llmcompressor-ubi9-python-3-11-
-commonLabels:
-  app: jupyter-pytorch-llmcompressor-ubi9-python-3-11
+labels:
+  - includeSelectors: true
+    pairs:
+      app: jupyter-pytorch-llmcompressor-ubi9-python-3-11
 resources:
   - service.yaml
   - statefulset.yaml


### PR DESCRIPTION
## Description

* https://github.com/opendatahub-io/notebooks/pull/996

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/16799610538

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated label configuration in deployment settings to use a selector-based structure for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->