### PR TITLE
NO-JIRA: only show crio debug info if we actually managed to install crio packages

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -386,6 +386,7 @@ jobs:
 
       # https://cri-o.io/
       - name: Install cri-o
+        id: install-crio
         if: ${{ steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
@@ -478,7 +479,7 @@ jobs:
           sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
       - name: Show kubelet debug data (on failure)
-        if: ${{ failure() && steps.have-tests.outputs.tests == 'true' }}
+        if: ${{ failure() && steps.have-tests.outputs.tests == 'true' && steps.install-crio.outcome == 'success' }}
         run: |
           set -Eeuxo pipefail
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17432746520/job/49494816390

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow improvements: Added a unique identifier to the CRI-O installation step to enable clearer step referencing.
  * Refined the failure-debug condition for CRI-O to run only when installation succeeded, reducing irrelevant debug output and making failure logs more actionable.
  * Overall, improves reliability and signal-to-noise in CI logs without impacting application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->