### PR TITLE
RHAIENG-540, RHAIENG-580: add `dnf upgrade` to base images to mitigate fixable vulnerabilities

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER root
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER root
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.rocm
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER root
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -21,6 +21,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER root
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -12,9 +12,10 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 # OS Packages needs to be installed as root
 USER root
 
-# upgrade first to avoid fixable vulnerabilities
+# upgrade first to avoid fixable vulnerabilities begin
 RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
     && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -12,9 +12,10 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 # OS Packages needs to be installed as root
 USER root
 
-# upgrade first to avoid fixable vulnerabilities
+# upgrade first to avoid fixable vulnerabilities begin
 RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
     && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -12,9 +12,10 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 # OS Packages needs to be installed as root
 USER root
 
-# upgrade first to avoid fixable vulnerabilities
+# upgrade first to avoid fixable vulnerabilities begin
 RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
     && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -12,9 +12,10 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
 # OS Packages needs to be installed as root
 USER root
 
-# upgrade first to avoid fixable vulnerabilities
+# upgrade first to avoid fixable vulnerabilities begin
 RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
     && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -8,6 +8,11 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER 0
 
+# upgrade first to avoid fixable vulnerabilities begin
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+# upgrade first to avoid fixable vulnerabilities end
+
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -19,6 +19,15 @@ def main():
 
         blockinfile(
             dockerfile,
+            textwrap.dedent(r"""
+            RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+                && dnf clean all -y
+            """),
+            prefix="upgrade first to avoid fixable vulnerabilities",
+        )
+
+        blockinfile(
+            dockerfile,
             textwrap.dedent('''RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"'''),
             prefix="Install micropipenv and uv to deploy packages from requirements.txt",
         )


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHAIENG-540
* https://issues.redhat.com/browse/RHAIENG-580

## Description

This resolves https://github.com/opendatahub-io/notebooks/actions/runs/16897956925#summary-47882405179

<img width="1822" height="1950" alt="image" src="https://github.com/user-attachments/assets/5f7f4d26-7d09-4442-9ee0-b9588e935077" />

This is similar to what has been done in

* #1488

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/16902361965

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * All UBI9-based images now upgrade OS packages during build before installing extras, reducing known vulnerabilities and improving stability. Applies to Python 3.11/3.12 variants across Codeserver, Jupyter (minimal/datascience/pytorch/tensorflow/trustyai; CPU/CUDA/ROCm), Runtimes, and RStudio.
  * Cache cleanup added post-upgrade to help control image size.

* **Documentation**
  * Standardized begin/end comments around the upgrade step across Dockerfiles for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->