### PR TITLE
RHAIENG-304, RHAIENG-786: chore(ci): update Trivy scan to handle `pyproject.toml` using `uv lock`

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,6 +19,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      # https://github.com/astral-sh/setup-uv
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+          python-version: "3.12"
+          enable-cache: false
+          activate-environment: true
+
+      # Trivy does not support pylock.toml https://github.com/aquasecurity/trivy/discussions/9408
+      - run: find . -name pyproject.toml -execdir uv lock \;
+
       - name: Trivy scan
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4  # 0.32.0
         with:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-786

## Description

Create on-the-fly requirements.txt (or uv.lock?) for trivy to scan, apparently trivy can't scan pylock.toml

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17321973516
* https://github.com/jiridanek/notebooks/security/code-scanning?query=is%3Aopen+branch%3Ajd_fix_trivy+

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security scanning workflow by setting up a standardized Python environment and generating dependency lock files before scans, improving consistency and reliability of results.
  * Streamlined CI steps to reduce variability across runs and make vulnerability detection more reproducible.
  * No impact on application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->