### PR TITLE
RHAIENG-347: fix(manifests): consistency in accelerator info display on workbenches

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -19,7 +19,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "code-server", "version": "4.98"},
+            {"name": "code-server", "version": "4.104"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -20,6 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
+            {"name": "ROCm", "version": "v6.4"},
             {"name": "Python", "version": "v3.12"},
             {"name": "ROCm-PyTorch", "version": "2.7"}
           ]
@@ -59,6 +60,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
+            {"name": "ROCm", "version": "v6.2"},
             {"name": "Python", "version": "v3.11"},
             {"name": "ROCm-PyTorch", "version": "2.6"}
           ]

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -20,14 +20,15 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
+            {"name": "ROCm", "version": "v6.4"},
             {"name": "Python", "version": "v3.12"},
-            {"name": "ROCm-TensorFlow", "version": "2.18"}
+            {"name": "TensorFlow-ROCm", "version": "2.18"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab","version": "4.4"},
-            {"name": "ROCm-TensorFlow", "version": "2.18"},
+            {"name": "TensorFlow-ROCm", "version": "2.18"},
             {"name": "Tensorboard", "version": "2.18"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.10"},
@@ -58,14 +59,15 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
+            {"name": "ROCm", "version": "v6.2"},
             {"name": "Python", "version": "v3.11"},
-            {"name": "ROCm-TensorFlow", "version": "2.14"}
+            {"name": "TensorFlow-ROCm", "version": "2.14"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab","version": "4.4"},
-            {"name": "ROCm-TensorFlow", "version": "2.14"},
+            {"name": "TensorFlow-ROCm", "version": "2.14"},
             {"name": "Tensorboard", "version": "2.14"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.10"},


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-347

Reported by @bredamc on slack https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1746711179522259

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added ROCm entries to ROCm-PyTorch and ROCm-TensorFlow notebook images (v6.4 for 2025.2, v6.2 for 2025.1).

* Improvements
  * Updated code-server in the 2025.2 notebook image to version 4.104.
  * Standardized naming from “ROCm-TensorFlow” to “TensorFlow-ROCm” across annotations for consistency.
  * Minor annotation refinements to improve clarity of available software and versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->