### PR TITLE
RHAIENG-816: fix(jupyter/rocm/tensorflow/ubi9-python-3.12): image has outdated jupyterlab and jupyterlab-git packages

### DIFF
--- a/examples/jupyterlab-with-elyra/Dockerfile
+++ b/examples/jupyterlab-with-elyra/Dockerfile
@@ -58,7 +58,7 @@ nbdime~=4.0.2
 nbgitpuller~=1.2.2
 
 # Elyra
-odh-elyra==4.2.1
+odh-elyra==4.2.3
 kfp~=2.12.1
 
 # Miscellaneous datascience packages

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -511,9 +511,9 @@ wheels = [
 
 [[packages]]
 name = "click"
-version = "8.2.1"
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", upload-time = 2025-05-20T23:19:49Z, size = 286342, hashes = { sha256 = "27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", upload-time = 2025-05-20T23:19:47Z, size = 102215, hashes = { sha256 = "61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b" } }]
+version = "8.1.8"
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", upload-time = 2024-12-21T18:38:44Z, size = 226593, hashes = { sha256 = "ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", upload-time = 2024-12-21T18:38:41Z, size = 98188, hashes = { sha256 = "63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2" } }]
 
 [[packages]]
 name = "codeflare-sdk"
@@ -1360,9 +1360,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/5a/80/5a1162f78414298
 
 [[packages]]
 name = "jupyter-server"
-version = "2.15.0"
-sdist = { url = "https://files.pythonhosted.org/packages/61/8c/df09d4ab646141f130f9977b32b206ba8615d1969b2eba6a2e84b7f89137/jupyter_server-2.15.0.tar.gz", upload-time = 2024-12-20T13:02:42Z, size = 725227, hashes = { sha256 = "9d446b8697b4f7337a1b7cdcac40778babdd93ba614b6d68ab1c0c918f1c4084" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/e2/a2/89eeaf0bb954a123a909859fa507fa86f96eb61b62dc30667b60dbd5fdaf/jupyter_server-2.15.0-py3-none-any.whl", upload-time = 2024-12-20T13:02:37Z, size = 385826, hashes = { sha256 = "872d989becf83517012ee669f09604aa4a28097c0bd90b2f424310156c2cdae3" } }]
+version = "2.16.0"
+sdist = { url = "https://files.pythonhosted.org/packages/41/c8/ba2bbcd758c47f1124c4ca14061e8ce60d9c6fd537faee9534a95f83521a/jupyter_server-2.16.0.tar.gz", upload-time = 2025-05-12T16:44:46Z, size = 728177, hashes = { sha256 = "65d4b44fdf2dcbbdfe0aa1ace4a842d4aaf746a2b7b168134d5aaed35621b7f6" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/46/1f/5ebbced977171d09a7b0c08a285ff9a20aafb9c51bde07e52349ff1ddd71/jupyter_server-2.16.0-py3-none-any.whl", upload-time = 2025-05-12T16:44:43Z, size = 386904, hashes = { sha256 = "3d8db5be3bc64403b1c65b400a1d7f4647a5ce743f3b20dbdefe8ddb7b55af9e" } }]
 
 [[packages]]
 name = "jupyter-server-mathjax"
@@ -1384,15 +1384,15 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.2.7"
-sdist = { url = "https://files.pythonhosted.org/packages/8f/51/9e1e089b7e3b4b60d5564463067bde91d9ad00410ed781ddb0139dda5f82/jupyterlab-4.2.7.tar.gz", upload-time = 2025-01-08T12:26:44Z, size = 21508689, hashes = { sha256 = "7353c0704aec0e1219eb1e376c2d51f855a2522605f9ecdcab4993c006991ea3" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/71/0d/8b1e890d317b5beb9a727d7326e59921f1a4bd1f8c4f4bdf40a60ca9ab20/jupyterlab-4.2.7-py3-none-any.whl", upload-time = 2025-01-08T12:26:38Z, size = 11642874, hashes = { sha256 = "a16a10a114360a4249c855e382b95260ebf2b91341884739dde954936096684d" } }]
+version = "4.4.4"
+sdist = { url = "https://files.pythonhosted.org/packages/e2/4d/7ca5b46ea56742880d71a768a9e6fb8f8482228427eb89492d55c5d0bb7d/jupyterlab-4.4.4.tar.gz", upload-time = 2025-06-28T13:07:20Z, size = 23044296, hashes = { sha256 = "163fee1ef702e0a057f75d2eed3ed1da8a986d59eb002cbeb6f0c2779e6cd153" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f8/82/66910ce0995dbfdb33609f41c99fe32ce483b9624a3e7d672af14ff63b9f/jupyterlab-4.4.4-py3-none-any.whl", upload-time = 2025-06-28T13:07:15Z, size = 12296310, hashes = { sha256 = "711611e4f59851152eb93316c3547c3ec6291f16bb455f1f4fa380d25637e0dd" } }]
 
 [[packages]]
 name = "jupyterlab-git"
-version = "0.50.2"
-sdist = { url = "https://files.pythonhosted.org/packages/c5/00/a8123e22ead190dce24c75aeb9a5708f3a6886abc91a3e18d45d7418e8aa/jupyterlab_git-0.50.2.tar.gz", upload-time = 2024-10-29T15:43:17Z, size = 15248711, hashes = { sha256 = "ceefdc85632caf499a048b434459d03b5e621665801e9db7197bd486f5d33433" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/65/70/fb5a07776b00802afae9687e61db5e44b08959129988ba5df3791bd420b9/jupyterlab_git-0.50.2-py3-none-any.whl", upload-time = 2024-10-29T15:43:14Z, size = 1154095, hashes = { sha256 = "059114d19fcb5560f82914b070ed7654fab62392e3c1fdd5946c5dc460ae3697" } }]
+version = "0.51.2"
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a2/071e86f015ce319b42131d543a1108fd92a97e7d5bea622a81a51cd4cf5e/jupyterlab_git-0.51.2.tar.gz", upload-time = 2025-06-12T14:44:39Z, size = 14471184, hashes = { sha256 = "ad91d56f0298fd70e7d8f8cd1ee76d261f0dfb940cc490717a31d64df4b7d562" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/50/dc/d59ae2a9e4671c090ba9ef9f1228a62cf49ad80b4bc3d716565bb7e6a81b/jupyterlab_git-0.51.2-py3-none-any.whl", upload-time = 2025-06-12T14:44:37Z, size = 367704, hashes = { sha256 = "1150edabd844f9a5a3c7ba676409b18b8cc95b1a7bb171f357318f4075db2263" } }]
 
 [[packages]]
 name = "jupyterlab-lsp"
@@ -2145,9 +2145,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.1"
-sdist = { url = "https://files.pythonhosted.org/packages/65/df/ebdb17819a6bb03462bb9a18fcf8562134a6480294fb0aa57cac1007a4af/odh_elyra-4.2.1.tar.gz", upload-time = 2025-05-07T17:39:30Z, size = 2155327, hashes = { sha256 = "a2c1c56ee9cb413f24efd3837410dd714745536036dc444bd722084406435a78" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/de/c9/ef598a974b7913b4efc6eab7e6fa7736b5025194ced4ce378bae5137f7c2/odh_elyra-4.2.1-py3-none-any.whl", upload-time = 2025-05-07T17:39:28Z, size = 4316225, hashes = { sha256 = "255ada78cfac3f5f60427b1106baaca269513dfd06694ebb06755dcb20618689" } }]
+version = "4.2.3"
+sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e0301699073905b357542548f31f7bf74412526980bc2cbdba972/odh_elyra-4.2.3.tar.gz", upload-time = 2025-08-01T11:16:37Z, size = 2155613, hashes = { sha256 = "15799e9a00bb57e1c76404808a07710563a7a0ef0c67716facc3e09416ac96b0" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
 name = "onnx"
@@ -3703,9 +3703,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc
 
 [[packages]]
 name = "skl2onnx"
-version = "1.17.0"
-sdist = { url = "https://files.pythonhosted.org/packages/f2/91/53c1d0085fb11c6ae2b2092160f55380fa361b8ced1144eada49add70adb/skl2onnx-1.17.0.tar.gz", upload-time = 2024-05-30T12:28:02Z, size = 931965, hashes = { sha256 = "7127dc84e470f489f68094ccfff9a5a815b609f700d43e708e6f658a33b06403" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/61/db/343223f105c34cbf8dd1237693e8628deb5009f2a9c4f2e3d2c6546f2766/skl2onnx-1.17.0-py2.py3-none-any.whl", upload-time = 2024-05-30T12:27:59Z, size = 298421, hashes = { sha256 = "27942fc2743efe9dff56380001da4685812d0f5b1b0b9c1a032e80d059d6779a" } }]
+version = "1.18.0"
+sdist = { url = "https://files.pythonhosted.org/packages/a9/fb/f91b284365bab4ddcb0f77f573e60dc96bc232648de997814e3ddd832e97/skl2onnx-1.18.0.tar.gz", upload-time = 2024-12-18T07:25:09Z, size = 935240, hashes = { sha256 = "39ea4ae30c5c182355a1824467013158214444e0ce0b18f33338bd827d4fb00f" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/08/de/e8825727acd80484aa28080de62e4dc21f076d6887c10db49e2c8a66578f/skl2onnx-1.18.0-py2.py3-none-any.whl", upload-time = 2024-12-18T07:25:06Z, size = 300310, hashes = { sha256 = "1345d8a1d3aa4a11abfbed4bc984b777023dad85e1c9fe4eb727cba5ee0fcaa8" } }]
 
 [[packages]]
 name = "smart-open"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "plotly~=6.0.0",
     "scikit-learn~=1.6.1",
     "scipy~=1.15.2",
-    "skl2onnx~=1.17.0",
+    "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.29.0",
     "kubeflow-training==1.9.0",
@@ -33,17 +33,17 @@ dependencies = [
     "mysql-connector-python~=9.3.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.1",
+    "odh-elyra==4.2.3",
 
-    "jupyterlab==4.2.7",
+    "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",
-    "jupyter-server~=2.15.0",
+    "jupyter-server~=2.16.0",
     "jupyter-server-proxy~=4.4.0",
     "jupyter-server-terminals~=0.5.3",
-    "jupyterlab-git~=0.50.1",
+    "jupyterlab-git~=0.51.1",
     "jupyterlab-lsp~=5.1.0",
     "jupyterlab-widgets~=3.0.13",
-    "jupyter-resource-usage~=1.1.0",
+    "jupyter-resource-usage~=1.1.1",
     "nbdime~=4.0.2",
     "nbgitpuller~=1.2.2",
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -3099,9 +3099,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc
 
 [[packages]]
 name = "skl2onnx"
-version = "1.17.0"
-sdist = { url = "https://files.pythonhosted.org/packages/f2/91/53c1d0085fb11c6ae2b2092160f55380fa361b8ced1144eada49add70adb/skl2onnx-1.17.0.tar.gz", upload-time = 2024-05-30T12:28:02Z, size = 931965, hashes = { sha256 = "7127dc84e470f489f68094ccfff9a5a815b609f700d43e708e6f658a33b06403" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/61/db/343223f105c34cbf8dd1237693e8628deb5009f2a9c4f2e3d2c6546f2766/skl2onnx-1.17.0-py2.py3-none-any.whl", upload-time = 2024-05-30T12:27:59Z, size = 298421, hashes = { sha256 = "27942fc2743efe9dff56380001da4685812d0f5b1b0b9c1a032e80d059d6779a" } }]
+version = "1.18.0"
+sdist = { url = "https://files.pythonhosted.org/packages/a9/fb/f91b284365bab4ddcb0f77f573e60dc96bc232648de997814e3ddd832e97/skl2onnx-1.18.0.tar.gz", upload-time = 2024-12-18T07:25:09Z, size = 935240, hashes = { sha256 = "39ea4ae30c5c182355a1824467013158214444e0ce0b18f33338bd827d4fb00f" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/08/de/e8825727acd80484aa28080de62e4dc21f076d6887c10db49e2c8a66578f/skl2onnx-1.18.0-py2.py3-none-any.whl", upload-time = 2024-12-18T07:25:06Z, size = 300310, hashes = { sha256 = "1345d8a1d3aa4a11abfbed4bc984b777023dad85e1c9fe4eb727cba5ee0fcaa8" } }]
 
 [[packages]]
 name = "smart-open"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "plotly~=6.0.0",
     "scikit-learn~=1.6.1",
     "scipy~=1.15.2",
-    "skl2onnx~=1.17.0",
+    "skl2onnx~=1.18.0",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
     "codeflare-sdk~=0.29.0",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -245,9 +245,6 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
             logging.debug(f"skipping {directory.name}/pyproject.toml as it is not an image directory")
             continue
 
-        if _skip_unimplemented_manifests(directory, call_skip=False):
-            continue
-
         pyproject = tomllib.loads(file.read_text())
         for d in pyproject["project"]["dependencies"]:
             requirement = packaging.requirements.Requirement(d)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-816

## Description

```
============================================================================================================ FAILURES =============================================================================================================
_______________________________________________________________ test_image_pyprojects_version_alignment [checking versions of skl2onnx across all pyproject.tomls] ________________________________________________________________
tests/test_main.py:295: in test_image_pyprojects_version_alignment
    pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
E   Failed: skl2onnx has multiple specifiers: [<SpecifierSet('~=1.17.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.17.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>,
E    <SpecifierSet('~=1.18.0')>]
-------------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------------

_______________________________________________________________ test_image_pyprojects_version_alignment [checking versions of odh-elyra across all pyproject.tomls] _______________________________________________________________
tests/test_main.py:295: in test_image_pyprojects_version_alignment
    pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
E   Failed: odh-elyra has multiple specifiers: [<SpecifierSet('==4.2.3')>,
E    <SpecifierSet('==4.2.3')>,
E    <SpecifierSet('==4.2.3')>,
E    <SpecifierSet('==4.2.1')>,
E    <SpecifierSet('==4.2.3')>,
E    <SpecifierSet('==4.2.3')>,
E    <SpecifierSet('==4.2.3')>]
-------------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------------

______________________________________________________________ test_image_pyprojects_version_alignment [checking versions of jupyterlab across all pyproject.tomls] _______________________________________________________________
tests/test_main.py:295: in test_image_pyprojects_version_alignment
    pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
E   Failed: jupyterlab has multiple specifiers: [<SpecifierSet('==4.4.4')>,
E    <SpecifierSet('==4.4.4')>,
E    <SpecifierSet('==4.4.4')>,
E    <SpecifierSet('==4.4.4')>,
E    <SpecifierSet('==4.2.7')>,
E    <SpecifierSet('==4.4.4')>,
E    <SpecifierSet('==4.4.4')>,
E    <SpecifierSet('==4.4.4')>]
-------------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------------

____________________________________________________________ test_image_pyprojects_version_alignment [checking versions of jupyter-server across all pyproject.tomls] _____________________________________________________________
tests/test_main.py:295: in test_image_pyprojects_version_alignment
    pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
E   Failed: jupyter-server has multiple specifiers: [<SpecifierSet('~=2.16.0')>,
E    <SpecifierSet('~=2.16.0')>,
E    <SpecifierSet('~=2.16.0')>,
E    <SpecifierSet('~=2.16.0')>,
E    <SpecifierSet('~=2.15.0')>,
E    <SpecifierSet('~=2.16.0')>,
E    <SpecifierSet('~=2.16.0')>,
E    <SpecifierSet('~=2.16.0')>]
-------------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------------

____________________________________________________________ test_image_pyprojects_version_alignment [checking versions of jupyterlab-git across all pyproject.tomls] _____________________________________________________________
tests/test_main.py:295: in test_image_pyprojects_version_alignment
    pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
E   Failed: jupyterlab-git has multiple specifiers: [<SpecifierSet('~=0.51.1')>,
E    <SpecifierSet('~=0.51.1')>,
E    <SpecifierSet('~=0.51.1')>,
E    <SpecifierSet('~=0.51.1')>,
E    <SpecifierSet('~=0.50.1')>,
E    <SpecifierSet('~=0.51.1')>,
E    <SpecifierSet('~=0.51.1')>,
E    <SpecifierSet('~=0.51.1')>]
-------------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------------

________________________________________________________ test_image_pyprojects_version_alignment [checking versions of jupyter-resource-usage across all pyproject.tomls] _________________________________________________________
tests/test_main.py:295: in test_image_pyprojects_version_alignment
    pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
E   Failed: jupyter-resource-usage has multiple specifiers: [<SpecifierSet('~=1.1.1')>,
E    <SpecifierSet('~=1.1.1')>,
E    <SpecifierSet('~=1.1.1')>,
E    <SpecifierSet('~=1.1.0')>,
E    <SpecifierSet('~=1.1.1')>,
E    <SpecifierSet('~=1.1.1')>,
E    <SpecifierSet('~=1.1.1')>]
-------------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------------

===================================================================================================== short test summary info =====================================================================================================
[checking versions of skl2onnx across all pyproject.tomls] SUBFAIL tests/test_main.py::test_image_pyprojects_version_alignment - Failed: skl2onnx has multiple specifiers: [<SpecifierSet('~=1.17.0')>,
[checking versions of odh-elyra across all pyproject.tomls] SUBFAIL tests/test_main.py::test_image_pyprojects_version_alignment - Failed: odh-elyra has multiple specifiers: [<SpecifierSet('==4.2.3')>,
[checking versions of jupyterlab across all pyproject.tomls] SUBFAIL tests/test_main.py::test_image_pyprojects_version_alignment - Failed: jupyterlab has multiple specifiers: [<SpecifierSet('==4.4.4')>,
[checking versions of jupyter-server across all pyproject.tomls] SUBFAIL tests/test_main.py::test_image_pyprojects_version_alignment - Failed: jupyter-server has multiple specifiers: [<SpecifierSet('~=2.16.0')>,
[checking versions of jupyterlab-git across all pyproject.tomls] SUBFAIL tests/test_main.py::test_image_pyprojects_version_alignment - Failed: jupyterlab-git has multiple specifiers: [<SpecifierSet('~=0.51.1')>,
[checking versions of jupyter-resource-usage across all pyproject.tomls] SUBFAIL tests/test_main.py::test_image_pyprojects_version_alignment - Failed: jupyter-resource-usage has multiple specifiers: [<SpecifierSet('~=1.1.1')>,
================================================================================== 6 failed, 32 passed, 48 skipped, 114 subtests passed in 2.88s ==================================================================================
gmake: *** [Makefile:518: test] Error 1
```

## How Has This Been Tested?

    gmake test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Elyra in the JupyterLab example image to the latest 4.2.3 release.
  - Refreshed ROCm TensorFlow notebook dependencies: jupyterlab (4.4.4), jupyter-server (2.16.0), jupyterlab-git (0.51.x), jupyter-resource-usage (1.1.1), and odh-elyra (4.2.3).
  - Bumped skl2onnx to 1.18.0 across relevant environments and synchronized lockfiles.

- Tests
  - Improved version alignment test to validate pyproject/pylock files without pre-skipping unimplemented manifests, while still skipping during manifest loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->