### PR TITLE
Re-enable llmCompressor for ODH availability

### DIFF
--- a/manifests/base/params-latest.env
+++ b/manifests/base/params-latest.env
@@ -44,7 +44,7 @@ odh-workbench-jupyter-datascience-cpu-py312-ubi9-n=quay.io/opendatahub/odh-workb
 
 odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9@sha256:53fecde306a0a8ccaf46a4bce85ddd63ac1381dcf22a17ee7b2d7ed16a8be8e1
 
-odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9@sha256:585263a8d1429d3cb75c976e6a47d7dacb8d8bbf269eed27225f23904ea0a0ee
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9@sha256:eca01c29832052824c299922f4d4bae78b59150d6cd7b2f1a5c007fdfc9cbcff
 
 odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9@sha256:cc97aa8ac408d1cecd5ba3a67336ee0299a94dbcce11e4372c6dc90064b3f779
 
@@ -64,4 +64,4 @@ odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeli
 
 odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9@sha256:17aaffc22f57e19655621513bd27a14c945f7e8668e72e8a1573c6def7af0161
 
-odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9@sha256:cc97aa8ac408d1cecd5ba3a67336ee0299a94dbcce11e4372c6dc90064b3f779
+odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9@sha256:ad2a67549b36485862378c392f1fb76e8c5457065d60478d977a8141393f9752

--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -13,13 +13,13 @@ resources:
   - jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
   - jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
   - jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
-  # - jupyter-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
+  - jupyter-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
   - runtime-datascience-cpu-py312-ubi9-imagestream.yaml
   - runtime-minimal-cpu-py312-ubi9-imagestream.yaml
   - runtime-pytorch-cuda-py312-ubi9-imagestream.yaml
   - runtime-pytorch-rocm-py312-ubi9-imagestream.yaml
   - runtime-tensorflow-cuda-py312-ubi9-imagestream.yaml
-  # - runtime-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
+  - runtime-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
 
 labels:
   - includeSelectors: true
@@ -66,19 +66,19 @@ replacements:
           kind: ImageStream
           name: jupyter-minimal-cuda-py312-ubi9
           version: v1
-  # - source:
-  #     fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n
-  #     kind: ConfigMap
-  #     name: notebook-image-params
-  #     version: v1
-  #   targets:
-  #     - fieldPaths:
-  #         - spec.tags.0.from.name
-  #       select:
-  #         group: image.openshift.io
-  #         kind: ImageStream
-  #         name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
-  #         version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
+          version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n
       kind: ConfigMap
@@ -196,19 +196,19 @@ replacements:
           kind: ImageStream
           name: jupyter-minimal-cuda-py312-ubi9
           version: v1
-  # - source:
-  #     fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-n
-  #     kind: ConfigMap
-  #     name: notebook-image-commithash
-  #     version: v1
-  #   targets:
-  #     - fieldPaths:
-  #         - spec.tags.0.annotations.[opendatahub.io/notebook-build-commit]
-  #       select:
-  #         group: image.openshift.io
-  #         kind: ImageStream
-  #         name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
-  #         version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-n
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
+          version: v1
   - source:
       fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n
       kind: ConfigMap
@@ -313,19 +313,19 @@ replacements:
           kind: ImageStream
           name: runtime-datascience-cpu-py312-ubi9
           version: v1
-  # - source:
-  #     fieldPath: data.odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n
-  #     kind: ConfigMap
-  #     name: notebook-image-params
-  #     version: v1
-  #   targets:
-  #     - fieldPaths:
-  #         - spec.tags.0.from.name
-  #       select:
-  #         group: image.openshift.io
-  #         kind: ImageStream
-  #         name: runtime-pytorch-llmcompressor-cuda-py312-ubi9
-  #         version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-pytorch-llmcompressor-cuda-py312-ubi9
+          version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n
       kind: ConfigMap


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://issues.redhat.com/browse/RHAIENG-332 
## Description
<!--- Describe your changes in detail -->
Re-enable llmCompressor for ODH availability.
JFR: https://github.com/opendatahub-io/notebooks/pull/2079

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added PyTorch LLMCompressor (CUDA, Python 3.12, UBI9) notebook and runtime images to the catalog.
  - Enabled configurable image tags and build commit metadata, ensuring consistent version visibility across ImageStreams.
- Chores
  - Updated LLMCompressor notebook and runtime images to the latest digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->