### PR TITLE
RHAIENG-287, Issue #2110: chore(ci): suppress DL3048 in Hadolint configuration for invalid label

### DIFF
--- a/ci/hadolint-config.yaml
+++ b/ci/hadolint-config.yaml
@@ -38,3 +38,5 @@ ignored:
   - SC1091
   # DL3003 warning: Use WORKDIR to switch to a directory
   - DL3003
+  # DL3048 style: Invalid label key (seems like a hadolint bug not accepting `com.redhat.license_terms="https://..."`)
+  - DL3048


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

## Description

```
./codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu:127 DL3048 style: Invalid label key.
```

https://github.com/red-hat-data-services/notebooks/actions/runs/18616855668/job/53082552951?pr=1651#step:7:80

* https://github.com/opendatahub-io/notebooks/issues/2110

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->