### PR TITLE
RHOAIENG-36105: update to Elyra 4.2.5

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -2449,9 +2449,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -2703,9 +2703,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -2594,9 +2594,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -2456,9 +2456,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2508,9 +2508,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2619,9 +2619,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -2319,9 +2319,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.2.4"
-sdist = { url = "https://files.pythonhosted.org/packages/39/58/9a76992bcd402f7eaf9a23fb164d56993db6c079d3fad67dc0a4df799d03/odh_elyra-4.2.4.tar.gz", upload-time = 2025-09-11T18:09:43Z, size = 2155769, hashes = { sha256 = "9563849a41e3d5f45f4923a00d9e6480a9d53787e076d6369248f880795d2130" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f9/48/b852bc3107a6d92c1c6c63b0fa6255897e515df6948778e521f603f59e75/odh_elyra-4.2.4-py3-none-any.whl", upload-time = 2025-09-11T18:09:41Z, size = 4317667, hashes = { sha256 = "227b1a35a3eef8a02409e3aa5081c3322bcd30cd8939b77575dfce397f3fa42b" } }]
+version = "4.2.5"
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8b/3f8b9d4757dd56588a3aecba7995bb12179bf5d189358df8485843144623/odh_elyra-4.2.5.tar.gz", upload-time = 2025-10-14T17:41:40Z, size = 2155088, hashes = { sha256 = "77bb92331b3b9a61b3b4f5a05a13c41da1c437dc6a0e1d5e6a396281703f5e8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/c2/2da23a11f91dcff7dc82dce2d0d088283c8dc908653a94d7373bb855fa96/odh_elyra-4.2.5-py3-none-any.whl", upload-time = 2025-10-14T17:41:38Z, size = 4317578, hashes = { sha256 = "ccc30bf392c4926479152786d96b701787102c04fc34d378deed9ac7ab7554a4" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.2.4",
+    "odh-elyra==4.2.5",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.7",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR should update Elyra to `4.2.5`, which includes required fixes for the next release.

## How Has This Been Tested?
Local tests

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the JupyterLab extension odh-elyra to version 4.2.5 across all UBI9 Python 3.12 images, including Data Science, PyTorch, PyTorch + LLMCompressor, TensorFlow, ROCm variants, and TrustyAI.
  - Refreshed lockfiles with the latest artifact metadata (urls, sizes, hashes) to align with the new version.
  - Ensures a consistent experience across images by aligning on the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->