### PR TITLE
RHOAIENG-36027: remove EPEL repo from TrustyAI image for ppc64le

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -168,8 +168,6 @@ COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml ./
 RUN --mount=type=cache,from=whl-cache,source=/root/OpenBLAS/,target=/OpenBlas/,rw \
     bash -c ' \
         if [[ $(uname -m) == "ppc64le" ]]; then \
-            dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
-            dnf install -y libraqm libimagequant; \
             PREFIX=/usr/ make install -C /OpenBlas; \
         fi '
 


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/RHOAIENG-36027

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of ppc64le image builds by addressing dependency compilation failures.
  * Ensured consistent Pillow artifacts by building and repairing the Pillow wheel during development setup.

* **Chores**
  * Removed unnecessary platform-specific packages to simplify builds and reduce complexity.
  * Added tooling to build and repair wheels, preserving the existing wheel workflow for smoother developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->