### PR TITLE
RHOAIENG-35792: disable 2025.1 image for Code Server and Rstudio

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -70,6 +70,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-n-1_PLACEHOLDER
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: odh-workbench-codeserver-datascience-cpu-py311-ubi9-n-1_PLACEHOLDER

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -55,6 +55,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cuda-py311-c9s-commit-n-1_PLACEHOLDER
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: odh-workbench-rstudio-minimal-cuda-py311-c9s-n-1_PLACEHOLDER

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -52,6 +52,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: odh-workbench-rstudio-minimal-cpu-py311-c9s-commit-n-1_PLACEHOLDER
+        opendatahub.io/image-tag-outdated: 'true'
       from:
         kind: DockerImage
         name: odh-workbench-rstudio-minimal-cpu-py311-c9s-n-1_PLACEHOLDER


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disable 2025.1 image for Code Server and Rstudio

Previously, Red Hat ODH 2.x offered various workbenches, including Jupyter, RStudio, and CodeServer.

With the advent of ODH 3.x, RStudio and CodeServer required an upgrade due to their reliance on an NGINX proxy.

The shift in authentication models from oauth-proxy to the Kubernetes Gateway API has rendered the prior method of routing traffic via an NGINX proxy obsolete. Consequently, these components must be updated to align with the new authentication model.

Given this transition, only the latest images of the RStudio and CodeServer workbenches (version 2025.2) have been upgraded. The 2025.1 image was not updated, presenting the following options:

1. Rebuild the 2025.1 image with the new authentication model. This option necessitates significant involvement from the DevOps and Notebook teams and would introduce delays in the release timeline.
2. Disable the 2025.1 image from the Dashboard UI and announce this in the migration guide.
3. Retain the 2025.1 image as is and announce its status in the migration guide.


The team has elected to proceed with option 2, which entails disabling the 2025.1 image from the Dashboard UI and communicating this decision within the migration guide.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image metadata to mark previous notebook image versions (code-server, RStudio, and RStudio GPU) as outdated for improved version management and deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->