### PR TITLE
RHAIENG-308, #2242: tests(make): add pyproject version alignment test and handle allowed specifier divergences

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -292,10 +292,10 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
                     continue
                 else:
                     pytest.fail(
-                        f"{name} is allowed to have {exception[1]} but actually has more versions: {pprint.pformat(set(data))}"
+                        f"{name} is allowed to have {exception[1]} but actually has more specifiers: {pprint.pformat(set(data))}"
                     )
             # all hope is lost, the check has failed
-            pytest.fail(f"{name} has multiple versions: {pprint.pformat(data)}")
+            pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
 
 
 def test_files_that_should_be_same_are_same(subtests: pytest_subtests.plugin.SubTests):


### PR DESCRIPTION
* Add test_image_pyprojects_version_alignment to compare dependency specifiers across all pyproject.toml files
* Import packaging.specifiers and store actual SpecifierSet objects instead of string reprs
* Introduce ignored_exceptions for known, acceptable specifier differences (e.g., torch variants, numpy caps)
* Compare specifiers using SpecifierSet equality and wrap checks in subtests for clearer reporting
* Minor cleanup: remove unused pyprojects variable

https://issues.redhat.com/browse/RHAIENG-308

## Description

Continuation of
* https://github.com/opendatahub-io/notebooks/pull/2254

## How Has This Been Tested?

    gmake test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated test that verifies dependency version alignment across all images using pyproject metadata.
  * Honors configured exceptions for intentional divergences and skips unimplemented manifests.
  * Produces clear failure reports listing packages with mismatched specifiers to aid troubleshooting.
  * Complements existing alignment checks to catch inconsistencies earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->