### PR TITLE
NO-JIRA: sudo apt-get install -y --allow-downgrades "cri-o=${CRIO_VERSION}.*"

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -409,9 +409,15 @@ jobs:
             sudo tee /etc/apt/sources.list.d/cri-o.list
 
           sudo apt-get update
+
           # [ERROR FileExisting-conntrack]: conntrack not found in system path
           # see man apt-patterns for the ~name=version* syntax
-          sudo apt-get install -y \
+
+          # The following packages will be DOWNGRADED:
+          #  kubectl
+          # E: Packages were downgraded and -y was used without --allow-downgrades.
+
+          sudo apt-get install -y --allow-downgrades \
             "cri-o=${CRIO_VERSION}.*" \
             "kubelet=${KUBERNETES_VERSION}.*" "kubeadm=${KUBERNETES_VERSION}.*" "kubectl=${KUBERNETES_VERSION}.*" \
             conntrack


### PR DESCRIPTION
```
+ sudo apt-get install -y 'cri-o=1.32.*' 'kubelet=1.33.*' 'kubeadm=1.33.*' 'kubectl=1.33.*' conntrack
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  cri-tools kubernetes-cni
The following NEW packages will be installed:
  conntrack cri-o cri-tools kubeadm kubelet kubernetes-cni
The following packages will be DOWNGRADED:
  kubectl
E: Packages were downgraded and -y was used without --allow-downgrades.
0 upgraded, 6 newly installed, 1 downgraded, 0 to remove and 7 not upgraded.
Error: Process completed with exit code 100.
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
* https://github.com/jiridanek/notebooks/actions/runs/17433000461

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved intermittent build failures during notebook server provisioning by aligning Kubernetes/CRI-O package versions, reducing deployment errors.

- Chores
  - Updated build pipeline to permit safe package downgrades for compatibility, improving reliability of notebook server builds and publishes.
  - Enhanced build robustness to avoid common tooling mismatches (e.g., missing dependencies), leading to more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->