### PR TITLE
Make cuda base images available for amd and arm archs

### DIFF
--- a/.tekton/odh-base-image-cuda-py311-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py311-c9s-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
   - name: path-context

--- a/.tekton/odh-base-image-cuda-py311-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-py311-c9s-push.yaml
@@ -25,6 +25,10 @@ spec:
     value: quay.io/opendatahub/odh-base-image-cuda-py311-c9s:{{revision}}
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   - name: path-context
     value: .
   - name: additional-tags
@@ -32,7 +36,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - v12.6
   pipelineRef:
-    name: singlearch-push-pipeline
+    name: multiarch-pull-request-pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-base-image-cuda-py311-c9s-poc
   workspaces:

--- a/.tekton/odh-base-image-cuda-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py312-c9s-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
   - name: path-context

--- a/.tekton/odh-base-image-cuda-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-py312-c9s-push.yaml
@@ -26,6 +26,10 @@ spec:
     value: quay.io/opendatahub/odh-base-image-cuda-py312-c9s:{{revision}}
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   - name: path-context
     value: .
   - name: additional-tags
@@ -33,7 +37,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - v12.6
   pipelineRef:
-    name: singlearch-push-pipeline
+    name: multiarch-pull-request-pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-base-image-cuda-py312-c9s-poc
   workspaces:

--- a/.tekton/odh-base-image-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py312-ubi9-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context

--- a/.tekton/odh-base-image-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-cuda-py312-ubi9-push.yaml
@@ -26,6 +26,10 @@ spec:
     value: quay.io/opendatahub/odh-base-image-cuda-py312-ubi9:{{revision}}
   - name: dockerfile
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   - name: path-context
     value: .
   - name: additional-tags
@@ -33,7 +37,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - v12.6
   pipelineRef:
-    name: singlearch-push-pipeline
+    name: multiarch-pull-request-pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-base-image-cuda-py312-ubi9-poc
   workspaces:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://issues.redhat.com/browse/RHAIENG-778


## Description
<!--- Describe your changes in detail -->
Make cuda base images available for amd and arm archs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added ARM64 support for CUDA Python 3.11 and 3.12 base images (CentOS Stream 9 and UBI9). Images are now built and published for both x86_64 and ARM64 across pull request and push workflows.
* Chores
  * Updated CI/CD to run multi-architecture builds and configured build platforms to include ARM64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->