### PR TITLE
Issue #2404: chore(ci): reduce swap size in gha_lvm_overlay.sh

### DIFF
--- a/ci/cached-builds/gha_lvm_overlay.sh
+++ b/ci/cached-builds/gha_lvm_overlay.sh
@@ -11,7 +11,9 @@ set -Eeuo pipefail
 root_reserve_mb=4096
 temp_reserve_mb=100
 # compilation from sources needs memory, for now that's codeserver
-swap_size_mb=16384
+# 16GB is wasteful, 0.5GB is not enough, arm64 froze with 2GB and 4GB
+# https://github.com/opendatahub-io/notebooks/issues/2404
+swap_size_mb=8196
 
 build_mount_path="${HOME}/.local/share/containers"
 build_mount_path_ownership="runner:runner"


### PR DESCRIPTION
* #2404

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17941484896
* https://github.com/jiridanek/notebooks/actions/runs/17946984207/job/51036494302

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced CI swap allocation from 16GB to ~8GB to improve runner resource efficiency and stability; no impact on application behavior or user experience.
  * Added inline comments documenting the adjustment and referencing the rationale for future maintenance and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->