### PR TITLE
chore(gha): combine multiple `apt-get remove` patterns into a single command in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -141,8 +141,8 @@ jobs:
           df -h
 
           sudo apt-get update
-          sudo apt-get remove -y '^dotnet-.*' '^llvm-.*' 'php.*' '^mongodb-.*'
-          sudo apt-get autoremove -y
+          sudo apt-get purge -y '^dotnet-.*' '^llvm-.*' 'php.*' '^mongodb-.*'
+          sudo apt-get autoremove -y --purge
           sudo apt-get clean
           sudo rm -rf /usr/local/.ghcup &
           sudo rm -rf /usr/local/lib/android &


### PR DESCRIPTION
## Description

This should shave off a few seconds from every run that does this.

And purge will give a little bit more disk space than just remove.

## How Has This Been Tested?

```
0 upgraded, 0 newly installed, 80 to remove and 183 not upgraded.
After this operation, 2076 MB disk space will be freed.
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow: consolidated multiple package-removal steps into a single purge command and enabled purge during autoremove. This streamlines the build pipeline, reduces logs and maintenance, and ensures residual configuration is removed. No impact on product features, UI, or user data; no action required by users or administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->