### PR TITLE
RHAIENG-287, AIPCC-6072: fix(tests): exclude MPI libraries from unsatisfied dependency checks in CUDA AIPCC test

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -117,6 +117,12 @@ class TestBaseImage:
                     if deps.startswith("libtracker-extract.so"):
                         continue  # it's in ../
 
+                    # AIPCC-6072: Unsatisfied library dependencies in the cuda aipcc image
+                    if deps.startswith("libmpi.so"):
+                        continue  # it's in ${MPI_HOME}/lib
+                    if deps.startswith("liboshmem.so"):
+                        continue  # it's in ${MPI_HOME}/lib
+
                     with subtests.test(f"{dlib=}"):
                         pytest.fail(f"{dlib=} has unsatisfied dependencies {deps=}")
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

## Description


https://issues.redhat.com/browse/AIPCC-6072

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/18654671513
* https://github.com/jiridanek/notebooks/actions/runs/18654690596

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for CUDA AIPCC image by extending the allowlist for expected runtime dependencies. Tests now properly handle MPI-related library dependencies, reducing false test failures in relevant environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->