### PR TITLE
Add cuda folder under rhel repo as removed after the restructuring of the base odh-images

### DIFF
--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -41,7 +41,7 @@ FROM cuda-base-${TARGETARCH} AS cuda-base
 
 ARG TARGETARCH
 
-ARG CUDA_SOURCE_CODE=cuda
+ARG CUDA_SOURCE_CODE=rstudio/rhel9-python-3.11/cuda
 # Access the client's secret for the subscription manager from the environment variable
 ARG SECRET_DIR=/opt/app-root/src/.sec
 ARG SERVERURL_DEFAULT=""

--- a/rstudio/rhel9-python-3.11/cuda/NGC-DL-CONTAINER-LICENSE
+++ b/rstudio/rhel9-python-3.11/cuda/NGC-DL-CONTAINER-LICENSE
@@ -1,0 +1,230 @@
+NVIDIA DEEP LEARNING CONTAINER LICENSE
+
+This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs the use
+of the NVIDIA container and all its contents (“CONTAINER”).
+
+This license can be accepted only by an adult of legal age of majority in the country in which the
+CONTAINER is used. If you are under the legal age of majority, you must ask your parent or legal
+guardian to consent to this license. If you are entering this license on behalf of a company or
+other legal entity, you represent that you have legal authority and “you” will mean the entity you
+represent.
+
+By using the CONTAINER, you affirm that you have reached the legal age of majority, you accept the
+terms of this license, and you take legal and financial responsibility for the actions of your
+permitted users.
+
+You agree to use the CONTAINER only for purposes that are permitted by (a) this license, and (b) any
+applicable law, regulation or generally accepted practices or guidelines in the relevant
+jurisdictions.
+
+1. LICENSE. Subject to the terms of this license, NVIDIA hereby grants you a non-exclusive,
+non-transferable license, without the right to sublicense (except as expressly provided in this
+license) to:
+
+a. Install and use copies of the CONTAINER, and modify and create derivative works of samples or
+example source code delivered in the CONTAINER (if applicable), to develop and test services and
+applications,
+
+b. Deploy the CONTAINER on infrastructure you own or lease to offer a service to third parties,
+without distributing the CONTAINER or exposing the NVIDIA APIs in the CONTAINER directly to such
+service users, and
+
+c. Develop and extend the CONTAINER to create a Compatible (as defined below) derived CONTAINER that
+includes the entire CONTAINER plus other software with primary functionality, to develop and compile
+applications, and distribute such derived CONTAINER to run applications, subject to the distribution
+requirements indicated in this license. As used in this section, “Compatible” means that extensions
+to the CONTAINER must not adversely affect the functionality of the other components in the
+CONTAINER.
+
+2. DISTRIBUTION REQUIREMENTS. For purposes of this Section 2, the term “distribution” also means the
+deployment of CONTAINERS in a service or an application for third parties to access over the
+internet. These are the distribution requirements for you to exercise the grants above:
+
+a. A service or an application must have material additional functionality, beyond the included
+portions of the CONTAINER.
+
+b. The following notice shall be included in modifications and derivative works of source code
+distributed: “This software contains source code provided by NVIDIA Corporation.”
+
+c. You agree to distribute the CONTAINER subject to the terms at least as protective as the terms of
+this license, including (without limitation) terms relating to the license grant, license
+restrictions and protection of NVIDIA’s intellectual property rights. Additionally, you agree that
+you will protect the privacy, security and legal rights of your application users.
+
+d. You agree to notify NVIDIA in writing of any known or suspected distribution or use of the
+CONTAINER not in compliance with the requirements of this license, and to enforce the terms of your
+agreements with respect to the distributed CONTAINER.
+
+3. AUTHORIZED USERS. You may allow employees and contractors of your entity or of your
+subsidiary(ies) to access and use the CONTAINER from your secure network to perform work on your
+behalf. If you are an academic institution you may allow users enrolled or employed by the academic
+institution to access and use the CONTAINER from your secure network. You are responsible for the
+compliance with the terms of this license by your authorized users.
+
+4. LIMITATIONS. Your license to use the CONTAINER is restricted as follows:
+
+a. The CONTAINER is licensed for you to develop services and applications only for their use in
+systems with NVIDIA GPUs.
+
+b. You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary
+notices from any portion of the CONTAINER or copies of the CONTAINER.
+
+c. Except as expressly provided in this license, you may not copy, sell, rent, sublicense, transfer,
+distribute, modify, or create derivative works of any portion of the CONTAINER. For clarity, you may
+not distribute or sublicense the CONTAINER as a stand-alone product.
+
+d. Unless you have an agreement with NVIDIA for this purpose, you may not indicate that a service or
+an application created with the CONTAINER is sponsored or endorsed by NVIDIA.
+
+e. You may not bypass, disable, or circumvent any technical limitation, encryption, security,
+digital rights management or authentication mechanism in the CONTAINER.
+
+f. You may not replace any NVIDIA software components in the CONTAINER that are governed by this
+license with other software that implements NVIDIA APIs.
+
+g. You may not use the CONTAINER in any manner that would cause it to become subject to an open
+source software license. As examples, licenses that require as a condition of use, modification,
+and/or distribution that the CONTAINER be: (i) disclosed or distributed in source code form; (ii)
+licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+
+h. Unless you have an agreement with NVIDIA for this purpose, you may not use the CONTAINER with any
+system or application where the use or failure of the system or application can reasonably be
+expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use
+in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA
+does not design, test or manufacture the CONTAINER for these critical uses and NVIDIA shall not be
+liable to you or any third party, in whole or in part, for any claims or damages arising from such
+uses.
+
+i. You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective
+employees, contractors, agents, officers and directors, from and against any and all claims,
+damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses
+(including but not limited to attorney’s fees and costs incident to establishing the right of
+indemnification) arising out of or related to your use of the CONTAINER outside of the scope of this
+license, or not in compliance with its terms.
+
+5. UPDATES. NVIDIA may, at its option, make available patches, workarounds or other updates to this
+CONTAINER. Unless the updates are provided with their separate governing terms, they are deemed part
+of the CONTAINER licensed to you as provided in this license. You agree that the form and content of
+the CONTAINER that NVIDIA provides may change without prior notice to you. While NVIDIA generally
+maintains compatibility between versions, NVIDIA may in some cases make changes that introduce
+incompatibilities in future versions of the CONTAINER.
+
+6. PRE-RELEASE VERSIONS. CONTAINER versions identified as alpha, beta, preview, early access or
+otherwise as pre-release may not be fully functional, may contain errors or design flaws, and may
+have reduced or different security, privacy, availability, and reliability standards relative to
+commercial versions of NVIDIA software and materials. You may use a pre-release CONTAINER version at
+your own risk, understanding that these versions are not intended for use in production or
+business-critical systems. NVIDIA may choose not to make available a commercial version of any
+pre-release CONTAINER. NVIDIA may also choose to abandon development and terminate the availability
+of a pre-release CONTAINER at any time without liability.
+
+7. THIRD-PARTY COMPONENTS. The CONTAINER may include third-party components with separate legal
+notices or terms as may be described in proprietary notices accompanying the CONTAINER. If and to
+the extent there is a conflict between the terms in this license and the third-party license terms,
+the third-party terms control only to the extent necessary to resolve the conflict.
+
+You acknowledge and agree that it is your sole responsibility to obtain any additional third-party
+licenses required to make, have made, use, have used, sell, import, and offer for sale your products
+or services that include or incorporate any third-party software and content relating to audio
+and/or video encoders and decoders from, including but not limited to, Microsoft, Thomson,
+Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding Technologies. NVIDIA does not grant to you under
+this license any necessary patent or other rights with respect to any audio and/or video encoders
+and decoders.
+
+Subject to the other terms of this license, you may use the CONTAINER to develop and test
+applications released under Open Source Initiative (OSI) approved open source software licenses.
+
+8. OWNERSHIP.
+
+8.1 NVIDIA reserves all rights, title and interest in and to the CONTAINER not expressly granted to
+you under this license. NVIDIA and its suppliers hold all rights, title and interest in and to the
+CONTAINER, including their respective intellectual property rights. The CONTAINER is copyrighted and
+protected by the laws of the United States and other countries, and international treaty provisions.
+
+8.2 Subject to the rights of NVIDIA and its suppliers in the CONTAINER, you hold all rights, title
+and interest in and to your services, applications and your derivative works of the sample source
+code delivered in the CONTAINER including their respective intellectual property rights.
+
+9. FEEDBACK. You may, but are not obligated to, provide to NVIDIA suggestions, fixes, modifications,
+feature requests or other feedback regarding the CONTAINER (“Feedback”). Feedback, even if
+designated as confidential by you, shall not create any confidentiality obligation for NVIDIA.
+NVIDIA and its designees have a perpetual, non-exclusive, worldwide, irrevocable license to use,
+reproduce, publicly display, modify, create derivative works of, license, sublicense, and otherwise
+distribute and exploit Feedback as NVIDIA sees fit without payment and without obligation or
+restriction of any kind on account of intellectual property rights or otherwise.
+
+10. NO WARRANTIES. THE CONTAINER IS PROVIDED AS-IS. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE
+LAW NVIDIA AND ITS AFFILIATES EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND OR NATURE, WHETHER
+EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY,
+NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE CONTAINER
+WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR
+THAT ALL ERRORS WILL BE CORRECTED.
+
+11. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW NVIDIA AND ITS
+AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR
+FOR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF
+PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR
+PERFORMANCE OF THE CONTAINER, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF
+CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF
+ACTION OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY
+HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL
+CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE
+LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT.
+
+12. TERMINATION. Your rights under this license will terminate automatically without notice from
+NVIDIA if you fail to comply with any term and condition of this license or if you commence or
+participate in any legal proceeding against NVIDIA with respect to the CONTAINER. NVIDIA may
+terminate this license with advance written notice to you, if NVIDIA decides to no longer provide
+the CONTAINER in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer
+commercially viable. Upon any termination of this license, you agree to promptly discontinue use of
+the CONTAINER and destroy all copies in your possession or control. Your prior distributions in
+accordance with this license are not affected by the termination of this license. All provisions of
+this license will survive termination, except for the license granted to you.
+
+13. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States
+and of the State of Delaware, without regard to the conflicts of laws principles. The United Nations
+Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to
+all terms of this license in the English language. The state or federal courts residing in Santa
+Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of
+this license. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for
+injunctive remedies or urgent legal relief in any jurisdiction.
+
+14. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by
+you by any means or operation of law without NVIDIA’s permission. Any attempted assignment not
+approved by NVIDIA in writing shall be void and of no effect. NVIDIA may assign, delegate or
+transfer this license and its rights and obligations, and if to a non-affiliate you will be
+notified.
+
+15. EXPORT. The CONTAINER is subject to United States export laws and regulations. You agree to
+comply with all applicable
+
+U.S. and international export laws, including the Export Administration Regulations (EAR)
+administered by the U.S. Department of Commerce and economic sanctions administered by the U.S.
+Department of Treasury’s Office of Foreign Assets Control (OFAC). These laws include restrictions on
+destinations, end-users and end-use. By accepting this license, you confirm that you are not
+currently residing in a country or region currently embargoed by the U.S. and that you are not
+otherwise prohibited from receiving the CONTAINER.
+
+16. GOVERNMENT USE. The CONTAINER is, and shall be treated as being, “Commercial Items” as that term
+is defined at 48 CFR § 2.101, consisting of “commercial computer software” and “commercial computer
+software documentation”, respectively, as such terms are used in, respectively, 48 CFR § 12.212 and
+48 CFR §§ 227.7202 & 252.227-7014(a)(1). Use, duplication or disclosure by the U.S. Government or a
+U.S. Government subcontractor is subject to the restrictions in this license pursuant to 48 CFR §
+12.212 or 48 CFR § 227.7202. In no event shall the US Government user acquire rights in the
+CONTAINER beyond those specified in 48 C.F.R. 52.227-19(b)(1)-(2).
+
+17. NOTICES. Please direct your legal notices or other correspondence to NVIDIA Corporation, 2788
+San Tomas Expressway, Santa Clara, California 95051, United States of America, Attention: Legal
+Department.
+
+18. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the
+parties relating to the subject matter of this license and supersedes all prior or contemporaneous
+understandings and agreements relating to this subject matter, whether oral or written. If any court
+of competent jurisdiction determines that any provision of this license is illegal, invalid or
+unenforceable, the remaining provisions will remain in full force and effect. Any amendment or
+waiver under this license shall be in writing and signed by representatives of both parties.
+
+19. LICENSING. If the distribution terms in this license are not suitable for your organization, or
+for any questions regarding this license, please contact NVIDIA at nvidia-compute-license-questions@nvidia.com.
+
+(v. December 4, 2020)

--- a/rstudio/rhel9-python-3.11/cuda/cuda.repo-amd64
+++ b/rstudio/rhel9-python-3.11/cuda/cuda.repo-amd64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/rstudio/rhel9-python-3.11/cuda/cuda.repo-arm64
+++ b/rstudio/rhel9-python-3.11/cuda/cuda.repo-arm64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda-sbsa
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA


### PR DESCRIPTION
Add cuda folder under rhel repo as removed after the restructuring of the base odh-images
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ensure that the GHA now builds successfully the image cuda-RStudio: https://github.com/opendatahub-io/notebooks/actions/runs/17673355868/job/50229799372?pr=2440 

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default CUDA source path used during container builds for the RHEL 9 / Python 3.11 CUDA image variant to improve build reliability and reduce path-related errors. No runtime behavior changes.

* **New Files**
  * Added CUDA package repository configurations for x86_64 and ARM64 to enable installation of NVIDIA CUDA packages during image builds.
  * Added the NVIDIA Deep Learning Container license document governing use and distribution of the CUDA container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->