### PR TITLE
NO-JIRA: fix(ci): remove the microsoft deb repo to install genuine upstream kubelet

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -439,7 +439,7 @@ jobs:
           # E: Packages were downgraded and -y was used without --allow-downgrades.
 
           sudo apt-get install -y --allow-downgrades \
-            "cri-o=${CRIO_VERSION}.*" "cri-tools=${CRIO_VERSION}.*" \
+            "cri-o=${CRIO_VERSION}.*" \
             "kubelet=${KUBERNETES_VERSION}.*" "kubeadm=${KUBERNETES_VERSION}.*" "kubectl=${KUBERNETES_VERSION}.*" \
             conntrack
 
@@ -456,12 +456,13 @@ jobs:
           sudo systemctl daemon-reload
           sudo systemctl start crio.service
         env:
-          CRIO_VERSION: 1.34
+          # TODO(jdanek): install also "cri-tools=${CRIO_VERSION}.*" when updating to 1.33
+          CRIO_VERSION: 1.32
           # This has to be kept in sync with the packages above, otherwise
           # [ERROR KubeletVersion]: the kubelet version is higher than the control plane version.
           #  This is not a supported version skew and may lead to a malfunctional cluster.
           #  Kubelet version: "1.33.0" Control plane version: "1.30.12"
-          KUBERNETES_VERSION: 1.34
+          KUBERNETES_VERSION: 1.33
           # Also update version in kubeadm.yaml
 
       - run: sudo crictl info
@@ -550,7 +551,7 @@ jobs:
         if: ${{ steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
-          kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.32/deploy/local-path-storage.yaml
+          kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml
           kubectl wait deployments --all --namespace=local-path-storage --for=condition=Available --timeout=100s
           # https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
           kubectl get storageclass

--- a/ci/cached-builds/kubeadm.yaml
+++ b/ci/cached-builds/kubeadm.yaml
@@ -39,7 +39,7 @@ timeouts:
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
-kubernetesVersion: 1.34.0
+kubernetesVersion: 1.33.0
 clusterName: kubernetes
 caCertificateValidityPeriod: 87600h0m0s
 certificateValidityPeriod: 8760h0m0s


### PR DESCRIPTION
## Description

https://github.com/opendatahub-io/notebooks/actions/runs/17971438786/job/51114822510?pr=2535#step:37:18

```
Run sudo crictl images
sudo: crictl: command not found
Error: Process completed with exit code 1.
```

and

```
Sep 24 11:36:11 runnervmf4ws1 kubelet[14322]: E0924 11:36:11.029046   14322 run.go:72] "command failed" err="failed to run Kubelet: validate service connection: validate CRI v1 runtime API for endpoint \"unix:///run/containerd/containerd.sock\": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"
```

because `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` is missing from the Micrsoft variant and kubeadm needs that.

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/17982322887

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by cleaning stale apt sources before updates.
  * Ensured service startup consistency by reloading system daemons before launching the container runtime.
  * Reset container runtime before cluster initialization for a clean setup.
  * Added a runtime verification step, executed only when tests are enabled.

* **Bug Fixes**
  * Prevented startup conflicts by removing leftover Microsoft apt source entries.
  * Resolved service initialization issues via explicit daemon reloads.

* **Tests**
  * Enhanced diagnostics after cluster init failures with detailed kubelet config and unit outputs.
  * Added runtime info checks to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->