### PR TITLE
RHAIENG-308, #2242: tests(make): enforce version parity validation between imagestreams

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -286,8 +286,8 @@ def _skip_unimplemented_manifests(directory: pathlib.Path, call_skip=True) -> bo
         "runtimes/rocm-tensorflow/ubi9-python-3.12",
         "jupyter/rocm/tensorflow/ubi9-python-3.12",
     )
-    for dir in dirs:
-        if is_suffix(directory.parts, pathlib.Path(dir).parts):
+    for d in dirs:
+        if is_suffix(directory.parts, pathlib.Path(d).parts):
             if call_skip:
                 pytest.skip(f"Manifest not implemented {directory.parts}")
             else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -222,17 +222,17 @@ def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubT
             continue
 
         mapping = {str(d.manifest.filename.relative_to(PROJECT_ROOT)): d.version for d in data}
-
-        exception = next((it for it in ignored_exceptions if it[0] == name), None)
-        if exception:
-            if set(versions) == set(exception[1]):
-                continue
-            else:
-                pytest.fail(
-                    f"{name} is allowed to have {exception} but actually has more versions: {pprint.pformat(mapping)}"
-                )
-
         with subtests.test(msg=f"checking versions for {name} across the latest tags in all imagestreams"):
+            exception = next((it for it in ignored_exceptions if it[0] == name), None)
+            if exception:
+                # exception may save us from failing
+                if set(versions) == set(exception[1]):
+                    continue
+                else:
+                    pytest.fail(
+                        f"{name} is allowed to have {exception} but actually has more versions: {pprint.pformat(mapping)}"
+                    )
+            # all hope is lost, the check has failed
             pytest.fail(f"{name} has multiple versions: {pprint.pformat(mapping)}")
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,7 +173,7 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests):
 
 
 def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubTests):
-    manifests = []
+    collected_manifests = []
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):
         logging.info(file)
         directory = file.parent  # "ubi9-python-3.11"
@@ -187,7 +187,7 @@ def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubT
             continue
 
         manifest = load_manifests_file_for(directory)
-        manifests.append(manifest)
+        collected_manifests.append(manifest)
 
     @dataclasses.dataclass
     class VersionData:
@@ -195,7 +195,7 @@ def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubT
         version: str
 
     packages: dict[str, list[VersionData]] = defaultdict(list)
-    for manifest in manifests:
+    for manifest in collected_manifests:
         for dep in manifest.dep:
             name = dep["name"]
             version = dep["version"]
@@ -300,8 +300,8 @@ class Manifest:
     filename: pathlib.Path
     imagestream: dict[str, Any]
     metadata: manifests.NotebookMetadata
-    sw: dict
-    dep: dict
+    sw: list[dict[str, Any]]
+    dep: list[dict[str, Any]]
 
 
 def load_manifests_file_for(directory: pathlib.Path) -> Manifest:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -202,7 +202,8 @@ def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubT
             packages[name].append(VersionData(manifest=manifest, version=version))
 
     # TODO(jdanek): review these, if any are unwarranted
-    ignored_exceptions = (
+    ignored_exceptions: tuple[tuple[str, tuple[str, ...]], ...] = (
+        # ("package name", ("allowed version 1", "allowed version 2", ...))
         ("Codeflare-SDK", ("0.30", "0.29")),
         ("Scikit-learn", ("1.7", "1.6")),
         ("Pandas", ("2.2", "1.5")),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -211,11 +211,7 @@ def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubT
     )
 
     for name, data in packages.items():
-        versions = [
-            d.version
-            for d in data
-            if (d.manifest.filename.relative_to(PROJECT_ROOT), d.version) not in ignored_exceptions
-        ]
+        versions = [d.version for d in data]
 
         # if there is only a single version, all is good
         if len(set(versions)) == 1:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-308

## Description

Continuation of
* https://github.com/opendatahub-io/notebooks/pull/2254

## How Has This Been Tested?

    gmake test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Unified manifest loading in tests to replace ad-hoc parsing.
  * Refactored workload tests to read manifest metadata for software and dependency checks.
  * Added cross-image version alignment test to ensure consistent package versions across image streams, with per-package exceptions.
  * Expanded package name normalization and mappings to align manifests with lockfile entries.
  * Added conditional skipping for known-unimplemented manifests.
  * Included supporting scaffolding for clearer, more maintainable tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->