### PR TITLE
opendatahub-io/notebooks#1924: skip expensive GHA for updates related to Konflux branches

### DIFF
--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -20,6 +20,10 @@ jobs:
   gen:
     name: Generate job matrix
     runs-on: ubuntu-latest
+    # for odh-io/notebooks and rhds/notebooks, allow only main, rhoai-*, release-*
+    if: ${{ (github.repository != 'opendatahub-io/notebooks' && github.repository != 'red-hat-data-services/notebooks')
+      || github.ref_name == 'main' || github.ref_name == '2024b' || github.ref_name == '2024a'
+      || startsWith(github.ref_name, 'rhoai-') || startsWith(github.ref_name, 'release-') }}
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}


### PR DESCRIPTION
* opendatahub-io/notebooks#1924

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

* runs on jiridanek/notebooks https://github.com/jiridanek/notebooks/actions/runs/17408853602
* does not trigger on odh-io/notebooks https://github.com/opendatahub-io/notebooks/actions/runs/17408886041

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to restrict when the generation job runs, executing only on designated branches (main, 2024a/2024b, and specific release prefixes) for select repositories; for others, it continues to run unconditionally.
  * Added a clarifying comment to document the behavior and intent.
  * No changes to build steps or outputs; end-user functionality and release artifacts remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->