### PR TITLE
NO-JIRA: workflows: allow parallelism with concurrency groups by adding Python version matrix in `piplock-renewal.yaml`

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -36,7 +36,7 @@ jobs:
   refresh-pipfile-locks:
     runs-on: ubuntu-latest
     concurrency:
-      group: refresh-pipfile-locks-${{ github.ref }}
+      group: refresh-pipfile-locks-${{ matrix.python-version }}-${{ github.ref }}
       cancel-in-progress: false
     strategy:
       fail-fast: false


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/pull/1397
* https://github.com/opendatahub-io/notebooks/pull/1398

## Description

Before:
<img width="1236" height="551" alt="Screenshot 2025-08-07 at 1 43 28 PM" src="https://github.com/user-attachments/assets/046b2e96-167a-4416-9119-7130a8abd42a" />

After:
<img width="1090" height="530" alt="Screenshot 2025-08-07 at 1 43 36 PM" src="https://github.com/user-attachments/assets/1765407a-3c07-4d5b-a9cb-7c93d3a265cb" />

## How Has This Been Tested?

* Before: https://github.com/jiridanek/notebooks/actions/runs/16803230273
* After: https://github.com/jiridanek/notebooks/actions/runs/16803462147

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to improve concurrency control for pipfile lock refresh jobs, allowing separate handling per Python version and branch.
  * Upgraded several Python package dependencies to newer versions across multiple environments for improved stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->