### PR TITLE
fix(codeserver): seems to need krb5-devel

### DIFF
--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -30,8 +30,8 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	# install build dependencies
 #	dnf install -y \
-#	    git automake rsync libX11-devel gettext
-	dnf install -y jq patch libtool gcc-toolset-13 krb5-devel
+#	    git automake rsync gettext
+	dnf install -y jq patch libtool gcc-toolset-13 krb5-devel libX11-devel
 
 	. /opt/rh/gcc-toolset-13/enable
 


### PR DESCRIPTION
With AIPCC bases, there are additional build requirements that we have to install explicitly ourselves.

```
npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm error In file included from ../src/kerberos_common.h:5,
npm error                  from ../src/kerberos.h:13,
npm error                  from ../src/kerberos.cc:1:
npm error ../src/unix/kerberos_gss.h:21:14: fatal error: gssapi/gssapi.h: No such file or directory
npm error    21 |     #include <gssapi/gssapi.h>
npm error       |              ^~~~~~~~~~~~~~~~~
npm error compilation terminated.
npm error make: *** [kerberos.target.mk:125: Release/obj.target/kerberos/src/kerberos.o] Error 1
npm error gyp ERR! build error
npm error gyp ERR! stack Error: `make` failed with exit code: 2
npm error gyp ERR! stack at ChildProcess.<anonymous> (/root/.nvm/versions/node/v20.19.5/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:209:23)
npm error gyp ERR! System Linux 6.11.0-1018-azure
npm error gyp ERR! command "/root/.nvm/versions/node/v20.19.5/bin/node" "/root/.nvm/versions/node/v20.19.5/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm error gyp ERR! cwd /root/code-server/lib/vscode/node_modules/kerberos
npm error gyp ERR! node -v v20.19.5
npm error gyp ERR! node-gyp -v v10.1.0
npm error gyp ERR! not ok
npm error A complete log of this run can be found in: /root/.npm/_logs/2025-09-11T09_07_11_850Z-debug-0.log
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build dependencies to include Kerberos and X11 development libraries for targeted architectures, improving build reliability.
- **Documentation**
  - Adjusted commented dependency notes to reflect the current dependency set.
- **Notes**
  - No user-facing behavior or performance changes; this update impacts build configuration only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->