### PR TITLE
RHOAIENG-34309: Remove gio command call and manually delete files

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -2436,9 +2436,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/minimal/ubi9-python-3.12/pylock.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pylock.toml
@@ -973,9 +973,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "overrides"

--- a/jupyter/minimal/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "==3.12.*"
 
 dependencies = [
     # JupyterLab packages
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-server~=2.16.0",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -2723,9 +2723,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -2584,9 +2584,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -2444,9 +2444,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2514,9 +2514,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2625,9 +2625,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=4.0.5",

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -2323,9 +2323,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"
-version = "0.1.0"
-sdist = { url = "https://files.pythonhosted.org/packages/76/e9/0c59b5cb4ee54edb49166afbfe33a8964f01821cabd32efd63d0fb5648f2/odh_jupyter_trash_cleanup-0.1.0.tar.gz", upload-time = 2025-09-02T19:28:01Z, size = 43287, hashes = { sha256 = "ded78615bd084ba0649979f1b518c9c48f4c859b0f8bc119ca04517031e4378d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/9a/c0/dc3c91367e6405b7a2a8ed0f5ad1e7f524ba171c9ee353e02c0e0e4280ab/odh_jupyter_trash_cleanup-0.1.0-py3-none-any.whl", upload-time = 2025-09-02T19:28:00Z, size = 49009, hashes = { sha256 = "586baa432bee32027b42350cec2d1f6d283fe77c22bb3e852a816230ecdfb441" } }]
+version = "0.1.1"
+sdist = { url = "https://files.pythonhosted.org/packages/c7/77/19ddf2683bcf03ef73ff6f5d68e51ef6d6ff8c5ba4024f2330009dcc71ff/odh_jupyter_trash_cleanup-0.1.1.tar.gz", upload-time = 2025-09-18T14:04:56Z, size = 27480, hashes = { sha256 = "d97d3a6c70fcf4e47041dc89445505ba6b6964c9319254917f30393b656e6b5c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5e/c2/37eaa2c4efd7c1a6403aaa59822f0df2730b0f43b3fc274f4bd14998bd12/odh_jupyter_trash_cleanup-0.1.1-py3-none-any.whl", upload-time = 2025-09-18T14:04:55Z, size = 27553, hashes = { sha256 = "19b409372d5781937b42e047bf23503f4d602461765a9b145b0a6974cd090623" } }]
 
 [[packages]]
 name = "onnx"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
     # JupyterLab packages
     "odh-elyra==4.2.4",
-    "odh-jupyter-trash-cleanup==0.1.0",
+    "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.4",
     "jupyter-bokeh~=3.0.7", # trustyai 0.6.2 depends on jupyter-bokeh~=3.0.7


### PR DESCRIPTION
Update Trash Cleanup so we can fix the issue with `gio` not cleaning the trash in the notebooks containers.