### PR TITLE
NO-JIRA: sort environment variables alphabetically in `update-commit-latest-env.py`

### DIFF
--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -111,7 +111,7 @@ async def main():
         output.append((re.sub(r'-n$', "-commit-n", variable), commit_hash[:7]))
 
     with open(PROJECT_ROOT / "manifests/base/commit-latest.env", "wt") as file:
-        for line in output:
+        for line in sorted(output):
             print(*line, file=file, sep="=", end="\n")
 
 


### PR DESCRIPTION
## Description

This was not necessary before because following the order established in `params-latest.env` led to a consistent ordering.

## How Has This Been Tested?

    python3 scripts/update-commit-latest-env.py

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The automation that generates the commit reference environment file now writes variables in alphabetical order. This produces deterministic output across runs, simplifies code reviews by yielding cleaner diffs, and reduces noise in change logs. Behavior and content remain the same; only the ordering is affected. No user-facing features or runtime behavior are impacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->