### PR TITLE
RHAIENG-308: ref(tests): refactor tests to replace `pytest.fail` with assertions for clearer error reporting in `test_main.py`

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -224,12 +224,10 @@ def test_image_manifests_version_alignment(subtests: pytest_subtests.plugin.SubT
             exception = next((it for it in ignored_exceptions if it[0] == name), None)
             if exception:
                 # exception may save us from failing
-                if set(versions) == set(exception[1]):
-                    continue
-                else:
-                    pytest.fail(
-                        f"{name} is allowed to have {exception} but actually has more versions: {pprint.pformat(mapping)}"
-                    )
+                assert set(versions) == set(exception[1]), (
+                    f"{name} is allowed to have {exception} but actually has {pprint.pformat(mapping)}"
+                )
+                continue
             # all hope is lost, the check has failed
             pytest.fail(f"{name} has multiple versions: {pprint.pformat(mapping)}")
 
@@ -285,12 +283,10 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
             exception = next((it for it in ignored_exceptions if it[0] == name), None)
             if exception:
                 # exception may save us from failing
-                if set(data) == {packaging.specifiers.SpecifierSet(e) for e in exception[1]}:
-                    continue
-                else:
-                    pytest.fail(
-                        f"{name} is allowed to have {exception[1]} but actually has more specifiers: {pprint.pformat(set(data))}"
-                    )
+                assert set(data) == {packaging.specifiers.SpecifierSet(e) for e in exception[1]}, (
+                    f"{name} is allowed to have {exception[1]} but actually has {pprint.pformat(set(data))}"
+                )
+                continue
             # all hope is lost, the check has failed
             pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-308

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined exception-handling branches by replacing manual failure paths with direct assertions, improving readability and providing clearer, concise error messages.
  - Preserved original control flow and final failure behavior for non-exception cases, maintaining test intent.
  - Enhances CI diagnostics and consistency across version alignment and dependency checks.
  - No changes to runtime behavior, features, or public interfaces; impact is limited to test reliability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->