### PR TITLE
Update version of Tekton build images

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py311-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py311-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py311-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py311-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py311-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py311-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py311-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py311-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py311-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py311-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py311-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py311-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py311-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py311-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py311-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py311-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py311-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py311-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py311-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py311-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py311-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py311-c9s-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py311-c9s-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py311-c9s-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py311-c9s-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.34
+    - 2025a-v1.35
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Update image tags to `2025a-v1.35` for all Tekton image files.

## Description
This PR will change the tag for the next release version of ODH, `2025a-v1.35`.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated additional image tag from 2025a-v1.34 to 2025a-v1.35 across Tekton pipelines for:
    - Runtimes: datascience (py311/py312), minimal (cpu), PyTorch (CUDA/ROCM, py311/py312), TensorFlow (CUDA/ROCM, py311/py312)
    - Workbench: code-server (datascience, py311/py312), Jupyter (datascience/minimal/pytorch/tensorflow variants incl. CUDA/ROCM, py311/py312), TrustyAI (cpu, py311/py312), RStudio (minimal cpu/cuda)
  - Dynamic branch/revision tag remains unchanged
  - No functional, control-flow, or error-handling changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->