### PR TITLE
fix(codeserver): the builder rpm stage also needs to have ubi9.repo file installed if missing on aipcc

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -14,6 +14,11 @@ WORKDIR /root
 
 ENV HOME=/root
 
+# Inject the official UBI 9 repository configuration into the AIPCC base image.
+# The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
+# By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
+COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
 ARG NODE_VERSION=20


### PR DESCRIPTION
```
+ dnf install -y jq libtool gcc-toolset-13
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN ./get_code_server_rpm.sh && touch /tmp/control": exit status 1
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables package installation and upgrades during image builds by adding the official repository configuration.
- Bug Fixes
  - Resolves failures when using dnf/yum in build stages, improving build reliability.
- Chores
  - Updated base image configuration to include required repository metadata.
- Notes
  - No changes to runtime behavior or configuration; build-time only impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->