### PR TITLE
RHAIENG-308, #2242: tests(make): enforce version parity validation between imagest

### DIFF
--- a/manifests/overlays/additional/jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -35,7 +35,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},

--- a/manifests/overlays/additional/jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
@@ -40,7 +40,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},

--- a/manifests/overlays/additional/jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
@@ -37,7 +37,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},

--- a/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
@@ -41,7 +41,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

    make test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Codeflare‑SDK to 0.30 across Python 3.12 UBI9 Jupyter notebook image variants (Datascience CPU, PyTorch CUDA, PyTorch ROCm, TensorFlow CUDA).

* **Tests**
  * Enhanced test validations to parse and compare manifest vs locked dependency versions, asserting major/minor consistency to prevent version drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->