### PR TITLE
NO-JIRA: bump default Python version in `refresh-pipfilelock-files` Makefile task from 3.11 to 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ validate-rstudio-image: bin/kubectl
 
 # This recipe used mainly from the Pipfile.locks Renewal Action
 # Default Python version
-PYTHON_VERSION ?= 3.11
+PYTHON_VERSION ?= 3.12
 ROOT_DIR := $(shell pwd)
 ifeq ($(PYTHON_VERSION), 3.11)
 	BASE_DIRS := \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Python version to 3.12 for build and packaging pipelines.
  * Users building from source will now target Python 3.12 by default; 3.11 remains available when explicitly selected.
  * No functional changes to the application; this aligns the project with the latest Python release and may require local environment/tooling adjustments if you depend on 3.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->