### PR TITLE
RHAIENG-581: filter out and remove from the release notes the automated PR titles generated by Konflux

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# Configuration for GitHub's automatically generated release notes
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+---
+changelog:
+  exclude:
+    labels:
+      - konflux-nudge
+    authors:
+      # RHAIENG-581: bots and automation accounts (suppress noisy PRs)
+      - app/red-hat-konflux
+      - app/github-actions
+      # known bots
+      - dependabot
+      - ide-developer
+      - codeflare-machine-account
+  categories:
+    - title: "What's Changed"
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,5 +12,5 @@ changelog:
       # known bots
       - dependabot
       - ide-developer
-      - red-hat-konflux
+      - red-hat-konflux[bot]
       - codeflare-machine-account

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,7 @@ changelog:
   # RHAIENG-581: bots and automation accounts (suppress noisy PRs)
   exclude:
     labels:
-      #
+      # https://github.com/opendatahub-io/notebooks/pull/1961
       - konflux-nudge
     authors:
       # chore(deps): update odh-workbench-jupyter-minimal-rocm-py312-ubi9 to 636a39a by @red-hat-konflux[bot] in #1961

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@
 changelog:
   # RHAIENG-581: bots and automation accounts (suppress noisy PRs)
   exclude:
+    # TESTING: use https://github.com/opendatahub-io/notebooks/releases/new with custom branch to test this out
+    # selecting the + Create new tag in dropdown actually does not create new tag unless form is submitted
+    # then click Generate release notes to see how it comes out
     labels:
       # https://github.com/opendatahub-io/notebooks/pull/1961
       - konflux-nudge
@@ -12,3 +15,23 @@ changelog:
       - app/red-hat-konflux
       # chore(deps): update konflux references by @red-hat-konflux[bot] in #1974
       - red-hat-konflux[bot]
+
+      # the following are candidates for exclusion, need to determine if app/ or [bot] should be used
+
+      # [main] RHOAIENG-19036: chore(gha): fix workflow_dispatch invocation by @openshift-cherrypick-robot in #896
+      # openshift-cherrypick-robot
+
+      # RHOAIENG-28188: add `.tekton/` files for version 2025a-v1.34 by @odh-devops-app[bot] in #1365
+      # odh-devops-app[bot]
+
+      # [Digest Updater Action] Update Runtimes Images by @github-actions[bot] in #550
+      # github-actions[bot]
+
+      # RHAIENG-540: build(deps): bump `tornado` dependency from `~6.5.1` to `~6.5.2` across all relevant Pipfiles by @dependabot[bot] in #1754
+      # dependabot[bot]
+
+      # CodeRabbit Chat: Update .coderabbit.yaml to filter for main and 2024b branches only by @coderabbitai[bot] in #1491
+      # coderabbitai[bot]
+
+      # [Codeflare Action] Update notebook's pipfile to sync with Codeflare-SDK release 0.16.2 by @codeflare-machine-account in #542
+      # codeflare-machine-account

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,4 +12,5 @@ changelog:
       # known bots
       - dependabot
       - ide-developer
+      - red-hat-konflux
       - codeflare-machine-account

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,8 +9,8 @@ changelog:
       # RHAIENG-581: bots and automation accounts (suppress noisy PRs)
       - app/red-hat-konflux
       - app/github-actions
-      # known bots
       - dependabot
       - ide-developer
+      # chore(deps): update konflux references by @red-hat-konflux[bot] in https://github.com/opendatahub-io/notebooks/pull/1974
       - red-hat-konflux[bot]
       - codeflare-machine-account

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,7 +13,3 @@ changelog:
       - dependabot
       - ide-developer
       - codeflare-machine-account
-  categories:
-    - title: "What's Changed"
-      labels:
-        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,15 +2,13 @@
 # Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 ---
 changelog:
+  # RHAIENG-581: bots and automation accounts (suppress noisy PRs)
   exclude:
     labels:
+      #
       - konflux-nudge
     authors:
-      # RHAIENG-581: bots and automation accounts (suppress noisy PRs)
+      # chore(deps): update odh-workbench-jupyter-minimal-rocm-py312-ubi9 to 636a39a by @red-hat-konflux[bot] in #1961
       - app/red-hat-konflux
-      - app/github-actions
-      - dependabot
-      - ide-developer
-      # chore(deps): update konflux references by @red-hat-konflux[bot] in https://github.com/opendatahub-io/notebooks/pull/1974
+      # chore(deps): update konflux references by @red-hat-konflux[bot] in #1974
       - red-hat-konflux[bot]
-      - codeflare-machine-account


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-581

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

* before: https://github.com/opendatahub-io/notebooks/releases/tag/untagged-b110e32482ff26149ca1
* after: https://github.com/opendatahub-io/notebooks/releases/tag/untagged-26ae6792f8341508917b

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated release-notes config to filter out routine automation updates and a non-user-facing label, reducing noise in changelogs.
  - Will better surface user-impacting changes by omitting maintenance-only entries from automation accounts and bots.
  - Added in-repo configuration and documentation reference to help maintainers manage release-note behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->