### PR TITLE
NO-JIRA: ensure empty lines are skipped while processing env files in `check-params-env.sh`

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -52,7 +52,7 @@ function check_variables_uniq() {
     echo "Checking that all variables in the file '${env_file_path_1}' & '${env_file_path_2}' are unique and expected"
 
     local content
-    content=$(sed 's#\(.*\)=.*#\1#' "${env_file_path_1}"; sed 's#\(.*\)=.*#\1#' "${env_file_path_2}" | sort)
+    content=$(sed '/^$/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#\(.*\)=.*#\1#' | sort)
 
     local num_records
     num_records=$(echo "${content}" | wc -l)
@@ -69,7 +69,7 @@ function check_variables_uniq() {
     if test "${allow_value_duplicity}" = "false"; then
         echo "Checking that all values assigned to variables in the file '${env_file_path_1}' & '${env_file_path_2}' are unique and expected"
 
-        content=$(sed 's#\(.*\)=.*#\1#' "${env_file_path_1}"; sed 's#\(.*\)=.*#\1#' "${env_file_path_2}" | sort)
+        content=$(sed '/^$/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#\(.*\)=.*#\1#' | sort)
 
         local num_values
         num_values=$(echo "${content}" | wc -l)
@@ -589,6 +589,9 @@ check_variables_uniq "${PARAMS_ENV_PATH}" "${PARAMS_LATEST_ENV_PATH}" "false" "t
 process_file() {
     local_ret_code=0
     while IFS= read -r LINE; do
+        # If the line is empty, skip to the next one
+        [[ -z "$LINE" ]] && continue
+
         echo "Checking format of: '${LINE}'"
         [[ "${LINE}" = *[[:space:]]* ]] && {
             echo "ERROR: Line contains white-space and it shouldn't!"


### PR DESCRIPTION
This solves the issues in https://github.com/opendatahub-io/notebooks/actions/runs/16837438136/job/47700268773

triggered by introduction of empty lines in `params-latest.env` in

* https://github.com/opendatahub-io/notebooks/pull/1730

```
Checking that all variables in the file 'manifests/base/params.env' & 'manifests/base/params-latest.env' are unique and expected
Some of the variables in the file aren't unique!
```

```
Checking that all values assigned to variables in the file 'manifests/base/params.env' & 'manifests/base/params-latest.env' are unique and expected
Some of the values in the file aren't unique!
```

```
Checking that there are expected number of records in the file 'manifests/base/params.env' + 'manifests/base/params-latest.env'
Number of records in the file is incorrect - expected '44' but got '75'!
```

```
Checking format of: ''
ERROR: Line doesn't contain '=' and it should!
```

## Description

The way this has been written, only the `env_file_path_2` file is sorted; this is unrelated bug, but it means we won't detect duplicates in `env_file_path_1` and when there is one instance in the first file and the second in the other file, and it's not the last and first (in file and also alphabetically) entry, respectively.

https://github.com/opendatahub-io/notebooks/blob/159ae40b5508dc85f08fddbf09eb53c4badea811/ci/check-params-env.sh#L55

https://github.com/opendatahub-io/notebooks/blob/159ae40b5508dc85f08fddbf09eb53c4badea811/ci/check-params-env.sh#L72

The proposed fix is to remove empty lines first with an added `sed '/^$/d'`, and then apply the rest of the processing as before.

## How Has This Been Tested?

    ❯ ./ci/check-params-env.sh

be aware that the above command requires `gcut` and won't work with macOS version of `cut`

* https://github.com/opendatahub-io/notebooks/actions/runs/16837622618/job/47700865290

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty lines in environment variable files to prevent false errors during checks.
  * Enhanced script reliability by ensuring empty lines do not affect variable uniqueness or format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->