### PR TITLE
chore(README.md): add inventory table with the list of images and supported architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,42 @@ Clean up the environment when the tests are finished:
 make  undeployX-${WORKBENCH_NAME}
 ```
 
+## Image Inventory List
+This table provides a concise overview of the support status for various container images.
+
+| Workbench | Version | Python | OS | x86_64 | aarch64 | ppc64le | s390x | Container |
+|------------|----------|--------|------|---------|----------|----------|--------|-------------|
+| CPU Minimal | - | 3.12 | UBI9 | ✅ | ✅ | ✅ | ✅ | [quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9?tab=tags) |
+| CPU DataScience | - | 3.12 | UBI9 | ✅ | ✅ | ✅ | ✅ | [quay.io/repository/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9?tab=tags) |
+| CPU TrustyAI | - | 3.12 | UBI9 | ✅ | ✅ | ✅ | - | [quay.io/repository/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9?tab=tags) |
+| CPU CodeServer | - | 3.12 | UBI9 | ✅ | ✅ | ✅ | ✅ | [quay.io/repository/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9?tab=tags) |
+| CPU RStudio | - | 3.12 | C9S | ✅ | ✅ | - | - | [quay.io/repository/opendatahub/odh-workbench-rstudio-minimal-cpu-py312-c9s](https://quay.io/repository/opendatahub/odh-workbench-rstudio-minimal-cpu-py312-c9s?tab=tags) |
+| CUDA Minimal | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ✅ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9?tab=tags) |
+| CUDA PyTorch | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ⏰ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9?tab=tags) |
+| CUDA PyTorch LLMCompressor | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ⏰ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9?tab=tags) |
+| CUDA TensorFlow | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ✅ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9?tab=tags) |
+| CUDA RStudio | 12.8 | 3.12 | C9S | ✅ | ✅ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-rstudio-minimal-cuda-py312-c9s](https://quay.io/repository/opendatahub/odh-workbench-rstudio-minimal-cuda-py312-c9s?tab=tags) |
+| ROCM Minimal | 6.3 | 3.12 | UBI9/RHEL9.6 | ✅ | ❌ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9) |
+| ROCM PyTorch | 6.3 | 3.12 | UBI9/RHEL9.6 | ✅ | ❌ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9?tab=tags) |
+| ROCM TensorFlow | 6.3 | 3.12 | UBI9/RHEL9.6 | ✅ | ❌ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9?tab=tags) |
+
+
+| Runtime | Version | Python | UBI | x86_64 | aarch64 | ppc64le | s390x | Container |
+|----------|----------|--------|------|---------|----------|----------|--------|-------------|
+| CPU Minimal | - | 3.12 | UBI9 | ✅ | ✅ | ✅ | ✅ | [quay.io/repository/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9?tab=tags) |
+| CPU DataScience | - | 3.12 | UBI9 | ✅ | ✅ | ✅ | ✅ | [quay.io/repository/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9?tab=tags) |
+| CUDA PyTorch | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ⏰ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9?tab=tags) |
+| CUDA PyTorch LLMCompressor | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ⏰ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9) |
+| CUDA TensorFlow | 12.8 | 3.12 | UBI9/RHEL9.6 | ✅ | ⏰ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9?tab=tags) |
+| ROCM PyTorch | 6.3 | 3.12 | UBI9/RHEL9.6 | ✅ | ❌ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9?tab=tags) |
+| ROCM TensorFlow | 6.3 | 3.12 | UBI9/RHEL9.6 | ✅ | ❌ | ❌ | ❌ | [quay.io/repository/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9](https://quay.io/repository/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9?tab=tags) |
+
+
+* ✅ supported
+* ⚠️ under development
+* ⏰ planned in the future
+* ❌ not supported by vendor
+
 ## Contributing
 
 Whether you're fixing bugs, adding new notebooks, or improving documentation, your contributions are welcome. Please refer to our [Contribution Guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added inventory table with the list of images
Related to: https://issues.redhat.com/browse/RHAIENG-1020 

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Image Inventory List" with Workbench and Runtime tables showing per-architecture availability and container URLs.
  * Included a legend explaining status icons for quick reference.
  * Inserted the inventory block in two locations (duplicated) to increase visibility.
  * Added a "For AI Agents" subsection linking to the Agents Guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->