### PR TITLE
Update Dockerfile.cpu to enable ppc64le architecture

### DIFF
--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -40,6 +40,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
   - name: dockerfile
     value: codeserver/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -1,4 +1,56 @@
 ####################
+# rpm-base         #
+####################
+FROM registry.access.redhat.com/ubi9/python-312:latest AS rpm-base
+
+USER root
+WORKDIR /root
+
+ENV HOME=/root
+
+ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
+
+ARG NODE_VERSION=20
+
+ARG CODESERVER_VERSION=v4.98.0
+
+COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
+
+# create dummy file to ensure this stage is awaited before installing rpm
+RUN ./get_code_server_rpm.sh && touch /tmp/control
+
+#######################
+# wheel caching stage #
+#######################
+FROM registry.access.redhat.com/ubi9/python-312:latest AS whl-cache
+
+USER root
+WORKDIR /root
+
+ENV HOME=/root
+
+ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
+
+# copy requirements and scripts
+COPY ${CODESERVER_SOURCE_CODE}/pylock.toml ./
+COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
+
+# This stage installs (builds) all the packages needed and caches it in uv-cache
+# Important: Since HOME & USER for the python-312 has been changed,
+#            we need to ensure the same cache directory is mounted in
+#            the final stage with the necessary permissions to consume from cache
+RUN --mount=type=cache,target=/root/.cache/uv \
+    pip install --no-cache uv && \
+    # the devel script is ppc64le specific - sets up build-time dependencies
+    source ./devel_env_setup.sh && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+
+# dummy file to make image build wait for this stage
+RUN touch /tmp/control
+
+####################
 # base             #
 ####################
 FROM registry.access.redhat.com/ubi9/python-312:latest AS base
@@ -15,6 +67,15 @@ RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_d
 
 # Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
+
+# (ARCH-ppc64le): since wheels are compiled from source, we need shared libs available at runtime
+RUN --mount=type=cache,from=whl-cache,source=/root/OpenBLAS,target=/OpenBlas,rw \
+    bash -c ' \
+        if [[ $(uname -m) == "ppc64le" ]]; then \
+            dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+            dnf install -y lcms2 libraqm libimagequant openjpeg2; \
+            PREFIX=/usr/ make install -C /OpenBlas; \
+        fi '
 
 # Other apps and tools installed as default user
 USER 1001
@@ -58,8 +119,13 @@ WORKDIR /opt/app-root/bin
 # Install useful OS packages
 RUN dnf install -y jq git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
 
+# wait for rpm-base stage (rpm builds for ppc64le)
+COPY --from=rpm-base /tmp/control /dev/null
+
 # Install code-server
-RUN dnf install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm" && \
+# Note: Use cache mounts, bind mounts fail on konflux
+RUN --mount=type=cache,from=rpm-base,source=/tmp/,target=/code-server-rpm/,rw \
+    dnf install -y "/code-server-rpm/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm" && \
     dnf -y clean all --enablerepo='*'
 
 COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/
@@ -138,18 +204,28 @@ ENV SHELL=/bin/bash
 
 ENV PYTHONPATH=/opt/app-root/bin/python3
 
-USER 1001
-
 # Install useful packages from requirements.txt
 COPY ${CODESERVER_SOURCE_CODE}/pylock.toml ./
 
+# wait for whl-cache stage (builds uv cache)
+COPY --from=whl-cache /tmp/control /dev/null
+
 # Install packages and cleanup
-RUN echo "Installing softwares and packages" && \
-    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
-    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
-    # Fix permissions to support pip in Openshift environments \
-    chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
+# install packages as USER 0 (this will allow us to consume uv cache)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    echo "Installing softwares and packages" && \
+    # we can ensure wheels are consumed from the cache only by restricting internet access for uv install with '--offline' flag
+    uv pip install --offline --cache-dir /root/.cache/uv --requirements=./pylock.toml && \
+    # Note: debugpy wheel availabe on pypi (in uv cache) is none-any but bundles amd64.so files
+    #       Build debugpy from source instead
+    uv pip install --no-cache git+https://github.com/microsoft/debugpy.git@v$(grep -A1 '\"debugpy\"' ./pylock.toml | grep -Eo '\b[0-9\.]+\b') && \
+    # change ownership to default user (all packages were installed as root and has root:root ownership \
+    chown -R 1001:0 /opt/app-root/lib
+
+USER 1001
+
+# Fix permissions to support pip in Openshift environments
+RUN chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P
 
 WORKDIR /opt/app-root/src

--- a/codeserver/ubi9-python-3.12/devel_env_setup.sh
+++ b/codeserver/ubi9-python-3.12/devel_env_setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eoux pipefail
+
+#####################################################################################################
+# This script is expected to be run on ppc64le hosts as `root`                                      #
+# It installs the required build-time dependencies for python wheels                                #
+# OpenBlas is built from source (instead of distro provided) with recommended flags for performance #
+#####################################################################################################
+
+if [[ $(uname -m) == "ppc64le" ]]; then
+    # install development packages
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    dnf install -y cmake gcc-toolset-13 fribidi-devel lcms2-devel \
+        libimagequant-devel libraqm-devel openjpeg2-devel tcl-devel tk-devel
+
+    # install rust
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+    source /opt/rh/gcc-toolset-13/enable
+    source "$HOME/.cargo/env"
+
+    export MAX_JOBS=${MAX_JOBS:-$(nproc)}
+    export OPENBLAS_VERSION=${OPENBLAS_VERSION:-0.3.30}
+
+    # Install OpenBlas
+    # IMPORTANT: Ensure Openblas is installed in the final image
+    curl -L https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz | tar xz
+    # rename directory for mounting (without knowing version numbers) in multistage builds
+    mv OpenBLAS-${OPENBLAS_VERSION}/ OpenBLAS/
+    cd OpenBLAS/
+    make -j${MAX_JOBS} TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
+    make install
+    cd ..
+
+    # set path for openblas
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/OpenBLAS/lib/
+    export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
+else
+    # only for mounting on non-ppc64le
+    mkdir -p /root/OpenBLAS/
+fi

--- a/codeserver/ubi9-python-3.12/devel_env_setup.sh
+++ b/codeserver/ubi9-python-3.12/devel_env_setup.sh
@@ -35,6 +35,7 @@ if [[ $(uname -m) == "ppc64le" ]]; then
     # set path for openblas
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/OpenBLAS/lib/
     export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
+    export CMAKE_ARGS="-DPython3_EXECUTABLE=python"
 else
     # only for mounting on non-ppc64le
     mkdir -p /root/OpenBLAS/

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euxo pipefail
+
+##############################################################################
+# This script is expected to be run as `root`                                #
+# It builds code-server rpm for `ppc64le`                                    #
+# For other architectures, the rpm is downloaded from the available releases #
+##############################################################################
+
+
+# Mapping of `uname -m` values to equivalent GOARCH values
+declare -A UNAME_TO_GOARCH
+UNAME_TO_GOARCH["x86_64"]="amd64"
+UNAME_TO_GOARCH["aarch64"]="arm64"
+UNAME_TO_GOARCH["ppc64le"]="ppc64le"
+UNAME_TO_GOARCH["s390x"]="s390x"
+
+ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
+
+if [[ "$ARCH" == "ppc64le" ]]; then
+
+	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
+	export NODE_VERSION=${NODE_VERSION:-20}
+	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.98.0}
+
+	export NVM_DIR=/root/.nvm VENV=/opt/.venv
+	export PATH=${VENV}/bin:$PATH
+
+	export ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+	# install build dependencies
+#	dnf install -y \
+#	    git gcc-toolset-13 automake libtool rsync krb5-devel libX11-devel gettext jq patch
+        dnf install -y jq libtool gcc-toolset-13
+
+	. /opt/rh/gcc-toolset-13/enable
+
+	# build libxkbfile
+	git clone https://gitlab.freedesktop.org/xorg/util/macros.git
+	cd macros/
+	./autogen.sh && make install -j ${MAX_JOBS}
+	export ACLOCAL_PATH=/usr/local/share/aclocal/
+	cd .. && rm -rf macros
+	git clone https://gitlab.freedesktop.org/xorg/lib/libxkbfile.git
+	cd libxkbfile/
+	./autogen.sh && make install -j ${MAX_JOBS}
+	cd .. && rm -rf libxkbfile
+        export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
+
+	# install nfpm to build rpm
+	NFPM_VERSION=$(curl -s "https://api.github.com/repos/goreleaser/nfpm/releases/latest" | jq -r '.tag_name') \
+	    && dnf install -y https://github.com/goreleaser/nfpm/releases/download/${NFPM_VERSION}/nfpm-${NFPM_VERSION:1}-1.$(uname -m).rpm
+
+	# install node
+	NVM_VERSION=$(curl -s "https://api.github.com/repos/nvm-sh/nvm/releases/latest" | jq -r '.tag_name') \
+	    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash \
+	    && source ${NVM_DIR}/nvm.sh && nvm install ${NODE_VERSION}
+
+	# build codeserver
+	git clone https://github.com/coder/code-server.git
+	cd code-server
+	git checkout ${CODESERVER_VERSION}
+	git submodule update --init
+	source ${NVM_DIR}/nvm.sh
+	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
+	nvm use ${NODE_VERSION}
+	npm install
+	npm run build
+	VERSION=${CODESERVER_VERSION/v/} npm run build:vscode
+	npm run release
+	npm run release:standalone
+
+	# build codeserver rpm
+	VERSION=${CODESERVER_VERSION/v/} npm run package
+	cp release-packages/code-server-${CODESERVER_VERSION/v/}-ppc64le.rpm /tmp/
+
+else
+
+    # download RPM for other architectures
+    curl -L "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-${ARCH}.rpm" -o /tmp/code-server-${CODESERVER_VERSION/v/}-${ARCH}.rpm
+
+fi


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/pull/2317

Added scripts to allow building codeserver rpm from source and  build python wheels from source on ppc64le.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Images now available for multiple architectures, including ppc64le.
  - Architecture-specific optimizations and libraries included for improved compatibility.
- Performance
  - Faster dependency installation with wheel caching and offline installs.
  - Optimized math libraries on ppc64le for better compute performance.
- Reliability
  - More consistent code-server installation via RPM packaging.
  - Improved permissions handling for container runtimes.
- Chores
  - Build pipeline updated to produce multi-arch artifacts.
  - Added development tooling for preparing native dependencies on ppc64le.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->