### PR TITLE
Issue #2580: fix(trusty): set same permissions for group as for owner for OpenShift compatibility

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -200,7 +200,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     #       Build debugpy from source instead
     UV_LINK_MODE=copy uv pip install --no-cache git+https://github.com/microsoft/debugpy.git@v$(grep -A1 '\"debugpy\"' ./pylock.toml | grep -Eo '\b[0-9\.]+\b') && \
     # change ownership to default user (all packages were installed as root and has root:root ownership \
-    chown -R 1001:0 /opt/app-root/
+    chown -R 1001:0 /opt/app-root/ && \
+    chmod -R g=u /opt/app-root
 
 USER 1001
 


### PR DESCRIPTION
## Description

```
=========================== short test summary info ============================
[Checking permissions of the: /opt/app-root/share] SUBFAIL tests/containers/base_image_test.py::TestBaseImage::test_file_permissions[ghcr.io/opendatahub-io/notebooks/workbench-images:jupyter-trustyai-ubi9-python-3.12-_40a15f26ca1f3af8135ddbadee43708501cd19b1] - AssertionError: assert '755:0:1001' == '775:0:1001'

  - 775:0:1001
  ?  ^
  + 755:0:1001
  ?  ^
FAILED
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image file permissions so group permissions mirror user permissions for application files, improving consistency for non-root execution and platform deployments. This reduces permission-related errors when running containers or mounting volumes and enhances reliability across environments. No functional changes to application features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->