### PR TITLE
RHOAIENG-31964: Add trash-cleanup 0.1.0

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -2088,6 +2088,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.3",
+    "odh-jupyter-trash-cleanup==0.1.0",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/minimal/ubi9-python-3.12/pylock.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pylock.toml
@@ -972,6 +972,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8
 wheels = [{ url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", upload-time = 2024-02-14T23:35:16Z, size = 13307, hashes = { sha256 = "411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "overrides"
 version = "7.7.0"
 sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", upload-time = 2024-01-27T21:01:33Z, size = 22812, hashes = { sha256 = "55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a" } }

--- a/jupyter/minimal/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pyproject.toml
@@ -5,6 +5,8 @@ requires-python = "==3.12.*"
 
 dependencies = [
     # JupyterLab packages
+    "odh-jupyter-trash-cleanup==0.1.0",
+    
     "jupyterlab==4.4.4",
     "jupyter-server~=2.16.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -3066,6 +3066,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.3",
+    "odh-jupyter-trash-cleanup==0.1.0",
+    
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.16.0",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -2246,6 +2246,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.3",
+    "odh-jupyter-trash-cleanup==0.1.0",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -2106,6 +2106,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.3",
+    "odh-jupyter-trash-cleanup==0.1.0",
+    
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.16.0",

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2167,6 +2167,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.3",
+    "odh-jupyter-trash-cleanup==0.1.0",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2268,6 +2268,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.3",
+    "odh-jupyter-trash-cleanup==0.1.0",
+    
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.16.0",

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -2295,6 +2295,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/6d/0a17cc7e030169907
 wheels = [{ url = "https://files.pythonhosted.org/packages/ab/f6/545f2e578a3da76b0719dd193e7c54113130501bc036fb5a6cccdcf911cd/odh_elyra-4.2.3-py3-none-any.whl", upload-time = 2025-08-01T11:16:35Z, size = 4316571, hashes = { sha256 = "e4a5f19d54a4d07497d0c7aceb26ca1316e543f3c135d9aede72341611532f87" } }]
 
 [[packages]]
+name = "odh-jupyter-trash-cleanup"
+version = "0.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.19.0"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", upload-time = 2025-08-27T02:34:27Z, size = 11949859, hashes = { sha256 = "aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473" } }

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
     # JupyterLab packages
     'odh-elyra==4.2.3',
+    "odh-jupyter-trash-cleanup==0.1.0",
 
     'jupyterlab==4.4.4',
     'jupyter-bokeh~=3.0.5', # trustyai 0.6.1 depends on jupyter-bokeh~=3.0.5


### PR DESCRIPTION
PR for [RHOAIENG-31964](https://issues.redhat.com/browse/RHOAIENG-31964)

Adds new Jupyterlab extension - Trash Cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic trash cleanup added to Jupyter Python 3.12 images (Datascience, Minimal, PyTorch, TensorFlow, ROCm variants, TrustyAI, LLMCompressor) to free disk space and keep workspaces tidy.

- Chores
  - Added the trash-cleanup dependency and updated lockfiles across the affected Jupyter images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->