### PR TITLE
RHAIENG-287: fix(ci): hadolint warnings

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -281,7 +281,7 @@ COPY ${CODESERVER_SOURCE_CODE}/test /tmp/test
 # TODO(jdanek): add --mount=type=bind,target=/opt/app-root/src
 RUN <<'EOF'
 set -Eeuxo pipefail
-python3 /tmp/test/test_startup.py |& tee /tmp/test_log.txt
+python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF
 
 from codeserver

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rpm-base         #
 ####################
@@ -17,7 +20,7 @@ ENV HOME=/root
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
@@ -74,7 +77,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -12,6 +12,7 @@ FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
 # e.g., registry.access.redhat.com/ubi9/python-312:latest
 FROM ${BASE_IMAGE} AS rpm-base
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -38,6 +39,7 @@ RUN ./get_code_server_rpm.sh && touch /tmp/control
 #######################
 FROM registry.access.redhat.com/ubi9/python-312:latest AS whl-cache
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -287,5 +289,5 @@ set -Eeuxo pipefail
 python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF
 
-from codeserver
+FROM codeserver
 COPY --from=tests /tmp/test_log.txt /tmp/test_log.txt

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -284,7 +284,7 @@ FROM codeserver as tests
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 COPY ${CODESERVER_SOURCE_CODE}/test /tmp/test
 # TODO(jdanek): add --mount=type=bind,target=/opt/app-root/src
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -51,7 +51,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 #            we need to ensure the same cache directory is mounted in
 #            the final stage with the necessary permissions to consume from cache
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -66,27 +66,33 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y $PACKAGES && \
     dnf clean all && rm -rf /var/cache/yum
 
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo && \
-    export HOME=/root && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh && \
-    chmod +x rustup-init.sh && \
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path && \
-    rm -f rustup-init.sh && \
-    chown -R 1001:0 /opt/.cargo && \
+    mkdir -p /opt/.cargo
+    export HOME=/root
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+    chmod +x rustup-init.sh
+    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    rm -f rustup-init.sh
+    chown -R 1001:0 /opt/.cargo
     # Set environment variables
-    echo 'export PATH=/opt/.cargo/bin:$PATH' >> /etc/profile.d/cargo.sh && \
-    echo 'export CARGO_HOME=/opt/.cargo' >> /etc/profile.d/cargo.sh && \
-    echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/cargo.sh; \
+    cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
+export PATH=/opt/.cargo/bin:$PATH
+export CARGO_HOME=/opt/.cargo
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+CARGO_EOF
 fi
+EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
-    alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    python --version && python3 --version; \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
+    alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    python --version && python3 --version
 fi
+EOF
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -44,7 +47,7 @@ ARG TARGETARCH
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -216,7 +216,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
+    wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
     unzip OpenBLAS-${OPENBLAS_VERSION}.zip
     cd OpenBLAS-${OPENBLAS_VERSION}
     make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -23,7 +23,7 @@ RUN arch="${TARGETARCH:-$(uname -m)}" && \
     arch=$(echo "$arch" | cut -d- -f1) && \
     if [ "$arch" = "s390x" ]; then \
         echo "Skipping mongocli build for ${arch}, creating dummy binary"; \
-        mkdir -p /tmp && echo -e '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
+        mkdir -p /tmp && printf '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
         chmod +x /tmp/mongocli; \
     else \
         echo "Building mongocli for ${arch}"; \
@@ -177,7 +177,7 @@ FROM cpu-base AS common-builder
 ARG TARGETARCH
 # hadolint ignore=DL3002
 USER root
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip
@@ -309,7 +309,7 @@ COPY --from=openblas-builder /root/OpenBLAS-${OPENBLAS_VERSION} /openblas
 COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 
 # Power-specific ONNX/OpenBLAS installation
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     pip install --no-cache-dir /onnxwheels/*.whl
@@ -319,7 +319,7 @@ fi
 EOF
 
 USER root
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     rm -rf /onnxwheels
@@ -328,7 +328,7 @@ else
 fi
 EOF
 
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     PREFIX=/usr/local make -C /openblas install

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -219,6 +219,7 @@ else
     echo "Skipping OpenBLAS build on non-Power"
 fi
 EOF
+
 ####################
 # jupyter-minimal #
 ####################

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -23,7 +23,7 @@ RUN arch="${TARGETARCH:-$(uname -m)}" && \
     arch=$(echo "$arch" | cut -d- -f1) && \
     if [ "$arch" = "s390x" ]; then \
         echo "Skipping mongocli build for ${arch}, creating dummy binary"; \
-        mkdir -p /tmp && printf '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
+        mkdir -p /tmp && printf '#!/bin/sh\necho "mongocli not supported on s390x"\n' > /tmp/mongocli && \
         chmod +x /tmp/mongocli; \
     else \
         echo "Building mongocli for ${arch}"; \
@@ -69,7 +69,8 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y $PACKAGES && \
     dnf clean all && rm -rf /var/cache/yum
 
-RUN <<EOF
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
     mkdir -p /opt/.cargo
@@ -89,7 +90,8 @@ fi
 EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN <<EOF
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     alternatives --install /usr/bin/python python /usr/bin/python3.12 1
     alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -197,7 +197,7 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     cd onnx
     git checkout ${ONNX_VERSION}
     git submodule update --init --recursive
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel
@@ -307,7 +307,7 @@ COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    pip install /onnxwheels/*.whl
+    pip install --no-cache-dir /onnxwheels/*.whl
 else
     echo "Skipping ONNX/OpenBLAS install on non-Power"
 fi

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -198,7 +198,8 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     git checkout ${ONNX_VERSION}
     git submodule update --init --recursive
     pip install -r requirements.txt
-    export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel
 else
     echo "Skipping ONNX build on non-Power"

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -118,6 +118,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 FROM cpu-base AS pyarrow-builder
 
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER 0
 WORKDIR /tmp/build-wheels
 
@@ -174,6 +175,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 #######################################################
 FROM cpu-base AS common-builder
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER root
 RUN <<'EOF'
 set -Eeuxo pipefail

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -29,7 +32,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -29,7 +32,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -23,6 +23,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 FROM ${BASE_IMAGE} AS whl-cache
 
+# hadolint ignore=DL3002
 USER root
 ENV HOME=/root
 WORKDIR /root

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -30,7 +30,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -50,7 +53,7 @@ USER root
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -200,7 +200,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         source /opt/rh/gcc-toolset-13/enable && \
-        wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
+        wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
     else \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -226,7 +226,8 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \
     	pip install -r requirements.txt && \
-    	export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    	CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    	export CMAKE_ARGS && \
     	pip wheel . -w /onnx_wheels; \
     else \
         echo "Not ppc64le, skipping ONNX build" && mkdir -p /onnx_wheels; \
@@ -249,8 +250,10 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive && \
     	cd arrow && rm -rf .git && mkdir dist                                  && \
     	pip3 install -r python/requirements-build.txt                          && \
-    	export ARROW_HOME=$(pwd)/dist                                          && \
-    	export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH                && \
+    	ARROW_HOME=$(pwd)/dist && \
+    	export ARROW_HOME && \
+    	LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH && \
+    	export LD_LIBRARY_PATH && \
     	export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH                && \
     	export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"  && \
     	export ARROW_TEST_DATA="${PWD}/testing/data"                           && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -51,6 +51,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     fi
 
 RUN <<EOF
+set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH
@@ -65,6 +66,7 @@ EOF
 
 # For s390x only, set ENV vars and install Rust
 RUN <<EOF
+set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
     mkdir -p /opt/.cargo
@@ -85,6 +87,7 @@ EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
 RUN <<EOF
+set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     alternatives --install /usr/bin/python python /usr/bin/python3.12 1
     alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -113,6 +113,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 FROM cpu-base AS s390x-builder
 
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER 0
 WORKDIR /tmp/build-wheels
 
@@ -191,6 +192,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ##################################
 
 FROM cpu-base AS openblas-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -215,6 +217,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 ###################################
 
 FROM cpu-base AS onnx-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -241,6 +244,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 ##################################
 
 FROM cpu-base AS arrow-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -225,7 +225,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \
-    	pip install -r requirements.txt && \
+    	pip install --no-cache-dir -r requirements.txt && \
     	CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
     	export CMAKE_ARGS && \
     	pip wheel . -w /onnx_wheels; \
@@ -249,7 +249,7 @@ RUN echo "arrow-builder stage TARGETARCH: ${TARGETARCH}"
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive && \
     	cd arrow && rm -rf .git && mkdir dist                                  && \
-    	pip3 install -r python/requirements-build.txt                          && \
+    	pip3 install --no-cache-dir -r python/requirements-build.txt                          && \
     	ARROW_HOME=$(pwd)/dist && \
     	export ARROW_HOME && \
     	LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH && \
@@ -281,7 +281,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         export PYARROW_WITH_PARQUET=1       && \
         export PYARROW_WITH_DATASET=1       && \
         export PYARROW_BUNDLE_ARROW_CPP=1   && \
-        pip3 install wheel                  && \
+        pip3 install --no-cache-dir wheel                  && \
         cd ../../python                     && \
         python setup.py build_ext              \
             --build-type=release               \
@@ -319,7 +319,7 @@ COPY --from=arrow-builder /arrowwheels /tmp/arrowwheels
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	echo "Installing ppc64le ONNX, pyarrow wheels and OpenBLAS..." && \
-    	HOME=/root pip install /tmp/onnx_wheels/*.whl /tmp/arrowwheels/*.whl && \
+    	HOME=/root pip install --no-cache-dir /tmp/onnx_wheels/*.whl /tmp/arrowwheels/*.whl && \
         if [ -d "/openblas" ] && [ "$(ls -A /openblas 2>/dev/null)" ]; then \
     		PREFIX=/usr/local make -C /openblas install; \
         fi && rm -rf /openblas /tmp/onnx_wheels /tmp/arrowwheels; \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -47,38 +47,47 @@ RUN --mount=type=cache,target=/var/cache/dnf \
         dnf clean all && rm -rf /var/cache/yum; \
     fi
 
-RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        echo 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export OPENBLAS_VERSION=0.3.30' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export ONNX_VERSION=1.19.0' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export PYARROW_VERSION=17.0.0' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/ppc64le.sh; \
-    fi
+RUN <<EOF
+if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
+export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH
+export OPENBLAS_VERSION=0.3.30
+export ONNX_VERSION=1.19.0
+export PYARROW_VERSION=17.0.0
+export PATH="$HOME/.cargo/bin:$PATH"
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+PROFILE_EOF
+fi
+EOF
 
 # For s390x only, set ENV vars and install Rust
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo && \
-    export HOME=/root && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh && \
-    chmod +x rustup-init.sh && \
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path && \
-    rm -f rustup-init.sh && \
-    chown -R 1001:0 /opt/.cargo && \
+    mkdir -p /opt/.cargo
+    export HOME=/root
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+    chmod +x rustup-init.sh
+    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    rm -f rustup-init.sh
+    chown -R 1001:0 /opt/.cargo
     # Set environment variables
-    echo 'export PATH=/opt/.cargo/bin:$PATH' >> /etc/profile.d/cargo.sh && \
-    echo 'export CARGO_HOME=/opt/.cargo' >> /etc/profile.d/cargo.sh && \
-    echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/cargo.sh; \
+    cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
+export PATH=/opt/.cargo/bin:$PATH
+export CARGO_HOME=/opt/.cargo
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+CARGO_EOF
 fi
+EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
-    alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    python --version && python3 --version; \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
+    alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    python --version && python3 --version
 fi
+EOF
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ARG TARGETARCH
 

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -20,7 +23,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287
* https://github.com/opendatahub-io/notebooks/pull/2546

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Standardized UBI9 repository injection across Python 3.12 images and consolidated architecture-specific setup into clearer, self-contained steps.

- Chores
  - Adjusted Python package install behavior to avoid cached artifacts and improve image hygiene; minor formatting and capitalization cleanups.

- Tests
  - Improved test startup shell invocation and log capture for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->