### PR TITLE
ppc64le(jupyter/trustyai): create multiarch build for ppc64le

### DIFF
--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -36,6 +36,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
   - name: dockerfile
     value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -15,6 +15,27 @@ RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mo
 RUN unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
     CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
+####################
+# wheel-cache-base #
+####################
+FROM ${BASE_IMAGE} AS whl-cache
+
+USER root
+ENV HOME=/root
+WORKDIR /root
+
+ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
+
+COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
+COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    pip install --no-cache uv && \
+    # the devel script is ppc64le specific - sets up build-time dependencies
+    source ./devel_env_setup.sh && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
 
 ####################
 # cpu-base         #
@@ -117,6 +138,8 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib
+
 LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.12" \
     summary="Jupyter trustyai notebook image for ODH notebooks" \
     description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
@@ -134,16 +157,39 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*'
 
-USER 1001
-
 # Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml ./
 
-RUN echo "Installing softwares and packages" && \
-    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
-    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
-    # setup path for runtime configuration
+# install openblas for ppc64le
+RUN --mount=type=cache,from=whl-cache,source=/root/OpenBLAS/,target=/OpenBlas/,rw \
+    bash -c ' \
+        if [[ $(uname -m) == "ppc64le" ]]; then \
+            dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+            dnf install -y libraqm libimagequant; \
+            PREFIX=/usr/ make install -C /OpenBlas; \
+        fi '
+
+# Install packages and cleanup
+# install packages as USER 0 (this will allow us to consume uv cache)
+RUN --mount=type=cache,from=whl-cache,source=/wheelsdir/,target=/wheelsdir/,rw \
+    --mount=type=cache,target=/root/.cache/uv \
+    bash -c ' \
+        if [[ $(uname -m) == "ppc64le" ]]; then \
+            UV_LINK_MODE=copy uv pip install /wheelsdir/*.whl accelerate --cache-dir /root/.cache/uv; \
+        fi '
+RUN --mount=type=cache,target=/root/.cache/uv \
+    echo "Installing softwares and packages" && \
+    # we can ensure wheels are consumed from the cache only by restricting internet access for uv install with '--offline' flag
+    UV_LINK_MODE=copy uv pip install --cache-dir /root/.cache/uv --requirements=./pylock.toml && \
+    # Note: debugpy wheel availabe on pypi (in uv cache) is none-any but bundles amd64.so files
+    #       Build debugpy from source instead
+    UV_LINK_MODE=copy uv pip install --no-cache git+https://github.com/microsoft/debugpy.git@v$(grep -A1 '\"debugpy\"' ./pylock.toml | grep -Eo '\b[0-9\.]+\b') && \
+    # change ownership to default user (all packages were installed as root and has root:root ownership \
+    chown -R 1001:0 /opt/app-root/
+
+USER 1001
+
+RUN # setup path for runtime configuration \
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \

--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -eoux pipefail
+
+#####################################################################################################
+# This script is expected to be run on ppc64le hosts as `root`                                      #
+# It installs the required build-time dependencies for python wheels                                #
+# OpenBlas is built from source (instead of distro provided) with recommended flags for performance #
+#####################################################################################################
+WHEELS_DIR=/wheelsdir
+mkdir -p ${WHEELS_DIR}
+if [[ $(uname -m) == "ppc64le" ]]; then
+    CURDIR=$(pwd)
+
+    # install development packages
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    dnf install -y fribidi-devel gcc-toolset-13 lcms2-devel libimagequant-devel \
+        libraqm-devel openjpeg2-devel tcl-devel tk-devel unixODBC-devel
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+    source /opt/rh/gcc-toolset-13/enable
+    source $HOME/.cargo/env
+    
+    uv pip install cmake
+
+    export MAX_JOBS=${MAX_JOBS:-$(nproc)}
+    export OPENBLAS_VERSION=${OPENBLAS_VERSION:-0.3.30}
+
+    # Install OpenBlas
+    # IMPORTANT: Ensure Openblas is installed in the final image
+    cd /root
+    curl -L https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz | tar xz
+    # rename directory for mounting (without knowing version numbers) in multistage builds
+    mv OpenBLAS-${OPENBLAS_VERSION}/ OpenBLAS/
+    cd OpenBLAS/
+    make -j${MAX_JOBS} TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
+    make install
+    cd ..
+
+    # set path for openblas
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/OpenBLAS/lib/:/usr/local/lib64:/usr/local/lib
+    export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
+    export CMAKE_ARGS="-DPython3_EXECUTABLE=python"
+    export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
+    TMP=$(mktemp -d)
+
+    # Torch
+    cd ${CURDIR}
+    TORCH_VERSION=$(grep -A1 '"torch"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
+    cd ${TMP}
+    git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION}
+    cd pytorch
+    uv pip install -r requirements.txt
+    python setup.py develop
+    rm -f dist/torch*+git*whl
+    MAX_JOBS=${MAX_JOBS:-$(nproc)} \
+        PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 uv build --wheel --out-dir ${WHEELS_DIR}
+
+    cd ${CURDIR}
+    # Pyarrow
+    PYARROW_VERSION=$(grep -A1 '"pyarrow"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
+    cd ${TMP}
+    git clone --recursive https://github.com/apache/arrow.git -b apache-arrow-${PYARROW_VERSION}
+    cd arrow/cpp
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DARROW_PYTHON=ON \
+        -DARROW_BUILD_TESTS=OFF \
+        -DARROW_JEMALLOC=ON \
+        -DARROW_BUILD_STATIC="OFF" \
+        -DARROW_PARQUET=ON \
+        .. && \
+    make install -j ${MAX_JOBS:-$(nproc)} && \
+    cd ../../python/ && \
+    uv pip install -v -r requirements-wheel-build.txt && \
+    PYARROW_PARALLEL=${PYARROW_PARALLEL:-$(nproc)} \
+    python setup.py build_ext \
+    --build-type=release --bundle-arrow-cpp \
+    bdist_wheel --dist-dir ${WHEELS_DIR}
+
+    ls -ltr ${WHEELS_DIR}
+
+    cd ${CURDIR}
+    uv pip install --refresh ${WHEELS_DIR}/*.whl accelerate==$(grep -A1 '"accelerate"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
+
+    uv pip list
+    cd ${CURDIR}
+else
+    # only for mounting on non-ppc64le
+    mkdir -p /root/OpenBLAS/
+fi

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 [[packages]]
 name = "accelerate"
 version = "1.5.2"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/a9/4c/a61132924da12cef62a88c04b5825246ab83dcc1bae6291d098cfcb0b72d/accelerate-1.5.2.tar.gz", upload-time = 2025-03-14T14:14:55Z, size = 352341, hashes = { sha256 = "a1cf39473edc0e42772a9d9a18c9eb1ce8ffd9e1719dc0ab80670f5c1fd4dc43" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/70/83/167d4b638bb758a966828eb8d23c5e7047825edfdf768ff5f4fb01440063/accelerate-1.5.2-py3-none-any.whl", upload-time = 2025-03-14T14:14:53Z, size = 345146, hashes = { sha256 = "68a3b272f6a6ffebb457bdc138581a2bf52efad6a5e0214dc46675f3edd98792" } }]
 
@@ -111,6 +112,7 @@ wheels = [
 [[packages]]
 name = "aiohttp-cors"
 version = "0.8.1"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", upload-time = 2025-03-31T14:16:20Z, size = 38626, hashes = { sha256 = "ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/98/3b/40a68de458904bcc143622015fff2352b6461cd92fd66d3527bf1c6f5716/aiohttp_cors-0.8.1-py3-none-any.whl", upload-time = 2025-03-31T14:16:18Z, size = 25231, hashes = { sha256 = "3180cf304c5c712d626b9162b195b1db7ddf976a2a25172b35bb2448b890a80d" } }]
 
@@ -123,6 +125,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/fb/76/641ae3715086764
 [[packages]]
 name = "annotated-types"
 version = "0.7.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", upload-time = 2024-05-20T21:33:25Z, size = 16081, hashes = { sha256 = "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", upload-time = 2024-05-20T21:33:24Z, size = 13643, hashes = { sha256 = "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53" } }]
 
@@ -227,6 +230,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc
 [[packages]]
 name = "bcrypt"
 version = "4.3.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", upload-time = 2025-02-28T01:24:09Z, size = 25697, hashes = { sha256 = "3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", upload-time = 2025-02-28T01:22:34Z, size = 483719, hashes = { sha256 = "f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281" } },
@@ -329,15 +333,15 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/96/9a/8e641b5415e1203
 
 [[packages]]
 name = "boto3"
-version = "1.40.30"
-sdist = { url = "https://files.pythonhosted.org/packages/77/a7/3fde131d2431d1801e3f16f1b428cf9b8c6677996716c5286a72eb43ecb7/boto3-1.40.30.tar.gz", upload-time = 2025-09-12T19:23:22Z, size = 111636, hashes = { sha256 = "e95db539c938710917f4cb4fc5915f71b27f2c836d949a1a95df7895d2e9ec8b" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/3f/43/f1865e3e2aa91c1aa54db90a82ed17b8c0dc60c354045adf1c2134e5cbd8/boto3-1.40.30-py3-none-any.whl", upload-time = 2025-09-12T19:23:20Z, size = 139343, hashes = { sha256 = "04e89abf61240857bf7dec160e22f097eec68c502509b2bb3c5010a22cb91052" } }]
+version = "1.40.32"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/c7/39b10ce9e79fb40327c8e96074223cfca01b5b9165827c8a9b2e4c7a8935/boto3-1.40.32.tar.gz", upload-time = 2025-09-16T19:30:22Z, size = 111562, hashes = { sha256 = "6951aac75ce25611df55a31c844b118c288460648535ce9125fb15b490387ba4" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5f/40/2ce4219d4df77c50d3de58fa33a9f6eea1ff183f01d1d42ae333c9789eb9/boto3-1.40.32-py3-none-any.whl", upload-time = 2025-09-16T19:30:19Z, size = 139344, hashes = { sha256 = "9edf07327f444ddd142f45120c6979902712921b6e90fdb05963996b97bd7689" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.40.30"
-sdist = { url = "https://files.pythonhosted.org/packages/c5/be/086ff6f031c407540e8226b3a4921dd18a05688224324c2df60457f9bcc0/botocore-1.40.30.tar.gz", upload-time = 2025-09-12T19:23:12Z, size = 14349135, hashes = { sha256 = "8a74f77cfe5c519826d22f7613f89544cbb8491a1a49d965031bd997f89a8e3f" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/a8/3644f482b7b319f3fda87d4583f7b073c0cdf4a6d1b58e5a92555fe3e2e3/botocore-1.40.30-py3-none-any.whl", upload-time = 2025-09-12T19:23:09Z, size = 14022003, hashes = { sha256 = "1d87874ad81234bec3e83f9de13618f67ccdfefd08d6b8babc041cd45007447e" } }]
+version = "1.40.32"
+sdist = { url = "https://files.pythonhosted.org/packages/b6/9f/679a62a91414907b7f27d1757238b95f821f769ca98b1418d4e32758d8b5/botocore-1.40.32.tar.gz", upload-time = 2025-09-16T19:30:10Z, size = 14344643, hashes = { sha256 = "e027adff8d6e177b396dff68340dafa7548b84aeb2cff149d84844d56ad29bae" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/53/00/7598993d4838262316c75810e6a8d2e0bdeaefed8159125c949e26a643b4/botocore-1.40.32-py3-none-any.whl", upload-time = 2025-09-16T19:30:05Z, size = 14016094, hashes = { sha256 = "a7cc409648aaf08a7d1aab76c675818868a0b76745b9deb478f91c1d8898aa8a" } }]
 
 [[packages]]
 name = "cachetools"
@@ -354,6 +358,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c9
 [[packages]]
 name = "cffi"
 version = "2.0.0"
+marker = "python_full_version < '3.14' or platform_python_implementation != 'PyPy'"
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", upload-time = 2025-09-08T23:24:04Z, size = 523588, hashes = { sha256 = "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", upload-time = 2025-09-08T23:22:08Z, size = 184283, hashes = { sha256 = "0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44" } },
@@ -541,6 +546,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3
 [[packages]]
 name = "codeflare-sdk"
 version = "0.31.1"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
@@ -553,6 +559,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e
 [[packages]]
 name = "colorful"
 version = "0.5.7"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/0c/0c/d180ebf230b771907f46981023a80f62cf592d49673cc5f8a5993aa67bb6/colorful-0.5.7.tar.gz", upload-time = 2025-06-30T15:24:03Z, size = 209487, hashes = { sha256 = "c5452179b56601c178b03d468a5326cc1fe37d9be81d24d0d6bdab36c4b93ad8" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/e2/98/0d791b3d1eaed89d7d370b5cf9b8079b124da0545559417f394ba21b5532/colorful-0.5.7-py2.py3-none-any.whl", upload-time = 2025-06-30T15:24:02Z, size = 201475, hashes = { sha256 = "495dd3a23151a9568cee8a90fc1174c902ad7ef06655f50b6bddf9e80008da69" } }]
 
@@ -744,6 +751,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f
 [[packages]]
 name = "distlib"
 version = "0.4.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", upload-time = 2025-07-17T16:52:00Z, size = 614605, hashes = { sha256 = "feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", upload-time = 2025-07-17T16:51:58Z, size = 469047, hashes = { sha256 = "9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16" } }]
 
@@ -1058,9 +1066,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/40/86/bda7241a8da2d28
 
 [[packages]]
 name = "google-cloud-storage"
-version = "3.3.0"
-sdist = { url = "https://files.pythonhosted.org/packages/1e/91/10b9ddd5baacde375dcd7e6716b5024b3f65a22366f74c26926b6aa84e4e/google_cloud_storage-3.3.0.tar.gz", upload-time = 2025-08-12T09:10:36Z, size = 7781974, hashes = { sha256 = "ae9d891d53e17d9681d7c4ef1ffeea0cde9bdc53d5b64fa6ff6bf30d1911cf61" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/41/9d/2814a2c47429dc2e197e176de25a946d4538422b081ade8638e585e4006f/google_cloud_storage-3.3.0-py3-none-any.whl", upload-time = 2025-08-12T09:10:34Z, size = 274270, hashes = { sha256 = "0338ecd6621b3ecacb108f1cf7513ff0d1bca7f1ff4d58e0220b59f3a725ff23" } }]
+version = "3.4.0"
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/6e0a318f70975a3c048c0e1a18aee4f7b6d7dac1e798fdc5353c5248d418/google_cloud_storage-3.4.0.tar.gz", upload-time = 2025-09-15T10:40:05Z, size = 17226847, hashes = { sha256 = "4c77ec00c98ccc6428e4c39404926f41e2152f48809b02af29d5116645c3c317" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/16/12/164a90e4692423ed5532274928b0e19c8cae345ae1aa413d78c6b688231b/google_cloud_storage-3.4.0-py3-none-any.whl", upload-time = 2025-09-15T10:40:03Z, size = 278423, hashes = { sha256 = "16eeca305e4747a6871f8f7627eef3b862fdd365b872ca74d4a89e9841d0f8e8" } }]
 
 [[packages]]
 name = "google-crc32c"
@@ -1116,60 +1124,60 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15
 
 [[packages]]
 name = "grpcio"
-version = "1.74.0"
-marker = "python_full_version >= '3.10'"
-sdist = { url = "https://files.pythonhosted.org/packages/38/b4/35feb8f7cab7239c5b94bd2db71abb3d6adb5f335ad8f131abb6060840b6/grpcio-1.74.0.tar.gz", upload-time = 2025-07-24T18:54:23Z, size = 12756048, hashes = { sha256 = "80d1f4fbb35b0742d3e3d3bb654b7381cd5f015f8497279a1e9c21ba623e01b1" } }
+version = "1.75.0"
+marker = "python_full_version >= '3.10' and platform_machine != 'ppc64le'"
+sdist = { url = "https://files.pythonhosted.org/packages/91/88/fe2844eefd3d2188bc0d7a2768c6375b46dfd96469ea52d8aeee8587d7e0/grpcio-1.75.0.tar.gz", upload-time = 2025-09-16T09:20:21Z, size = 12722485, hashes = { sha256 = "b989e8b09489478c2d19fecc744a298930f40d8b27c3638afbfe84d22f36ce4e" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/54/68e51a90797ad7afc5b0a7881426c337f6a9168ebab73c3210b76aa7c90d/grpcio-1.74.0-cp310-cp310-linux_armv7l.whl", upload-time = 2025-07-24T18:52:43Z, size = 5481935, hashes = { sha256 = "85bd5cdf4ed7b2d6438871adf6afff9af7096486fcf51818a81b77ef4dd30907" } },
-    { url = "https://files.pythonhosted.org/packages/32/2a/af817c7e9843929e93e54d09c9aee2555c2e8d81b93102a9426b36e91833/grpcio-1.74.0-cp310-cp310-macosx_11_0_universal2.whl", upload-time = 2025-07-24T18:52:47Z, size = 10986796, hashes = { sha256 = "68c8ebcca945efff9d86d8d6d7bfb0841cf0071024417e2d7f45c5e46b5b08eb" } },
-    { url = "https://files.pythonhosted.org/packages/d5/94/d67756638d7bb07750b07d0826c68e414124574b53840ba1ff777abcd388/grpcio-1.74.0-cp310-cp310-manylinux_2_17_aarch64.whl", upload-time = 2025-07-24T18:52:49Z, size = 5983663, hashes = { sha256 = "e154d230dc1bbbd78ad2fdc3039fa50ad7ffcf438e4eb2fa30bce223a70c7486" } },
-    { url = "https://files.pythonhosted.org/packages/35/f5/c5e4853bf42148fea8532d49e919426585b73eafcf379a712934652a8de9/grpcio-1.74.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2025-07-24T18:52:51Z, size = 6653765, hashes = { sha256 = "e8978003816c7b9eabe217f88c78bc26adc8f9304bf6a594b02e5a49b2ef9c11" } },
-    { url = "https://files.pythonhosted.org/packages/fd/75/a1991dd64b331d199935e096cc9daa3415ee5ccbe9f909aa48eded7bba34/grpcio-1.74.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-07-24T18:52:53Z, size = 6215172, hashes = { sha256 = "c3d7bd6e3929fd2ea7fbc3f562e4987229ead70c9ae5f01501a46701e08f1ad9" } },
-    { url = "https://files.pythonhosted.org/packages/01/a4/7cef3dbb3b073d0ce34fd507efc44ac4c9442a0ef9fba4fb3f5c551efef5/grpcio-1.74.0-cp310-cp310-musllinux_1_1_aarch64.whl", upload-time = 2025-07-24T18:52:54Z, size = 6329142, hashes = { sha256 = "136b53c91ac1d02c8c24201bfdeb56f8b3ac3278668cbb8e0ba49c88069e1bdc" } },
-    { url = "https://files.pythonhosted.org/packages/bf/d3/587920f882b46e835ad96014087054655312400e2f1f1446419e5179a383/grpcio-1.74.0-cp310-cp310-musllinux_1_1_i686.whl", upload-time = 2025-07-24T18:52:56Z, size = 7018632, hashes = { sha256 = "fe0f540750a13fd8e5da4b3eaba91a785eea8dca5ccd2bc2ffe978caa403090e" } },
-    { url = "https://files.pythonhosted.org/packages/1f/95/c70a3b15a0bc83334b507e3d2ae20ee8fa38d419b8758a4d838f5c2a7d32/grpcio-1.74.0-cp310-cp310-musllinux_1_1_x86_64.whl", upload-time = 2025-07-24T18:52:58Z, size = 6509641, hashes = { sha256 = "4e4181bfc24413d1e3a37a0b7889bea68d973d4b45dd2bc68bb766c140718f82" } },
-    { url = "https://files.pythonhosted.org/packages/4b/06/2e7042d06247d668ae69ea6998eca33f475fd4e2855f94dcb2aa5daef334/grpcio-1.74.0-cp310-cp310-win32.whl", upload-time = 2025-07-24T18:53:00Z, size = 3817478, hashes = { sha256 = "1733969040989f7acc3d94c22f55b4a9501a30f6aaacdbccfaba0a3ffb255ab7" } },
-    { url = "https://files.pythonhosted.org/packages/93/20/e02b9dcca3ee91124060b65bbf5b8e1af80b3b76a30f694b44b964ab4d71/grpcio-1.74.0-cp310-cp310-win_amd64.whl", upload-time = 2025-07-24T18:53:02Z, size = 4493971, hashes = { sha256 = "9e912d3c993a29df6c627459af58975b2e5c897d93287939b9d5065f000249b5" } },
-    { url = "https://files.pythonhosted.org/packages/e7/77/b2f06db9f240a5abeddd23a0e49eae2b6ac54d85f0e5267784ce02269c3b/grpcio-1.74.0-cp311-cp311-linux_armv7l.whl", upload-time = 2025-07-24T18:53:03Z, size = 5487368, hashes = { sha256 = "69e1a8180868a2576f02356565f16635b99088da7df3d45aaa7e24e73a054e31" } },
-    { url = "https://files.pythonhosted.org/packages/48/99/0ac8678a819c28d9a370a663007581744a9f2a844e32f0fa95e1ddda5b9e/grpcio-1.74.0-cp311-cp311-macosx_11_0_universal2.whl", upload-time = 2025-07-24T18:53:05Z, size = 10999804, hashes = { sha256 = "8efe72fde5500f47aca1ef59495cb59c885afe04ac89dd11d810f2de87d935d4" } },
-    { url = "https://files.pythonhosted.org/packages/45/c6/a2d586300d9e14ad72e8dc211c7aecb45fe9846a51e558c5bca0c9102c7f/grpcio-1.74.0-cp311-cp311-manylinux_2_17_aarch64.whl", upload-time = 2025-07-24T18:53:07Z, size = 5987667, hashes = { sha256 = "a8f0302f9ac4e9923f98d8e243939a6fb627cd048f5cd38595c97e38020dffce" } },
-    { url = "https://files.pythonhosted.org/packages/c9/57/5f338bf56a7f22584e68d669632e521f0de460bb3749d54533fc3d0fca4f/grpcio-1.74.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2025-07-24T18:53:09Z, size = 6655612, hashes = { sha256 = "2f609a39f62a6f6f05c7512746798282546358a37ea93c1fcbadf8b2fed162e3" } },
-    { url = "https://files.pythonhosted.org/packages/82/ea/a4820c4c44c8b35b1903a6c72a5bdccec92d0840cf5c858c498c66786ba5/grpcio-1.74.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-07-24T18:53:11Z, size = 6219544, hashes = { sha256 = "c98e0b7434a7fa4e3e63f250456eaef52499fba5ae661c58cc5b5477d11e7182" } },
-    { url = "https://files.pythonhosted.org/packages/a4/17/0537630a921365928f5abb6d14c79ba4dcb3e662e0dbeede8af4138d9dcf/grpcio-1.74.0-cp311-cp311-musllinux_1_1_aarch64.whl", upload-time = 2025-07-24T18:53:12Z, size = 6334863, hashes = { sha256 = "662456c4513e298db6d7bd9c3b8df6f75f8752f0ba01fb653e252ed4a59b5a5d" } },
-    { url = "https://files.pythonhosted.org/packages/e2/a6/85ca6cb9af3f13e1320d0a806658dca432ff88149d5972df1f7b51e87127/grpcio-1.74.0-cp311-cp311-musllinux_1_1_i686.whl", upload-time = 2025-07-24T18:53:15Z, size = 7019320, hashes = { sha256 = "3d14e3c4d65e19d8430a4e28ceb71ace4728776fd6c3ce34016947474479683f" } },
-    { url = "https://files.pythonhosted.org/packages/4f/a7/fe2beab970a1e25d2eff108b3cf4f7d9a53c185106377a3d1989216eba45/grpcio-1.74.0-cp311-cp311-musllinux_1_1_x86_64.whl", upload-time = 2025-07-24T18:53:16Z, size = 6514228, hashes = { sha256 = "1bf949792cee20d2078323a9b02bacbbae002b9e3b9e2433f2741c15bdeba1c4" } },
-    { url = "https://files.pythonhosted.org/packages/6a/c2/2f9c945c8a248cebc3ccda1b7a1bf1775b9d7d59e444dbb18c0014e23da6/grpcio-1.74.0-cp311-cp311-win32.whl", upload-time = 2025-07-24T18:53:20Z, size = 3817216, hashes = { sha256 = "55b453812fa7c7ce2f5c88be3018fb4a490519b6ce80788d5913f3f9d7da8c7b" } },
-    { url = "https://files.pythonhosted.org/packages/ff/d1/a9cf9c94b55becda2199299a12b9feef0c79946b0d9d34c989de6d12d05d/grpcio-1.74.0-cp311-cp311-win_amd64.whl", upload-time = 2025-07-24T18:53:22Z, size = 4495380, hashes = { sha256 = "86ad489db097141a907c559988c29718719aa3e13370d40e20506f11b4de0d11" } },
-    { url = "https://files.pythonhosted.org/packages/4c/5d/e504d5d5c4469823504f65687d6c8fb97b7f7bf0b34873b7598f1df24630/grpcio-1.74.0-cp312-cp312-linux_armv7l.whl", upload-time = 2025-07-24T18:53:23Z, size = 5445551, hashes = { sha256 = "8533e6e9c5bd630ca98062e3a1326249e6ada07d05acf191a77bc33f8948f3d8" } },
-    { url = "https://files.pythonhosted.org/packages/43/01/730e37056f96f2f6ce9f17999af1556df62ee8dab7fa48bceeaab5fd3008/grpcio-1.74.0-cp312-cp312-macosx_11_0_universal2.whl", upload-time = 2025-07-24T18:53:25Z, size = 10979810, hashes = { sha256 = "2918948864fec2a11721d91568effffbe0a02b23ecd57f281391d986847982f6" } },
-    { url = "https://files.pythonhosted.org/packages/79/3d/09fd100473ea5c47083889ca47ffd356576173ec134312f6aa0e13111dee/grpcio-1.74.0-cp312-cp312-manylinux_2_17_aarch64.whl", upload-time = 2025-07-24T18:53:27Z, size = 5941946, hashes = { sha256 = "60d2d48b0580e70d2e1954d0d19fa3c2e60dd7cbed826aca104fff518310d1c5" } },
-    { url = "https://files.pythonhosted.org/packages/8a/99/12d2cca0a63c874c6d3d195629dcd85cdf5d6f98a30d8db44271f8a97b93/grpcio-1.74.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2025-07-24T18:53:29Z, size = 6621763, hashes = { sha256 = "3601274bc0523f6dc07666c0e01682c94472402ac2fd1226fd96e079863bfa49" } },
-    { url = "https://files.pythonhosted.org/packages/9d/2c/930b0e7a2f1029bbc193443c7bc4dc2a46fedb0203c8793dcd97081f1520/grpcio-1.74.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-07-24T18:53:30Z, size = 6180664, hashes = { sha256 = "176d60a5168d7948539def20b2a3adcce67d72454d9ae05969a2e73f3a0feee7" } },
-    { url = "https://files.pythonhosted.org/packages/db/d5/ff8a2442180ad0867717e670f5ec42bfd8d38b92158ad6bcd864e6d4b1ed/grpcio-1.74.0-cp312-cp312-musllinux_1_1_aarch64.whl", upload-time = 2025-07-24T18:53:32Z, size = 6301083, hashes = { sha256 = "e759f9e8bc908aaae0412642afe5416c9f983a80499448fcc7fab8692ae044c3" } },
-    { url = "https://files.pythonhosted.org/packages/b0/ba/b361d390451a37ca118e4ec7dccec690422e05bc85fba2ec72b06cefec9f/grpcio-1.74.0-cp312-cp312-musllinux_1_1_i686.whl", upload-time = 2025-07-24T18:53:34Z, size = 6994132, hashes = { sha256 = "9e7c4389771855a92934b2846bd807fc25a3dfa820fd912fe6bd8136026b2707" } },
-    { url = "https://files.pythonhosted.org/packages/3b/0c/3a5fa47d2437a44ced74141795ac0251bbddeae74bf81df3447edd767d27/grpcio-1.74.0-cp312-cp312-musllinux_1_1_x86_64.whl", upload-time = 2025-07-24T18:53:36Z, size = 6489616, hashes = { sha256 = "cce634b10aeab37010449124814b05a62fb5f18928ca878f1bf4750d1f0c815b" } },
-    { url = "https://files.pythonhosted.org/packages/ae/95/ab64703b436d99dc5217228babc76047d60e9ad14df129e307b5fec81fd0/grpcio-1.74.0-cp312-cp312-win32.whl", upload-time = 2025-07-24T18:53:37Z, size = 3807083, hashes = { sha256 = "885912559974df35d92219e2dc98f51a16a48395f37b92865ad45186f294096c" } },
-    { url = "https://files.pythonhosted.org/packages/84/59/900aa2445891fc47a33f7d2f76e00ca5d6ae6584b20d19af9c06fa09bf9a/grpcio-1.74.0-cp312-cp312-win_amd64.whl", upload-time = 2025-07-24T18:53:39Z, size = 4490123, hashes = { sha256 = "42f8fee287427b94be63d916c90399ed310ed10aadbf9e2e5538b3e497d269bc" } },
-    { url = "https://files.pythonhosted.org/packages/d4/d8/1004a5f468715221450e66b051c839c2ce9a985aa3ee427422061fcbb6aa/grpcio-1.74.0-cp313-cp313-linux_armv7l.whl", upload-time = 2025-07-24T18:53:41Z, size = 5449488, hashes = { sha256 = "2bc2d7d8d184e2362b53905cb1708c84cb16354771c04b490485fa07ce3a1d89" } },
-    { url = "https://files.pythonhosted.org/packages/94/0e/33731a03f63740d7743dced423846c831d8e6da808fcd02821a4416df7fa/grpcio-1.74.0-cp313-cp313-macosx_11_0_universal2.whl", upload-time = 2025-07-24T18:53:43Z, size = 10974059, hashes = { sha256 = "c14e803037e572c177ba54a3e090d6eb12efd795d49327c5ee2b3bddb836bf01" } },
-    { url = "https://files.pythonhosted.org/packages/0d/c6/3d2c14d87771a421205bdca991467cfe473ee4c6a1231c1ede5248c62ab8/grpcio-1.74.0-cp313-cp313-manylinux_2_17_aarch64.whl", upload-time = 2025-07-24T18:53:45Z, size = 5945647, hashes = { sha256 = "f6ec94f0e50eb8fa1744a731088b966427575e40c2944a980049798b127a687e" } },
-    { url = "https://files.pythonhosted.org/packages/c5/83/5a354c8aaff58594eef7fffebae41a0f8995a6258bbc6809b800c33d4c13/grpcio-1.74.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2025-07-24T18:53:47Z, size = 6626101, hashes = { sha256 = "566b9395b90cc3d0d0c6404bc8572c7c18786ede549cdb540ae27b58afe0fb91" } },
-    { url = "https://files.pythonhosted.org/packages/3f/ca/4fdc7bf59bf6994aa45cbd4ef1055cd65e2884de6113dbd49f75498ddb08/grpcio-1.74.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-07-24T18:53:48Z, size = 6182562, hashes = { sha256 = "e1ea6176d7dfd5b941ea01c2ec34de9531ba494d541fe2057c904e601879f249" } },
-    { url = "https://files.pythonhosted.org/packages/fd/48/2869e5b2c1922583686f7ae674937986807c2f676d08be70d0a541316270/grpcio-1.74.0-cp313-cp313-musllinux_1_1_aarch64.whl", upload-time = 2025-07-24T18:53:50Z, size = 6303425, hashes = { sha256 = "64229c1e9cea079420527fa8ac45d80fc1e8d3f94deaa35643c381fa8d98f362" } },
-    { url = "https://files.pythonhosted.org/packages/a6/0e/bac93147b9a164f759497bc6913e74af1cb632c733c7af62c0336782bd38/grpcio-1.74.0-cp313-cp313-musllinux_1_1_i686.whl", upload-time = 2025-07-24T18:53:52Z, size = 6996533, hashes = { sha256 = "0f87bddd6e27fc776aacf7ebfec367b6d49cad0455123951e4488ea99d9b9b8f" } },
-    { url = "https://files.pythonhosted.org/packages/84/35/9f6b2503c1fd86d068b46818bbd7329db26a87cdd8c01e0d1a9abea1104c/grpcio-1.74.0-cp313-cp313-musllinux_1_1_x86_64.whl", upload-time = 2025-07-24T18:53:55Z, size = 6491489, hashes = { sha256 = "3b03d8f2a07f0fea8c8f74deb59f8352b770e3900d143b3d1475effcb08eec20" } },
-    { url = "https://files.pythonhosted.org/packages/75/33/a04e99be2a82c4cbc4039eb3a76f6c3632932b9d5d295221389d10ac9ca7/grpcio-1.74.0-cp313-cp313-win32.whl", upload-time = 2025-07-24T18:53:56Z, size = 3805811, hashes = { sha256 = "b6a73b2ba83e663b2480a90b82fdae6a7aa6427f62bf43b29912c0cfd1aa2bfa" } },
-    { url = "https://files.pythonhosted.org/packages/34/80/de3eb55eb581815342d097214bed4c59e806b05f1b3110df03b2280d6dfd/grpcio-1.74.0-cp313-cp313-win_amd64.whl", upload-time = 2025-07-24T18:53:59Z, size = 4489214, hashes = { sha256 = "fd3c71aeee838299c5887230b8a1822795325ddfea635edd82954c1eaa831e24" } },
-    { url = "https://files.pythonhosted.org/packages/0d/de/dd7db504703c3b669f1b83265e2fbb5d79c8d3da86ea52cbd9202b9a8b05/grpcio-1.74.0-cp39-cp39-linux_armv7l.whl", upload-time = 2025-07-24T18:54:01Z, size = 5480998, hashes = { sha256 = "4bc5fca10aaf74779081e16c2bcc3d5ec643ffd528d9e7b1c9039000ead73bae" } },
-    { url = "https://files.pythonhosted.org/packages/1c/57/6537ace3af4c97f2b013ceff1f2e789c52b8448334ca3a0c36e7421cf6ed/grpcio-1.74.0-cp39-cp39-macosx_11_0_universal2.whl", upload-time = 2025-07-24T18:54:03Z, size = 10990945, hashes = { sha256 = "6bab67d15ad617aff094c382c882e0177637da73cbc5532d52c07b4ee887a87b" } },
-    { url = "https://files.pythonhosted.org/packages/d8/f2/579410017de16cd27f35326df6fecde81bff6e9b43c871d28263fa8a77a4/grpcio-1.74.0-cp39-cp39-manylinux_2_17_aarch64.whl", upload-time = 2025-07-24T18:54:06Z, size = 5983968, hashes = { sha256 = "655726919b75ab3c34cdad39da5c530ac6fa32696fb23119e36b64adcfca174a" } },
-    { url = "https://files.pythonhosted.org/packages/a0/6a/0f3571003663d991f4ea953b82dc518fed094c182decc48c9b0242bec7e3/grpcio-1.74.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2025-07-24T18:54:08Z, size = 6654768, hashes = { sha256 = "1a2b06afe2e50ebfd46247ac3ba60cac523f54ec7792ae9ba6073c12daf26f0a" } },
-    { url = "https://files.pythonhosted.org/packages/24/e3/1d42cb00e0390bacab3c9ee79e37416140d907c8c7c7a92654c535805963/grpcio-1.74.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-07-24T18:54:10Z, size = 6215627, hashes = { sha256 = "5f251c355167b2360537cf17bea2cf0197995e551ab9da6a0a59b3da5e8704f9" } },
-    { url = "https://files.pythonhosted.org/packages/77/84/4f8312bc4430eda1cdbc4e8689f54daa807b5d304d4ea53e9d27c448889b/grpcio-1.74.0-cp39-cp39-musllinux_1_1_aarch64.whl", upload-time = 2025-07-24T18:54:12Z, size = 6330938, hashes = { sha256 = "8f7b5882fb50632ab1e48cb3122d6df55b9afabc265582808036b6e51b9fd6b7" } },
-    { url = "https://files.pythonhosted.org/packages/2f/c0/422d2b40110716a4775212256a56ac71586be2403a7b7055818bfd0fc203/grpcio-1.74.0-cp39-cp39-musllinux_1_1_i686.whl", upload-time = 2025-07-24T18:54:14Z, size = 7019216, hashes = { sha256 = "834988b6c34515545b3edd13e902c1acdd9f2465d386ea5143fb558f153a7176" } },
-    { url = "https://files.pythonhosted.org/packages/6f/84/668ab6df27fb35886dfa1242f2d302d0cd319c72e3dd3845a322ecabf61b/grpcio-1.74.0-cp39-cp39-musllinux_1_1_x86_64.whl", upload-time = 2025-07-24T18:54:16Z, size = 6510719, hashes = { sha256 = "22b834cef33429ca6cc28303c9c327ba9a3fafecbf62fae17e9a7b7163cc43ac" } },
-    { url = "https://files.pythonhosted.org/packages/ed/6a/981150f20dd435b9c46cd504038b4fbae2171b43fe70019914d80159e156/grpcio-1.74.0-cp39-cp39-win32.whl", upload-time = 2025-07-24T18:54:18Z, size = 3819185, hashes = { sha256 = "7d95d71ff35291bab3f1c52f52f474c632db26ea12700c2ff0ea0532cb0b5854" } },
-    { url = "https://files.pythonhosted.org/packages/75/5f/d64b9745bb9def186e1be11b42d4d310570799d6170ac75829ef1c67c176/grpcio-1.74.0-cp39-cp39-win_amd64.whl", upload-time = 2025-07-24T18:54:20Z, size = 4495789, hashes = { sha256 = "ecde9ab49f58433abe02f9ed076c7b5be839cf0153883a6d23995937a82392fa" } },
+    { url = "https://files.pythonhosted.org/packages/23/90/91f780f6cb8b2aa1bc8b8f8561a4e9d3bfe5dea10a4532843f2b044e18ac/grpcio-1.75.0-cp310-cp310-linux_armv7l.whl", upload-time = 2025-09-16T09:18:07Z, size = 5696373, hashes = { sha256 = "1ec9cbaec18d9597c718b1ed452e61748ac0b36ba350d558f9ded1a94cc15ec7" } },
+    { url = "https://files.pythonhosted.org/packages/fc/c6/eaf9065ff15d0994e1674e71e1ca9542ee47f832b4df0fde1b35e5641fa1/grpcio-1.75.0-cp310-cp310-macosx_11_0_universal2.whl", upload-time = 2025-09-16T09:18:12Z, size = 11465905, hashes = { sha256 = "7ee5ee42bfae8238b66a275f9ebcf6f295724375f2fa6f3b52188008b6380faf" } },
+    { url = "https://files.pythonhosted.org/packages/8a/21/ae33e514cb7c3f936b378d1c7aab6d8e986814b3489500c5cc860c48ce88/grpcio-1.75.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-16T09:18:15Z, size = 6282149, hashes = { sha256 = "9146e40378f551eed66c887332afc807fcce593c43c698e21266a4227d4e20d2" } },
+    { url = "https://files.pythonhosted.org/packages/d5/46/dff6344e6f3e81707bc87bba796592036606aca04b6e9b79ceec51902b80/grpcio-1.75.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", upload-time = 2025-09-16T09:18:17Z, size = 6940277, hashes = { sha256 = "0c40f368541945bb664857ecd7400acb901053a1abbcf9f7896361b2cfa66798" } },
+    { url = "https://files.pythonhosted.org/packages/9a/5f/e52cb2c16e097d950c36e7bb2ef46a3b2e4c7ae6b37acb57d88538182b85/grpcio-1.75.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-16T09:18:19Z, size = 6460422, hashes = { sha256 = "50a6e43a9adc6938e2a16c9d9f8a2da9dd557ddd9284b73b07bd03d0e098d1e9" } },
+    { url = "https://files.pythonhosted.org/packages/fd/16/527533f0bd9cace7cd800b7dae903e273cc987fc472a398a4bb6747fec9b/grpcio-1.75.0-cp310-cp310-musllinux_1_2_aarch64.whl", upload-time = 2025-09-16T09:18:21Z, size = 7089969, hashes = { sha256 = "dce15597ca11913b78e1203c042d5723e3ea7f59e7095a1abd0621be0e05b895" } },
+    { url = "https://files.pythonhosted.org/packages/88/4f/1d448820bc88a2be7045aac817a59ba06870e1ebad7ed19525af7ac079e7/grpcio-1.75.0-cp310-cp310-musllinux_1_2_i686.whl", upload-time = 2025-09-16T09:18:23Z, size = 8033548, hashes = { sha256 = "851194eec47755101962da423f575ea223c9dd7f487828fe5693920e8745227e" } },
+    { url = "https://files.pythonhosted.org/packages/37/00/19e87ab12c8b0d73a252eef48664030de198514a4e30bdf337fa58bcd4dd/grpcio-1.75.0-cp310-cp310-musllinux_1_2_x86_64.whl", upload-time = 2025-09-16T09:18:25Z, size = 7487161, hashes = { sha256 = "ca123db0813eef80625a4242a0c37563cb30a3edddebe5ee65373854cf187215" } },
+    { url = "https://files.pythonhosted.org/packages/37/d0/f7b9deaa6ccca9997fa70b4e143cf976eaec9476ecf4d05f7440ac400635/grpcio-1.75.0-cp310-cp310-win32.whl", upload-time = 2025-09-16T09:18:28Z, size = 3946254, hashes = { sha256 = "222b0851e20c04900c63f60153503e918b08a5a0fad8198401c0b1be13c6815b" } },
+    { url = "https://files.pythonhosted.org/packages/6d/42/8d04744c7dc720cc9805a27f879cbf7043bb5c78dce972f6afb8613860de/grpcio-1.75.0-cp310-cp310-win_amd64.whl", upload-time = 2025-09-16T09:18:30Z, size = 4640072, hashes = { sha256 = "bb58e38a50baed9b21492c4b3f3263462e4e37270b7ea152fc10124b4bd1c318" } },
+    { url = "https://files.pythonhosted.org/packages/95/b7/a6f42596fc367656970f5811e5d2d9912ca937aa90621d5468a11680ef47/grpcio-1.75.0-cp311-cp311-linux_armv7l.whl", upload-time = 2025-09-16T09:18:32Z, size = 5699769, hashes = { sha256 = "7f89d6d0cd43170a80ebb4605cad54c7d462d21dc054f47688912e8bf08164af" } },
+    { url = "https://files.pythonhosted.org/packages/c2/42/284c463a311cd2c5f804fd4fdbd418805460bd5d702359148dd062c1685d/grpcio-1.75.0-cp311-cp311-macosx_11_0_universal2.whl", upload-time = 2025-09-16T09:18:35Z, size = 11480362, hashes = { sha256 = "cb6c5b075c2d092f81138646a755f0dad94e4622300ebef089f94e6308155d82" } },
+    { url = "https://files.pythonhosted.org/packages/0b/10/60d54d5a03062c3ae91bddb6e3acefe71264307a419885f453526d9203ff/grpcio-1.75.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-16T09:18:38Z, size = 6284753, hashes = { sha256 = "494dcbade5606128cb9f530ce00331a90ecf5e7c5b243d373aebdb18e503c346" } },
+    { url = "https://files.pythonhosted.org/packages/cf/af/381a4bfb04de5e2527819452583e694df075c7a931e9bf1b2a603b593ab2/grpcio-1.75.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", upload-time = 2025-09-16T09:18:40Z, size = 6944103, hashes = { sha256 = "050760fd29c8508844a720f06c5827bb00de8f5e02f58587eb21a4444ad706e5" } },
+    { url = "https://files.pythonhosted.org/packages/16/18/c80dd7e1828bd6700ce242c1616871927eef933ed0c2cee5c636a880e47b/grpcio-1.75.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-16T09:18:43Z, size = 6464036, hashes = { sha256 = "266fa6209b68a537b2728bb2552f970e7e78c77fe43c6e9cbbe1f476e9e5c35f" } },
+    { url = "https://files.pythonhosted.org/packages/79/3f/78520c7ed9ccea16d402530bc87958bbeb48c42a2ec8032738a7864d38f8/grpcio-1.75.0-cp311-cp311-musllinux_1_2_aarch64.whl", upload-time = 2025-09-16T09:18:45Z, size = 7097455, hashes = { sha256 = "06d22e1d8645e37bc110f4c589cb22c283fd3de76523065f821d6e81de33f5d4" } },
+    { url = "https://files.pythonhosted.org/packages/ad/69/3cebe4901a865eb07aefc3ee03a02a632e152e9198dadf482a7faf926f31/grpcio-1.75.0-cp311-cp311-musllinux_1_2_i686.whl", upload-time = 2025-09-16T09:18:47Z, size = 8037203, hashes = { sha256 = "9880c323595d851292785966cadb6c708100b34b163cab114e3933f5773cba2d" } },
+    { url = "https://files.pythonhosted.org/packages/04/ed/1e483d1eba5032642c10caf28acf07ca8de0508244648947764956db346a/grpcio-1.75.0-cp311-cp311-musllinux_1_2_x86_64.whl", upload-time = 2025-09-16T09:18:50Z, size = 7492085, hashes = { sha256 = "55a2d5ae79cd0f68783fb6ec95509be23746e3c239290b2ee69c69a38daa961a" } },
+    { url = "https://files.pythonhosted.org/packages/ee/65/6ef676aa7dbd9578dfca990bb44d41a49a1e36344ca7d79de6b59733ba96/grpcio-1.75.0-cp311-cp311-win32.whl", upload-time = 2025-09-16T09:18:53Z, size = 3944697, hashes = { sha256 = "352dbdf25495eef584c8de809db280582093bc3961d95a9d78f0dfb7274023a2" } },
+    { url = "https://files.pythonhosted.org/packages/0d/83/b753373098b81ec5cb01f71c21dfd7aafb5eb48a1566d503e9fd3c1254fe/grpcio-1.75.0-cp311-cp311-win_amd64.whl", upload-time = 2025-09-16T09:18:56Z, size = 4642235, hashes = { sha256 = "678b649171f229fb16bda1a2473e820330aa3002500c4f9fd3a74b786578e90f" } },
+    { url = "https://files.pythonhosted.org/packages/0d/93/a1b29c2452d15cecc4a39700fbf54721a3341f2ddbd1bd883f8ec0004e6e/grpcio-1.75.0-cp312-cp312-linux_armv7l.whl", upload-time = 2025-09-16T09:18:58Z, size = 5661861, hashes = { sha256 = "fa35ccd9501ffdd82b861809cbfc4b5b13f4b4c5dc3434d2d9170b9ed38a9054" } },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/7280df197e602d14594e61d1e60e89dfa734bb59a884ba86cdd39686aadb/grpcio-1.75.0-cp312-cp312-macosx_11_0_universal2.whl", upload-time = 2025-09-16T09:19:01Z, size = 11459982, hashes = { sha256 = "0fcb77f2d718c1e58cc04ef6d3b51e0fa3b26cf926446e86c7eba105727b6cd4" } },
+    { url = "https://files.pythonhosted.org/packages/7c/9b/37e61349771f89b543a0a0bbc960741115ea8656a2414bfb24c4de6f3dd7/grpcio-1.75.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-16T09:19:04Z, size = 6239680, hashes = { sha256 = "36764a4ad9dc1eb891042fab51e8cdf7cc014ad82cee807c10796fb708455041" } },
+    { url = "https://files.pythonhosted.org/packages/a6/66/f645d9d5b22ca307f76e71abc83ab0e574b5dfef3ebde4ec8b865dd7e93e/grpcio-1.75.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", upload-time = 2025-09-16T09:19:07Z, size = 6908511, hashes = { sha256 = "725e67c010f63ef17fc052b261004942763c0b18dcd84841e6578ddacf1f9d10" } },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/34b11cd62d03c01b99068e257595804c695c3c119596c7077f4923295e19/grpcio-1.75.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-16T09:19:10Z, size = 6429105, hashes = { sha256 = "91fbfc43f605c5ee015c9056d580a70dd35df78a7bad97e05426795ceacdb59f" } },
+    { url = "https://files.pythonhosted.org/packages/1a/46/76eaceaad1f42c1e7e6a5b49a61aac40fc5c9bee4b14a1630f056ac3a57e/grpcio-1.75.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2025-09-16T09:19:12Z, size = 7060578, hashes = { sha256 = "7a9337ac4ce61c388e02019d27fa837496c4b7837cbbcec71b05934337e51531" } },
+    { url = "https://files.pythonhosted.org/packages/3d/82/181a0e3f1397b6d43239e95becbeb448563f236c0db11ce990f073b08d01/grpcio-1.75.0-cp312-cp312-musllinux_1_2_i686.whl", upload-time = 2025-09-16T09:19:15Z, size = 8003283, hashes = { sha256 = "ee16e232e3d0974750ab5f4da0ab92b59d6473872690b5e40dcec9a22927f22e" } },
+    { url = "https://files.pythonhosted.org/packages/de/09/a335bca211f37a3239be4b485e3c12bf3da68d18b1f723affdff2b9e9680/grpcio-1.75.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2025-09-16T09:19:18Z, size = 7460319, hashes = { sha256 = "55dfb9122973cc69520b23d39867726722cafb32e541435707dc10249a1bdbc6" } },
+    { url = "https://files.pythonhosted.org/packages/aa/59/6330105cdd6bc4405e74c96838cd7e148c3653ae3996e540be6118220c79/grpcio-1.75.0-cp312-cp312-win32.whl", upload-time = 2025-09-16T09:19:21Z, size = 3934011, hashes = { sha256 = "fb64dd62face3d687a7b56cd881e2ea39417af80f75e8b36f0f81dfd93071651" } },
+    { url = "https://files.pythonhosted.org/packages/ff/14/e1309a570b7ebdd1c8ca24c4df6b8d6690009fa8e0d997cb2c026ce850c9/grpcio-1.75.0-cp312-cp312-win_amd64.whl", upload-time = 2025-09-16T09:19:23Z, size = 4637934, hashes = { sha256 = "6b365f37a9c9543a9e91c6b4103d68d38d5bcb9965b11d5092b3c157bd6a5ee7" } },
+    { url = "https://files.pythonhosted.org/packages/00/64/dbce0ffb6edaca2b292d90999dd32a3bd6bc24b5b77618ca28440525634d/grpcio-1.75.0-cp313-cp313-linux_armv7l.whl", upload-time = 2025-09-16T09:19:25Z, size = 5666860, hashes = { sha256 = "1bb78d052948d8272c820bb928753f16a614bb2c42fbf56ad56636991b427518" } },
+    { url = "https://files.pythonhosted.org/packages/f3/e6/da02c8fa882ad3a7f868d380bb3da2c24d35dd983dd12afdc6975907a352/grpcio-1.75.0-cp313-cp313-macosx_11_0_universal2.whl", upload-time = 2025-09-16T09:19:28Z, size = 11455148, hashes = { sha256 = "9dc4a02796394dd04de0b9673cb79a78901b90bb16bf99ed8cb528c61ed9372e" } },
+    { url = "https://files.pythonhosted.org/packages/ba/a0/84f87f6c2cf2a533cfce43b2b620eb53a51428ec0c8fe63e5dd21d167a70/grpcio-1.75.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-16T09:19:31Z, size = 6243865, hashes = { sha256 = "437eeb16091d31498585d73b133b825dc80a8db43311e332c08facf820d36894" } },
+    { url = "https://files.pythonhosted.org/packages/be/12/53da07aa701a4839dd70d16e61ce21ecfcc9e929058acb2f56e9b2dd8165/grpcio-1.75.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", upload-time = 2025-09-16T09:19:33Z, size = 6915102, hashes = { sha256 = "c2c39984e846bd5da45c5f7bcea8fafbe47c98e1ff2b6f40e57921b0c23a52d0" } },
+    { url = "https://files.pythonhosted.org/packages/5b/c0/7eaceafd31f52ec4bf128bbcf36993b4bc71f64480f3687992ddd1a6e315/grpcio-1.75.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-16T09:19:36Z, size = 6432042, hashes = { sha256 = "38d665f44b980acdbb2f0e1abf67605ba1899f4d2443908df9ec8a6f26d2ed88" } },
+    { url = "https://files.pythonhosted.org/packages/6b/12/a2ce89a9f4fc52a16ed92951f1b05f53c17c4028b3db6a4db7f08332bee8/grpcio-1.75.0-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2025-09-16T09:19:39Z, size = 7062984, hashes = { sha256 = "2e8e752ab5cc0a9c5b949808c000ca7586223be4f877b729f034b912364c3964" } },
+    { url = "https://files.pythonhosted.org/packages/55/a6/2642a9b491e24482d5685c0f45c658c495a5499b43394846677abed2c966/grpcio-1.75.0-cp313-cp313-musllinux_1_2_i686.whl", upload-time = 2025-09-16T09:19:41Z, size = 8001212, hashes = { sha256 = "3a6788b30aa8e6f207c417874effe3f79c2aa154e91e78e477c4825e8b431ce0" } },
+    { url = "https://files.pythonhosted.org/packages/19/20/530d4428750e9ed6ad4254f652b869a20a40a276c1f6817b8c12d561f5ef/grpcio-1.75.0-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2025-09-16T09:19:44Z, size = 7457207, hashes = { sha256 = "ffc33e67cab6141c54e75d85acd5dec616c5095a957ff997b4330a6395aa9b51" } },
+    { url = "https://files.pythonhosted.org/packages/e2/6f/843670007e0790af332a21468d10059ea9fdf97557485ae633b88bd70efc/grpcio-1.75.0-cp313-cp313-win32.whl", upload-time = 2025-09-16T09:19:46Z, size = 3934235, hashes = { sha256 = "c8cfc780b7a15e06253aae5f228e1e84c0d3c4daa90faf5bc26b751174da4bf9" } },
+    { url = "https://files.pythonhosted.org/packages/4b/92/c846b01b38fdf9e2646a682b12e30a70dc7c87dfe68bd5e009ee1501c14b/grpcio-1.75.0-cp313-cp313-win_amd64.whl", upload-time = 2025-09-16T09:19:49Z, size = 4637558, hashes = { sha256 = "0c91d5b16eff3cbbe76b7a1eaaf3d91e7a954501e9d4f915554f87c470475c3d" } },
+    { url = "https://files.pythonhosted.org/packages/0c/06/2b4e62715f095076f2a128940802f149d5fc8ffab39edcd661af55ab913d/grpcio-1.75.0-cp39-cp39-linux_armv7l.whl", upload-time = 2025-09-16T09:19:51Z, size = 5695891, hashes = { sha256 = "0b85f4ebe6b56d2a512201bb0e5f192c273850d349b0a74ac889ab5d38959d16" } },
+    { url = "https://files.pythonhosted.org/packages/ca/a3/366150e3ccebb790add4b85f6674700d9b7df11a34040363d712ac42ddad/grpcio-1.75.0-cp39-cp39-macosx_11_0_universal2.whl", upload-time = 2025-09-16T09:19:54Z, size = 11471210, hashes = { sha256 = "68c95b1c1e3bf96ceadf98226e9dfe2bc92155ce352fa0ee32a1603040e61856" } },
+    { url = "https://files.pythonhosted.org/packages/38/cd/98ed092861e85863f56ca253b218b88d4f0121934b1ac4bdf82a601c721d/grpcio-1.75.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-16T09:19:57Z, size = 6283573, hashes = { sha256 = "153c5a7655022c3626ad70be3d4c2974cb0967f3670ee49ece8b45b7a139665f" } },
+    { url = "https://files.pythonhosted.org/packages/68/95/128e66b6ec5a69fb22956a83572355fb732b20afc404959ac7e936f5f5c8/grpcio-1.75.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", upload-time = 2025-09-16T09:19:59Z, size = 6941461, hashes = { sha256 = "53067c590ac3638ad0c04272f2a5e7e32a99fec8824c31b73bc3ef93160511fa" } },
+    { url = "https://files.pythonhosted.org/packages/80/f4/ffee9b56685b5496bdcfa123682bb7d7b50042f0fc472f414b25d7310b11/grpcio-1.75.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-16T09:20:03Z, size = 6461215, hashes = { sha256 = "78dcc025a144319b66df6d088bd0eda69e1719eb6ac6127884a36188f336df19" } },
+    { url = "https://files.pythonhosted.org/packages/f8/2d/373664a92b5f5e6d156e43e48d54c42d46fedf4f2b52f153edd1953ed8d8/grpcio-1.75.0-cp39-cp39-musllinux_1_2_aarch64.whl", upload-time = 2025-09-16T09:20:05Z, size = 7089833, hashes = { sha256 = "1ec2937fd92b5b4598cbe65f7e57d66039f82b9e2b7f7a5f9149374057dde77d" } },
+    { url = "https://files.pythonhosted.org/packages/9e/b5/ca68656ffe094087db85bc3652f168dfa637ff3a83c00157dae2a46a585b/grpcio-1.75.0-cp39-cp39-musllinux_1_2_i686.whl", upload-time = 2025-09-16T09:20:10Z, size = 8034902, hashes = { sha256 = "597340a41ad4b619aaa5c9b94f7e6ba4067885386342ab0af039eda945c255cd" } },
+    { url = "https://files.pythonhosted.org/packages/e6/33/17f243baf59d30480dc3a25d42f8b7d6d8abfad4813599ef8f352ae062b9/grpcio-1.75.0-cp39-cp39-musllinux_1_2_x86_64.whl", upload-time = 2025-09-16T09:20:13Z, size = 7486436, hashes = { sha256 = "0aa795198b28807d28570c0a5f07bb04d5facca7d3f27affa6ae247bbd7f312a" } },
+    { url = "https://files.pythonhosted.org/packages/b8/5f/a019ab5f5116fb8a17efe2e2b4a62231131a2fb3c1a71c9e6477b09c1999/grpcio-1.75.0-cp39-cp39-win32.whl", upload-time = 2025-09-16T09:20:15Z, size = 3947720, hashes = { sha256 = "585147859ff4603798e92605db28f4a97c821c69908e7754c44771c27b239bbd" } },
+    { url = "https://files.pythonhosted.org/packages/33/4d/e9d518d0de09781d4bd21da0692aaff2f6170b609de3967b58f3a017a352/grpcio-1.75.0-cp39-cp39-win_amd64.whl", upload-time = 2025-09-16T09:20:18Z, size = 4641965, hashes = { sha256 = "eafbe3563f9cb378370a3fa87ef4870539cf158124721f3abee9f11cd8162460" } },
 ]
 
 [[packages]]
@@ -1180,17 +1188,17 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d14
 
 [[packages]]
 name = "hf-xet"
-version = "1.1.9"
+version = "1.1.10"
 marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'"
-sdist = { url = "https://files.pythonhosted.org/packages/23/0f/5b60fc28ee7f8cc17a5114a584fd6b86e11c3e0a6e142a7f97a161e9640a/hf_xet-1.1.9.tar.gz", upload-time = 2025-08-27T23:05:19Z, size = 484242, hashes = { sha256 = "c99073ce404462e909f1d5839b2d14a3827b8fe75ed8aed551ba6609c026c803" } }
+sdist = { url = "https://files.pythonhosted.org/packages/74/31/feeddfce1748c4a233ec1aa5b7396161c07ae1aa9b7bdbc9a72c3c7dd768/hf_xet-1.1.10.tar.gz", upload-time = 2025-09-12T20:10:27Z, size = 487910, hashes = { sha256 = "408aef343800a2102374a883f283ff29068055c111f003ff840733d3b715bb97" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/12/56e1abb9a44cdef59a411fe8a8673313195711b5ecce27880eb9c8fa90bd/hf_xet-1.1.9-cp37-abi3-macosx_10_12_x86_64.whl", upload-time = 2025-08-27T23:05:15Z, size = 2762553, hashes = { sha256 = "a3b6215f88638dd7a6ff82cb4e738dcbf3d863bf667997c093a3c990337d1160" } },
-    { url = "https://files.pythonhosted.org/packages/3a/e6/2d0d16890c5f21b862f5df3146519c182e7f0ae49b4b4bf2bd8a40d0b05e/hf_xet-1.1.9-cp37-abi3-macosx_11_0_arm64.whl", upload-time = 2025-08-27T23:05:13Z, size = 2623216, hashes = { sha256 = "9b486de7a64a66f9a172f4b3e0dfe79c9f0a93257c501296a2521a13495a698a" } },
-    { url = "https://files.pythonhosted.org/packages/81/42/7e6955cf0621e87491a1fb8cad755d5c2517803cea174229b0ec00ff0166/hf_xet-1.1.9-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-08-27T23:05:12Z, size = 3186789, hashes = { sha256 = "a4c5a840c2c4e6ec875ed13703a60e3523bc7f48031dfd750923b2a4d1a5fc3c" } },
-    { url = "https://files.pythonhosted.org/packages/df/8b/759233bce05457f5f7ec062d63bbfd2d0c740b816279eaaa54be92aa452a/hf_xet-1.1.9-cp37-abi3-manylinux_2_28_aarch64.whl", upload-time = 2025-08-27T23:05:10Z, size = 3088747, hashes = { sha256 = "96a6139c9e44dad1c52c52520db0fffe948f6bce487cfb9d69c125f254bb3790" } },
-    { url = "https://files.pythonhosted.org/packages/6c/3c/28cc4db153a7601a996985bcb564f7b8f5b9e1a706c7537aad4b4809f358/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_aarch64.whl", upload-time = 2025-08-27T23:05:16Z, size = 3251429, hashes = { sha256 = "ad1022e9a998e784c97b2173965d07fe33ee26e4594770b7785a8cc8f922cd95" } },
-    { url = "https://files.pythonhosted.org/packages/84/17/7caf27a1d101bfcb05be85850d4aa0a265b2e1acc2d4d52a48026ef1d299/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_x86_64.whl", upload-time = 2025-08-27T23:05:17Z, size = 3354643, hashes = { sha256 = "86754c2d6d5afb11b0a435e6e18911a4199262fe77553f8c50d75e21242193ea" } },
-    { url = "https://files.pythonhosted.org/packages/cd/50/0c39c9eed3411deadcc98749a6699d871b822473f55fe472fad7c01ec588/hf_xet-1.1.9-cp37-abi3-win_amd64.whl", upload-time = 2025-08-27T23:05:20Z, size = 2804797, hashes = { sha256 = "5aad3933de6b725d61d51034e04174ed1dce7a57c63d530df0014dea15a40127" } },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/343e6d05de96908366bdc0081f2d8607d61200be2ac802769c4284cc65bd/hf_xet-1.1.10-cp37-abi3-macosx_10_12_x86_64.whl", upload-time = 2025-09-12T20:10:22Z, size = 2761466, hashes = { sha256 = "686083aca1a6669bc85c21c0563551cbcdaa5cf7876a91f3d074a030b577231d" } },
+    { url = "https://files.pythonhosted.org/packages/31/f9/6215f948ac8f17566ee27af6430ea72045e0418ce757260248b483f4183b/hf_xet-1.1.10-cp37-abi3-macosx_11_0_arm64.whl", upload-time = 2025-09-12T20:10:21Z, size = 2623807, hashes = { sha256 = "71081925383b66b24eedff3013f8e6bbd41215c3338be4b94ba75fd75b21513b" } },
+    { url = "https://files.pythonhosted.org/packages/15/07/86397573efefff941e100367bbda0b21496ffcdb34db7ab51912994c32a2/hf_xet-1.1.10-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-09-12T20:10:19Z, size = 3186960, hashes = { sha256 = "6b6bceb6361c80c1cc42b5a7b4e3efd90e64630bcf11224dcac50ef30a47e435" } },
+    { url = "https://files.pythonhosted.org/packages/01/a7/0b2e242b918cc30e1f91980f3c4b026ff2eedaf1e2ad96933bca164b2869/hf_xet-1.1.10-cp37-abi3-manylinux_2_28_aarch64.whl", upload-time = 2025-09-12T20:10:17Z, size = 3087167, hashes = { sha256 = "eae7c1fc8a664e54753ffc235e11427ca61f4b0477d757cc4eb9ae374b69f09c" } },
+    { url = "https://files.pythonhosted.org/packages/4a/25/3e32ab61cc7145b11eee9d745988e2f0f4fafda81b25980eebf97d8cff15/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_aarch64.whl", upload-time = 2025-09-12T20:10:24Z, size = 3248612, hashes = { sha256 = "0a0005fd08f002180f7a12d4e13b22be277725bc23ed0529f8add5c7a6309c06" } },
+    { url = "https://files.pythonhosted.org/packages/2c/3d/ab7109e607ed321afaa690f557a9ada6d6d164ec852fd6bf9979665dc3d6/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_x86_64.whl", upload-time = 2025-09-12T20:10:25Z, size = 3353360, hashes = { sha256 = "f900481cf6e362a6c549c61ff77468bd59d6dd082f3170a36acfef2eb6a6793f" } },
+    { url = "https://files.pythonhosted.org/packages/ee/0e/471f0a21db36e71a2f1752767ad77e92d8cde24e974e03d662931b1305ec/hf_xet-1.1.10-cp37-abi3-win_amd64.whl", upload-time = 2025-09-12T20:10:28Z, size = 2804691, hashes = { sha256 = "5f54b19cc347c13235ae7ee98b330c26dd65ef1df47e5316ffb1e87713ca7045" } },
 ]
 
 [[packages]]
@@ -1207,9 +1215,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a9830475
 
 [[packages]]
 name = "huggingface-hub"
-version = "0.34.4"
-sdist = { url = "https://files.pythonhosted.org/packages/45/c9/bdbe19339f76d12985bc03572f330a01a93c04dffecaaea3061bdd7fb892/huggingface_hub-0.34.4.tar.gz", upload-time = 2025-08-08T09:14:52Z, size = 459768, hashes = { sha256 = "a4228daa6fb001be3f4f4bdaf9a0db00e1739235702848df00885c9b5742c85c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/39/7b/bb06b061991107cd8783f300adff3e7b7f284e330fd82f507f2a1417b11d/huggingface_hub-0.34.4-py3-none-any.whl", upload-time = 2025-08-08T09:14:50Z, size = 561452, hashes = { sha256 = "9b365d781739c93ff90c359844221beef048403f1bc1f1c123c191257c3c890a" } }]
+version = "0.35.0"
+sdist = { url = "https://files.pythonhosted.org/packages/37/79/d71d40efa058e8c4a075158f8855bc2998037b5ff1c84f249f34435c1df7/huggingface_hub-0.35.0.tar.gz", upload-time = 2025-09-16T13:49:33Z, size = 461486, hashes = { sha256 = "ccadd2a78eef75effff184ad89401413629fabc52cefd76f6bbacb9b1c0676ac" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/fe/85/a18508becfa01f1e4351b5e18651b06d210dbd96debccd48a452acccb901/huggingface_hub-0.35.0-py3-none-any.whl", upload-time = 2025-09-16T13:49:30Z, size = 563436, hashes = { sha256 = "f2e2f693bca9a26530b1c0b9bcd4c1495644dad698e6a0060f90e22e772c31e9" } }]
 
 [[packages]]
 name = "idna"
@@ -1226,6 +1234,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521
 [[packages]]
 name = "invoke"
 version = "2.2.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz", upload-time = 2023-07-12T18:05:17Z, size = 299835, hashes = { sha256 = "ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/0a/66/7f8c48009c72d73bc6bbe6eb87ac838d6a526146f7dab14af671121eb379/invoke-2.2.0-py3-none-any.whl", upload-time = 2023-07-12T18:05:16Z, size = 160274, hashes = { sha256 = "6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820" } }]
 
@@ -1470,8 +1479,8 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/e8/ab/327af362b1dd1cb
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.14.0"
-sdist = { url = "https://files.pythonhosted.org/packages/8e/0d/d32f59147424ec60bf4671a8c8d72f1c73b31752e4224a55e5dffe21e482/kfp_server_api-2.14.0.tar.gz", upload-time = 2025-08-06T19:04:16Z, size = 64797, hashes = { sha256 = "7470bb084b057c367f176b82a2837cae8a34b0b73fff06722a010fcea6edf418" } }
+version = "2.14.3"
+sdist = { url = "https://files.pythonhosted.org/packages/b9/3b/5f84fc7d430c34691e1c626932255878119a5c8806c41a5d92206eda424e/kfp_server_api-2.14.3.tar.gz", upload-time = 2025-09-02T19:40:54Z, size = 64881, hashes = { sha256 = "8e2f3b196dc0c37764fde46ee0591df45a61f5a225df6762a42c52ad07d6935d" } }
 
 [[packages]]
 name = "kiwisolver"
@@ -1608,6 +1617,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/5a/33/68c6c3819368453
 [[packages]]
 name = "markdown-it-py"
 version = "4.0.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", upload-time = 2025-08-11T12:57:52Z, size = 73070, hashes = { sha256 = "cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", upload-time = 2025-08-11T12:57:51Z, size = 87321, hashes = { sha256 = "87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147" } }]
 
@@ -1754,6 +1764,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c20793
 [[packages]]
 name = "mdurl"
 version = "0.1.2"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", upload-time = 2022-08-14T12:40:10Z, size = 8729, hashes = { sha256 = "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", upload-time = 2022-08-14T12:40:09Z, size = 9979, hashes = { sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8" } }]
 
@@ -1819,13 +1830,14 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1
 [[packages]]
 name = "mpmath"
 version = "1.3.0"
-marker = "python_full_version >= '3.9'"
+marker = "python_full_version >= '3.9' and platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", upload-time = 2023-03-07T16:47:11Z, size = 508106, hashes = { sha256 = "7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", upload-time = 2023-03-07T16:47:09Z, size = 536198, hashes = { sha256 = "a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c" } }]
 
 [[packages]]
 name = "msgpack"
 version = "1.1.1"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/45/b1/ea4f68038a18c77c9467400d166d74c4ffa536f34761f7983a104357e614/msgpack-1.1.1.tar.gz", upload-time = 2025-06-13T06:52:51Z, size = 173555, hashes = { sha256 = "77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/52/f30da112c1dc92cf64f57d08a273ac771e7b29dea10b4b30369b2d7e8546/msgpack-1.1.1-cp310-cp310-macosx_10_9_x86_64.whl", upload-time = 2025-06-13T06:51:37Z, size = 81799, hashes = { sha256 = "353b6fc0c36fde68b661a12949d7d49f8f51ff5fa019c1e47c87c4ff34b080ed" } },
@@ -2063,9 +2075,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.4.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/8f/b0a99455f6e5fe2d4e77deeee8b133cfa06e1f5441c77a70defdbbfbf639/narwhals-2.4.0.tar.gz", upload-time = 2025-09-08T13:17:36Z, size = 556886, hashes = { sha256 = "a71931f7fb3c8e082cbe18ef0740644d87d60eba841ddfa9ba9394de1d43062f" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8a/8c/ac6f6bd2d118ac49e1bc0285e401c1dc50cf878d48156bbc7969902703b0/narwhals-2.4.0-py3-none-any.whl", upload-time = 2025-09-08T13:17:35Z, size = 406233, hashes = { sha256 = "06d958b03e3e3725ae16feee6737b4970991bb52e8465ef75f388c574732ac59" } }]
+version = "2.5.0"
+sdist = { url = "https://files.pythonhosted.org/packages/7b/b8/3cb005704866f1cc19e8d6b15d0467255821ba12d82f20ea15912672e54c/narwhals-2.5.0.tar.gz", upload-time = 2025-09-12T10:04:24Z, size = 558573, hashes = { sha256 = "8ae0b6f39597f14c0dc52afc98949d6f8be89b5af402d2d98101d2f7d3561418" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f8/5a/22741c5c0e5f6e8050242bfc2052ba68bc94b1735ed5bca35404d136d6ec/narwhals-2.5.0-py3-none-any.whl", upload-time = 2025-09-12T10:04:22Z, size = 407296, hashes = { sha256 = "7e213f9ca7db3f8bf6f7eff35eaee6a1cf80902997e1b78d49b7755775d8f423" } }]
 
 [[packages]]
 name = "nbclient"
@@ -2364,48 +2376,56 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c335
 [[packages]]
 name = "opencensus"
 version = "0.11.4"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", upload-time = 2024-01-03T18:04:07Z, size = 64966, hashes = { sha256 = "cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b5/ed/9fbdeb23a09e430d87b7d72d430484b88184633dc50f6bfb792354b6f661/opencensus-0.11.4-py2.py3-none-any.whl", upload-time = 2024-01-03T18:04:05Z, size = 128225, hashes = { sha256 = "a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864" } }]
 
 [[packages]]
 name = "opencensus-context"
 version = "0.1.3"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/4c/96/3b6f638f6275a8abbd45e582448723bffa29c1fb426721dedb5c72f7d056/opencensus-context-0.1.3.tar.gz", upload-time = 2022-08-03T22:20:22Z, size = 4066, hashes = { sha256 = "a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/10/68/162c97ea78c957d68ecf78a5c5041d2e25bd5562bdf5d89a6cbf7f8429bf/opencensus_context-0.1.3-py2.py3-none-any.whl", upload-time = 2022-08-03T22:20:20Z, size = 5060, hashes = { sha256 = "073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039" } }]
 
 [[packages]]
 name = "openshift-client"
 version = "1.0.18"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/61/4d/96d40621a88e430127f98467b6ef67ff2e39f2d33b9740ea0e470cf2b8bc/openshift-client-1.0.18.tar.gz", upload-time = 2022-09-13T22:08:36Z, size = 78332, hashes = { sha256 = "be3979440cfd96788146a3a1650dabe939d4d516eea0b39f87e66d2ab39495b1" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/1d/23/a84f274a534dfcd8454f20fc19d129a7d832e5816830946670b8c954438c/openshift_client-1.0.18-py2.py3-none-any.whl", upload-time = 2022-09-13T22:08:35Z, size = 75076, hashes = { sha256 = "d8a84080307ccd9556f6c62a3707a3e6507baedee36fa425754f67db9ded528b" } }]
 
 [[packages]]
 name = "opentelemetry-api"
 version = "1.37.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/63/04/05040d7ce33a907a2a02257e601992f0cdf11c73b33f13c4492bf6c3d6d5/opentelemetry_api-1.37.0.tar.gz", upload-time = 2025-09-11T10:29:01Z, size = 64923, hashes = { sha256 = "540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/91/48/28ed9e55dcf2f453128df738210a980e09f4e468a456fa3c763dbc8be70a/opentelemetry_api-1.37.0-py3-none-any.whl", upload-time = 2025-09-11T10:28:41Z, size = 65732, hashes = { sha256 = "accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47" } }]
 
 [[packages]]
 name = "opentelemetry-exporter-prometheus"
 version = "0.58b0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/e351559526ee35fa36d990d3455e81a5607c1fa3e544b599ad802f2481f8/opentelemetry_exporter_prometheus-0.58b0.tar.gz", upload-time = 2025-09-11T10:29:05Z, size = 14972, hashes = { sha256 = "70f2627b4bb82bac65a1fcf95f6e0dcce9e823dd47379ced854753a7e14dfc93" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/a6/e3/50e9cdc5a52c2ab19585dd69e668ec9fee0343fafc4bffa919ca79230a4f/opentelemetry_exporter_prometheus-0.58b0-py3-none-any.whl", upload-time = 2025-09-11T10:28:47Z, size = 13016, hashes = { sha256 = "02005033a7a108ab9f3000ff3aa49e2d03a8893b5bf3431322ffa246affbf951" } }]
 
 [[packages]]
 name = "opentelemetry-proto"
 version = "1.37.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/dd/ea/a75f36b463a36f3c5a10c0b5292c58b31dbdde74f6f905d3d0ab2313987b/opentelemetry_proto-1.37.0.tar.gz", upload-time = 2025-09-11T10:29:11Z, size = 46151, hashes = { sha256 = "30f5c494faf66f77faeaefa35ed4443c5edb3b0aa46dad073ed7210e1a789538" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/c4/25/f89ea66c59bd7687e218361826c969443c4fa15dfe89733f3bf1e2a9e971/opentelemetry_proto-1.37.0-py3-none-any.whl", upload-time = 2025-09-11T10:28:56Z, size = 72534, hashes = { sha256 = "8ed8c066ae8828bbf0c39229979bdf583a126981142378a9cbe9d6fd5701c6e2" } }]
 
 [[packages]]
 name = "opentelemetry-sdk"
 version = "1.37.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/f4/62/2e0ca80d7fe94f0b193135375da92c640d15fe81f636658d2acf373086bc/opentelemetry_sdk-1.37.0.tar.gz", upload-time = 2025-09-11T10:29:11Z, size = 170404, hashes = { sha256 = "cc8e089c10953ded765b5ab5669b198bbe0af1b3f89f1007d19acd32dc46dda5" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/9f/62/9f4ad6a54126fb00f7ed4bb5034964c6e4f00fcd5a905e115bd22707e20d/opentelemetry_sdk-1.37.0-py3-none-any.whl", upload-time = 2025-09-11T10:28:57Z, size = 131941, hashes = { sha256 = "8f3c3c22063e52475c5dbced7209495c2c16723d016d39287dfc215d1771257c" } }]
 
 [[packages]]
 name = "opentelemetry-semantic-conventions"
 version = "0.58b0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", upload-time = 2025-09-11T10:29:12Z, size = 129867, hashes = { sha256 = "6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", upload-time = 2025-09-11T10:28:59Z, size = 207954, hashes = { sha256 = "5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28" } }]
 
@@ -2469,6 +2489,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/61/55/83ce641bc61a70c
 [[packages]]
 name = "paramiko"
 version = "4.0.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/1f/e7/81fdcbc7f190cdb058cffc9431587eb289833bdd633e2002455ca9bb13d4/paramiko-4.0.0.tar.gz", upload-time = 2025-08-04T01:02:03Z, size = 1630743, hashes = { sha256 = "6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/a9/90/a744336f5af32c433bd09af7854599682a383b37cfd78f7de263de6ad6cb/paramiko-4.0.0-py3-none-any.whl", upload-time = 2025-08-04T01:02:02Z, size = 223932, hashes = { sha256 = "0e20e00ac666503bf0b4eda3b6d833465a2b7aff2e2b3d79a8bba5ef144ee3b9" } }]
 
@@ -2800,7 +2821,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 [[packages]]
 name = "py-spy"
 version = "0.4.1"
-marker = "python_full_version >= '3.12'"
+marker = "python_full_version >= '3.12' and platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/19/e2/ff811a367028b87e86714945bb9ecb5c1cc69114a8039a67b3a862cef921/py_spy-0.4.1.tar.gz", upload-time = 2025-07-31T19:33:25Z, size = 244726, hashes = { sha256 = "e53aa53daa2e47c2eef97dd2455b47bb3a7e7f962796a86cc3e7dbde8e6f4db4" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/e3/3a32500d845bdd94f6a2b4ed6244982f42ec2bc64602ea8fcfe900678ae7/py_spy-0.4.1-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", upload-time = 2025-07-31T19:33:13Z, size = 3682508, hashes = { sha256 = "809094208c6256c8f4ccadd31e9a513fe2429253f48e20066879239ba12cd8cc" } },
@@ -2894,7 +2915,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/3a/d8/a211b3f85e99a0d
 [[packages]]
 name = "pycparser"
 version = "2.23"
-marker = "implementation_name != 'PyPy'"
+marker = "(python_full_version < '3.14' and implementation_name != 'PyPy') or (implementation_name != 'PyPy' and platform_python_implementation != 'PyPy')"
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", upload-time = 2025-09-09T13:23:47Z, size = 173734, hashes = { sha256 = "78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", upload-time = 2025-09-09T13:23:46Z, size = 118140, hashes = { sha256 = "e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934" } }]
 
@@ -2947,13 +2968,15 @@ wheels = [
 
 [[packages]]
 name = "pydantic"
-version = "2.11.7"
-sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", upload-time = 2025-06-14T08:33:17Z, size = 788350, hashes = { sha256 = "d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", upload-time = 2025-06-14T08:33:14Z, size = 444782, hashes = { sha256 = "dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b" } }]
+version = "2.11.9"
+marker = "platform_machine != 'ppc64le'"
+sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", upload-time = 2025-09-13T11:26:39Z, size = 788495, hashes = { sha256 = "6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", upload-time = 2025-09-13T11:26:36Z, size = 444855, hashes = { sha256 = "c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2" } }]
 
 [[packages]]
 name = "pydantic-core"
 version = "2.33.2"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", upload-time = 2025-04-23T18:33:52Z, size = 435195, hashes = { sha256 = "7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/92/b31726561b5dae176c2d2c2dc43a9c5bfba5d32f96f8b4c0a600dd492447/pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", upload-time = 2025-04-23T18:30:43Z, size = 2028817, hashes = { sha256 = "2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8" } },
@@ -3157,18 +3180,35 @@ wheels = [
 
 [[packages]]
 name = "pynacl"
-version = "1.5.0"
-sdist = { url = "https://files.pythonhosted.org/packages/a7/22/27582568be639dfe22ddb3902225f91f2f17ceff88ce80e4db396c8986da/PyNaCl-1.5.0.tar.gz", upload-time = 2022-01-07T22:05:41Z, size = 3392854, hashes = { sha256 = "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba" } }
+version = "1.6.0"
+sdist = { url = "https://files.pythonhosted.org/packages/06/c6/a3124dee667a423f2c637cfd262a54d67d8ccf3e160f3c50f622a85b7723/pynacl-1.6.0.tar.gz", upload-time = 2025-09-10T23:39:22Z, size = 3505641, hashes = { sha256 = "cb36deafe6e2bce3b286e5d1f3e1c246e0ccdb8808ddb4550bb2792f2df298f2" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/75/0b8ede18506041c0bf23ac4d8e2971b4161cd6ce630b177d0a08eb0d8857/PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", upload-time = 2022-01-07T22:05:49Z, size = 349920, hashes = { sha256 = "401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1" } },
-    { url = "https://files.pythonhosted.org/packages/59/bb/fddf10acd09637327a97ef89d2a9d621328850a72f1fdc8c08bdf72e385f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", upload-time = 2022-01-07T22:05:50Z, size = 601722, hashes = { sha256 = "52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92" } },
-    { url = "https://files.pythonhosted.org/packages/5d/70/87a065c37cca41a75f2ce113a5a2c2aa7533be648b184ade58971b5f7ccc/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = 2022-01-07T22:05:52Z, size = 680087, hashes = { sha256 = "a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394" } },
-    { url = "https://files.pythonhosted.org/packages/ee/87/f1bb6a595f14a327e8285b9eb54d41fef76c585a0edef0a45f6fc95de125/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", upload-time = 2022-01-07T22:05:54Z, size = 856678, hashes = { sha256 = "0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d" } },
-    { url = "https://files.pythonhosted.org/packages/66/28/ca86676b69bf9f90e710571b67450508484388bfce09acf8a46f0b8c785f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2022-01-07T22:05:56Z, size = 1133660, hashes = { sha256 = "06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858" } },
-    { url = "https://files.pythonhosted.org/packages/3d/85/c262db650e86812585e2bc59e497a8f59948a005325a11bbbc9ecd3fe26b/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", upload-time = 2022-01-07T22:05:57Z, size = 663824, hashes = { sha256 = "a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b" } },
-    { url = "https://files.pythonhosted.org/packages/fd/1a/cc308a884bd299b651f1633acb978e8596c71c33ca85e9dc9fa33a5399b9/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", upload-time = 2022-01-07T22:05:58Z, size = 1117912, hashes = { sha256 = "61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff" } },
-    { url = "https://files.pythonhosted.org/packages/25/2d/b7df6ddb0c2a33afdb358f8af6ea3b8c4d1196ca45497dd37a56f0c122be/PyNaCl-1.5.0-cp36-abi3-win32.whl", upload-time = 2022-01-07T22:06:00Z, size = 204624, hashes = { sha256 = "e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543" } },
-    { url = "https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", upload-time = 2022-01-07T22:06:01Z, size = 212141, hashes = { sha256 = "20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93" } },
+    { url = "https://files.pythonhosted.org/packages/70/24/1b639176401255605ba7c2b93a7b1eb1e379e0710eca62613633eb204201/pynacl-1.6.0-cp314-cp314t-macosx_10_10_universal2.whl", upload-time = 2025-09-10T23:38:28Z, size = 384141, hashes = { sha256 = "f46386c24a65383a9081d68e9c2de909b1834ec74ff3013271f1bca9c2d233eb" } },
+    { url = "https://files.pythonhosted.org/packages/5e/7b/874efdf57d6bf172db0df111b479a553c3d9e8bb4f1f69eb3ffff772d6e8/pynacl-1.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-10T23:38:38Z, size = 808132, hashes = { sha256 = "dea103a1afcbc333bc0e992e64233d360d393d1e63d0bc88554f572365664348" } },
+    { url = "https://files.pythonhosted.org/packages/f3/61/9b53f5913f3b75ac3d53170cdb897101b2b98afc76f4d9d3c8de5aa3ac05/pynacl-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-10T23:38:40Z, size = 1407253, hashes = { sha256 = "04f20784083014e265ad58c1b2dd562c3e35864b5394a14ab54f5d150ee9e53e" } },
+    { url = "https://files.pythonhosted.org/packages/7c/0a/b138916b22bbf03a1bdbafecec37d714e7489dd7bcaf80cd17852f8b67be/pynacl-1.6.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2025-09-10T23:38:30Z, size = 843719, hashes = { sha256 = "bbcc4452a1eb10cd5217318c822fde4be279c9de8567f78bad24c773c21254f8" } },
+    { url = "https://files.pythonhosted.org/packages/01/3b/17c368197dfb2c817ce033f94605a47d0cc27901542109e640cef263f0af/pynacl-1.6.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-09-10T23:38:33Z, size = 1445441, hashes = { sha256 = "51fed9fe1bec9e7ff9af31cd0abba179d0e984a2960c77e8e5292c7e9b7f7b5d" } },
+    { url = "https://files.pythonhosted.org/packages/35/3c/f79b185365ab9be80cd3cd01dacf30bf5895f9b7b001e683b369e0bb6d3d/pynacl-1.6.0-cp314-cp314t-manylinux_2_34_aarch64.whl", upload-time = 2025-09-10T23:38:34Z, size = 825691, hashes = { sha256 = "10d755cf2a455d8c0f8c767a43d68f24d163b8fe93ccfaabfa7bafd26be58d73" } },
+    { url = "https://files.pythonhosted.org/packages/f7/1f/8b37d25e95b8f2a434a19499a601d4d272b9839ab8c32f6b0fc1e40c383f/pynacl-1.6.0-cp314-cp314t-manylinux_2_34_x86_64.whl", upload-time = 2025-09-10T23:38:36Z, size = 1410726, hashes = { sha256 = "536703b8f90e911294831a7fbcd0c062b837f3ccaa923d92a6254e11178aaf42" } },
+    { url = "https://files.pythonhosted.org/packages/bd/93/5a4a4cf9913014f83d615ad6a2df9187330f764f606246b3a744c0788c03/pynacl-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2025-09-10T23:38:42Z, size = 801035, hashes = { sha256 = "6b08eab48c9669d515a344fb0ef27e2cbde847721e34bba94a343baa0f33f1f4" } },
+    { url = "https://files.pythonhosted.org/packages/bf/60/40da6b0fe6a4d5fd88f608389eb1df06492ba2edca93fca0b3bebff9b948/pynacl-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2025-09-10T23:38:44Z, size = 1371854, hashes = { sha256 = "5789f016e08e5606803161ba24de01b5a345d24590a80323379fc4408832d290" } },
+    { url = "https://files.pythonhosted.org/packages/44/b2/37ac1d65008f824cba6b5bf68d18b76d97d0f62d7a032367ea69d4a187c8/pynacl-1.6.0-cp314-cp314t-win32.whl", upload-time = 2025-09-10T23:38:48Z, size = 230345, hashes = { sha256 = "4853c154dc16ea12f8f3ee4b7e763331876316cc3a9f06aeedf39bcdca8f9995" } },
+    { url = "https://files.pythonhosted.org/packages/f4/5a/9234b7b45af890d02ebee9aae41859b9b5f15fb4a5a56d88e3b4d1659834/pynacl-1.6.0-cp314-cp314t-win_amd64.whl", upload-time = 2025-09-10T23:38:45Z, size = 243103, hashes = { sha256 = "347dcddce0b4d83ed3f32fd00379c83c425abee5a9d2cd0a2c84871334eaff64" } },
+    { url = "https://files.pythonhosted.org/packages/c9/2c/c1a0f19d720ab0af3bc4241af2bdf4d813c3ecdcb96392b5e1ddf2d8f24f/pynacl-1.6.0-cp314-cp314t-win_arm64.whl", upload-time = 2025-09-10T23:38:46Z, size = 187778, hashes = { sha256 = "2d6cd56ce4998cb66a6c112fda7b1fdce5266c9f05044fa72972613bef376d15" } },
+    { url = "https://files.pythonhosted.org/packages/63/37/87c72df19857c5b3b47ace6f211a26eb862ada495cc96daa372d96048fca/pynacl-1.6.0-cp38-abi3-macosx_10_10_universal2.whl", upload-time = 2025-09-10T23:38:49Z, size = 382610, hashes = { sha256 = "f4b3824920e206b4f52abd7de621ea7a44fd3cb5c8daceb7c3612345dfc54f2e" } },
+    { url = "https://files.pythonhosted.org/packages/0c/64/3ce958a5817fd3cc6df4ec14441c43fd9854405668d73babccf77f9597a3/pynacl-1.6.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-09-10T23:38:58Z, size = 798744, hashes = { sha256 = "16dd347cdc8ae0b0f6187a2608c0af1c8b7ecbbe6b4a06bff8253c192f696990" } },
+    { url = "https://files.pythonhosted.org/packages/e4/8a/3f0dd297a0a33fa3739c255feebd0206bb1df0b44c52fbe2caf8e8bc4425/pynacl-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-10T23:39:00Z, size = 1397879, hashes = { sha256 = "16c60daceee88d04f8d41d0a4004a7ed8d9a5126b997efd2933e08e93a3bd850" } },
+    { url = "https://files.pythonhosted.org/packages/41/94/028ff0434a69448f61348d50d2c147dda51aabdd4fbc93ec61343332174d/pynacl-1.6.0-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2025-09-10T23:38:50Z, size = 833907, hashes = { sha256 = "25720bad35dfac34a2bcdd61d9e08d6bfc6041bebc7751d9c9f2446cf1e77d64" } },
+    { url = "https://files.pythonhosted.org/packages/52/bc/a5cff7f8c30d5f4c26a07dfb0bcda1176ab8b2de86dda3106c00a02ad787/pynacl-1.6.0-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-09-10T23:38:52Z, size = 1436649, hashes = { sha256 = "8bfaa0a28a1ab718bad6239979a5a57a8d1506d0caf2fba17e524dbb409441cf" } },
+    { url = "https://files.pythonhosted.org/packages/7a/20/c397be374fd5d84295046e398de4ba5f0722dc14450f65db76a43c121471/pynacl-1.6.0-cp38-abi3-manylinux_2_34_aarch64.whl", upload-time = 2025-09-10T23:38:54Z, size = 817142, hashes = { sha256 = "ef214b90556bb46a485b7da8258e59204c244b1b5b576fb71848819b468c44a7" } },
+    { url = "https://files.pythonhosted.org/packages/12/30/5efcef3406940cda75296c6d884090b8a9aad2dcc0c304daebb5ae99fb4a/pynacl-1.6.0-cp38-abi3-manylinux_2_34_x86_64.whl", upload-time = 2025-09-10T23:38:56Z, size = 1401794, hashes = { sha256 = "49c336dd80ea54780bcff6a03ee1a476be1612423010472e60af83452aa0f442" } },
+    { url = "https://files.pythonhosted.org/packages/be/e1/a8fe1248cc17ccb03b676d80fa90763760a6d1247da434844ea388d0816c/pynacl-1.6.0-cp38-abi3-musllinux_1_1_aarch64.whl", upload-time = 2025-09-10T23:39:01Z, size = 772161, hashes = { sha256 = "f3482abf0f9815e7246d461fab597aa179b7524628a4bc36f86a7dc418d2608d" } },
+    { url = "https://files.pythonhosted.org/packages/a3/76/8a62702fb657d6d9104ce13449db221a345665d05e6a3fdefb5a7cafd2ad/pynacl-1.6.0-cp38-abi3-musllinux_1_1_x86_64.whl", upload-time = 2025-09-10T23:39:03Z, size = 1370720, hashes = { sha256 = "140373378e34a1f6977e573033d1dd1de88d2a5d90ec6958c9485b2fd9f3eb90" } },
+    { url = "https://files.pythonhosted.org/packages/6d/38/9e9e9b777a1c4c8204053733e1a0269672c0bd40852908c9ad6b6eaba82c/pynacl-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", upload-time = 2025-09-10T23:39:05Z, size = 791252, hashes = { sha256 = "6b393bc5e5a0eb86bb85b533deb2d2c815666665f840a09e0aa3362bb6088736" } },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d972ce3d92ae05c9091363cf185e8646933f91c376e97b8be79ea6e96c22/pynacl-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", upload-time = 2025-09-10T23:39:06Z, size = 1362910, hashes = { sha256 = "4a25cfede801f01e54179b8ff9514bd7b5944da560b7040939732d1804d25419" } },
+    { url = "https://files.pythonhosted.org/packages/35/2c/ee0b373a1861f66a7ca8bdb999331525615061320dd628527a50ba8e8a60/pynacl-1.6.0-cp38-abi3-win32.whl", upload-time = 2025-09-10T23:39:11Z, size = 226461, hashes = { sha256 = "dcdeb41c22ff3c66eef5e63049abf7639e0db4edee57ba70531fc1b6b133185d" } },
+    { url = "https://files.pythonhosted.org/packages/75/f7/41b6c0b9dd9970173b6acc026bab7b4c187e4e5beef2756d419ad65482da/pynacl-1.6.0-cp38-abi3-win_amd64.whl", upload-time = 2025-09-10T23:39:08Z, size = 238802, hashes = { sha256 = "cf831615cc16ba324240de79d925eacae8265b7691412ac6b24221db157f6bd1" } },
+    { url = "https://files.pythonhosted.org/packages/8e/0f/462326910c6172fa2c6ed07922b22ffc8e77432b3affffd9e18f444dbfbb/pynacl-1.6.0-cp38-abi3-win_arm64.whl", upload-time = 2025-09-10T23:39:10Z, size = 183846, hashes = { sha256 = "84709cea8f888e618c21ed9a0efdb1a59cc63141c403db8bf56c469b71ad56f2" } },
 ]
 
 [[packages]]
@@ -3216,9 +3256,9 @@ wheels = [
 
 [[packages]]
 name = "pyparsing"
-version = "3.2.3"
-sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", upload-time = 2025-03-25T05:01:28Z, size = 1088608, hashes = { sha256 = "b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", upload-time = 2025-03-25T05:01:24Z, size = 111120, hashes = { sha256 = "a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf" } }]
+version = "3.2.4"
+sdist = { url = "https://files.pythonhosted.org/packages/98/c9/b4594e6a81371dfa9eb7a2c110ad682acf985d96115ae8b25a1d63b4bf3b/pyparsing-3.2.4.tar.gz", upload-time = 2025-09-13T05:47:19Z, size = 1098809, hashes = { sha256 = "fff89494f45559d0f2ce46613b419f632bbb6afbdaed49696d322bcf98a58e99" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/53/b8/fbab973592e23ae313042d450fc26fa24282ebffba21ba373786e1ce63b4/pyparsing-3.2.4-py3-none-any.whl", upload-time = 2025-09-13T05:47:17Z, size = 113869, hashes = { sha256 = "91d0fcde680d42cd031daf3a6ba20da3107e08a75de50da58360e7d94ab24d36" } }]
 
 [[packages]]
 name = "python-dateutil"
@@ -3416,6 +3456,7 @@ wheels = [
 [[packages]]
 name = "ray"
 version = "2.47.1"
+marker = "platform_machine != 'ppc64le'"
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/fe/2f1fc21b7a321385fe34fd159c27245c06bad795aba7de71f29e7a00e741/ray-2.47.1-cp310-cp310-macosx_11_0_arm64.whl", upload-time = 2025-06-17T22:26:11Z, size = 66145880, hashes = { sha256 = "36a30930e8d265e708df96f37f6f1f5484f4b97090d505912f992e045a69d310" } },
     { url = "https://files.pythonhosted.org/packages/87/4a/60b0ce7dc1ac04e9c48fc398afed557f0f0cb3fd74c07cb71b567a041157/ray-2.47.1-cp310-cp310-macosx_12_0_x86_64.whl", upload-time = 2025-06-17T22:26:18Z, size = 68562947, hashes = { sha256 = "7c03a1e366d3a868a55f8c2f728f5ce35ac85ddf093ac81d0c1a35bf1c25c377" } },
@@ -3587,6 +3628,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd
 [[packages]]
 name = "rich"
 version = "13.9.4"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", upload-time = 2024-11-01T16:43:57Z, size = 223149, hashes = { sha256 = "439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", upload-time = 2024-11-01T16:43:55Z, size = 242424, hashes = { sha256 = "6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90" } }]
 
@@ -3971,6 +4013,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/08/de/e8825727acd8048
 [[packages]]
 name = "smart-open"
 version = "7.3.1"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/16/be/bf2d60280a9d7fac98ece2150a22538fa4332cda67d04d9618c8406f791e/smart_open-7.3.1.tar.gz", upload-time = 2025-09-08T10:03:53Z, size = 51405, hashes = { sha256 = "b33fee8dffd206f189d5e704106a8723afb4210d2ff47e0e1f7fbe436187a990" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/e5/d9/460cf1d58945dd771c228c29d5664f431dfc4060d3d092fed40546b11472/smart_open-7.3.1-py3-none-any.whl", upload-time = 2025-09-08T10:03:52Z, size = 61722, hashes = { sha256 = "e243b2e7f69d6c0c96dd763d6fbbedbb4e0e4fc6d74aa007acc5b018d523858c" } }]
 
@@ -4007,7 +4050,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 [[packages]]
 name = "sympy"
 version = "1.13.1"
-marker = "python_full_version >= '3.9'"
+marker = "python_full_version >= '3.9' and platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz", upload-time = 2024-07-19T09:26:51Z, size = 7533040, hashes = { sha256 = "9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl", upload-time = 2024-07-19T09:26:48Z, size = 6189177, hashes = { sha256 = "db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8" } }]
 
@@ -4077,6 +4120,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e2
 [[packages]]
 name = "torch"
 version = "2.6.0+cu126"
+marker = "platform_machine != 'ppc64le'"
 wheels = [
     { url = "https://download.pytorch.org/whl/cu126/torch-2.6.0%2Bcu126-cp310-cp310-linux_aarch64.whl", hashes = { sha256 = "48775b8544e6705aa72256117f33c5f0c3c1ab51cb7abef1989dcfc3cf2e6500" } },
     { url = "https://download.pytorch.org/whl/cu126/torch-2.6.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "c55280b4da58e565d8a25e0e844dc27d0c96aaada7b90b4de70a45397faf604e" } },
@@ -4166,6 +4210,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a
 [[packages]]
 name = "typing-inspection"
 version = "0.4.1"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", upload-time = 2025-05-21T18:55:23Z, size = 75726, hashes = { sha256 = "6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", upload-time = 2025-05-21T18:55:22Z, size = 14552, hashes = { sha256 = "389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51" } }]
 
@@ -4274,6 +4319,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9
 [[packages]]
 name = "virtualenv"
 version = "20.34.0"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", upload-time = 2025-08-13T14:24:07Z, size = 6003808, hashes = { sha256 = "44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", upload-time = 2025-08-13T14:24:05Z, size = 5983279, hashes = { sha256 = "341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026" } }]
 
@@ -4358,6 +4404,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/ca/51/5447876806d1088
 [[packages]]
 name = "wrapt"
 version = "1.17.3"
+marker = "platform_machine != 'ppc64le'"
 sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", upload-time = 2025-08-12T05:53:21Z, size = 55547, hashes = { sha256 = "f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", upload-time = 2025-08-12T05:51:44Z, size = 53482, hashes = { sha256 = "88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04" } },

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "==3.12.*"
 
 dependencies = [
     # PyTorch packages
-    "torch==2.6.0+cu126",
+    "torch==2.6.0+cu126; platform_machine != 'ppc64le'",
 
     # TrustyAI packages
     # More information available at:
@@ -13,7 +13,7 @@ dependencies = [
     #   - https://github.com/trustyai-explainability/trustyai-explainability-python/blob/main/requirements.txt
     "transformers~=4.55.0",
     "datasets~=3.4.1",
-    "accelerate~=1.5.2",
+    "accelerate~=1.5.2; platform_machine != 'ppc64le'",
     "trustyai~=0.6.2",
     # Datascience and useful extensions
     "boto3~=1.40.27",
@@ -27,7 +27,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.31.0; platform_machine != 'ppc64le'",
     "kubeflow-training==1.9.2",
 
     # DB connectors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux PPC64LE support for the Jupyter TrustyAI image and PR pipeline.

* **Chores**
  * Added wheel caching and build-stage optimizations to speed PPC64LE builds.
  * Updated packaging to gate or adjust select dependencies on PPC64LE for compatibility.
  * Improved image metadata, runtime setup, environment variables, and permissions for more consistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->