### PR TITLE
[RHAIENG-1439]: chore: `--ServerApp.tornado_settings` removal

### DIFF
--- a/codeserver/ubi9-python-3.12/test/test_startup.py
+++ b/codeserver/ubi9-python-3.12/test/test_startup.py
@@ -39,7 +39,6 @@ class TestStartup(unittest.TestCase):
                 "--ServerApp.password=''",
                 f"--ServerApp.base_url=/notebook/{self.project_name}/{self.notebook_id}",
                 "--ServerApp.quit_button=False",
-                f'--ServerApp.tornado_settings={{"user":"{self.translated_username}","hub_host":"{self.origin}","hub_prefix":"/projects/{self.project_name}"}}',
             ]
         )
         return expected_args

--- a/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
                 --ServerApp.password=''
                 --ServerApp.base_url=/notebook/opendatahub/jovyan
                 --ServerApp.quit_button=False
-                --ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}
           ports:
             - name: notebook-port
               protocol: TCP

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -36,7 +36,6 @@ class TestJupyterLabImage:
                     "--ServerApp.password=''",
                     "--ServerApp.base_url=/notebook/opendatahub/jovyan",
                     "--ServerApp.quit_button=False",
-                    """--ServerApp.tornado_settings={"user":"jovyan","hub_host":"https://opendatahub.io","hub_prefix":"/notebookController/jovyan"}""",
                 ]
             ),
         )


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1452

This configuration has been removed from the Dashboard code as we decided to disable the Log out possibility from workbench. I think we can remove this option also from this codebase despite it's not necessary as the presence of this code doesn't affect the production code.

Relevant ODH dashboard change: opendatahub-io/odh-dashboard#5162.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed a legacy server startup setting from Notebook arguments across all Jupyter images, simplifying configuration while leaving other options unchanged. Default behavior now applies where that setting was previously specified.
- Tests
  - Updated test configurations to reflect the removal of the legacy startup setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->