### PR TITLE
RHAIENG-974: enable missing module `mod_mime.so`

### DIFF
--- a/codeserver/ubi9-python-3.12/httpd/httpd.conf
+++ b/codeserver/ubi9-python-3.12/httpd/httpd.conf
@@ -5,6 +5,7 @@ Listen 8080
 # Load modules
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
 LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule mime_module modules/mod_mime.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule cgi_module modules/mod_cgi.so
 LoadModule rewrite_module modules/mod_rewrite.so
@@ -38,4 +39,4 @@ ErrorLog "/var/log/httpd/error_log"
 LogLevel warn
 
 # Include additional configurations
-IncludeOptional conf.d/*.conf
+# IncludeOptional conf.d/*.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
related to: https://issues.redhat.com/browse/RHAIENG-974 
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled MIME type handling for web content, ensuring files (e.g., CSS, JS, images) are served with correct content types for proper browser rendering and downloads.
- Chores
  - Disabled automatic inclusion of extra server configuration files to provide a more predictable and consistent runtime environment across deployments, reducing unexpected behavior from external configs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->