### PR TITLE
RHAIENG-608: Update all runtimes imagestream names with new naming format

### DIFF
--- a/manifests/base/runtime-datascience-imagestream.yaml
+++ b/manifests/base/runtime-datascience-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Datascience with Python 3.12 (UBI9)"
+    opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
   name: runtime-datascience
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Datascience with Python 3.12 (UBI9)",
+              "display_name": "Runtime | Datascience | CPU | Python 3.12",
               "metadata": {
                 "tags": [
                   "datascience"
                 ],
-                "display_name": "Datascience with Python 3.12 (UBI9)",
+                "display_name": "Runtime | Datascience | CPU | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/base/runtime-minimal-imagestream.yaml
+++ b/manifests/base/runtime-minimal-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Python 3.12 (UBI9)"
+    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
     opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
   name: runtime-minimal
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Python 3.12 (UBI9)",
+              "display_name": "Runtime | Minimal | CPU | Python 3.12",
               "metadata": {
                 "tags": [
                   "minimal"
                 ],
-                "display_name": "Python 3.12 (UBI9)",
+                "display_name": "Runtime | Minimal | CPU | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-pytorch-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "PyTorch with CUDA and Python 3.12 (UBI9)"
+    opendatahub.io/runtime-image-name: "Runtime | Pytorch | CUDA | Python 3.12"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "PyTorch with CUDA and Python 3.12 (UBI9)",
+              "display_name": "Runtime | Pytorch | CUDA | Python 3.12",
               "metadata": {
                 "tags": [
                   "pytorch"
                 ],
-                "display_name": "PyTorch with CUDA and Python 3.12 (UBI9)",
+                "display_name": "Runtime | Pytorch | CUDA | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-rocm-pytorch-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "PyTorch with ROCm and Python 3.12 (UBI9)"
+    opendatahub.io/runtime-image-name: "Runtime | Pytorch | ROCm | Python 3.12"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-pytorch
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "PyTorch with ROCm and Python 3.12 (UBI9)",
+              "display_name": "Runtime | Pytorch | ROCm | Python 3.12",
               "metadata": {
                 "tags": [
                   "rocm-pytorch"
                 ],
-                "display_name": "PyTorch with ROCm and Python 3.12 (UBI9)",
+                "display_name": "Runtime | Pytorch | ROCm | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     # TODO: once the restraction takes a final shape need to update that url
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "TensorFlow with ROCm and Python 3.12 (UBI9)"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12"
     opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-tensorflow
 spec:
@@ -19,12 +19,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "TensorFlow with ROCm and Python 3.12 (UBI9)",
+              "display_name": "Runtime | TensorFlow | ROCm | Python 3.12",
               "metadata": {
                 "tags": [
                   "rocm-tensorflow"
                 ],
-                "display_name": "TensorFlow with ROCm and Python 3.12 (UBI9)",
+                "display_name": "Runtime | TensorFlow | ROCm | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-tensorflow-imagestream.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     # TODO: once the restraction takes a final shape need to update that url
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "TensorFlow with CUDA and Python 3.12 (UBI9)"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-tensorflow
 spec:
@@ -19,12 +19,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "TensorFlow with CUDA and Python 3.12 (UBI9)",
+              "display_name": "Runtime | TensorFlow| CUDA | Python 3.12",
               "metadata": {
                 "tags": [
                   "tensorflow"
                 ],
-                "display_name": "TensorFlow with CUDA and Python 3.12 (UBI9)",
+                "display_name": "Runtime | TensorFlow| CUDA | Python 3.12",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Fixes for https://issues.redhat.com/browse/RHAIENG-608
## Description
<!--- Describe your changes in detail -->
Update all runtimes imagestream names with new naming format
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized display names for Python 3.12 runtimes to the "Runtime | <Type> | <Accelerator> | Python 3.12" format.
  * Updated runtime labels for Datascience (CPU), Minimal (CPU), PyTorch (CUDA), PyTorch (ROCm), TensorFlow (CUDA), TensorFlow (ROCm).
  * Improves consistency and clarity in runtime selection menus and image listings, making choices easier to scan and compare.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->