### PR TITLE
NO-JIRA: fix(gha): add concurrency group to GitHub Actions workflows for PR builds

### DIFF
--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -18,7 +18,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ format('build-notebooks-pr-{0}', github.event.pull_request.number) }}
+  group: ${{ format('build-notebooks-pr-apicc-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -17,6 +17,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ format('build-notebooks-pr-rhel-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: true
+
 env:
   # language=json
   contributors: |


### PR DESCRIPTION
fixes omission from
* https://github.com/opendatahub-io/notebooks/pull/2367

without this, the -aipcc group was canceling the base pr group and vice versa

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated pull request build pipelines to cancel in-progress runs when a new commit is pushed, reducing redundant executions and speeding feedback.
  - Introduced per-PR concurrency groups for relevant build workflows to ensure only the latest run proceeds.
  - Adjusted concurrency grouping identifiers to better isolate runs across related pipelines.
  - No functional changes to product features; these updates improve build efficiency and reliability during pull request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->