### PR TITLE
NO-JIRA: bump TensorFlow and Tensorboard versions to 2.19 in `jupyter-tensorflow-cuda-py312-ubi9` imagestream YAML

### DIFF
--- a/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
@@ -21,14 +21,14 @@ spec:
           [
             {"name": "CUDA", "version": "12.6"},
             {"name": "Python", "version": "v3.12"},
-            {"name": "TensorFlow", "version": "2.18"}
+            {"name": "TensorFlow", "version": "2.19"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab","version": "4.4"},
-            {"name": "TensorFlow", "version": "2.18"},
-            {"name": "Tensorboard", "version": "2.18"},
+            {"name": "TensorFlow", "version": "2.19"},
+            {"name": "Tensorboard", "version": "2.19"},
             {"name": "Nvidia-CUDA-CU12-Bundle", "version": "12.5"},
             {"name": "Boto3", "version": "1.37"},
             {"name": "Kafka-Python-ng", "version": "2.2"},


### PR DESCRIPTION
```
======================================================================
FAIL: test_tensorflow_version (__main__.TestTensorflowNotebook.test_tensorflow_version)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/ipykernel_120/875229086.py", line 37, in test_tensorflow_version
    self.assertEqual(actual_major_minor, expected_major_minor, "Incorrect TensorFlow version")
AssertionError: '2.19' != '2.18'
- 2.19
?    ^
+ exit 1
make: *** [Makefile:299: test-cuda-jupyter-tensorflow-ubi9-python-3.12] Error 1
+ 2.18
?    ^
 : Incorrect TensorFlow version

----------------------------------------------------------------------
Ran 5 tests in 75.635s
```

https://github.com/opendatahub-io/notebooks/actions/runs/16885746404/job/47835110894?pr=1878#step:42:2714

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded TensorFlow to 2.19 in the Jupyter TensorFlow CUDA (Python 3.12, UBI9) notebook software selection.
  - Updated notebook Python dependencies to TensorFlow 2.19 and TensorBoard 2.19 for consistency.
  - No other dependencies changed. Users launching these notebooks will receive the updated versions by default, benefiting from the latest fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->