### PR TITLE
NO-JIRA: fix `notify-team-to-review-pr.yml` by using `on:` `pull_request_target:` to resolve 403 error

### DIFF
--- a/.github/workflows/notify-team-to-review-pr.yml
+++ b/.github/workflows/notify-team-to-review-pr.yml
@@ -1,7 +1,9 @@
 ---
 name: Add Review Requested Label
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  # the regular `secrets.GITHUB_TOKEN` with `on: pull_request` results in a 403 error
+  #  HttpError: Resource not accessible by integration
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -14,9 +16,13 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'konflux-nudge') == false
     runs-on: ubuntu-latest
     steps:
+
+      # SECURITY: never clone untrusted code in pull_request_target workflows
+
       - name: Add review-requested label
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # language=javascript
           script: |
             await github.rest.issues.addLabels({


### PR DESCRIPTION
## Description

the regular `secrets.GITHUB_TOKEN` results in a 403 error HttpError: Resource not accessible by integration

* https://github.com/opendatahub-io/notebooks/actions/runs/16902390874/job/47884152861#step:2:17

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/pull/22
   * https://github.com/jiridanek/notebooks/actions/runs/16904322750/job/47890434815

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable automated labeling so PRs consistently receive the "review-requested" label.

* **Chores**
  * Updated CI workflow trigger and authentication to prevent permission errors when handling opened PRs.
  * Added a security precaution to avoid executing untrusted code in review-related workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->