### PR TITLE
RHAIENG-287: fix(manifests): replace `commonLabels` with `labels` in `kustomization.yaml` to avoid a warning

### DIFF
--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ../../base
 
-commonLabels:
-  opendatahub.io/component: "true"
-  component.opendatahub.io/name: notebooks
+labels:
+  - includeSelectors: true
+    pairs:
+      component.opendatahub.io/name: notebooks
+      opendatahub.io/component: "true"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

* https://github.com/opendatahub-io/notebooks/actions/runs/18018933972/job/51271029002#step:8:334

```
Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

[1 tool called]

Excellent! The fix worked perfectly. Let me also check the stderr to confirm there are no warnings:

[1 tool called]

Perfect! The deprecation warning has been completely resolved. Let me summarize what was done:

## Summary

The kustomize deprecation warning has been successfully fixed! Here's what happened:

### Problem
The `manifests/overlays/additional/kustomization.yaml` file was using the deprecated `commonLabels` field, which kustomize warned about:
```
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead.
```

### Solution
I ran the recommended fix command:
```bash
kustomize edit fix
```

This automatically converted the deprecated syntax from:
```yaml
commonLabels:
  opendatahub.io/component: "true"
  component.opendatahub.io/name: notebooks
```

To the new format:
```yaml
labels:
- includeSelectors: true
  pairs:
    component.opendatahub.io/name: notebooks
    opendatahub.io/component: "true"
```

## How Has This Been Tested?

### Verification
Running `kustomize build ./manifests/overlays/additional` now produces clean output with no deprecation warnings.

The fix aligns the overlay file with the base kustomization file, which was already using the newer `labels` format. This ensures consistent behavior across all manifests in the project.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated labeling configuration to apply labels to both resources and their selectors, standardizing identification of the Notebooks component across deployments.
  * Improves consistency for filtering, monitoring, and policy tooling that relies on labels.
  * No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->