### PR TITLE
opendatahub-io/notebooks#1994: remove unnecessary ROCm dependencies across Dockerfiles

### DIFF
--- a/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
@@ -32,8 +32,24 @@ RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "baseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/9.4/main/x86_64" >> /etc/yum.repos.d/amdgpu.repo && \
     echo "enabled=1" >> /etc/yum.repos.d/amdgpu.repo && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo && \
-    dnf install -y rocm-developer-tools rocm-ml-sdk rocm-opencl-sdk rocm-openmp-sdk rocm-utils && \
+    dnf install -y \
+      rocm-core hip-runtime-amd \
+    # system utilities
+      rocm-smi-lib rocminfo \
+      rocblas rocsolver rocfft rocrand rocsparse miopen-hip rccl \
+    # HIP (Heterogeneous-compute Interface for Portability)
+      hipblas hipblaslt hipfft hipsparse hiprand hipsolver \
+    # suitesparse's /lib64/libspqr.so.2.0.9 needs libtbb.so.2
+      tbb && \
     dnf clean all && rm -rf /var/cache/yum
+
+# https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/post-install.html#configure-rocm-shared-objects
+RUN tee --append /etc/ld.so.conf.d/rocm.conf <<EOF
+  /opt/rocm/lib
+  /opt/rocm/lib64
+EOF
+
+RUN ldconfig
 
 # Restore user workspace
 USER 1001

--- a/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
@@ -1,7 +1,7 @@
 ####################
 # base             #
 ####################
-FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+FROM quay.io/sclorg/python-312-c9s:c9s AS base
 
 WORKDIR /opt/app-root/bin
 
@@ -14,12 +14,12 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Please keep in sync with ROCm/python3.12 dependent images
-ARG ROCM_VERSION=6.2.4
-ARG AMDGPU_VERSION=6.2.4
+ARG ROCM_VERSION=6.4.3
+ARG AMDGPU_VERSION=6.4.3
 
 # Install the ROCm rpms
 # ref: https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
-# Note: Based on 6.2 above new package mivisionx is a pre-requistes, which bring in more dependent packages
+# Note: Based on 6.4 above new package mivisionx is a pre-requistes, which bring in more dependent packages
 # so we are only installing meta packages of rocm
 # ref: https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/package-manager-integration.html#packages-in-rocm-programming-models
 RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \

--- a/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
@@ -14,12 +14,12 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Please keep in sync with ROCm/python3.12 dependent images
-ARG ROCM_VERSION=6.2.4
-ARG AMDGPU_VERSION=6.2.4
+ARG ROCM_VERSION=6.4.3
+ARG AMDGPU_VERSION=6.4.3
 
 # Install the ROCm rpms
 # ref: https://github.com/ROCm/ROCm-docker/blob/master/dev/Dockerfile-centos-7-complete
-# Note: Based on 6.2 above new package mivisionx is a pre-requistes, which bring in more dependent packages
+# Note: Based on 6.4 above new package mivisionx is a pre-requistes, which bring in more dependent packages
 # so we are only installing meta packages of rocm
 # ref: https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/package-manager-integration.html#packages-in-rocm-programming-models
 RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \


### PR DESCRIPTION
Discussed it with Gemini at https://gemini.google.com/app/2d75c1134ae55d54 and it thinks it's a good idea.

## Description

* https://github.com/opendatahub-io/notebooks/issues/1994

```
    # provides /etc/ld.so.conf.d/10-rocm-opencl.conf that adds ROCm .so libs to library path
      rocm-opencl \
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ROCm packages in Python 3.12 base images (6.2, 6.4), adding core and HIP libraries for broader GPU workloads.
  * Configured dynamic linker paths so ROCm libraries are discoverable at runtime.
  * Added a ROCm 6.4 multi-stage base with configurable build args for ROCm/AMDGPU versions.
  * Restores a default non-root workspace after installation.

* **Chores**
  * Standardized installation flow and cleaned package caches to reduce image size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->