### PR TITLE
NO-JIRA: bump `actions/checkout` to version 5 across workflows

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -59,11 +59,11 @@ jobs:
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >>${GITHUB_ENV}
           echo "CACHE=${CACHE,,}" >>${GITHUB_ENV}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ fromJson(inputs.github).event_name != 'pull_request_target' }}
       # we need to checkout the pr branch, not pr target (the default for pull_request_target)
       # user access check is done in calling workflow
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ fromJson(inputs.github).event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ fromJson(inputs.github).event.number }}/merge"

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -39,11 +39,11 @@ jobs:
 
       # Here we are checking out the pull request, so that we can build from the new code
       # We can do this because we already checked that the submitting user is a contributor
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ github.event_name != 'pull_request_target' }}
 
       - name: Determine targets to build based on changed files

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine targets to build (we want to build everything on push)
         run: |

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -12,7 +12,7 @@ jobs:
   check-generated-code:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rerun all code generators we have
         run: bash ci/generate_code.sh
@@ -32,7 +32,7 @@ jobs:
   pytest-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # https://github.com/astral-sh/setup-uv
       - name: Install the latest version of uv
@@ -60,7 +60,7 @@ jobs:
   code-static-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Do not check secrets, they are encrypted
         run: rm -rf ./ci/secrets

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Generate notebooks release

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Generate list of images for release notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # https://github.com/astral-sh/setup-uv
       - name: Install the latest version of uv

--- a/.github/workflows/notebooks-digest-updater.yaml
+++ b/.github/workflows/notebooks-digest-updater.yaml
@@ -50,7 +50,7 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.BRANCH_NAME }}
 
@@ -61,7 +61,7 @@ jobs:
          git push --set-upstream origin ${{ env.TMP_BRANCH }}
 
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.TMP_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/notebooks-release.yaml
+++ b/.github/workflows/notebooks-release.yaml
@@ -72,7 +72,7 @@ jobs:
       pr_merged_m: ${{ steps.check_pr.outputs.pr_merged }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
       pr_merged_b: ${{ steps.check_pr.outputs.pr_merged }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -18,7 +18,7 @@ jobs:
   validation-of-params-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.BRANCH }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
       - name: Install skopeo

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Checkout the branch
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.BRANCH_NAME }}
 
@@ -52,7 +52,7 @@ jobs:
 
       # Get the latest weekly build commit hash: https://github.com/opendatahub-io/notebooks/commits/2023b
       - name: Checkout upstream notebooks repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N }}
@@ -64,7 +64,7 @@ jobs:
           echo "HASH_N=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: Checkout "N - 1" branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N_1 }}
@@ -76,7 +76,7 @@ jobs:
           echo "HASH_N_1=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: Checkout "main" branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: opendatahub-io/notebooks.git
           ref: main
@@ -89,7 +89,7 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.SEC_SCAN_BRANCH }}
 
@@ -126,7 +126,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: pull-request
         uses: repo-sync/pull-request@v2

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Trivy scan
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4  # 0.32.0

--- a/.github/workflows/software-versions.yaml
+++ b/.github/workflows/software-versions.yaml
@@ -25,7 +25,7 @@ jobs:
       # Some pieces of code (image pulls for example) in podman consult TMPDIR or default to /var/tmp
       TMPDIR: /home/runner/.local/share/containers/tmpdir
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Mount lvm overlay for podman operations
         run: |

--- a/.github/workflows/sync-branches-through-pr.yml
+++ b/.github/workflows/sync-branches-through-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.target }}
           fetch-depth: 0

--- a/.github/workflows/update-buildconfigs.yaml
+++ b/.github/workflows/update-buildconfigs.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

* https://github.com/actions/checkout/releases/tag/v5.0.0

This is internal improvements release of the action that should have no user-facing impact. Good opportunity to check the PR labeling action.

## How Has This Been Tested?

*

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
