### PR TITLE
NO-JIRA: fix(codeserver): build needs envsubst at some point which is absent from aipcc bases

### DIFF
--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -30,8 +30,8 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	# install build dependencies
 #	dnf install -y \
-#	    git automake gettext
-	dnf install -y jq patch libtool rsync gcc-toolset-13 krb5-devel libX11-devel
+#	    git automake
+	dnf install -y jq patch libtool rsync gettext gcc-toolset-13 krb5-devel libX11-devel
 
 	. /opt/rh/gcc-toolset-13/enable
 


### PR DESCRIPTION
```
done (release-packages/code-server-4.98.0-linux-arm64)
./ci/build/build-packages.sh: line 57: envsubst: command not found
Error: building at STEP "RUN ./get_code_server_rpm.sh && touch /tmp/control": while running runtime: exit status 127
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build dependencies to include gettext alongside existing tools, improving completeness of the build environment.
  - Cleaned up commented dependency lines for clarity and maintainability.
  - No changes to runtime behavior or user-facing features.
  - Expected impact: smoother, more reliable builds and improved compatibility in the UBI9 Python 3.12 environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->