### PR TITLE
NO-JIRA: docs(ci): add reference for using `transient_store = true` in Podman

### DIFF
--- a/ci/cached-builds/storage.conf
+++ b/ci/cached-builds/storage.conf
@@ -9,6 +9,7 @@ driver = "overlay"
 graphroot = "/home/runner/.local/share/containers/storage"
 runroot = "/home/runner/.local/share/containers/storage"
 
+# https://www.redhat.com/en/blog/speed-containers-podman-raspberry-pi
 transient_store = true
 
 [storage.options]


### PR DESCRIPTION
…n Podman

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference comment with a URL in the cached-builds storage configuration to clarify the transient_store setting.
  * No code, UI, or configuration values changed. No impact on features, performance, or workflows; build and deployment behavior remains identical. No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->