### PR TITLE
RHAIENG-1284: fix(Dockerfiles) libcrypt.so.1 not found in runtime-datascience-rocm-tensorflow-ubi9-python-3.12 image

### DIFF
--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -27,7 +27,7 @@ RUN dnf -y upgrade --refresh --nobest --skip-broken --nodocs --noplugins --setop
 # upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
-RUN dnf install -y perl mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y perl mesa-libGL skopeo libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user
 USER 1001


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1284

## Description

* https://github.com/opendatahub-io/notebooks/pull/1386
* https://github.com/opendatahub-io/notebooks/actions/runs/18015977991/job/51261264149#step:31:206

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved runtime errors in the ROCm TensorFlow (Python 3.12) image caused by missing libxcrypt symbols by bundling the necessary compatibility library, improving startup and package installation reliability.

* **Chores**
  * Updated OS dependencies installed during image build to include required compatibility packages, enhancing overall compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->