### PR TITLE
RHOAIENG-34310: support odh gateway auth with adjusting code-server and rstudio nginx

### DIFF
--- a/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
@@ -39,7 +39,7 @@ location /api/kernels/ {
 ###############
 # root and prefix get to code-server endpoint
 ###############
-location = ${NB_PREFIX} {
+location ${NB_PREFIX} {
     return 302 $custom_scheme://$http_host${NB_PREFIX}/codeserver/;
 }
 
@@ -54,25 +54,6 @@ location = / {
 location ${NB_PREFIX}/codeserver/ {
     rewrite ^${NB_PREFIX}/codeserver/(.*)$ /$1 break;
     # Standard code-server/NGINX configuration
-    proxy_pass http://workbench_server/;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 20d;
-
-    # Needed to make it work properly
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $custom_scheme;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-NginX-Proxy true;
-    proxy_redirect off;
-
-    access_log /var/log/nginx/codeserver.access.log json if=$loggable;
-}
-
-location /codeserver/ {
-    # Standard code-server/NGINX configuration (fallback without prefix)
     proxy_pass http://workbench_server/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/codeserver/ubi9-python-3.12/run-nginx.sh
+++ b/codeserver/ubi9-python-3.12/run-nginx.sh
@@ -18,9 +18,9 @@ fi
 if [ -z "$NB_PREFIX" ]; then
     cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
 else
-    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    export BASE_URL=$(echo "$NB_PREFIX" | awk -F/ '{ print $4"-"$3 }')$(echo "$NOTEBOOK_ARGS" | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
     # If BASE_URL is empty or invalid (missing hub_host), use wildcard server_name
-    if [ -z "$BASE_URL" ] || [ "$BASE_URL" = "$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')" ]; then
+    if [ -z "$BASE_URL" ] || [ "$BASE_URL" = "$(echo "$NB_PREFIX" | awk -F/ '{ print $4"-"$3 }')" ]; then
         export BASE_URL="_"
     fi
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf

--- a/rstudio/c9s-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/rstudio/c9s-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
@@ -66,7 +66,7 @@ location /api/kernels/ {
 ###############
 # root and prefix get to RStudio endpoint
 ###############
-location = ${NB_PREFIX} {
+location ${NB_PREFIX} {
     return 302 $custom_scheme://$http_host${NB_PREFIX}/rstudio/;
 }
 
@@ -90,24 +90,6 @@ location ${NB_PREFIX}/rstudio/ {
     # Needed to make it work properly
     proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
     proxy_set_header X-RStudio-Root-Path ${NB_PREFIX}/rstudio;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Proto $custom_scheme;
-
-    access_log /var/log/nginx/rstudio.access.log json if=$loggable;
-}
-
-location /rstudio/ {
-    rewrite ^/rstudio/(.*)$ /$1 break;
-    # Standard RStudio/NGINX configuration (fallback without prefix)
-    proxy_pass http://workbench_server/;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 20d;
-
-    # Needed to make it work properly
-    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
-    proxy_set_header X-RStudio-Root-Path /rstudio;
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto $custom_scheme;
 

--- a/rstudio/c9s-python-3.12/run-nginx.sh
+++ b/rstudio/c9s-python-3.12/run-nginx.sh
@@ -18,9 +18,9 @@ fi
 if [ -z "$NB_PREFIX" ]; then
     cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
 else
-    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    export BASE_URL=$(echo "$NB_PREFIX" | awk -F/ '{ print $4"-"$3 }')$(echo "$NOTEBOOK_ARGS" | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
     # If BASE_URL is empty or invalid (missing hub_host), use wildcard server_name
-    if [ -z "$BASE_URL" ] || [ "$BASE_URL" = "$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')" ]; then
+    if [ -z "$BASE_URL" ] || [ "$BASE_URL" = "$(echo "$NB_PREFIX" | awk -F/ '{ print $4"-"$3 }')" ]; then
         export BASE_URL="_"
     fi
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf

--- a/rstudio/rhel9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/rstudio/rhel9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
@@ -66,7 +66,7 @@ location /api/kernels/ {
 ###############
 # root and prefix get to RStudio endpoint
 ###############
-location = ${NB_PREFIX} {
+location ${NB_PREFIX} {
     return 302 $custom_scheme://$http_host${NB_PREFIX}/rstudio/;
 }
 
@@ -90,24 +90,6 @@ location ${NB_PREFIX}/rstudio/ {
     # Needed to make it work properly
     proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
     proxy_set_header X-RStudio-Root-Path ${NB_PREFIX}/rstudio;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Proto $custom_scheme;
-
-    access_log /var/log/nginx/rstudio.access.log json if=$loggable;
-}
-
-location /rstudio/ {
-    rewrite ^/rstudio/(.*)$ /$1 break;
-    # Standard RStudio/NGINX configuration (fallback without prefix)
-    proxy_pass http://workbench_server/;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 20d;
-
-    # Needed to make it work properly
-    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
-    proxy_set_header X-RStudio-Root-Path /rstudio;
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto $custom_scheme;
 

--- a/rstudio/rhel9-python-3.12/run-nginx.sh
+++ b/rstudio/rhel9-python-3.12/run-nginx.sh
@@ -18,9 +18,9 @@ fi
 if [ -z "$NB_PREFIX" ]; then
     cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
 else
-    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    export BASE_URL=$(echo "$NB_PREFIX" | awk -F/ '{ print $4"-"$3 }')$(echo "$NOTEBOOK_ARGS" | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
     # If BASE_URL is empty or invalid (missing hub_host), use wildcard server_name
-    if [ -z "$BASE_URL" ] || [ "$BASE_URL" = "$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')" ]; then
+    if [ -z "$BASE_URL" ] || [ "$BASE_URL" = "$(echo "$NB_PREFIX" | awk -F/ '{ print $4"-"$3 }')" ]; then
         export BASE_URL="_"
     fi
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Related-to: https://issues.redhat.com/browse/RHOAIENG-34310

### Problem
When migrating from OpenShift Route + oauth-proxy to Kubernetes Gateway API + kube-rbac-proxy, workbenches fail with either infinite redirect loops (`ERR_TOO_MANY_REDIRECTS`) or health check failures causing crash loops.

### Root Cause
Gateway API HTTPRoute **preserves the full path** (e.g., `/notebook/<namespace>/<workbench>/codeserver/`) when forwarding requests, unlike OpenShift Routes which strip path prefixes. The nginx configuration was designed for the Route behavior and had two critical issues:

1. **Overly broad location block**: `location ${NB_PREFIX}/` matched all paths under the prefix, including `/codeserver/` itself, creating infinite redirect loops
2. **Missing prefix-aware proxy block**: Only `location /codeserver/` existed, which couldn't match requests with the full NB_PREFIX path, causing 404 errors on health checks

### Changes

#### Files Modified
- `codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix`
- `rstudio/c9s-python-3.11/nginx/serverconf/proxy.conf.template_nbprefix`
- `rstudio/rhel9-python-3.11/nginx/serverconf/proxy.conf.template_nbprefix`
- `codeserver/ubi9-python-3.12/run-nginx.sh`
- `rstudio/*/run-nginx.sh`

#### Key Fixes

1. **Removed `location ${NB_PREFIX}/` block** - Prevented infinite redirects by eliminating the overly broad location matcher

2. **Added `location ${NB_PREFIX}/codeserver/` (or `/rstudio/`) block** - Handles proxying for requests with the full prefix path, strips the prefix via rewrite, and forwards to the backend server

3. **Updated all redirects to preserve `${NB_PREFIX}`** - Ensures redirects stay within HTTPRoute matching rules (e.g., `return 302 ${NB_PREFIX}/codeserver/` instead of `/codeserver/`)

4. **Added wildcard `server_name` fallback** - When `hub_host` is missing, uses `server_name _` to accept requests from any hostname (Gateway API uses different hostnames than Route-based setups)


Assisted by AI Agent: Cursor

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested this in a cluster with ODH 3.0 with Gateway API.


Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prefixed routing for Codeserver and RStudio with fallback to unprefixed paths.

* **Bug Fixes**
  * Safer BASE_URL handling: empty/invalid values now fall back to a wildcard server name to prevent broken configs.

* **Improvements**
  * Redirects and sign-in/out flows honor the configured prefix.
  * Proxy behavior standardized for headers, redirects, and logging to ensure consistent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->