### PR TITLE
Switch from aippc to ubi/rhel images for rstudio

### DIFF
--- a/rstudio/rhel9-python-3.12/build-args/cpu.conf
+++ b/rstudio/rhel9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-# Base Image   : RHEL 9.6 with Python 3.12
+# Base Image   : UBI 9 with Python 3.12
 # Architectures: linux/arm64, linux/x86_64
-# Source       : https://quay.io/repository/aipcc/base-images/cpu
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1758182126
+BASE_IMAGE=registry.redhat.io/rhel9/python-312:latest

--- a/rstudio/rhel9-python-3.12/build-args/cuda.conf
+++ b/rstudio/rhel9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,4 @@
-# Base Image   : RHEL 9.6 with Python 3.12
+# Base Image   : UBI 9 with Python 3.12
 # CUDA Version : 12.8.1
 # Architectures: linux/arm64, linux/x86_64
-# Source       : https://quay.io/repository/aipcc/base-images/cuda
-BASE_IMAGE=quay.io/aipcc/base-images/cuda:3.0-1758181710
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9:v12.8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

https://issues.redhat.com/browse/RHAIENG-1022

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container image for Python 3.12 (CPU) to UBI 9.
  * Updated base container image for Python 3.12 (CUDA) to a UBI 9-based CUDA image.
  * Replaced legacy image references with new registry sources.
  * Removed obsolete source URL metadata from build configs.
  * CUDA version and supported architectures remain unchanged.
  * No functional changes expected for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->