### PR TITLE
RHAIENG-1193: codeserver(repo): update vscode extensions for 2025b release from Open VSX Registry

### DIFF
--- a/codeserver/Extensions.md
+++ b/codeserver/Extensions.md
@@ -5,18 +5,20 @@ Our code-server image will provide an easy way for users to deploy a code instan
 All extensions can be downloaded from either [https://open-vsx.org](https://open-vsx.org) (preferred) or [https://marketplace.visualstudio.com](https://marketplace.visualstudio.com)
 
 > Detail: some extensions are already available inside of other extensions, that are called "extension packages", i.e., when you install the `ms-python.python` extension, it already comes bundled with the `ms-python.debugpy` extension.
-> 
+>
 > All extension files are available inside the `ubiX-python-Y/utils/` directory, but only the main ones will be installed.
 
 List of extensions used:
 
-- Python [ms-python.python]
-  - Python Debugger [ms-python.debugpy]
-- Jupyter [ms-toolsai.jupyter]
-  - Jupyter Keymap [ms-toolsai.jupyter-keymap]
-  - Jupyter Notebook Renderers [ms-toolsai.jupyter-renderers]
-  - Jupyter Cell Tags [ms-toolsai.vscode-jupyter-cell-tags]
-  - Jupyter Slide Show [ms-toolsai.vscode-jupyter-slideshow]
+_Extensions in the second-order list items are already bundled in the first order list item `vsix` file, no need to install separately._
+
+- Python [[ms-python.python]](https://open-vsx.org/extension/ms-python/python)
+  - Python Debugger [[ms-python.debugpy]](https://open-vsx.org/extension/ms-python/debugpy)
+- Jupyter [[ms-toolsai.jupyter]](https://open-vsx.org/extension/ms-toolsai/jupyter)
+  - Jupyter Keymap [[ms-toolsai.jupyter-keymap]](https://open-vsx.org/extension/ms-toolsai/jupyter-keymap)
+  - Jupyter Notebook Renderers [[ms-toolsai.jupyter-renderers]](https://open-vsx.org/extension/ms-toolsai/jupyter-renderers)
+  - Jupyter Cell Tags [[ms-toolsai.vscode-jupyter-cell-tags]](https://open-vsx.org/extension/ms-toolsai/vscode-jupyter-cell-tags)
+  - Jupyter Slide Show [[ms-toolsai.vscode-jupyter-slideshow]](https://open-vsx.org/extension/ms-toolsai/vscode-jupyter-slideshow)
 
 ## Prerequisites
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -155,9 +155,10 @@ RUN --mount=type=cache,from=rpm-base,source=/tmp/,target=/code-server-rpm/,rw \
 COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/
 
 # Create and intall the extensions though build-time on a temporary directory. Later this directory will copied on the `/opt/app-root/src/.local/share/code-server/extensions` via run-code-server.sh file when it starts up.
+# https://coder.com/docs/code-server/FAQ#how-do-i-install-an-extension
 RUN mkdir -p /opt/app-root/extensions-temp && \
-    code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.2.0.vsix --extensions-dir /opt/app-root/extensions-temp && \
-    code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.2.0.vsix --extensions-dir /opt/app-root/extensions-temp
+    code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.14.0.vsix --extensions-dir /opt/app-root/extensions-temp && \
+    code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.8.0.vsix --extensions-dir /opt/app-root/extensions-temp
 
 # Install NGINX to proxy code-server and pass probes check
 ENV APP_ROOT=/opt/app-root \

--- a/codeserver/ubi9-python-3.12/utils/ms-python.debugpy-2025.4.1@linux-x64.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.debugpy-2025.4.1@linux-x64.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a853ea0d4f84a5d6f3c73868c55b4081712f63ad6e61abb6c5641c676e7b5ad4
-size 9002932

--- a/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.14.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.14.0.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d561d57f5820c0bdbc2b822f417e524afba256c60b28a9a1670f7923b1bddabc
+size 6771811

--- a/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.2.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.2.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6e7f640bc1b2a184597b518d8d5f73b447009a650c59fa5d2b1b4f68d19d9b1
-size 6795729

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.2.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.2.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d3f3fb56c004dda88ef6fb636d80270ce687407d78c1b27c66242d9b6e4628e
-size 13853707

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.8.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.8.0.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e0373fe1b309660e6e53189ab7ad34f7e374d3c7a76b8e4621d6a5b93d4caae
+size 12619222

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-keymap-1.1.2.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-keymap-1.1.2.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d2998929bb43156f3b428116aee290543c437875df616ec755692219b4afa17
-size 80264

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-renderers-1.1.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-renderers-1.1.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00044cf206d83cc3643e7538001590da19efad703b855451832ae79d77b92f4a
-size 7666936

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.vscode-jupyter-cell-tags-0.1.9.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.vscode-jupyter-cell-tags-0.1.9.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7cd43af55cf562a001dc475e92d9f3fd4b7173011adca0c02da22fbf891c274b
-size 180458

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.vscode-jupyter-slideshow-0.1.6.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.vscode-jupyter-slideshow-0.1.6.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b8dee0d569b7e0990bb4847c34748cdc0102078779351ed415d9d71cfa3e945
-size 174914


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1193

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

* https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-release/pipelineruns/odh-workbench-codeserver-datascience-cpu-py312-ubi9-on-pultpbls

```
  [4/6] STEP 13/33: RUN mkdir -p /opt/app-root/extensions-temp &&     code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.14.0.vsix --extensions-dir /opt/app-root/extensions-temp &&     code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.8.0.vsix --extensions-dir /opt/app-root/extensions-temp
  [2025-09-19T12:14:52.672Z] info  Wrote default config file to /opt/app-root/src/.config/code-server/config.yaml
  Installing extensions...
  Extension 'ms-python.python-2025.14.0.vsix' was successfully installed.
  Installing extensions...
  Extension 'ms-toolsai.jupyter-2025.8.0.vsix' was successfully installed.
```

```
❯ podman run --platform=linux/amd64 -p 8888:8888 --rm -it quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:on-pr-01b7e2d39f3ba2249be83db1eae6081fb452ac42-linux-extra-fast-amd64
```

<details>

```
Trying to pull quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:on-pr-01b7e2d39f3ba2249be83db1eae6081fb452ac42-linux-extra-fast-amd64...
Getting image source signatures
Copying blob sha256:ddd66796e0c513e29fc8bee1b53f83c980aa083974ccbb910d5ae809728dd60e
Copying blob sha256:5421398e4c94a8cf3b8024b51b9d86a177bfc25ab072ea2bd0da5fc28c5b211e
Copying blob sha256:d3cc7dd0729141f3fc64ea3f5d623225b86f29c02caefee54aa160c837b9b68e
Copying blob sha256:1afa39dd1b239cb1e882eec1b1e4579bcb2b4b0481551e8242648175f05134f5
Copying blob sha256:f1cb8c857177c7524711e894ec399eb85f7725c36919fe67682aff9ad5fd9802
Copying blob sha256:166a10f6345f836e406fa45279f20cfcfe921e27feaffe71f7ac3cef071f64e0
Copying blob sha256:09cb4fba2e4b965541db1a3e8ce00943a97c27f299565f97dce96d36e4abf42e
Copying config sha256:de64da97948658f4beb11526ae720ef16efa163ffa41a11c5d6c82906040c423
Writing manifest to image destination
Debug: Directory already exists.
Debug: '/opt/app-root/src/.local/share/code-server/User/settings.json' file not found, creating...
Debug: '/opt/app-root/src/.local/share/code-server/User/settings.json' file created.
Debug: Directory not found, creating '/opt/app-root/src/.vscode/'...
Debug: '/opt/app-root/src/.vscode/settings.json' file created.
Debug: Directory already exists.
Debug: '/opt/app-root/src/.vscode/launch.json' file not found, creating...
Debug: '/opt/app-root/src/.vscode/launch.json' file created.
Debug: Extension 'ms-python.debugpy-2025.10.0-linux-x64' copied to runtime directory.
Debug: Extension 'ms-python.python-2025.14.0' copied to runtime directory.
Debug: Extension 'ms-toolsai.jupyter-2025.8.0' copied to runtime directory.
Debug: Extension 'ms-toolsai.jupyter-keymap-1.1.2-universal' copied to runtime directory.
Debug: Extension 'ms-toolsai.jupyter-renderers-1.3.0-universal' copied to runtime directory.
Debug: Extension 'ms-toolsai.vscode-jupyter-cell-tags-0.1.9-universal' copied to runtime directory.
Debug: Extension 'ms-toolsai.vscode-jupyter-slideshow-0.1.6-universal' copied to runtime directory.
Checking IPv6 support...
IPv6 detected: binding to all interfaces (IPv4 + IPv6)
Running command: /usr/bin/code-server --bind-addr [::]:8787 --disable-telemetry --auth none --disable-update-check --disable-getting-started-override /opt/app-root/src
[2025-09-19T12:22:56.469Z] info  code-server 0.0.0 ba774d989b4983b38a857220b17e5301e71dba5c
[2025-09-19T12:22:56.856Z] info  Using user-data-dir /opt/app-root/src/.local/share/code-server
[2025-09-19T12:22:56.891Z] info  Using config file /opt/app-root/src/.config/code-server/config.yaml
[2025-09-19T12:22:56.892Z] info  HTTP server listening on http://[::]:8787/
[2025-09-19T12:22:56.892Z] info    - Authentication is disabled
[2025-09-19T12:22:56.894Z] info    - Not serving HTTPS
[2025-09-19T12:22:56.894Z] info  Session server listening on /opt/app-root/src/.local/share/code-server/code-server-ipc.sock
```

```
192.168.127.1 - - [19/Sep/2025:12:23:47 +0000] "GET / HTTP/1.1" 302 145 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36" "-"
[12:23:47] 




[12:23:47] Extension host agent started.
[12:23:47] Started initializing default profile extensions in extensions installation folder. file:///opt/app-root/src/.local/share/code-server/extensions
[12:23:47] Completed initializing default profile extensions in extensions installation folder. file:///opt/app-root/src/.local/share/code-server/extensions
File not found: /usr/lib/code-server/lib/vscode/node_modules/vsda/rust/web/vsda_bg.wasm
File not found: /usr/lib/code-server/lib/vscode/node_modules/vsda/rust/web/vsda.js
[12:23:48] [::ffff:127.0.0.1][64546419][ManagementConnection] New connection established.
[12:23:48] [::1][9def17b8][ExtensionHostConnection] New connection established.
[12:23:49] [::1][9def17b8][ExtensionHostConnection] <110> Launched Extension Host Process.
File not found: /usr/lib/code-server/lib/vscode/node_modules/vscode-regexp-languagedetection/dist/index.js
```

Kimi says the files not found errors are expected.

</details>

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified extensions section with explicit Python and Jupyter entries, added Open VSX links, noted sub-extensions are bundled, and added a separator and link to the extension install FAQ.
- Chores
  - Updated bundled Python and Jupyter extension versions and refreshed packaged extension assets / LFS pointers.
- Tests
  - Added unit tests for Dockerfile dependency parsing and a heredoc utility with accompanying test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->