### PR TITLE
ppc64le: implement datascience jupyter image build on ppc64le (#2406)

### DIFF
--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -37,6 +37,7 @@ spec:
     value:
     - linux/x86_64
     - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
   - name: dockerfile
     value: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/ci/cached-builds/gen_gha_matrix_jobs.py
+++ b/ci/cached-builds/gen_gha_matrix_jobs.py
@@ -30,6 +30,11 @@ ARM64_COMPATIBLE = {
     "runtime-cuda-tensorflow-ubi9-python-3.12",
 }
 
+PPC64LE_COMPATIBLE = {
+    "jupyter-minimal-ubi9-python-3.12",
+    "jupyter-datascience-ubi9-python-3.12",
+}
+
 S390X_COMPATIBLE = {
     "runtime-minimal-ubi9-python-3.11",
     "runtime-minimal-ubi9-python-3.12",
@@ -76,6 +81,9 @@ class Arm64Images(enum.Enum):
     INCLUDE = "include"
     ONLY = "only"
 
+class Ppc64leImages(enum.Enum):
+    EXCLUDE = "exclude"
+    INCLUDE = "include"
 
 class S390xImages(enum.Enum):
     EXCLUDE = "exclude"
@@ -110,6 +118,15 @@ def main() -> None:
         default=Arm64Images.INCLUDE,
         nargs="?",
         help="Whether to include, exclude, or only include arm64 images",
+    )
+    argparser.add_argument(
+        "--ppc64le-images",
+        type=Ppc64leImages,
+        choices=list(Ppc64leImages),
+        required=False,
+        default=Ppc64leImages.INCLUDE,
+        nargs="?",
+        help="Whether to include or exclude ppc64le images",
     )
     argparser.add_argument(
         "--s390x-images",
@@ -147,6 +164,9 @@ def main() -> None:
         if args.arm64_images != Arm64Images.EXCLUDE and args.s390x_images != S390xImages.ONLY:
             if target in ARM64_COMPATIBLE:
                 targets_with_platform.append((target, "linux/arm64"))
+        if args.ppc64le_images != Ppc64leImages.EXCLUDE:
+            if target in PPC64LE_COMPATIBLE:
+                targets_with_platform.append((target, "linux/ppc64le"))
         if args.s390x_images != S390xImages.EXCLUDE and args.arm64_images != Arm64Images.ONLY:
             # NOTE: hardcode the list of s390x-compatible Makefile targets in S390X_COMPATIBLE
             if target in S390X_COMPATIBLE:

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -166,12 +166,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM cpu-base AS common-builder
 ARG TARGETARCH
 USER root
-RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
-    dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip && \
-    dnf clean all; \
-    else \
-     echo "Skipping common-builder package install on non-Power"; \
-    fi
+RUN <<'EOF'
+set -Eeuxo pipefail
+if [ "${TARGETARCH}" = "ppc64le" ]; then
+    dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip
+    dnf clean all
+else
+    echo "Skipping common-builder package install on non-Power"
+fi
+EOF
 
 #######################################################
 # onnx-builder (Power-only)
@@ -180,18 +183,22 @@ FROM common-builder AS onnx-builder
 ARG TARGETARCH
 ARG ONNX_VERSION=v1.19.0
 WORKDIR /root
-RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
-    source /opt/rh/gcc-toolset-13/enable && \
-    git clone --recursive https://github.com/onnx/onnx.git && \
-    cd onnx && git checkout ${ONNX_VERSION} && \
-    git submodule update --init --recursive && \
-    pip install -r requirements.txt && \
-    export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
-    pip wheel . -w /root/onnx_wheel; \
-    else \
-    echo "Skipping ONNX build on non-Power"; \
-    mkdir -p /root/onnx_wheel; \
-    fi
+RUN <<'EOF'
+set -Eeuxo pipefail
+if [ "${TARGETARCH}" = "ppc64le" ]; then
+    source /opt/rh/gcc-toolset-13/enable
+    git clone --recursive https://github.com/onnx/onnx.git
+    cd onnx
+    git checkout ${ONNX_VERSION}
+    git submodule update --init --recursive
+    pip install -r requirements.txt
+    export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    pip wheel . -w /root/onnx_wheel
+else
+    echo "Skipping ONNX build on non-Power"
+    mkdir -p /root/onnx_wheel
+fi
+EOF
 
 #######################################################
 # openblas-builder (Power-only)
@@ -200,16 +207,18 @@ FROM common-builder AS openblas-builder
 ARG TARGETARCH
 ARG OPENBLAS_VERSION=0.3.30
 WORKDIR /root
-RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
-    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
-    unzip OpenBLAS-${OPENBLAS_VERSION}.zip && \
-    cd OpenBLAS-${OPENBLAS_VERSION} && \
-    make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
-    else \
-    mkdir -p OpenBLAS-${OPENBLAS_VERSION}; \
-    echo "Skipping OpenBLAS build on non-Power"; \
-    fi
-
+RUN <<'EOF'
+set -Eeuxo pipefail
+if [ "${TARGETARCH}" = "ppc64le" ]; then
+    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
+    unzip OpenBLAS-${OPENBLAS_VERSION}.zip
+    cd OpenBLAS-${OPENBLAS_VERSION}
+    make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
+else
+    mkdir -p OpenBLAS-${OPENBLAS_VERSION}
+    echo "Skipping OpenBLAS build on non-Power"
+fi
+EOF
 ####################
 # jupyter-minimal #
 ####################
@@ -287,13 +296,16 @@ COPY --from=openblas-builder /root/OpenBLAS-${OPENBLAS_VERSION} /openblas
 COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 
 # Power-specific ONNX/OpenBLAS installation
-RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
-    pip install /onnxwheels/*.whl && \
-    PREFIX=/usr/local make -C /openblas install && \
-    rm -rf /onnxwheels /openblas; \
-    else \
-    echo "Skipping ONNX/OpenBLAS install on non-Power"; \
-    fi
+RUN <<'EOF'
+set -Eeuxo pipefail
+if [ "${TARGETARCH}" = "ppc64le" ]; then
+    pip install /onnxwheels/*.whl
+    PREFIX=/usr/local make -C /openblas install
+    rm -rf /onnxwheels /openblas
+else
+    echo "Skipping ONNX/OpenBLAS install on non-Power"
+fi
+EOF
 
 # Install Python packages and Jupyterlab extensions from pylock.toml
 COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml ./

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -300,12 +300,32 @@ RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     pip install /onnxwheels/*.whl
-    PREFIX=/usr/local make -C /openblas install
-    rm -rf /onnxwheels /openblas
 else
     echo "Skipping ONNX/OpenBLAS install on non-Power"
 fi
 EOF
+
+USER root
+RUN <<'EOF'
+set -Eeuxo pipefail
+if [ "${TARGETARCH}" = "ppc64le" ]; then
+    rm -rf /onnxwheels
+else
+    echo "Skipping ONNX/OpenBLAS install on non-Power"
+fi
+EOF
+
+RUN <<'EOF'
+set -Eeuxo pipefail
+if [ "${TARGETARCH}" = "ppc64le" ]; then
+    PREFIX=/usr/local make -C /openblas install
+    rm -rf /openblas
+else
+    echo "Skipping ONNX/OpenBLAS install on non-Power"
+fi
+EOF
+
+USER 1001:0
 
 # Install Python packages and Jupyterlab extensions from pylock.toml
 COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml ./

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -164,8 +164,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # common-builder (for Power-only)
 #######################################################
 FROM cpu-base AS common-builder
+ARG TARGETARCH
 USER root
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
     dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip && \
     dnf clean all; \
     else \
@@ -176,9 +177,10 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 # onnx-builder (Power-only)
 #######################################################
 FROM common-builder AS onnx-builder
+ARG TARGETARCH
 ARG ONNX_VERSION=v1.19.0
 WORKDIR /root
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
     source /opt/rh/gcc-toolset-13/enable && \
     git clone --recursive https://github.com/onnx/onnx.git && \
     cd onnx && git checkout ${ONNX_VERSION} && \
@@ -195,9 +197,10 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 # openblas-builder (Power-only)
 #######################################################
 FROM common-builder AS openblas-builder
+ARG TARGETARCH
 ARG OPENBLAS_VERSION=0.3.30
 WORKDIR /root
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
     wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
     unzip OpenBLAS-${OPENBLAS_VERSION}.zip && \
     cd OpenBLAS-${OPENBLAS_VERSION} && \
@@ -238,6 +241,7 @@ ENTRYPOINT ["start-notebook.sh"]
 # jupytyer-datascience #
 ########################
 FROM jupyter-minimal AS jupyter-datascience
+ARG TARGETARCH
 
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG OPENBLAS_VERSION=0.3.30
@@ -283,7 +287,7 @@ COPY --from=openblas-builder /root/OpenBLAS-${OPENBLAS_VERSION} /openblas
 COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 
 # Power-specific ONNX/OpenBLAS installation
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
     pip install /onnxwheels/*.whl && \
     PREFIX=/usr/local make -C /openblas install && \
     rm -rf /onnxwheels /openblas; \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -120,7 +120,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         dnf install -y cmake make gcc-c++ pybind11-devel wget && \
         dnf clean all && \
         # Build and collect pyarrow wheel
-        git clone --depth 1 https://github.com/apache/arrow.git && \
+        git clone --depth 1 --branch "apache-arrow-17.0.0" https://github.com/apache/arrow.git && \
         cd arrow/cpp && \
         mkdir release && cd release && \
         cmake -DCMAKE_BUILD_TYPE=Release \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -160,6 +160,53 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         mkdir -p /tmp/wheels; \
     fi
 
+#######################################################
+# common-builder (for Power-only)
+#######################################################
+FROM cpu-base AS common-builder
+USER root
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+    dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip && \
+    dnf clean all; \
+    else \
+     echo "Skipping common-builder package install on non-Power"; \
+    fi
+
+#######################################################
+# onnx-builder (Power-only)
+#######################################################
+FROM common-builder AS onnx-builder
+ARG ONNX_VERSION=v1.19.0
+WORKDIR /root
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+    source /opt/rh/gcc-toolset-13/enable && \
+    git clone --recursive https://github.com/onnx/onnx.git && \
+    cd onnx && git checkout ${ONNX_VERSION} && \
+    git submodule update --init --recursive && \
+    pip install -r requirements.txt && \
+    export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    pip wheel . -w /root/onnx_wheel; \
+    else \
+    echo "Skipping ONNX build on non-Power"; \
+    mkdir -p /root/onnx_wheel; \
+    fi
+
+#######################################################
+# openblas-builder (Power-only)
+#######################################################
+FROM common-builder AS openblas-builder
+ARG OPENBLAS_VERSION=0.3.30
+WORKDIR /root
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
+    unzip OpenBLAS-${OPENBLAS_VERSION}.zip && \
+    cd OpenBLAS-${OPENBLAS_VERSION} && \
+    make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
+    else \
+    mkdir -p OpenBLAS-${OPENBLAS_VERSION}; \
+    echo "Skipping OpenBLAS build on non-Power"; \
+    fi
+
 ####################
 # jupyter-minimal #
 ####################
@@ -193,6 +240,7 @@ ENTRYPOINT ["start-notebook.sh"]
 FROM jupyter-minimal AS jupyter-datascience
 
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
+ARG OPENBLAS_VERSION=0.3.30
 ARG TARGETARCH
 
 LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.12" \
@@ -211,13 +259,16 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat && \
+    dnf clean all && rm -rf /var/cache/yum
 
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
 
 # Other apps and tools installed as default user
 USER 1001
+
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 
 # Copy wheels from build stage (s390x only)
 COPY --from=s390x-builder /tmp/wheels /tmp/wheels
@@ -227,7 +278,20 @@ else \
     echo "Skipping wheel install for $TARGETARCH"; \
 fi
 
-# Install Python packages and Jupyterlab extensions from requirements.txt
+# Copy OpenBLAS,ONNX wheels for Power
+COPY --from=openblas-builder /root/OpenBLAS-${OPENBLAS_VERSION} /openblas
+COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
+
+# Power-specific ONNX/OpenBLAS installation
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+    pip install /onnxwheels/*.whl && \
+    PREFIX=/usr/local make -C /openblas install && \
+    rm -rf /onnxwheels /openblas; \
+    else \
+    echo "Skipping ONNX/OpenBLAS install on non-Power"; \
+    fi
+
+# Install Python packages and Jupyterlab extensions from pylock.toml
 COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra setup to utils so that it's sourced at startup
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -104,18 +104,18 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 
 ##############################
 # wheel-builder stage        #
-# NOTE: Only used in s390x
+# NOTE: Only used in ppc64le and s390x
 ##############################
-FROM cpu-base AS s390x-builder
+FROM cpu-base AS pyarrow-builder
 
 ARG TARGETARCH
 USER 0
 WORKDIR /tmp/build-wheels
 
-# Build pyarrow optimized for s390x
+# Build pyarrow on ppc64le and s390x
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf \
-    if [ "$TARGETARCH" = "s390x" ]; then \
+    if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
         # Install build dependencies (shared for pyarrow and onnx)
         dnf install -y cmake make gcc-c++ pybind11-devel wget && \
         dnf clean all && \
@@ -283,9 +283,9 @@ USER 1001
 
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 
-# Copy wheels from build stage (s390x only)
-COPY --from=s390x-builder /tmp/wheels /tmp/wheels
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+# Copy wheels from build stage (ppc64le and s390x only)
+COPY --from=pyarrow-builder /tmp/wheels /tmp/wheels
+RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
     pip install --no-cache-dir /tmp/wheels/*.whl; \
 else \
     echo "Skipping wheel install for $TARGETARCH"; \
@@ -333,11 +333,11 @@ COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml ./
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    echo "Installing softwares and packages" && \
+    echo "Installing software and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    if [ "$TARGETARCH" = "s390x" ]; then \
-        # For s390x, we need special flags and environment variables for building packages
+    if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
+        # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress \

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -105,7 +105,7 @@ wheels = [
 [[packages]]
 name = "aiohttp-cors"
 version = "0.8.1"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", upload-time = 2025-03-31T14:16:20Z, size = 38626, hashes = { sha256 = "ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/98/3b/40a68de458904bcc143622015fff2352b6461cd92fd66d3527bf1c6f5716/aiohttp_cors-0.8.1-py3-none-any.whl", upload-time = 2025-03-31T14:16:18Z, size = 25231, hashes = { sha256 = "3180cf304c5c712d626b9162b195b1db7ddf976a2a25172b35bb2448b890a80d" } }]
 
@@ -222,7 +222,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc
 [[packages]]
 name = "bcrypt"
 version = "4.3.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", upload-time = 2025-02-28T01:24:09Z, size = 25697, hashes = { sha256 = "3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", upload-time = 2025-02-28T01:22:34Z, size = 483719, hashes = { sha256 = "f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281" } },
@@ -549,7 +549,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 [[packages]]
 name = "codeflare-sdk"
 version = "0.31.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
 
@@ -562,7 +562,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e
 [[packages]]
 name = "colorful"
 version = "0.5.7"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/0c/0c/d180ebf230b771907f46981023a80f62cf592d49673cc5f8a5993aa67bb6/colorful-0.5.7.tar.gz", upload-time = 2025-06-30T15:24:03Z, size = 209487, hashes = { sha256 = "c5452179b56601c178b03d468a5326cc1fe37d9be81d24d0d6bdab36c4b93ad8" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/e2/98/0d791b3d1eaed89d7d370b5cf9b8079b124da0545559417f394ba21b5532/colorful-0.5.7-py2.py3-none-any.whl", upload-time = 2025-06-30T15:24:02Z, size = 201475, hashes = { sha256 = "495dd3a23151a9568cee8a90fc1174c902ad7ef06655f50b6bddf9e80008da69" } }]
 
@@ -754,7 +754,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/46/d1/e73b6ad76f0b1fb
 [[packages]]
 name = "distlib"
 version = "0.4.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", upload-time = 2025-07-17T16:52:00Z, size = 614605, hashes = { sha256 = "feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", upload-time = 2025-07-17T16:51:58Z, size = 469047, hashes = { sha256 = "9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16" } }]
 
@@ -809,7 +809,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/37/f3/5cddcbada3d0bc7
 [[packages]]
 name = "filelock"
 version = "3.19.1"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", upload-time = 2025-08-14T16:56:03Z, size = 17687, hashes = { sha256 = "66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", upload-time = 2025-08-14T16:56:01Z, size = 15988, hashes = { sha256 = "d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d" } }]
 
@@ -1202,7 +1202,7 @@ wheels = [
 [[packages]]
 name = "grpcio"
 version = "1.74.0"
-marker = "python_full_version >= '3.10' and platform_machine != 's390x'"
+marker = "python_full_version >= '3.10' and platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/38/b4/35feb8f7cab7239c5b94bd2db71abb3d6adb5f335ad8f131abb6060840b6/grpcio-1.74.0.tar.gz", upload-time = 2025-07-24T18:54:23Z, size = 12756048, hashes = { sha256 = "80d1f4fbb35b0742d3e3d3bb654b7381cd5f015f8497279a1e9c21ba623e01b1" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/54/68e51a90797ad7afc5b0a7881426c337f6a9168ebab73c3210b76aa7c90d/grpcio-1.74.0-cp310-cp310-linux_armv7l.whl", upload-time = 2025-07-24T18:52:43Z, size = 5481935, hashes = { sha256 = "85bd5cdf4ed7b2d6438871adf6afff9af7096486fcf51818a81b77ef4dd30907" } },
@@ -1345,7 +1345,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521
 [[packages]]
 name = "invoke"
 version = "2.2.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz", upload-time = 2023-07-12T18:05:17Z, size = 299835, hashes = { sha256 = "ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/0a/66/7f8c48009c72d73bc6bbe6eb87ac838d6a526146f7dab14af671121eb379/invoke-2.2.0-py3-none-any.whl", upload-time = 2023-07-12T18:05:16Z, size = 160274, hashes = { sha256 = "6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820" } }]
 
@@ -1705,7 +1705,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd46
 [[packages]]
 name = "markdown-it-py"
 version = "4.0.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", upload-time = 2025-08-11T12:57:52Z, size = 73070, hashes = { sha256 = "cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", upload-time = 2025-08-11T12:57:51Z, size = 87321, hashes = { sha256 = "87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147" } }]
 
@@ -1852,7 +1852,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c20793
 [[packages]]
 name = "mdurl"
 version = "0.1.2"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", upload-time = 2022-08-14T12:40:10Z, size = 8729, hashes = { sha256 = "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", upload-time = 2022-08-14T12:40:09Z, size = 9979, hashes = { sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8" } }]
 
@@ -2045,7 +2045,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1
 [[packages]]
 name = "msgpack"
 version = "1.1.1"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/45/b1/ea4f68038a18c77c9467400d166d74c4ffa536f34761f7983a104357e614/msgpack-1.1.1.tar.gz", upload-time = 2025-06-13T06:52:51Z, size = 173555, hashes = { sha256 = "77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/52/f30da112c1dc92cf64f57d08a273ac771e7b29dea10b4b30369b2d7e8546/msgpack-1.1.1-cp310-cp310-macosx_10_9_x86_64.whl", upload-time = 2025-06-13T06:51:37Z, size = 81799, hashes = { sha256 = "353b6fc0c36fde68b661a12949d7d49f8f51ff5fa019c1e47c87c4ff34b080ed" } },
@@ -2489,56 +2489,56 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c335
 [[packages]]
 name = "opencensus"
 version = "0.11.4"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", upload-time = 2024-01-03T18:04:07Z, size = 64966, hashes = { sha256 = "cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b5/ed/9fbdeb23a09e430d87b7d72d430484b88184633dc50f6bfb792354b6f661/opencensus-0.11.4-py2.py3-none-any.whl", upload-time = 2024-01-03T18:04:05Z, size = 128225, hashes = { sha256 = "a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864" } }]
 
 [[packages]]
 name = "opencensus-context"
 version = "0.1.3"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/4c/96/3b6f638f6275a8abbd45e582448723bffa29c1fb426721dedb5c72f7d056/opencensus-context-0.1.3.tar.gz", upload-time = 2022-08-03T22:20:22Z, size = 4066, hashes = { sha256 = "a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/10/68/162c97ea78c957d68ecf78a5c5041d2e25bd5562bdf5d89a6cbf7f8429bf/opencensus_context-0.1.3-py2.py3-none-any.whl", upload-time = 2022-08-03T22:20:20Z, size = 5060, hashes = { sha256 = "073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039" } }]
 
 [[packages]]
 name = "openshift-client"
 version = "1.0.18"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/61/4d/96d40621a88e430127f98467b6ef67ff2e39f2d33b9740ea0e470cf2b8bc/openshift-client-1.0.18.tar.gz", upload-time = 2022-09-13T22:08:36Z, size = 78332, hashes = { sha256 = "be3979440cfd96788146a3a1650dabe939d4d516eea0b39f87e66d2ab39495b1" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/1d/23/a84f274a534dfcd8454f20fc19d129a7d832e5816830946670b8c954438c/openshift_client-1.0.18-py2.py3-none-any.whl", upload-time = 2022-09-13T22:08:35Z, size = 75076, hashes = { sha256 = "d8a84080307ccd9556f6c62a3707a3e6507baedee36fa425754f67db9ded528b" } }]
 
 [[packages]]
 name = "opentelemetry-api"
 version = "1.36.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/27/d2/c782c88b8afbf961d6972428821c302bd1e9e7bc361352172f0ca31296e2/opentelemetry_api-1.36.0.tar.gz", upload-time = 2025-07-29T15:12:06Z, size = 64780, hashes = { sha256 = "9a72572b9c416d004d492cbc6e61962c0501eaf945ece9b5a0f56597d8348aa0" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/bb/ee/6b08dde0a022c463b88f55ae81149584b125a42183407dc1045c486cc870/opentelemetry_api-1.36.0-py3-none-any.whl", upload-time = 2025-07-29T15:11:47Z, size = 65564, hashes = { sha256 = "02f20bcacf666e1333b6b1f04e647dc1d5111f86b8e510238fcc56d7762cda8c" } }]
 
 [[packages]]
 name = "opentelemetry-exporter-prometheus"
 version = "0.57b0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/d6/d8/5f04c6d51c0823c3d8ac973a2a38db6fcf2d040ca3f08fc66b3c14b6e164/opentelemetry_exporter_prometheus-0.57b0.tar.gz", upload-time = 2025-07-29T15:12:09Z, size = 14906, hashes = { sha256 = "9eb15bdc189235cf03c3f93abf56f8ff0ab57a493a189263bd7fe77a4249e689" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/c1/1c/40fb93a7b7e495985393bbc734104d5d20e470811644dd56c2402d683739/opentelemetry_exporter_prometheus-0.57b0-py3-none-any.whl", upload-time = 2025-07-29T15:11:54Z, size = 12922, hashes = { sha256 = "c5b893d1cdd593fb022af2c7de3258c2d5a4d04402ae80d9fa35675fed77f05c" } }]
 
 [[packages]]
 name = "opentelemetry-proto"
 version = "1.36.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/fd/02/f6556142301d136e3b7e95ab8ea6a5d9dc28d879a99f3dd673b5f97dca06/opentelemetry_proto-1.36.0.tar.gz", upload-time = 2025-07-29T15:12:15Z, size = 46152, hashes = { sha256 = "0f10b3c72f74c91e0764a5ec88fd8f1c368ea5d9c64639fb455e2854ef87dd2f" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b3/57/3361e06136225be8180e879199caea520f38026f8071366241ac458beb8d/opentelemetry_proto-1.36.0-py3-none-any.whl", upload-time = 2025-07-29T15:12:02Z, size = 72537, hashes = { sha256 = "151b3bf73a09f94afc658497cf77d45a565606f62ce0c17acb08cd9937ca206e" } }]
 
 [[packages]]
 name = "opentelemetry-sdk"
 version = "1.36.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/4c/85/8567a966b85a2d3f971c4d42f781c305b2b91c043724fa08fd37d158e9dc/opentelemetry_sdk-1.36.0.tar.gz", upload-time = 2025-07-29T15:12:16Z, size = 162557, hashes = { sha256 = "19c8c81599f51b71670661ff7495c905d8fdf6976e41622d5245b791b06fa581" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/0b/59/7bed362ad1137ba5886dac8439e84cd2df6d087be7c09574ece47ae9b22c/opentelemetry_sdk-1.36.0-py3-none-any.whl", upload-time = 2025-07-29T15:12:03Z, size = 119995, hashes = { sha256 = "19fe048b42e98c5c1ffe85b569b7073576ad4ce0bcb6e9b4c6a39e890a6c45fb" } }]
 
 [[packages]]
 name = "opentelemetry-semantic-conventions"
 version = "0.57b0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/7e/31/67dfa252ee88476a29200b0255bda8dfc2cf07b56ad66dc9a6221f7dc787/opentelemetry_semantic_conventions-0.57b0.tar.gz", upload-time = 2025-07-29T15:12:17Z, size = 124225, hashes = { sha256 = "609a4a79c7891b4620d64c7aac6898f872d790d75f22019913a660756f27ff32" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/05/75/7d591371c6c39c73de5ce5da5a2cc7b72d1d1cd3f8f4638f553c01c37b11/opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl", upload-time = 2025-07-29T15:12:04Z, size = 201627, hashes = { sha256 = "757f7e76293294f124c827e514c2a3144f191ef175b069ce8d1211e1e38e9e78" } }]
 
@@ -2617,7 +2617,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/61/55/83ce641bc61a70c
 [[packages]]
 name = "paramiko"
 version = "4.0.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/1f/e7/81fdcbc7f190cdb058cffc9431587eb289833bdd633e2002455ca9bb13d4/paramiko-4.0.0.tar.gz", upload-time = 2025-08-04T01:02:03Z, size = 1630743, hashes = { sha256 = "6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/a9/90/a744336f5af32c433bd09af7854599682a383b37cfd78f7de263de6ad6cb/paramiko-4.0.0-py3-none-any.whl", upload-time = 2025-08-04T01:02:02Z, size = 223932, hashes = { sha256 = "0e20e00ac666503bf0b4eda3b6d833465a2b7aff2e2b3d79a8bba5ef144ee3b9" } }]
 
@@ -2955,7 +2955,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 [[packages]]
 name = "py-spy"
 version = "0.4.1"
-marker = "python_full_version >= '3.12' and platform_machine != 's390x'"
+marker = "python_full_version >= '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/19/e2/ff811a367028b87e86714945bb9ecb5c1cc69114a8039a67b3a862cef921/py_spy-0.4.1.tar.gz", upload-time = 2025-07-31T19:33:25Z, size = 244726, hashes = { sha256 = "e53aa53daa2e47c2eef97dd2455b47bb3a7e7f962796a86cc3e7dbde8e6f4db4" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/e3/3a32500d845bdd94f6a2b4ed6244982f42ec2bc64602ea8fcfe900678ae7/py_spy-0.4.1-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", upload-time = 2025-07-31T19:33:13Z, size = 3682508, hashes = { sha256 = "809094208c6256c8f4ccadd31e9a513fe2429253f48e20066879239ba12cd8cc" } },
@@ -3559,7 +3559,7 @@ wheels = [
 [[packages]]
 name = "ray"
 version = "2.47.1"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/fe/2f1fc21b7a321385fe34fd159c27245c06bad795aba7de71f29e7a00e741/ray-2.47.1-cp310-cp310-macosx_11_0_arm64.whl", upload-time = 2025-06-17T22:26:11Z, size = 66145880, hashes = { sha256 = "36a30930e8d265e708df96f37f6f1f5484f4b97090d505912f992e045a69d310" } },
     { url = "https://files.pythonhosted.org/packages/87/4a/60b0ce7dc1ac04e9c48fc398afed557f0f0cb3fd74c07cb71b567a041157/ray-2.47.1-cp310-cp310-macosx_12_0_x86_64.whl", upload-time = 2025-06-17T22:26:18Z, size = 68562947, hashes = { sha256 = "7c03a1e366d3a868a55f8c2f728f5ce35ac85ddf093ac81d0c1a35bf1c25c377" } },
@@ -3638,7 +3638,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd
 [[packages]]
 name = "rich"
 version = "13.9.4"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", upload-time = 2024-11-01T16:43:57Z, size = 223149, hashes = { sha256 = "439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", upload-time = 2024-11-01T16:43:55Z, size = 242424, hashes = { sha256 = "6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90" } }]
 
@@ -4001,7 +4001,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/08/de/e8825727acd8048
 [[packages]]
 name = "smart-open"
 version = "7.3.1"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/16/be/bf2d60280a9d7fac98ece2150a22538fa4332cda67d04d9618c8406f791e/smart_open-7.3.1.tar.gz", upload-time = 2025-09-08T10:03:53Z, size = 51405, hashes = { sha256 = "b33fee8dffd206f189d5e704106a8723afb4210d2ff47e0e1f7fbe436187a990" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/e5/d9/460cf1d58945dd771c228c29d5664f431dfc4060d3d092fed40546b11472/smart_open-7.3.1-py3-none-any.whl", upload-time = 2025-09-08T10:03:52Z, size = 61722, hashes = { sha256 = "e243b2e7f69d6c0c96dd763d6fbbedbb4e0e4fc6d74aa007acc5b018d523858c" } }]
 
@@ -4373,7 +4373,7 @@ wheels = [
 [[packages]]
 name = "virtualenv"
 version = "20.34.0"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", upload-time = 2025-08-13T14:24:07Z, size = 6003808, hashes = { sha256 = "44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", upload-time = 2025-08-13T14:24:05Z, size = 5983279, hashes = { sha256 = "341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026" } }]
 
@@ -4645,7 +4645,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/ca/51/5447876806d1088
 [[packages]]
 name = "wrapt"
 version = "1.17.3"
-marker = "platform_machine != 's390x'"
+marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
 sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", upload-time = 2025-08-12T05:53:21Z, size = 55547, hashes = { sha256 = "f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", upload-time = 2025-08-12T05:51:44Z, size = 53482, hashes = { sha256 = "88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04" } },

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
-    "codeflare-sdk~=0.31.0; platform_machine != 's390x'",
+    "codeflare-sdk~=0.31.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "feast~=0.53.0",
 
     # DB connectors

--- a/scripts/generate_pull_request_pipelineruns.py
+++ b/scripts/generate_pull_request_pipelineruns.py
@@ -143,6 +143,7 @@ def transform_build_pipeline_to_pr_pipeline(push_pipeline_path: pathlib.Path):
 
     if component in [
         "odh-workbench-codeserver-datascience-cpu-py312-ubi9",
+        "odh-workbench-jupyter-datascience-cpu-py312-ubi9",
         "odh-workbench-jupyter-minimal-cpu-py312-ubi9",
         "odh-pipeline-runtime-minimal-cpu-py312-ubi9",
         "odh-pipeline-runtime-datascience-cpu-py312-ubi9",

--- a/scripts/generate_pull_request_pipelineruns.py
+++ b/scripts/generate_pull_request_pipelineruns.py
@@ -151,6 +151,7 @@ def transform_build_pipeline_to_pr_pipeline(push_pipeline_path: pathlib.Path):
         build_platforms.extend(["linux/ppc64le"])
 
     if component in [
+        "odh-workbench-jupyter-datascience-cpu-py312-ubi9",
         "odh-pipeline-runtime-minimal-cpu-py312-ubi9",
         "odh-pipeline-runtime-datascience-cpu-py312-ubi9",
     ]:


### PR DESCRIPTION
Conflict resolution from
* https://github.com/opendatahub-io/notebooks/pull/2406

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Jupyter Datascience (Python 3.12, UBI9) now built and shipped for linux/ppc64le and linux/s390x.
  - Power (ppc64le) additions: bundled ONNX wheels, OpenBLAS integration, and multi-arch pyarrow support.
  - unixODBC-devel included for improved ODBC compatibility.

- **Performance**
  - OpenBLAS packaged/optimized for POWER9 to boost numerical workloads on ppc64le.

- **Chores**
  - CI build matrix and dependency markers updated for correct multi-arch builds and installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->