### PR TITLE
Update RStudio manifests objects 

### DIFF
--- a/manifests/base/commit-latest.env
+++ b/manifests/base/commit-latest.env
@@ -16,5 +16,5 @@ odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-n=564f037
 odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-n=564f037
 odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-n=564f037
 odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-n=564f037
-odh-workbench-rstudio-minimal-cpu-py311-c9s-commit-n=564f037
-odh-workbench-rstudio-minimal-cuda-py311-c9s-commit-n=564f037
+odh-workbench-rstudio-minimal-cpu-py312-c9s-commit-n=564f037
+odh-workbench-rstudio-minimal-cuda-py312-c9s-commit-n=564f037

--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     opendatahub.io/notebook-image-creator: RHOAI
     opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/rstudio"
-    opendatahub.io/notebook-image-name: "RStudio | Minimal | CUDA | R 4.4"
+    opendatahub.io/notebook-image-name: "RStudio | Minimal | CUDA | R 4.5"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: cuda-rstudio-rhel9
@@ -18,14 +18,14 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name":"CUDA","version":"12.4"},
-            {"name":"R","version":"v4.4"},
-            {"name":"Python","version":"v3.11"}
+            {"name":"CUDA","version":"12.8"},
+            {"name":"R","version":"v4.5"},
+            {"name":"Python","version":"v3.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name":"rstudio-server","version":"2024.04.2"}
+            {"name":"rstudio-server","version":"2025.09"}
           ]
       referencePolicy:
         type: Source
@@ -42,11 +42,11 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.25
+      ref: rhoai-3.0
   strategy:
     type: Docker
     dockerStrategy:
-      dockerfilePath: "rstudio/rhel9-python-3.11/Dockerfile.cuda"
+      dockerfilePath: "rstudio/rhel9-python-3.12/Dockerfile.cuda"
       noCache: true
       volumes:
         - name: secret-mvn

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -224,7 +224,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-rstudio-minimal-cpu-py311-c9s-n
+      fieldPath: data.odh-workbench-rstudio-minimal-cpu-py312-c9s-n
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -250,7 +250,7 @@ replacements:
           name: rstudio-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-rstudio-minimal-cuda-py311-c9s-n
+      fieldPath: data.odh-workbench-rstudio-minimal-cuda-py312-c9s-n
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -549,7 +549,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-rstudio-minimal-cpu-py311-c9s-commit-n
+      fieldPath: data.odh-workbench-rstudio-minimal-cpu-py312-c9s-commit-n
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -575,7 +575,7 @@ replacements:
           name: rstudio-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-rstudio-minimal-cuda-py311-c9s-commit-n
+      fieldPath: data.odh-workbench-rstudio-minimal-cuda-py312-c9s-commit-n
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1

--- a/manifests/base/params-latest.env
+++ b/manifests/base/params-latest.env
@@ -16,5 +16,5 @@ odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeli
 odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9:2025b-v1.37
 odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9:2025b-v1.37
 odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-n=quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9:2025b-v1.37
-odh-workbench-rstudio-minimal-cuda-py311-c9s-n=quay.io/opendatahub/odh-workbench-rstudio-minimal-cuda-py311-c9s:2025b-v1.37
-odh-workbench-rstudio-minimal-cpu-py311-c9s-n=quay.io/opendatahub/odh-workbench-rstudio-minimal-cpu-py311-c9s:2025b-v1.37
+odh-workbench-rstudio-minimal-cuda-py312-c9s-n=quay.io/opendatahub/odh-workbench-rstudio-minimal-cuda-py312-c9s:2025b-v1.37
+odh-workbench-rstudio-minimal-cpu-py312-c9s-n=quay.io/opendatahub/odh-workbench-rstudio-minimal-cpu-py312-c9s:2025b-v1.37

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -14,5 +14,5 @@ odh-pipeline-runtime-pytorch-cuda-py311-ubi9-n-1=quay.io/opendatahub/odh-pipelin
 odh-pipeline-runtime-pytorch-rocm-py311-ubi9-n-1=quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py311-ubi9@sha256:b55bd2abd3a153ccd78069139a6b60a1fb0917d597f5b5a23b96044ed9eed134
 odh-pipeline-runtime-tensorflow-cuda-py311-ubi9-n-1=quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py311-ubi9@sha256:1582cb6d7dd2f949fa73e323b19b5ec0e10bc3e01fe0e752ceed275fe9613bc4
 odh-pipeline-runtime-tensorflow-rocm-py311-ubi9-n-1=quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py311-ubi9@sha256:71cbe8249b57af33e92216c11979e669882871cac4743a1cf5bd3230e671390a
-odh-workbench-rstudio-minimal-cpu-py311-c9s-n-1=quay.io/opendatahub/workbench-images@sha256:562fde56f25507435520920ac41edd9ced0e025198a56142c44692f6340e0f0f
-odh-workbench-rstudio-minimal-cuda-py311-c9s-n-1=quay.io/opendatahub/workbench-images@sha256:f2988efa77ba4725a701f5717e8b70b5141ad0cb04dfc42a68293752b28324a7
+odh-workbench-rstudio-minimal-cpu-py311-c9s-n-1=quay.io/opendatahub/odh-workbench-rstudio-minimal-cpu-py311-c9s@sha256:37589dd7124384d577812dbffd00df21278f14c2e3f39f804b182d7a4748b910
+odh-workbench-rstudio-minimal-cuda-py311-c9s-n-1=quay.io/opendatahub/odh-workbench-rstudio-minimal-cuda-py311-c9s@sha256:d99e13789fed4c493a1b80bb4c963a3e150c957591baf080f1a5df99dfd22d48

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     opendatahub.io/notebook-image-creator: RHOAI
     opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/rstudio"
-    opendatahub.io/notebook-image-name: "RStudio | Minimal | CPU | R 4.4"
+    opendatahub.io/notebook-image-name: "RStudio | Minimal | CPU | R 4.5"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
   name: rstudio-rhel9
 spec:
@@ -17,13 +17,13 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name":"R","version":"v4.4"},
-            {"name":"Python","version":"v3.11"}
+            {"name":"R","version":"v4.5"},
+            {"name":"Python","version":"v3.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name":"rstudio-server","version":"2024.04.2"}
+            {"name":"rstudio-server","version":"2025.09"}
           ]
       referencePolicy:
         type: Source
@@ -39,11 +39,11 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.25
+      ref: rhoai-3.0
   strategy:
     type: Docker
     dockerStrategy:
-      dockerfilePath: "rstudio/rhel9-python-3.11/Dockerfile.cpu"
+      dockerfilePath: "rstudio/rhel9-python-3.12/Dockerfile.cpu"
       volumes:
         - name: secret-mvn
           source:

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/notebook-image: "true"
   annotations:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
-    opendatahub.io/notebook-image-name: "RStudio | Minimal | CUDA | R 4.4"
+    opendatahub.io/notebook-image-name: "RStudio | Minimal | CUDA | R 4.5"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
     opendatahub.io/notebook-image-order: "22"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
@@ -16,6 +16,29 @@ spec:
     local: true
   tags:
     # N Version of the image
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.8"},
+            {"name": "R", "version": "v4.5"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "rstudio-server", "version": "2025.09"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cuda-py312-c9s-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-rstudio-minimal-cuda-py312-c9s-n_PLACEHOLDER
+      name: "2025.2"
+      referencePolicy:
+        type: Source
+    # N - 1  Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |
@@ -30,34 +53,11 @@ spec:
             {"name": "rstudio-server", "version": "2024.12"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
-        opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cuda-py311-c9s-commit-n_PLACEHOLDER
-      from:
-        kind: DockerImage
-        name: odh-workbench-rstudio-minimal-cuda-py311-c9s-n_PLACEHOLDER
-      name: "2025.1"
-      referencePolicy:
-        type: Source
-    # N - 1 Version of the image
-    - annotations:
-        # language=json
-        opendatahub.io/notebook-software: |
-          [
-            {"name": "CUDA", "version": "12.1"},
-            {"name": "R", "version": "v4.4"},
-            {"name": "Python", "version": "v3.11"}
-          ]
-        # language=json
-        opendatahub.io/notebook-python-dependencies: |
-          [
-            {"name": "rstudio-server", "version": "2024.04"}
-          ]
-        openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cuda-py311-c9s-commit-n-1_PLACEHOLDER
       from:
         kind: DockerImage
         name: odh-workbench-rstudio-minimal-cuda-py311-c9s-n-1_PLACEHOLDER
-      name: "2024.2"
+      name: "2025.1"
       referencePolicy:
         type: Source

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/notebook-image: "true"
   annotations:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
-    opendatahub.io/notebook-image-name: "RStudio | Minimal | CPU | R 4.4"
+    opendatahub.io/notebook-image-name: "RStudio | Minimal | CPU | R 4.5"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
     opendatahub.io/notebook-image-order: "21"
   name: rstudio-notebook
@@ -15,6 +15,28 @@ spec:
     local: true
   tags:
     # N  Version of the image
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "R", "version": "v4.5"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "rstudio-server", "version": "2025.09"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cpu-py312-c9s-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-rstudio-minimal-cpu-py312-c9s-n_PLACEHOLDER
+      name: "2025.2"
+      referencePolicy:
+        type: Source
+    # N -1 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |
@@ -28,33 +50,13 @@ spec:
             {"name": "rstudio-server", "version": "2024.12"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
-        opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cpu-py311-c9s-commit-n_PLACEHOLDER
-      from:
-        kind: DockerImage
-        name: odh-workbench-rstudio-minimal-cpu-py311-c9s-n_PLACEHOLDER
-      name: "2025.1"
-      referencePolicy:
-        type: Source
-    # N - 1 Version of the image
-    - annotations:
-        # language=json
-        opendatahub.io/notebook-software: |
-          [
-            {"name": "R", "version": "v4.4"},
-            {"name": "Python", "version": "v3.11"}
-          ]
-        # language=json
-        opendatahub.io/notebook-python-dependencies: |
-          [
-            {"name": "rstudio-server", "version": "2024.04"}
-          ]
-        openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cpu-py311-c9s-commit-n-1_PLACEHOLDER
       from:
         kind: DockerImage
         name: odh-workbench-rstudio-minimal-cpu-py311-c9s-n-1_PLACEHOLDER
-      name: "2024.1"
+      name: "2025.1"
       referencePolicy:
         type: Source
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
follow up pr for: https://github.com/opendatahub-io/notebooks/pull/2541 
## Description
<!--- Describe your changes in detail -->
Update RStudio manifests objects


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated RStudio Minimal notebook images to R 4.5 and Python 3.12 for both CPU and CUDA variants.
  - GPU images now use CUDA 12.8.
  - Image stream tags advanced (primary to 2025.2, N-1 to 2025.1) with refreshed N-1 snapshots.

- Improvements
  - RStudio Server upgraded to 2025.09 for improved compatibility and stability.

- Chores
  - Default parameters and image references updated to Python 3.12 variants.
  - Commit/image identifiers aligned to the new release train.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->