### PR TITLE
RHOAIENG-30769: disable PDF export for s390x architecture in Jupyter Minimal images

### DIFF
--- a/ci/cached-builds/gen_gha_matrix_jobs.py
+++ b/ci/cached-builds/gen_gha_matrix_jobs.py
@@ -33,6 +33,8 @@ ARM64_COMPATIBLE = {
 S390X_COMPATIBLE = {
     "runtime-minimal-ubi9-python-3.11",
     "runtime-minimal-ubi9-python-3.12",
+    "jupyter-minimal-ubi9-python-3.11",
+    "jupyter-minimal-ubi9-python-3.12",
     # add more here
 }
 

--- a/jupyter/datascience/ubi9-python-3.12/Pipfile
+++ b/jupyter/datascience/ubi9-python-3.12/Pipfile
@@ -45,7 +45,7 @@ nbgitpuller = "~=1.2.2"
 
 # Base packages
 wheel = "~=0.45.1"
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 
 [requires]
 python_version = "3.12"

--- a/jupyter/datascience/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/datascience/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d5b391168c57546b81cb6f95e45db5d5e246bda2c28e9b76b4af43e5eba1518f"
+            "sha256": "68a05da52572c870d37b37cb3c7318ce454e97a59589f545682f4e087dfd4965"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -3847,12 +3847,12 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "simpervisor": {
             "hashes": [

--- a/jupyter/datascience/ubi9-python-3.12/requirements.txt
+++ b/jupyter/datascience/ubi9-python-3.12/requirements.txt
@@ -2739,9 +2739,9 @@ scipy==1.15.3; python_version >= '3.10' \
 send2trash==1.8.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 simpervisor==1.0.0; python_version >= '3.8' \
     --hash=sha256:3e313318264559beea3f475ead202bc1cd58a2f1288363abb5657d306c5b8388 \
     --hash=sha256:7eb87ca86d5e276976f5bb0290975a05d452c6a7b7f58062daea7d8369c823c1

--- a/jupyter/minimal/ubi9-python-3.12/Pipfile
+++ b/jupyter/minimal/ubi9-python-3.12/Pipfile
@@ -18,7 +18,7 @@ nbgitpuller = "~=1.2.2"
 
 # Base packages
 wheel = "~=0.45.1"
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 
 [requires]
 python_version = "3.12"

--- a/jupyter/minimal/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/minimal/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78abf6055903cf51771c1f967953018584bd87bd7517d05c623af7bd3b6d2958"
+            "sha256": "0ae788ae6067bbc637462845eb1f345e91b3726aab8f37bb9f95e5c44e47f451"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1700,12 +1700,12 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "simpervisor": {
             "hashes": [

--- a/jupyter/minimal/ubi9-python-3.12/requirements.txt
+++ b/jupyter/minimal/ubi9-python-3.12/requirements.txt
@@ -1228,9 +1228,9 @@ rpds-py==0.27.0; python_version >= '3.9' \
 send2trash==1.8.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 simpervisor==1.0.0; python_version >= '3.8' \
     --hash=sha256:3e313318264559beea3f475ead202bc1cd58a2f1288363abb5657d306c5b8388 \
     --hash=sha256:7eb87ca86d5e276976f5bb0290975a05d452c6a7b7f58062daea7d8369c823c1

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Pipfile
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Pipfile
@@ -70,7 +70,7 @@ nbgitpuller = "~=1.2.2"
 
 # Base packages
 wheel = "~=0.45.1"
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 
 [requires]
 python_version = "3.11"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Pipfile.lock
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "69c0abed1f72e82b44b19295936a748ee4e53e701ded1005e8d2e8191e141998"
+            "sha256": "2460e9b21b0a65a6170bd502a859ae97a445a10117d911bef107a952d3b55882"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -4222,12 +4222,12 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "simpervisor": {
             "hashes": [
@@ -6738,11 +6738,11 @@
         },
         "openai": {
             "hashes": [
-                "sha256:2c9d8e498c298f51bb94bcac724257a3a6cac6139ccdfc1186c6708f7a93120f",
-                "sha256:8eeccc69e0ece1357b51ca0d9fb21324afee09b20c3e5b547d02445ca18a4e03"
+                "sha256:1a0e2910e4545d828c14218f2ac3276827c94a043f5353e43b9413b38b497897",
+                "sha256:c786a03f6cddadb5ee42c6d749aa4f6134fe14fdd7d69a667e5e7ce7fd29a719"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.99.1"
+            "version": "==1.99.3"
         },
         "opencv-python-headless": {
             "hashes": [

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/requirements.txt
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/requirements.txt
@@ -2968,9 +2968,9 @@ scipy==1.15.3; python_version >= '3.10' \
 send2trash==1.8.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 simpervisor==1.0.0; python_version >= '3.8' \
     --hash=sha256:3e313318264559beea3f475ead202bc1cd58a2f1288363abb5657d306c5b8388 \
     --hash=sha256:7eb87ca86d5e276976f5bb0290975a05d452c6a7b7f58062daea7d8369c823c1
@@ -4118,9 +4118,9 @@ numba==0.61.2; python_version >= '3.10' \
     --hash=sha256:cf9f9fc00d6eca0c23fc840817ce9f439b9f03c8f03d6246c0e7f0cb15b7162a \
     --hash=sha256:ea0247617edcb5dd61f6106a56255baab031acc4257bddaeddb3a1003b4ca3fd \
     --hash=sha256:efd3db391df53aaa5cfbee189b6c910a5b471488749fd6606c3f33fc984c2ae2
-openai==1.99.1; python_version >= '3.8' \
-    --hash=sha256:2c9d8e498c298f51bb94bcac724257a3a6cac6139ccdfc1186c6708f7a93120f \
-    --hash=sha256:8eeccc69e0ece1357b51ca0d9fb21324afee09b20c3e5b547d02445ca18a4e03
+openai==1.99.3; python_version >= '3.8' \
+    --hash=sha256:1a0e2910e4545d828c14218f2ac3276827c94a043f5353e43b9413b38b497897 \
+    --hash=sha256:c786a03f6cddadb5ee42c6d749aa4f6134fe14fdd7d69a667e5e7ce7fd29a719
 opencv-python-headless==4.11.0.86; python_version >= '3.6' \
     --hash=sha256:0e0a27c19dd1f40ddff94976cfe43066fbbe9dfbb2ec1907d66c19caef42a57b \
     --hash=sha256:48128188ade4a7e517237c8e1e11a9cdf5c282761473383e77beb875bb1e61ca \

--- a/jupyter/pytorch/ubi9-python-3.12/Pipfile
+++ b/jupyter/pytorch/ubi9-python-3.12/Pipfile
@@ -55,7 +55,7 @@ nbgitpuller = "~=1.2.2"
 
 # Base packages
 wheel = "~=0.45.1"
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 
 [requires]
 python_version = "3.12"

--- a/jupyter/pytorch/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/pytorch/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "66165cb754e099e3f26f32d3576b940b41720e40ebb937575d462ce3746dfbff"
+            "sha256": "df11d0210f4cd2baa77dfe6ec9774f1cb068226d27f830336d8d2bd12b2fddd1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -4004,12 +4004,12 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "simpervisor": {
             "hashes": [

--- a/jupyter/pytorch/ubi9-python-3.12/requirements.txt
+++ b/jupyter/pytorch/ubi9-python-3.12/requirements.txt
@@ -2813,9 +2813,9 @@ scipy==1.15.3; python_version >= '3.10' \
 send2trash==1.8.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 simpervisor==1.0.0; python_version >= '3.8' \
     --hash=sha256:3e313318264559beea3f475ead202bc1cd58a2f1288363abb5657d306c5b8388 \
     --hash=sha256:7eb87ca86d5e276976f5bb0290975a05d452c6a7b7f58062daea7d8369c823c1

--- a/jupyter/tensorflow/ubi9-python-3.12/Pipfile
+++ b/jupyter/tensorflow/ubi9-python-3.12/Pipfile
@@ -50,7 +50,7 @@ nbgitpuller = "~=1.2.2"
 
 # Base packages
 wheel = "~=0.45.1"
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 
 [requires]
 python_version = "3.12"

--- a/jupyter/tensorflow/ubi9-python-3.12/Pipfile.lock
+++ b/jupyter/tensorflow/ubi9-python-3.12/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "19d604546bf7d6325fe8a8787b92bd221b66e1d58127a3a254ec0aff1867e658"
+            "sha256": "9390adf167f390408009a2a759ae3ea35ce363ea0bde58ccd2dd855301fef9ad"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -4173,12 +4173,12 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "simpervisor": {
             "hashes": [

--- a/jupyter/tensorflow/ubi9-python-3.12/requirements.txt
+++ b/jupyter/tensorflow/ubi9-python-3.12/requirements.txt
@@ -2955,9 +2955,9 @@ scipy==1.15.3; python_version >= '3.10' \
 send2trash==1.8.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 simpervisor==1.0.0; python_version >= '3.8' \
     --hash=sha256:3e313318264559beea3f475ead202bc1cd58a2f1288363abb5657d306c5b8388 \
     --hash=sha256:7eb87ca86d5e276976f5bb0290975a05d452c6a7b7f58062daea7d8369c823c1

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -17,6 +17,12 @@ if [[ -z "${ARCH:-}" ]]; then
     exit 1
 fi
 
+# Skip PDF export installation for s390x architecture
+if [[ "$(uname -m)" == "s390x" ]]; then
+    echo "PDF export functionality is not supported on s390x architecture. Skipping installation."
+    exit 0
+fi
+
 # tex live installation
 echo "Installing TexLive to allow PDf export from Notebooks"
 curl -fL https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -o install-tl-unx.tar.gz

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Pipfile
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Pipfile
@@ -70,7 +70,7 @@ traitlets = "~=5.14.3"
 urllib3 = "~=2.3.0"
 
 # Base packages
-setuptools = "==75.8.2"
+setuptools = "~=78.1.1"
 wheel = "==0.45.1"
 
 [requires]

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -58,6 +58,14 @@ class TestJupyterLabImage:
     @allure.description("Check that PDF export is working correctly")
     def test_pdf_export(self, jupyterlab_image: conftest.Image) -> None:
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
+        # Skip if we're running on s390x architecture
+        container.start(wait_for_readiness=False)
+        try:
+            exit_code, arch_output = container.exec(["uname", "-m"])
+            if exit_code == 0 and arch_output.decode().strip() == "s390x":
+                pytest.skip("PDF export functionality is not supported on s390x architecture")
+        finally:
+            docker_utils.NotebookContainer(container).stop(timeout=0)
         test_file_name = "test.ipybn"
         test_file_content = """{
                 "cells": [


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/pull/1521

Pipfile locking
* https://github.com/jiridanek/notebooks/actions/runs/16814498242
* https://github.com/jiridanek/notebooks/actions/runs/16824400088 (redo after rebase to fix conflicts)

## Summary
This PR disables PDF export functionality for s390x (IBM Z) architecture in Jupyter Minimal images for both Python 3.11 and 3.12 versions due to known compatibility issues with this feature on s390x.

## Changes Made

### 1. Modified `jupyter/utils/install_pdf_deps.sh`
- Added early exit for s390x architecture detection using `uname -m`
- PDF export dependencies (TexLive and Pandoc) are now skipped for s390x

### 2. Updated `ci/cached-builds/gen_gha_matrix_jobs.py`
- Added `jupyter-minimal-ubi9-python-3.11` and `jupyter-minimal-ubi9-python-3.12` to `S390X_COMPATIBLE` set
- Enables s390x builds for these minimal Jupyter images in CI pipeline

### 3. Modified `tests/containers/workbenches/jupyterlab/jupyterlab_test.py`
- Added architecture detection to `test_pdf_export` test
- Test now skips PDF export functionality for s390x architecture
- Prevents test failures on s390x where PDF export is intentionally disabled

## Testing
- Local testing completed for both Python 3.11 and 3.12 versions
- Images build successfully on s390x without PDF export dependencies
- PDF export continues to work on other architectures (x86_64, arm64)
- Test suite passes with architecture-aware PDF export test

## Impact
- **s390x**: PDF export functionality is disabled (as intended)
- **Other architectures**: No change - PDF export continues to work normally
- **CI/CD**: s390x builds are now enabled for Jupyter Minimal images

## Validation
- Github CI Validation
1. Version(3.11)
<img width="1540" height="556" alt="image" src="https://github.com/user-attachments/assets/4483d765-6a75-49a0-a7b9-99367671100f" />
2. Version(3.12)
<img width="1634" height="770" alt="image" src="https://github.com/user-attachments/assets/75738165-afca-4201-8358-7bafe5a511db" />

-  Local Testing on s390x Cluster(3.11/3.12)
<img width="967" height="443" alt="image" src="https://github.com/user-attachments/assets/07455ef3-304f-4510-8720-6956f1d16867" />
<img width="1199" height="555" alt="image" src="https://github.com/user-attachments/assets/62517e80-598b-4bce-a33d-60bea361f08d" />
<img width="1639" height="421" alt="image" src="https://github.com/user-attachments/assets/0849f177-96e7-41d3-b0b6-07ae7a9e316f" />
<img width="1647" height="1006" alt="image" src="https://github.com/user-attachments/assets/9ae1e2c0-3cd1-4fc1-9449-c41997d7a466" />

- Precommit-validation
<img width="1278" height="304" alt="image" src="https://github.com/user-attachments/assets/984df8fa-f8fb-404d-977b-366e12433eb9" />

c.c:- @jiridanek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for new minimal Jupyter images with Python 3.11 and 3.12 for s390x architecture.

* **Bug Fixes**
  * PDF export dependencies and related tests are now properly skipped on s390x systems to prevent unsupported operations.

* **Chores**
  * Updated the setuptools package to version 78.1.1 across multiple Python environments for improved compatibility and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->