### PR TITLE
fix(codeserver/Dockerfile): with the AIPCC ppc64le base, installing `patch` explicitly is required, amd64 and arm64 bases already seem to have it

### DIFF
--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -30,8 +30,8 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	# install build dependencies
 #	dnf install -y \
-#	    git gcc-toolset-13 automake libtool rsync krb5-devel libX11-devel gettext jq patch
-        dnf install -y jq libtool gcc-toolset-13
+#	    git automake rsync krb5-devel libX11-devel gettext
+	dnf install -y jq patch libtool gcc-toolset-13
 
 	. /opt/rh/gcc-toolset-13/enable
 


### PR DESCRIPTION
```
+ patch -p1
./get_code_server_rpm.sh: line 65: patch: command not found
subprocess exited with status 127
subprocess exited with status 127
Error: building at STEP "RUN ./get_code_server_rpm.sh && touch /tmp/control": exit status 127
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation in the architecture-specific setup script to include jq, patch, libtool, and gcc-toolset-13.
  * Removed gettext from the installed package list.
  * Adjusted inline comments to reflect the new dependency set.
  * No changes to user-facing functionality; installation scripts will now pull the updated package set automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->