### PR TITLE
NO-JIRA: chore(ci): introduce a `make test` target

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -48,14 +48,17 @@ jobs:
         run: uv version
 
       - name: Install deps
+        id: install-deps
         run: uv sync --locked
 
       # https://github.com/pre-commit/action
       - name: Run pre-commit on all files
+        if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
         run: |
           uv run pre-commit run --all-files
 
-      - run: uv run pytest
+      - run: make test
+        if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
 
   code-static-analysis:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -512,3 +512,8 @@ endif
 .PHONY: print-release
 print-release:
 	@echo "$(RELEASE)"
+
+.PHONY: test
+test:
+	@echo "Running quick static tests"
+	uv run pytest

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Make sure the following tools are installed in your environment:
  - podman/docker
  - python
  - pipenv
- - make
+ - make (on macOS install/use: gmake)
  - curl
 
 ### Installation
@@ -76,8 +76,10 @@ uv sync --locked
 By completing configuration in previous section, you are able to run any tests that don't need to start a container using following command:
 
 ```
-uv run pytest
+make test
 ```
+
+Use `gmake test` if you're on macOS.
 
 ##### Container selftests
 


### PR DESCRIPTION
## Description

It seems apparent that the tests we have are unable to aid during, let alone "drive", development, and they seem more like a final-inspection-before-shipping bureaucratic process.

Here's my plan to improve it

1. create make test in Makefile
2. add fast and useful tests there
3. keep adding fast and useful tests

## How Has This Been Tested?

    make test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a Makefile test command (make test) to run the test suite easily.

* Chores
  * CI improved: pre-commit and test steps now run only after successful dependency installation.
  * CI test execution standardized to invoke the new make test target.

* Documentation
  * Testing docs updated to use make test with macOS note to use gmake test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->