### PR TITLE
RHAIENG-287: fix(runtime/datascience): set same permissions for group as for owner for OpenShift compatibility

### DIFF
--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -369,6 +369,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
         uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml; \
     fi && \
+    # change ownership to default user (all packages were installed as root and has root:root ownership
+    chown -R 1001:0 /opt/app-root/ && \
+    chmod -R g=u /opt/app-root && \
     # Fix permissions to support pip in Openshift environments
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

```
=================================== FAILURES ===================================
_ TestBaseImage.test_file_permissions[ghcr.io/opendatahub-io/notebooks/workbench-images:runtime-datascience-ubi9-python-3.12-_fdc10eaf1ab4a40309e04a455f9b9a79989c8130] [Checking permissions of the: /opt/app-root/share] _
tests/containers/base_image_test.py:243: in test_fn
    assert cleaned_output == f"{item[1]}:{item[2]}:{item[3]}"
E   AssertionError: assert '775:0:0' == '775:0:1001'
E
E     - 775:0:1001
E     ?       - --
E     + 775:0:0
```

https://github.com/opendatahub-io/notebooks/actions/runs/18564335121/job/52921264675?pr=2588#step:31:151

* see also issue #2580, PR #2581
* and #2465 which introduced the root thing in trustyai

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration to refine file ownership and permission settings within the container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->