### PR TITLE
s390x(runtime-datascience): fix pyarrow build in Dockerfile.cpu

### DIFF
--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -104,19 +104,34 @@ ARG TARGETARCH
 USER 0
 WORKDIR /tmp/build-wheels
 
+# Set pyarrow version for s390x
+RUN if [ "$TARGETARCH" = "s390x" ]; then \
+    echo 'export PYARROW_VERSION=17.0.0' >> /etc/profile.d/s390x.sh; \
+fi
+
 # Build pyarrow optimized for s390x
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf \
     if [ "$TARGETARCH" = "s390x" ]; then \
-        # Install build dependencies (shared for pyarrow and onnx)
-        dnf install -y cmake make gcc-c++ pybind11-devel wget && \
+        # Install build dependencies
+        dnf install -y cmake make gcc-c++ pybind11-devel wget git \
+            openssl-devel zlib-devel bzip2-devel lz4-devel \
+            ninja-build && \
         dnf clean all && \
-        # Build and collect pyarrow wheel
-        git clone --depth 1 https://github.com/apache/arrow.git && \
-        cd arrow/cpp && \
-        mkdir release && cd release && \
+        # Source the environment variables
+        source /etc/profile.d/s390x.sh && \
+        # Clone specific version of arrow
+        git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git && \
+        cd arrow && \
+        # Set environment variables for build
+        export ARROW_HOME=/usr/local && \
+        export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH && \
+        export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH && \
+        # Build C++ library first
+        cd cpp && \
+        mkdir build && cd build && \
         cmake -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX=/usr/local \
+              -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
               -DARROW_PYTHON=ON \
               -DARROW_PARQUET=ON \
               -DARROW_ORC=ON \
@@ -124,22 +139,30 @@ RUN --mount=type=cache,target=/root/.cache/pip \
               -DARROW_JSON=ON \
               -DARROW_CSV=ON \
               -DARROW_DATASET=ON \
-              -DARROW_DEPENDENCY_SOURCE=BUNDLED \
-              -DARROW_WITH_LZ4=OFF \
-              -DARROW_WITH_ZSTD=OFF \
+              -DARROW_WITH_LZ4=ON \
+              -DARROW_WITH_ZSTD=ON \
               -DARROW_WITH_SNAPPY=OFF \
+              -DARROW_WITH_BZ2=ON \
+              -DARROW_WITH_ZLIB=ON \
               -DARROW_BUILD_TESTS=OFF \
               -DARROW_BUILD_BENCHMARKS=OFF \
+              -DARROW_USE_CCACHE=OFF \
+              -GNinja \
               .. && \
-        make -j$(nproc) VERBOSE=1 && \
-        make install -j$(nproc) && \
+        ninja install && \
         cd ../../python && \
+        # Install Python build requirements
         pip install --no-cache-dir -r requirements-build.txt && \
+        # Build Python package
         PYARROW_WITH_PARQUET=1 \
         PYARROW_WITH_DATASET=1 \
         PYARROW_WITH_FILESYSTEM=1 \
         PYARROW_WITH_JSON=1 \
         PYARROW_WITH_CSV=1 \
+        PYARROW_WITH_LZ4=1 \
+        PYARROW_WITH_ZSTD=1 \
+        PYARROW_WITH_BZ2=1 \
+        PYARROW_BUNDLE_ARROW_CPP=1 \
         PYARROW_PARALLEL=$(nproc) \
         python setup.py build_ext --build-type=release --bundle-arrow-cpp bdist_wheel && \
         mkdir -p /tmp/wheels && \


### PR DESCRIPTION
This PR fixes the runtime-datascience build failures for s390x architecture by improving the pyarrow build configuration in Dockerfile.cpu

Changes made:
- Added parameterized pyarrow version (17.0.0) using environment variable in /etc/profile.d/s390x.sh
- Enhanced build dependencies for s390x (added compression libraries and build tools)
- Improved CMake configuration with proper compression support
- Added proper environment variables for library paths and pkg-config

This fix follows the same pattern used for ppc64le architecture, ensuring consistency across different platforms while addressing s390x-specific requirements.

Konflux Successfull Build:- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhoai-tenant/applications/automation/pipelineruns/odh-pipeline-runtime-datascience-cpu-py312-on-pull-requestmxdvx
<img width="1663" height="785" alt="image" src="https://github.com/user-attachments/assets/faf7117b-6436-42b8-9882-7456b1ad18b1" />


Follow Up PR on Downstream: https://github.com/red-hat-data-services/notebooks/pull/1568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added PyArrow support on s390x with a pinned version for improved compatibility.
  - Enabled key features: Parquet, Dataset, Filesystem, JSON, CSV, and compression (LZ4, ZSTD, BZ2, Zlib).
- Chores
  - Updated the runtime build to generate and include PyArrow wheels for s390x, improving reliability of installs on that architecture.
  - Ensured non-s390x builds remain unaffected with a safe fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->