### PR TITLE
NO-JIRA: resume testing of cuda-based rstudio images in GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,9 @@ scan-image-vulnerabilities:
 ifeq ($(RELEASE_PYTHON_VERSION), 3.11)
 all-images: \
 	rstudio-c9s-python-$(RELEASE_PYTHON_VERSION) \
-	rstudio-rhel9-python-$(RELEASE_PYTHON_VERSION)
+	rstudio-rhel9-python-$(RELEASE_PYTHON_VERSION) \
+	cuda-rstudio-c9s-python-$(RELEASE_PYTHON_VERSION) \
+	cuda-rstudio-rhel9-python-$(RELEASE_PYTHON_VERSION)
 else ifeq ($(RELEASE_PYTHON_VERSION), 3.12)
 all-images: \
 	jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION) \


### PR DESCRIPTION
## Description

Removed by accident in

* https://github.com/opendatahub-io/notebooks/pull/2114

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces CUDA-enabled container images for Python 3.11, providing GPU-ready options alongside existing CPU images. These images are available starting with this release.

- Chores
  - Updated the build configuration to publish an expanded Python 3.11 image set; other versions are unchanged.
  - No changes to runtime behavior or tooling; existing images and tags remain available and compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->