### PR TITLE
NO-JIRA: fix update-commit-latest-env.py to work with multiarch manifests

### DIFF
--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -28,7 +28,7 @@ async def get_image_vcs_ref(image_url: str, semaphore: asyncio.Semaphore) -> tup
     full_image_url = f"docker://{image_url}"
 
     # Use 'inspect --config' which is much faster as it only fetches the config blob.
-    command = ["skopeo", "inspect", "--retry-times=5", "--config", full_image_url]
+    command = ["skopeo", "inspect", "--override-os=linux", "--override-arch=amd64", "--retry-times=5", "--config", full_image_url]
 
     logging.info(f"Starting config inspection for: {image_url}")
 


### PR DESCRIPTION
## Description

```
ERROR: Skopeo command failed for quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:c0482a03d45fbe3a2acff4e9d583830d54324e939ba1bb19472af4f29d5e233f with exit code 1.
ERROR: Stderr: time="2025-08-22T14:34:19+02:00" level=fatal msg="Error parsing manifest for image: choosing image instance: no image found in image index for architecture \"arm64\", variant \"v8\", OS \"darwin\""
```

## How Has This Been Tested?

* https://github.com/red-hat-data-services/notebooks/pull/1503 ;p

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading image version metadata by explicitly targeting the linux/amd64 variant on multi-architecture images. This prevents mismatches and reduces failures in workflows that depend on image labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->