### PR TITLE
opendatahub-io/notebooks#2178: fix(ci): add missing `cri-tools` dependency in build-notebooks workflow

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -398,7 +398,7 @@ jobs:
 
           sudo apt-get update
           # [ERROR FileExisting-conntrack]: conntrack not found in system path
-          sudo apt-get install -y cri-o kubelet kubeadm kubectl conntrack
+          sudo apt-get install -y cri-o cri-tools kubelet kubeadm kubectl conntrack
 
           # make use of /etc/cni/net.d/11-crio-ipv4-bridge.conflist so we don't
           # need a pod network and just use the default bridge


### PR DESCRIPTION
## Description

* #2178

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17295050060

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline dependencies to include cri-tools during container runtime setup, improving reliability of build and test processes for notebooks.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->