### PR TITLE
NO-JIRA: comment out even more `pytorch-llmcompressor` entries in kustomization.yaml because we're not ready to release it yet

### DIFF
--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -66,19 +66,19 @@ replacements:
           kind: ImageStream
           name: jupyter-minimal-cuda-py312-ubi9
           version: v1
-  - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n
-      kind: ConfigMap
-      name: notebook-image-params
-      version: v1
-    targets:
-      - fieldPaths:
-          - spec.tags.0.from.name
-        select:
-          group: image.openshift.io
-          kind: ImageStream
-          name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
-          version: v1
+  # - source:
+  #     fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n
+  #     kind: ConfigMap
+  #     name: notebook-image-params
+  #     version: v1
+  #   targets:
+  #     - fieldPaths:
+  #         - spec.tags.0.from.name
+  #       select:
+  #         group: image.openshift.io
+  #         kind: ImageStream
+  #         name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
+  #         version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n
       kind: ConfigMap
@@ -196,19 +196,19 @@ replacements:
           kind: ImageStream
           name: jupyter-minimal-cuda-py312-ubi9
           version: v1
-  - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-n
-      kind: ConfigMap
-      name: notebook-image-commithash
-      version: v1
-    targets:
-      - fieldPaths:
-          - spec.tags.0.annotations.[opendatahub.io/notebook-build-commit]
-        select:
-          group: image.openshift.io
-          kind: ImageStream
-          name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
-          version: v1
+  # - source:
+  #     fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-n
+  #     kind: ConfigMap
+  #     name: notebook-image-commithash
+  #     version: v1
+  #   targets:
+  #     - fieldPaths:
+  #         - spec.tags.0.annotations.[opendatahub.io/notebook-build-commit]
+  #       select:
+  #         group: image.openshift.io
+  #         kind: ImageStream
+  #         name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
+  #         version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n
       kind: ConfigMap
@@ -313,19 +313,19 @@ replacements:
           kind: ImageStream
           name: runtime-datascience-cpu-py312-ubi9
           version: v1
-  - source:
-      fieldPath: data.odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n
-      kind: ConfigMap
-      name: notebook-image-params
-      version: v1
-    targets:
-      - fieldPaths:
-          - spec.tags.0.from.name
-        select:
-          group: image.openshift.io
-          kind: ImageStream
-          name: runtime-pytorch-llmcompressor-cuda-py312-ubi9
-          version: v1
+  # - source:
+  #     fieldPath: data.odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n
+  #     kind: ConfigMap
+  #     name: notebook-image-params
+  #     version: v1
+  #   targets:
+  #     - fieldPaths:
+  #         - spec.tags.0.from.name
+  #       select:
+  #         group: image.openshift.io
+  #         kind: ImageStream
+  #         name: runtime-pytorch-llmcompressor-cuda-py312-ubi9
+  #         version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n
       kind: ConfigMap


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/pull/1972

## Description

```
fieldPath `data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n`
is missing for replacement source
ConfigMap.v1.[noGrp]/notebook-image-params.[noNs]
```

in rhds which does not have this in `params-latest.env`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled image overrides for LLM Compressor variants in the additional overlay.
  * Ensures only standard PyTorch/Jupyter and runtime images continue to receive active replacements.
  * No functional changes introduced; environments using LLM Compressor variants will now rely on defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->