### PR TITLE
RHAIENG-304: tests(pytests): update the `pyproject.toml` integrity test since we no longer have Pipfiles anymore

### DIFF
--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rocm-tensorflow-ubi9-python-3.12"
 version = "0.1.0"
-requires-python = ">=3.12, <3.13"
+requires-python = "==3.12.*"
 
 dependencies = [
     "tf2onnx~=1.16.1",

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tensorflow-ubi9-python-3.12"
 version = "0.1.0"
-requires-python = ">=3.12, <3.13"
+requires-python = "==3.12.*"
 
 dependencies = [
     "tf2onnx~=1.16.1",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-304

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17379631044

    make test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned TensorFlow UBI9 images (standard and ROCm) to Python 3.12.x (requires-python set to ==3.12.*). Users should ensure environments use Python 3.12.x.

* **Tests**
  * Switched validation to inspect pyproject.toml files and verify the Python version constraint follows the 3.12.x pattern; added per-file subtests and improved handling of non-image directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->