### PR TITLE
RHAIENG-1186: chore(dockerfile): bump code-server version to v4.104.0 in UBI9 Python 3.12 image

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -21,7 +21,7 @@ COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/y
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
-ARG NODE_VERSION=24.8.0
+ARG NODE_VERSION=22.19.0
 
 ARG CODESERVER_VERSION=v4.104.0
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -21,7 +21,7 @@ COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/y
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24.8.0
 
 ARG CODESERVER_VERSION=v4.104.0
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -21,7 +21,7 @@ COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/y
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
-ARG NODE_VERSION=22.19.0
+ARG NODE_VERSION=22.18.0
 
 ARG CODESERVER_VERSION=v4.104.0
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -23,7 +23,7 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
 ARG NODE_VERSION=20
 
-ARG CODESERVER_VERSION=v4.98.0
+ARG CODESERVER_VERSION=v4.104.0
 
 COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
 
@@ -115,10 +115,11 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM cpu-base AS codeserver
 
-ARG TARGETOS TARGETARCH
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
-ARG CODESERVER_VERSION=v4.98.0
+ARG CODESERVER_VERSION=v4.104.0
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.12" \
       summary="code-server image with python 3.12 based on UBI 9" \

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -20,7 +20,7 @@ ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
 if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
-	export NODE_VERSION=${NODE_VERSION:-24.8.0}
+	export NODE_VERSION=${NODE_VERSION:-22.19.0}
 	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.104.0}
 
 	export NVM_DIR=/root/.nvm VENV=/opt/.venv

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -21,7 +21,7 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
 	export NODE_VERSION=${NODE_VERSION:-20}
-	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.98.0}
+	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.104.0}
 
 	export NVM_DIR=/root/.nvm VENV=/opt/.venv
 	export PATH=${VENV}/bin:$PATH

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -61,29 +61,9 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 	cd code-server
 	source ${NVM_DIR}/nvm.sh
 	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
-	# https://github.com/microsoft/vscode/issues/243708#issuecomment-2750733077
-	patch -p1 <<'EOF'
-diff --git i/package.json w/package.json
-index 925462fb087..dfff96eb051 100644
---- code-server.orig/lib/vscode/package.json
-+++ code-server/lib/vscode/package.json
-@@ -32,7 +32,7 @@
-     "watch-extensionsd": "deemon npm run watch-extensions",
-     "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
-     "precommit": "node build/hygiene.js",
--    "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
-+    "gulp": "node --max-old-space-size=16384 --optimize-for-size ./node_modules/gulp/bin/gulp.js",
-     "electron": "node build/lib/electron",
-     "7z": "7z",
-     "update-grammars": "node build/npm/update-all-grammars.mjs",
-EOF
 	nvm use ${NODE_VERSION}
 	npm install
 	npm run build
-	# https://github.com/coder/code-server/pull/7418
-	# node: --optimize-for-size is not allowed in NODE_OPTIONS
-	export NODE_OPTIONS="--max-old-space-size=16384"
-	export TERSER_PARALLEL=2
 	VERSION=${CODESERVER_VERSION/v/} npm run build:vscode
 	npm run release
 	npm run release:standalone

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -20,7 +20,7 @@ ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
 if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
-	export NODE_VERSION=${NODE_VERSION:-22.19.0}
+	export NODE_VERSION=${NODE_VERSION:-22.18.0}
 	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.104.0}
 
 	export NVM_DIR=/root/.nvm VENV=/opt/.venv

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -20,7 +20,7 @@ ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
 if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 
 	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
-	export NODE_VERSION=${NODE_VERSION:-20}
+	export NODE_VERSION=${NODE_VERSION:-24.8.0}
 	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.104.0}
 
 	export NVM_DIR=/root/.nvm VENV=/opt/.venv

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -29,9 +29,12 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 	export ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 	# install build dependencies
-	dnf install -y jq patch libtool rsync gettext gcc-toolset-13 krb5-devel libX11-devel
+	# https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle
+	# https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/developing_c_and_cpp_applications_in_rhel_9/assembly_additional-toolsets-for-development-rhel-9_developing-applications#cpp-compatibility-in-gcc-toolset-14_gcc-toolset-14
+	dnf install -y jq patch libtool rsync gettext gcc-toolset-14 krb5-devel libX11-devel
 
-	. /opt/rh/gcc-toolset-13/enable
+	# starting with node-22, c++20 is required
+	. /opt/rh/gcc-toolset-14/enable
 
 	# build libxkbfile
 	export UTIL_MACROS_VERSION=1.20.2

--- a/codeserver/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver/ubi9-python-3.12/run-code-server.sh
@@ -126,4 +126,5 @@ start_process /usr/bin/code-server \
     --disable-telemetry \
     --auth none \
     --disable-update-check \
+    --disable-getting-started-override \
     /opt/app-root/src


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1186

## Description

https://redhat-internal.slack.com/archives/C0961HQ858Q/p1758207145161039?thread_ts=1758191682.833179&cid=C0961HQ858Q

## How Has This Been Tested?

```
podman pull quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:odh-workbench-co5b9574113cba0e71458cccbb416a9adb-build-images-1
```

```
podman run --platform=linux/arm64 -p 8888:8888 --rm -it quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:odh-workbench-co5b9574113cba0e71458cccbb416a9adb-build-images-1
```

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated code-server to v4.104.0.
  - Getting‑started override prompt is disabled by default on launch.

- **Chores**
  - Bumped Node runtime default to 22.18.0.
  - Simplified packaging to upstream build steps; removed custom packaging patches and large-memory build overrides.
  - Upgraded compiler/toolchain to GCC toolset 14 with C++20; separated OS/ARCH build args.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->