### PR TITLE
Issue #2201, RHAIENG-304, RHAIENG-785: we now don't have any **/Pipfile.lock files, adjust check for it

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -82,22 +82,7 @@ jobs:
 
       - name: Validate JSON files (just syntax)
         id: validate-json-files
-        run: |
-          set -Eeuxo pipefail
-
-          type json_verify || sudo apt-get -y install yajl-tools
-          shopt -s globstar
-          ret_code=0
-          echo "-- Checking a regular '*.json' files"
-          for f in **/*.json; do echo "Checking: '${f}"; echo -n "  > "; [[ "$(basename "$f")" == "tsconfig.json" ]] && echo "Skipping ${f}" && continue; cat $f | json_verify || ret_code=1; done
-          echo "-- Checking a 'Pipfile.lock' files"
-          for f in **/Pipfile.lock; do echo "Checking: '${f}"; echo -n "  > "; cat $f | json_verify || ret_code=1; done
-          echo "-- Checking a '*.ipynb' Jupyter notebook files"
-          for f in **/*.ipynb; do echo "Checking: '${f}"; echo -n "  > "; cat $f | json_verify || ret_code=1; done
-          if test "${ret_code}" -ne 0; then
-              echo "There were errors in some of the checked files. Please run `json_verify` on such files and fix issues there."
-          fi
-          exit "${ret_code}"
+        run: ./ci/validate_json.py
 
       - name: Validate Dockerfiles
         id: validate-dockerfiles
@@ -112,5 +97,4 @@ jobs:
       # This simply checks that the manifests and respective kustomization.yaml finishes without an error.
       - name: Check kustomize manifest
         id: kustomize-manifests
-        run: |
-          ./ci/kustomize.sh
+        run: ./ci/kustomize.sh

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -66,6 +66,7 @@ jobs:
         run: rm -rf ./ci/secrets
 
       - name: Validate YAML files (best code practices check included)
+        if: ${{ !cancelled() }}
         id: validate-yaml-files
         run: |
           type yamllint || sudo apt-get -y install yamllint
@@ -75,16 +76,19 @@ jobs:
 
       # In some YAML files we use JSON strings, let's check these
       - name: Validate JSON strings in YAML files (just syntax)
+        if: ${{ !cancelled() }}
         id: validate-json-strings-in-yaml-files
         run: |
           type json_verify || sudo apt-get -y install yajl-tools
           bash ./ci/check-json.sh
 
       - name: Validate JSON files (just syntax)
+        if: ${{ !cancelled() }}
         id: validate-json-files
         run: ./ci/validate_json.py
 
       - name: Validate Dockerfiles
+        if: ${{ !cancelled() }}
         id: validate-dockerfiles
         run: |
           type hadolint || sudo apt-get -y install wget \
@@ -96,5 +100,6 @@ jobs:
 
       # This simply checks that the manifests and respective kustomization.yaml finishes without an error.
       - name: Check kustomize manifest
+        if: ${{ !cancelled() }}
         id: kustomize-manifests
         run: ./ci/kustomize.sh

--- a/ci/validate_json.py
+++ b/ci/validate_json.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def validate_json_file(filepath: Path) -> bool:
+    """Validates the JSON syntax of a single file.
+    Returns True if valid, False otherwise.
+    """
+    print(f"Checking: '{filepath}'")
+    try:
+        with filepath.open("r", encoding="utf-8") as f:
+            json.load(f)
+        print("  > OK")
+        return True
+    except json.JSONDecodeError as e:
+        # Print specific error for easier debugging
+        print(f"  > Invalid JSON: {e}", file=sys.stderr)
+        return False
+    except OSError as e:
+        print(f"  > Error reading file: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    """Recursively finds and validates all specified JSON-like files in the project."""
+    # Define file patterns to search for, relative to the current directory
+    file_patterns = [
+        "**/*.json",
+        "**/*.ipynb",
+    ]
+
+    # Define a set of file names to exclude from validation
+    exclude_filenames = {
+        "tsconfig.json",
+    }
+
+    print("--- Starting JSON syntax validation ---")
+    root_dir = Path(".")
+    errors: list[Path] = []
+
+    # Create a set to hold unique file paths, preventing duplicate checks
+    files_to_validate = set()
+    for pattern in file_patterns:
+        print(f"-- Searching for '{pattern}' files...")
+        files_to_validate.update(root_dir.glob(pattern))
+
+    if not files_to_validate:
+        print("\nNo files found to validate.")
+        sys.exit(0)
+
+    # Sort files for consistent, readable output
+    for filepath in sorted(files_to_validate):
+        if filepath.name in exclude_filenames:
+            print(f"Skipping excluded file: {filepath}")
+            continue
+
+        if not validate_json_file(filepath):
+            errors.append(filepath)
+
+    print("\n--- Validation finished ---")
+    if errors:
+        print("\nError: Invalid JSON found in one or more files:", file=sys.stderr)
+        print(*errors, sep="\n", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("\nSuccess: All checked files have valid JSON syntax.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* #2201

## Description

* https://github.com/opendatahub-io/notebooks/actions/runs/17319719154/job/49170077198?pr=2195#step:6:78

```
+ for f in **/Pipfile.lock
Checking: '**/Pipfile.lock
+ echo 'Checking: '\''**/Pipfile.lock'
+ echo -n '  > '
+ json_verify
+ cat '**/Pipfile.lock'
cat: '**/Pipfile.lock': No such file or directory
```

## How Has This Been Tested?

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now skips cancelled workflow steps to reduce wasted runner time.
  * JSON validation consolidated into a single, clearer validation step for faster, more readable feedback.
  * Manifest and Dockerfile checks streamlined for more consistent CI behavior.
  * Improved CI logging and error reporting to make validation results easier to interpret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->