### PR TITLE
chore: bump `codeflare-sdk` to v0.31.1 across all pyproject.toml files

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -548,10 +548,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
+version = "0.31.1"
 marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
-    "codeflare-sdk~=0.31.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
+    "codeflare-sdk~=0.31.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "feast~=0.53.0",
 
     # DB connectors

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -552,9 +552,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "kubeflow-training==1.9.2",
     "feast~=0.53.0",
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -552,9 +552,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "kubeflow-training==1.9.2",
     "feast~=0.53.0",
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -558,9 +558,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "kubeflow-training==1.9.0",
     "feast~=0.53.0",
 

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -558,9 +558,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "feast~=0.53.0",
 
     # DB connectors

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -540,9 +540,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "kubeflow-training==1.9.2",
 
     # DB connectors

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -477,10 +477,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
+version = "0.31.1"
 marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
+    "codeflare-sdk~=0.31.1; platform_machine != 's390x' and platform_machine != 'ppc64le'",
     "feast~=0.53.0",
 
     # DB connectors

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -476,9 +476,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "feast~=0.53.0",
 
     # DB connectors

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -476,9 +476,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.15.2",
     "skl2onnx~=1.18.0",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "feast~=0.53.0",
 
     # DB connectors

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -482,9 +482,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "skl2onnx~=1.18.0",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "feast~=0.53.0",
 
     # DB connectors

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -482,9 +482,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.0"
-sdist = { url = "https://files.pythonhosted.org/packages/d4/72/7991b33a0aeabee250bedb9a1fa0f30aa49f5739718df6f4b18aeb62df90/codeflare_sdk-0.31.0.tar.gz", upload-time = 2025-09-11T08:19:58Z, size = 89503, hashes = { sha256 = "f68e4cbb60e5a0b55fd14b55addf45eaee6c5bf49f0dd7d30ca340f4b6fd564c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/ad/84/8005beea8a1773be2860bb90fc8d2cbd4826a72ad2d3f29172f38caa0aca/codeflare_sdk-0.31.0-py3-none-any.whl", upload-time = 2025-09-11T08:19:56Z, size = 140633, hashes = { sha256 = "f477b7f382c3b85002aff6e566a76e54405a4ade4211041adbfc11f798896276" } }]
+version = "0.31.1"
+sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "skl2onnx~=1.18.0",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
-    "codeflare-sdk~=0.31.0",
+    "codeflare-sdk~=0.31.1",
     "feast~=0.53.0",
 
     # DB connectors


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C06C5MK3MT9/p1758008112242539?thread_ts=1753890157.168529&cid=C06C5MK3MT9

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded codeflare-sdk to 0.31.1 across Jupyter and runtime Python 3.12 images for improved stability and compatibility.
  - Refreshed dependency lockfiles to align with the new version.
  - Added colorama dependency in the TensorFlow runtime to improve terminal output consistency.
- Tests
  - No changes to test behavior expected.
- Documentation
  - No user-facing documentation updates required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->