### PR TITLE
RHAIENG-287: fix(Dockerfiles): use explicit /bin/bash RUN blocks to avoid Hadolint SC3041 warning

### DIFF
--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
         dnf clean all && rm -rf /var/cache/yum; \
     fi
 
-RUN <<EOF
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
@@ -65,7 +65,7 @@ fi
 EOF
 
 # For s390x only, set ENV vars and install Rust
-RUN <<EOF
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
@@ -86,7 +86,7 @@ fi
 EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN <<EOF
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     alternatives --install /usr/bin/python python /usr/bin/python3.12 1


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

* https://github.com/opendatahub-io/notebooks/pull/2547

## Description

```
./runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu:53 SC3041 warning: In POSIX sh, set flag -E is undefined.
./runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu:68 SC3041 warning: In POSIX sh, set flag -E is undefined.
./runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu:89 SC3041 warning: In POSIX sh, set flag -E is undefined.
```

# Fix hadolint SC3041 in datascience runtime Dockerfile

## Approach

- Replace POSIX heredoc invocations with explicit bash heredocs to make `set -E` valid, following patterns already used in `jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu`.
- Use a quoted delimiter to prevent Docker-time expansion while still allowing bash to expand variables at runtime.

## Targeted edits

- In `runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu`, change these RUN blocks:
```53:66:/Users/jdanek/IdeaProjects/notebooks/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
RUN <<EOF
set -Eeuxo pipefail
# ...
EOF
```

to:

```53:66:/Users/jdanek/IdeaProjects/notebooks/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
RUN /bin/bash <<'EOF'
set -Eeuxo pipefail
# ...
EOF
```

Similarly update the other two blocks:

```67:86:/Users/jdanek/IdeaProjects/notebooks/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
RUN <<EOF
set -Eeuxo pipefail
# ...
EOF
```

→

```67:86:/Users/jdanek/IdeaProjects/notebooks/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
RUN /bin/bash <<'EOF'
set -Eeuxo pipefail
# ...
EOF
```

```88:96:/Users/jdanek/IdeaProjects/notebooks/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
RUN <<EOF
set -Eeuxo pipefail
# ...
EOF
```

→

```88:96:/Users/jdanek/IdeaProjects/notebooks/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
RUN /bin/bash <<'EOF'
set -Eeuxo pipefail
# ...
EOF
```

## Notes

- This mirrors existing usage in `jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu` (e.g., lines with `RUN /bin/bash <<'EOF'`).
- No changes to the script bodies; only the heredoc invocations are updated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Hardened build process for the Data Science (Python 3.12) runtime by explicitly invoking Bash in multi-line build steps, ensuring consistent execution across environments.
  - Preserved existing scripts and logic; no functional changes to runtime behavior.
  - Improves reliability and transparency of build steps without impacting users or requiring any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->