### PR TITLE
Issue #2199: chore(ci): change build-notebooks workflow to use activation key for Red Hat subscription registration instead of storing entitlement certificates

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -100,7 +100,7 @@ jobs:
           # https://github.com/containers/common/issues/1735
           mkdir entitlement
           mkdir consumer
-          podman run \
+          docker run \
             -v ${PWD}/entitlement:/etc/pki/entitlement:Z \
             -v ${PWD}/consumer:/etc/pki/consumer:Z \
             --rm -t registry.access.redhat.com/ubi9/ubi \

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -98,10 +98,11 @@ jobs:
         run: |
           # https://access.redhat.com/solutions/5870841
           # https://github.com/containers/common/issues/1735
-          mkdir consumer
           mkdir entitlement
+          mkdir consumer
           podman run \
             -v ${PWD}/entitlement:/etc/pki/entitlement:Z \
+            -v ${PWD}/consumer:/etc/pki/consumer:Z \
             --rm -t registry.access.redhat.com/ubi9/ubi \
               /usr/sbin/subscription-manager register --org=${SUBSCRIPTION_ORG} --activationkey=${SUBSCRIPTION_ACTIVATION_KEY}
           printf "${PWD}/entitlement:/etc/pki/entitlement\n${PWD}/consumer:/etc/pki/consumer\n" | sudo tee /usr/share/containers/mounts.conf

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -90,17 +90,27 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
+      # https://console.redhat.com/insights/connector/activation-keys
+      # This runs slower than storing the entitlement certificates with git-crypt,
+      #  but on the other hand, it's then not necessary to regularly update them in the repo.
       - name: Add subscriptions from GitHub secret
         if: ${{ inputs.subscription }}
         run: |
-          sudo mkdir -p /etc/pki/
-          sudo cp -R ${PWD}/ci/secrets/pki/* /etc/pki/
           # https://access.redhat.com/solutions/5870841
           # https://github.com/containers/common/issues/1735
-          printf "${PWD}/ci/secrets/run/secrets/rhsm:/etc/rhsm\n${PWD}/ci/secrets/run/secrets/etc-pki-entitlement:/etc/pki/entitlement\n${PWD}/ci/secrets/pki/consumer:/etc/pki/consumer\n" | sudo tee /usr/share/containers/mounts.conf
+          mkdir consumer
+          mkdir entitlement
+          podman run \
+            -v ${PWD}/entitlement:/etc/pki/entitlement:Z \
+            --rm -t registry.access.redhat.com/ubi9/ubi \
+              /usr/sbin/subscription-manager register --org=${SUBSCRIPTION_ORG} --activationkey=${SUBSCRIPTION_ACTIVATION_KEY}
+          printf "${PWD}/entitlement:/etc/pki/entitlement\n${PWD}/consumer:/etc/pki/consumer\n" | sudo tee /usr/share/containers/mounts.conf
 
           mkdir -p $HOME/.config/containers/
           sudo cp ${PWD}/ci/secrets/pull-secret.json $HOME/.config/containers/auth.json
+        env:
+          SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
+          SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 
       # for bin/buildinputs in scripts/sandbox.py
       - uses: actions/setup-go@v5


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/issues/2199

## Description

```
gh secret set SUBSCRIPTION_ORG
gh secret set SUBSCRIPTION_ACTIVATION_KEY
```

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17335993972

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Build & Publish Notebook Servers workflow to use activation-key-based subscriptions via a containerized approach for entitlements.
  * Switched from embedding pre-stored certificates to using secrets-driven environment variables for organization and activation key.
  * Host-side entitlement and consumer data are mounted into the container rather than relying on static in-repo mounts.
  * Added guidance comments and preparation of host container config for reliability; slightly slower builds expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->