### PR TITLE
RHAIENG-792: Mark Python 3.11 image as non-notebook

### DIFF
--- a/manifests/overlays/additional/codeserver-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/codeserver-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/codeserver"
+    opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
+    opendatahub.io/notebook-image-order: "19"
+  name: codeserver-datascience-cpu-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "code-server", "version": "4.98"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "ipykernel", "version": "6.29"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-codeserver-datascience-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience"
+    opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
+    opendatahub.io/notebook-image-order: "8"
+  name: jupyter-datascience-cpu-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-datascience-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-minimal-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-cpu-py312-ubi9-imagestream.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
+    opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
+    opendatahub.io/notebook-image-order: "2"
+  name: jupyter-minimal-cpu-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-minimal-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-minimal-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
+    opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
+    opendatahub.io/notebook-image-order: "4"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+  name: jupyter-minimal-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.6"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.4"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-minimal-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-minimal-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-minimal-rocm-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm"
+    opendatahub.io/notebook-image-name: "Jupyter | Minimal | ROCm | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
+    opendatahub.io/notebook-image-order: "6"
+    opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
+  name: jupyter-minimal-rocm-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "ROCm", "version": "6.2"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.4"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-minimal-rocm-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch"
+    opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+    opendatahub.io/notebook-image-order: "10"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+  name: jupyter-pytorch-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.6"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.6"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"},
+            {"name": "PyTorch", "version": "2.6"},
+            {"name": "Tensorboard", "version": "2.19"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch+llmcompressor/ubi9-python-3.12"
+    opendatahub.io/notebook-image-name: "Jupyter | PyTorch LLM Compressor | CUDA | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch LLM Compressor libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+    opendatahub.io/notebook-image-order: "22"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+  name: jupyter-pytorch-llmcompressor-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.6"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.6"},
+            {"name": "LLM-Compressor", "version": "0.6"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"},
+            {"name": "PyTorch", "version": "2.6"},
+            {"name": "LLM-Compressor", "version": "0.6"},
+            {"name": "Tensorboard", "version": "2.19"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true' 
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-pytorch-rocm-py312-ubi9-imagestream.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm/pytorch"
+    opendatahub.io/notebook-image-name: "Jupyter | PyTorch | ROCm | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
+    opendatahub.io/notebook-image-order: "12"
+    opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
+  name: jupyter-pytorch-rocm-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"},
+            {"name": "ROCm-PyTorch", "version": "2.6"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"},
+            {"name": "ROCm-PyTorch", "version": "2.6"},
+            {"name": "Tensorboard", "version": "2.18"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-tensorflow-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/tensorflow"
+    opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | CUDA | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+    opendatahub.io/notebook-image-order: "14"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+  name: jupyter-tensorflow-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.6"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "TensorFlow", "version": "2.19"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"},
+            {"name": "TensorFlow", "version": "2.19"},
+            {"name": "Tensorboard", "version": "2.19"},
+            {"name": "Nvidia-CUDA-CU12-Bundle", "version": "12.5"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/jupyter-trustyai-cpu-py312-ubi9-imagestream.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "false"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai"
+    opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
+    opendatahub.io/notebook-image-order: "17"
+  name: jupyter-trustyai-cpu-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab","version": "4.4"},
+            {"name": "TrustyAI", "version": "0.6"},
+            {"name": "Transformers", "version": "4.55"},
+            {"name": "Datasets", "version": "3.4"},
+            {"name": "Accelerate", "version": "1.5"},
+            {"name": "Torch", "version": "2.6"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "1.5"},
+            {"name": "Scikit-learn", "version": "1.7"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "2025.1"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/runtime-datascience-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-datascience-cpu-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "false"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | Data Science | CPU | Python 3.12"
+    opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+  name: runtime-datascience-cpu-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | Data Science | CPU | Python 3.12",
+              "metadata": {
+                "tags": [
+                  "datascience"
+                ],
+                "display_name": "Runtime | Data Science | CPU | Python 3.12",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-datascience-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "datascience"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/runtime-minimal-cpu-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-minimal-cpu-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "false"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
+    opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+  name: runtime-minimal-cpu-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | Minimal | CPU | Python 3.12",
+              "metadata": {
+                "tags": [
+                  "minimal"
+                ],
+                "display_name": "Runtime | Minimal | CPU | Python 3.12",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-minimal-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "minimal"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/runtime-pytorch-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-pytorch-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "false"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | PyTorch | CUDA | Python 3.12",
+              "metadata": {
+                "tags": [
+                  "pytorch"
+                ],
+                "display_name": "Runtime | PyTorch | CUDA | Python 3.12",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "pytorch"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/runtime-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-pytorch-llmcompressor-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "false"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-llmcompressor-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12",
+              "metadata": {
+                "tags": [
+                  "pytorch"
+                ],
+                "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "pytorch-llmcompressor"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/runtime-pytorch-rocm-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-pytorch-rocm-py312-ubi9-imagestream.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "false"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12"
+    opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-rocm-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | PyTorch | ROCm | Python 3.12",
+              "metadata": {
+                "tags": [
+                  "rocm-pytorch"
+                ],
+                "display_name": "Runtime | PyTorch | ROCm | Python 3.12",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n_PLACEHOLDER
+      name: "rocm-pytorch"
+      referencePolicy:
+        type: Source

--- a/manifests/overlays/additional/runtime-tensorflow-cuda-py312-ubi9-imagestream.yaml
+++ b/manifests/overlays/additional/runtime-tensorflow-cuda-py312-ubi9-imagestream.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "false"
+  annotations:
+    # TODO: once the restraction takes a final shape need to update that url
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-tensorflow-cuda-py312-ubi9
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+              "metadata": {
+                "tags": [
+                  "tensorflow"
+                ],
+                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "tensorflow"
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes for https://issues.redhat.com/browse/RHAIENG-792
## Description
<!--- Describe your changes in detail -->
Disable Python 3.11 image as notebook by setting notebook-image=false
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced new workbench notebook images (Python 3.12, UBI9): Code Server Data Science (CPU), Jupyter Minimal (CPU/CUDA/ROCm), Jupyter PyTorch (CUDA/ROCm), Jupyter TensorFlow (CUDA), and Jupyter TrustyAI (CPU), plus a PyTorch LLM Compressor variant. All are available via ImageStreams with 2025.1 tags, dependency metadata, and GPU recommendations where applicable.
  - Added pipeline/runtime images: Minimal, Data Science (CPU), PyTorch (CUDA/ROCm/LLM Compressor), and TensorFlow (CUDA), each published as ImageStreams with display and usage metadata for streamlined discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->