### PR TITLE
RHOAIENG-35553: chore(dependencies): bump Codeflare SDK version from 0.31.1 to 0.32.0 across all Python 3.12 environments

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -548,10 +548,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
+version = "0.32.0"
 marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
-    "codeflare-sdk~=0.31.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
+    "codeflare-sdk~=0.32.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "feast~=0.55.0",
 
     # DB connectors

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -552,9 +552,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "kubeflow-training==1.9.3",
     "feast~=0.55.0",
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -552,9 +552,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "kubeflow-training==1.9.3",
     "feast~=0.55.0",
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -558,9 +558,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "kubeflow-training==1.9.3",
     "feast~=0.55.0",
 

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -558,9 +558,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "feast~=0.55.0",
 
     # DB connectors

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -545,10 +545,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
+version = "0.32.0"
 marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
+    "codeflare-sdk~=0.32.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "kubeflow-training==1.9.3",
 
     # DB connectors

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -36,7 +36,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Feast", "version": "0.55"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Feast", "version": "0.55"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -41,7 +41,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Feast", "version": "0.55"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -39,7 +39,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Feast", "version": "0.55"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -39,7 +39,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Feast", "version": "0.55"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Feast", "version": "0.55"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -41,7 +41,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.14"},
             {"name": "Pyodbc", "version": "5.2"},
-            {"name": "Codeflare-SDK", "version": "0.31"},
+            {"name": "Codeflare-SDK", "version": "0.32"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -477,10 +477,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
+version = "0.32.0"
 marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1; platform_machine != 's390x' and platform_machine != 'ppc64le'",
+    "codeflare-sdk~=0.32.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
     "feast~=0.55.0",
 
     # DB connectors

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -476,9 +476,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "feast~=0.55.0",
 
     # DB connectors

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -476,9 +476,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.16.1",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "feast~=0.55.0",
 
     # DB connectors

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -482,9 +482,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "feast~=0.55.0",
 
     # DB connectors

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -482,9 +482,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.31.1"
-sdist = { url = "https://files.pythonhosted.org/packages/81/ce/c76e45c1da86eb2727edd2faceaccc98d9266349d2d871787a16c45c2066/codeflare_sdk-0.31.1.tar.gz", upload-time = 2025-09-16T15:51:59Z, size = 89487, hashes = { sha256 = "df94cf0b74ab412384695d507ef177a856b4fbad1acb612a2f7808ab01dc8bd8" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/45/3d/6455a856f95e6b492ed02729ecf5af522dbb9e496fd87ba9242328625edd/codeflare_sdk-0.31.1-py3-none-any.whl", upload-time = 2025-09-16T15:51:57Z, size = 140634, hashes = { sha256 = "76fc797903374832592f016b515cc2a504ef2903fc1ebc32886a4d74978f5658" } }]
+version = "0.32.0"
+sdist = { url = "https://files.pythonhosted.org/packages/75/84/fd7f089111ddae5896059f28f02997d9b7650ff97ccf8917e35964a12795/codeflare_sdk-0.32.0.tar.gz", upload-time = 2025-10-16T11:51:24Z, size = 150607, hashes = { sha256 = "8cc4bc9e471c8dd2ec5baacda94d5f17a0bbbf3d4a944a213307c37521e1a300" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/9f/5007a20bf72f86400cfd935e8ac53888db024fbbdf2f278d9d6fcadbb017/codeflare_sdk-0.32.0-py3-none-any.whl", upload-time = 2025-10-16T11:51:22Z, size = 219307, hashes = { sha256 = "583910545d4e97c8ca18692150d3a3bdc45ed37dfb3cfda2f891a191b584d3f8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
-    "codeflare-sdk~=0.31.1",
+    "codeflare-sdk~=0.32.0",
     "feast~=0.55.0",
 
     # DB connectors


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-35553

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codeflare SDK from version 0.31.1 to 0.32.0 across all notebook and runtime environments, including DataScience, PyTorch, TensorFlow, and RocM variants. This includes corresponding updates to dependency manifests and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->