### PR TITLE
NO-JIRA: fix(ci): escape special characters in tabular data printouts

### DIFF
--- a/ci/package_versions.py
+++ b/ci/package_versions.py
@@ -145,7 +145,7 @@ def main():
     print("| Image name | Image version | Preinstalled packages |")
     print("|------------|---------------|-----------------------|")
     for row in tabular_data:
-        print(f"| {row[0]} | {row[1]} | {row[2]} |")
+        print(f"| {' | '.join(escape(r) for r in row)} |")
 
     print()
 
@@ -157,8 +157,14 @@ def main():
     print("Image name | Image version | Preinstalled packages")
     print("--------- | ---------")
     for row in tabular_data:
-        print(f"{row[0]} | {row[1]} | {row[2]}")
+        print(f"{' | '.join(escape(r) for r in row)}")
     print("```")
+
+
+def escape(s: str) -> str:
+    r"""> NOTE: To escape a character that would otherwise affect formatting (e.g. *, -, #, >, [, ], (, ), \, `)
+    and render it literally, use a backslash (\) before the character."""
+    return s.replace("\\", "\\\\").replace("|", "\\|")
 
 
 class TestManifest(unittest.TestCase):
@@ -182,6 +188,12 @@ class TestManifest(unittest.TestCase):
 
     def test_tag_sw_python(self):
         assert self.manifest.tags[0].sw_python == [{"name": "JupyterLab", "version": "4.2"}]
+
+
+class TestTabular(unittest.TestCase):
+    def test_escape(self):
+        assert escape("|") == "\\|"
+        assert escape("\\") == "\\\\"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/actions/runs/17294574135?pr=2177

## Description

Our images are currently named like

    Code Server | Data Science | CPU | Python 3.11

and this is breaking Markdown tables.

- Introduced `escape` function to handle characters affecting Markdown formatting.
- Updated tabular outputs in `package_versions.py` to apply escaping.
- Added unit tests for `escape` function.

## How Has This Been Tested?

<img width="1213" height="843" alt="image" src="https://github.com/user-attachments/assets/a81b7ce2-4454-4389-a0e5-f611c45848ce" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected Markdown table rendering in generated package version reports by safely escaping special characters in table cells and code blocks, preventing broken formatting across platforms.

- Tests
  - Added unit tests to validate escaping behavior for special characters, ensuring reliable table output.

- Chores
  - Refined CI output to produce consistently formatted Markdown tables for package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->