### PR TITLE
RHAIENG-394: add notebooks release version on the Dockefile Label section

### DIFF
--- a/.tekton/multiarch-pull-request-pipeline.yaml
+++ b/.tekton/multiarch-pull-request-pipeline.yaml
@@ -99,6 +99,10 @@ spec:
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
+  - default: []
+    description: Array of image labels to apply to the image (key=value strings)
+    name: image-labels
+    type: array
   results:
   - description: ""
     name: IMAGE_URL
@@ -219,6 +223,9 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
+    - name: IMAGE_LABELS
+      value:
+      - $(params.image-labels[*])
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/multiarch-push-pipeline.yaml
+++ b/.tekton/multiarch-push-pipeline.yaml
@@ -111,6 +111,10 @@ spec:
     description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
+  - default: []
+    description: Array of image labels to apply to the built image. 
+    name: image-labels
+    type: array
   - default:
     - linux/x86_64
     description: List of platforms to build the container images on. The available
@@ -275,6 +279,9 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
+    - name: IMAGE_LABELS
+      value: 
+      - $(params.image-labels[*])
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/odh-base-image-cuda-py311-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py311-c9s-pull-request.yaml
@@ -41,6 +41,9 @@ spec:
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
   - name: path-context
     value: .
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-py311-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-py311-c9s-push.yaml
@@ -30,6 +30,9 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+  - name: image-labels
+    value:
+    - release=2025b
   - name: path-context
     value: .
   - name: additional-tags

--- a/.tekton/odh-base-image-cuda-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py312-c9s-pull-request.yaml
@@ -41,6 +41,9 @@ spec:
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-py312-c9s-push.yaml
@@ -36,6 +36,9 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
     - v12.6
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-push-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py312-ubi9-pull-request.yaml
@@ -41,6 +41,9 @@ spec:
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-cuda-py312-ubi9-push.yaml
@@ -36,6 +36,9 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
     - v12.6
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-push-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-py312-c9s-pull-request.yaml
@@ -40,6 +40,9 @@ spec:
     value: base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-py312-c9s-push.yaml
@@ -31,6 +31,9 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
     - v6.2
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-py312-ubi9-pull-request.yaml
@@ -40,6 +40,9 @@ spec:
     value: base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-rocm-py312-ubi9-push.yaml
@@ -32,6 +32,9 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
     - v6.2
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -44,6 +44,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -45,6 +45,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -43,6 +43,9 @@ spec:
     value: .
   - name: build-args-file
     value: codeserver/ubi9-python-3.12/build-args/cpu.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -43,6 +43,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+  - name: image-labels
+    value:
+    - release=2025b
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes for https://issues.redhat.com/browse/RHAIENG-394?filter=-1
## Description
<!--- Describe your changes in detail -->
Add 2025b on the Dockefile Label section
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CI/CD now applies a release label (release=2025b) to built container images for easier discovery and filtering.

- **Chores**
  - Build pipelines updated to accept and propagate image-label metadata across supported variants (CPU/GPU, CUDA/ROCm, multiple runtimes).
  - Pipeline parameters standardized for consistent labeling.
  - Replaced or removed a few legacy build-args-file settings where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->