### PR TITLE
RHAIENG-308, #2242: tests(make): handle rstudio in a rhds-compatible manner

### DIFF
--- a/tests/manifests.py
+++ b/tests/manifests.py
@@ -185,7 +185,10 @@ def get_source_of_truth_filepath(
                 filename = f"jupyter-{notebook_id}-{file_suffix}"
 
         elif RSTUDIO_NOTEBOOK_ID in notebook_id:
-            filename = f"rstudio-gpu-{file_suffix}"
+            imagestream_filename = f"rstudio-gpu-{file_suffix}"
+            buildconfig_filename = "cuda-rstudio-buildconfig.yaml"
+            _ = imagestream_filename
+            filename = buildconfig_filename
 
     if not filename:
         raise ValueError(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -316,7 +316,12 @@ def load_manifests_file_for(directory: pathlib.Path) -> Manifest:
             f"Computed filepath '{manifest_file}' does not exist."
         )
 
-    imagestream = yaml.safe_load(manifest_file.read_text())
+    # BEWARE: rhds rstudio has imagestream bundled in the buildconfig yaml
+    if "buildconfig" in manifest_file.name:
+        # imagestream is the first document in the file
+        imagestream = next(yaml.safe_load_all(manifest_file.read_text()))
+    else:
+        imagestream = yaml.safe_load(manifest_file.read_text())
     recommended_tags = [
         tag
         for tag in imagestream["spec"]["tags"]


### PR DESCRIPTION
```
======================================================================================================================================================= FAILURES =======================================================================================================================================================
______________________________________________________________ test_image_pyprojects [checking imagestream manifest consistency with pylock.toml] (pyproject=PosixPath('/Users/jdanek/IdeaProjects/notebooks/rstudio/rhel9-python-3.11/pyproject.toml')) _______________________________________________________________
tests/test_main.py:79: in test_image_pyprojects
    raise FileNotFoundError(
E   FileNotFoundError: Unable to determine imagestream manifest for '/Users/jdanek/IdeaProjects/notebooks/rstudio/rhel9-python-3.11'. Computed filepath '/Users/jdanek/IdeaProjects/notebooks/manifests/base/rstudio-gpu-notebook-imagestream.yaml' does not exist.
-------------------------------------------------------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------------------------------------------------------
```

## Description

https://issues.redhat.com/browse/RHAIENG-308

## How Has This Been Tested?

    gmake test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for loading multi-document buildconfig manifests to improve compatibility with complex YAML files.
- Bug Fixes
  - RStudio GPU notebooks now target the correct CUDA build configuration, improving reliability and reducing deployment issues previously caused by imagestream selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->