### PR TITLE
NO-JIRA: chore(gha): add workflow to label PRs with "review-requested" on creation

### DIFF
--- a/.github/workflows/notify-team-to-review-pr.yml
+++ b/.github/workflows/notify-team-to-review-pr.yml
@@ -1,0 +1,25 @@
+---
+name: Add Review Requested Label
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-label:
+    if: contains(github.event.pull_request.labels.*.name, 'konflux-nudge') == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add review-requested label
+        uses: actions/github-script@v7
+        with:
+          # language=javascript
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['review-requested']
+            });


### PR DESCRIPTION
## Description

This follows @atheo89 's suggestion to set the label using Github Actions Workflow instead of using the PR TEMPLATE file and Prow as I intended originally.

The problem being solved is that Slack currently spams the PR notification channel with konflux-nudge PRs, which is distracting.

## How Has This Been Tested?

```
/github unsubscribe opendatahub-io/notebooks pulls
/github subscribe opendatahub-io/notebooks pulls +label:review-requested
```

---

Check that the GHA works to set the label

* https://github.com/jiridanek/notebooks/pull/20 (simulated regular PR)
* https://github.com/jiridanek/notebooks/pull/21 (simulated nudge PR)

---

Check that the slack commands work to subscribe the repo correctly

* https://github.com/opendatahub-io/notebooks/pull/1814 (did not trigger slack notify)
* https://github.com/opendatahub-io/notebooks/pull/1813 (did trigger slack notify)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow that adds a "review-requested" label to newly opened pull requests if not already labeled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->