### PR TITLE
Rename accelerator_flavor to keep both local and global variables

### DIFF
--- a/scripts/test_jupyter_with_papermill.sh
+++ b/scripts/test_jupyter_with_papermill.sh
@@ -346,8 +346,8 @@ function _handle_test()
     local notebook_id=
 
     # Due to existing logic - cuda accelerator value needs to be treated as empty string
-    local accelerator_flavor="${accelerator_flavor}"
-    accelerator_flavor="${accelerator_flavor##'cuda'}"
+    local accelerator="${accelerator_flavor}"
+    accelerator="${accelerator_flavor##'cuda'}"
 
 
     case "${notebook_workload_name}" in
@@ -361,10 +361,10 @@ function _handle_test()
             notebook_id="${jupyter_trustyai_notebook_id}"
             ;;
         *${jupyter_tensorflow_notebook_id}-*)
-            notebook_id="${accelerator_flavor:+$accelerator_flavor/}${jupyter_tensorflow_notebook_id}"
+            notebook_id="${accelerator:+$accelerator/}${jupyter_tensorflow_notebook_id}"
             ;;
         *${jupyter_pytorch_notebook_id}-*)
-            notebook_id="${accelerator_flavor:+$accelerator_flavor/}${jupyter_pytorch_notebook_id}"
+            notebook_id="${accelerator:+$accelerator/}${jupyter_pytorch_notebook_id}"
             ;;
         *)
             printf '%s\n' "No matching condition found for ${notebook_workload_name}."


### PR DESCRIPTION
This fix will keep the accelerator_flavor a global variable and turn the empty CUDA value empty just inside the function, as a local variable..

## Description

When a job was executed, it was searching by default for a CPU accelerator, even when an image was running with CUDA.

This did happen because in a function, if it was CUDA, the variable would be cleared out:

```
    # Due to existing logic - cuda accelerator value needs to be treated as empty string
    local accelerator_flavor="${accelerator_flavor}"
    accelerator_flavor="${accelerator_flavor##'cuda'}"
```

later, when dealing with Python 3.12 images, if the variable was empty, the default option would be CPU (but it was CUDA before the script cleared it out)

```
    case "${python_flavor}" in
        python-3.12)
            ...
            local imagestream_accelerator_flavor="${accelerator_flavor:-cpu}"
```

## How Has This Been Tested?
This has been locally tested.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal variable naming and handling for accelerator types in test scripts. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->