### PR TITLE
NO-JIRA: update `pr-merge-image-delete` workflow to remove Python 3.11 images and add 3.12 versions

### DIFF
--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -60,28 +60,30 @@ jobs:
           set +e # Don't abort if a delete operation fails as all images might not be available for the PR
 
           # Python 3.11
-          skopeo delete docker://${QUAY_IMAGE_REPO}:base-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:base-c9s-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-c9s-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-minimal-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-datascience-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-pytorch-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-trustyai-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-jupyter-minimal-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-jupyter-datascience-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-jupyter-tensorflow-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-minimal-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-datascience-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-pytorch-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-cuda-tensorflow-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:codeserver-ubi9-python-3.11-pr-${{ env.PR }}
           skopeo delete docker://${QUAY_IMAGE_REPO}:rstudio-c9s-python-3.11-pr-${{ env.PR }}
           skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-rstudio-c9s-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-minimal-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-datascience-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-tensorflow-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-pytorch-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-rocm-pytorch-ubi9-python-3.11-pr-${{ env.PR }}
-          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-rocm-tensorflow-ubi9-python-3.11-pr-${{ env.PR }}
+
+          # Python 3.12
+          skopeo delete docker://${QUAY_IMAGE_REPO}:base-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:base-c9s-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-c9s-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-minimal-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-datascience-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-pytorch-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:jupyter-trustyai-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-jupyter-minimal-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-jupyter-datascience-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:cuda-jupyter-tensorflow-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-minimal-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-datascience-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-pytorch-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-cuda-tensorflow-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:codeserver-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-minimal-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-datascience-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-tensorflow-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:rocm-jupyter-pytorch-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-rocm-pytorch-ubi9-python-3.12-pr-${{ env.PR }}
+          skopeo delete docker://${QUAY_IMAGE_REPO}:runtime-rocm-tensorflow-ubi9-python-3.12-pr-${{ env.PR }}


### PR DESCRIPTION
## Description

Follow-up to
* https://github.com/opendatahub-io/notebooks/pull/2114

## How Has This Been Tested?


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI image cleanup to target Python 3.12 images across base, CUDA, Jupyter, runtime, code-server, and ROCm families.
  - Retained cleanup steps for existing rstudio-related Python 3.11 images.
  - Preserved existing error handling and control flow in the workflow.
  - No impact on product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->