### PR TITLE
RHAIENG-287: fix(Dockerfiles): split up an ENV block to avoid hadolint DL3044 error

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -161,15 +161,17 @@ RUN mkdir -p /opt/app-root/extensions-temp && \
     code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.8.0.vsix --extensions-dir /opt/app-root/extensions-temp
 
 # Install NGINX to proxy code-server and pass probes check
-ENV APP_ROOT=/opt/app-root \
-    NGINX_VERSION=1.24 \
+ENV APP_ROOT=/opt/app-root
+
+ENV NGINX_VERSION=1.24 \
     NGINX_SHORT_VER=124 \
-    NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/nginx/nginx.conf \
-    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
     NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_LOG_PATH=/var/log/nginx
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
     NGINX_APP_ROOT=${APP_ROOT} \
-    NGINX_LOG_PATH=/var/log/nginx \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
 # Modules does not exist


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

* https://github.com/opendatahub-io/notebooks/actions/runs/18019691753/job/51273664696?pr=2545#step:7:115

```
./codeserver/ubi9-python-3.12/Dockerfile.cpu:164 DL3044 error: Do not refer to an environment variable within the same `ENV` statement where it is defined.
```

## Description

Great question! The hadolint DL3044 error exists for several important reasons, even though the code might appear to work in some cases:

## Why it's problematic:

### 1. **Undefined behavior across Docker versions**
Different versions of Docker and different container runtimes (Docker, Podman, etc.) may handle variable expansion within the same `ENV` statement differently. What works in one environment might fail in another.

### 2. **Order dependency issues**
Within a single `ENV` statement, the order of variable definitions matters, but it's not guaranteed to be processed in the order you write them. For example:
```dockerfile
# This might not work as expected:
ENV VAR1=value1 VAR2=${VAR1}/subpath VAR3=other
```

### 3. **Shell vs Docker expansion**
Docker handles environment variable expansion differently than shell expansion. When you reference `${APP_ROOT}` in the same statement where `APP_ROOT` is defined, you're relying on Docker's internal variable expansion logic, which can be inconsistent.

### 4. **Build-time vs runtime confusion**
It creates ambiguity about when the variable expansion happens - is it during the build process or when the container runs? This can lead to unexpected behavior.

### 5. **Maintainability and readability**
Code that works "by accident" is harder to maintain. Future developers (or even you later) might not understand why it works and could break it during refactoring.

## The safer approach:
```dockerfile
# Clear, predictable behavior:
ENV APP_ROOT=/opt/app-root
ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d
```

This ensures that:
- `APP_ROOT` is fully defined before being referenced
- The behavior is consistent across all Docker versions
- The code is more readable and maintainable
- There's no ambiguity about variable expansion order

So while your original code might work in your current environment, the hadolint rule helps prevent subtle bugs and ensures your Dockerfile works reliably across different systems and Docker versions. It's a defensive programming practice!

## How Has This Been Tested?

```
❯ find . -name 'Dockerfile*' | xargs hadolint --config ./ci/hadolint-config.yaml
```

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Reorganized environment variables for the built-in web server within the container image; no functional changes.
- Chores
  - Standardized configuration paths and added a dedicated logging path in the container environment.
- Impact
  - No user-visible changes; behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->