### PR TITLE
fix(datascience): enable Arrow S3 and Substrait support in pyarrow build

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -148,6 +148,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
               -DARROW_WITH_LZ4=OFF \
               -DARROW_WITH_ZSTD=OFF \
               -DARROW_WITH_SNAPPY=OFF \
+              -DARROW_S3=ON \
+              -DARROW_SUBSTRAIT=ON \
               -DARROW_BUILD_TESTS=OFF \
               -DARROW_BUILD_BENCHMARKS=OFF \
               .. && \


### PR DESCRIPTION
### Changes
- Added the following CMake flags to the PyArrow build:
  - `-DARROW_S3=ON` → Enables S3 filesystem support for PyArrow.
  - `-DARROW_SUBSTRAIT=ON` → Enables Substrait support required by Feast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled S3 filesystem support in PyArrow within the datascience CPU image, allowing direct read/write to S3 from Arrow-based workflows.
  * Enabled Substrait integration in PyArrow for improved interoperability with query plan standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->