### PR TITLE
RHAIENG-287: fix(tests/llmcompressor): resolve test issue about missing `kustomization.yaml`

### DIFF
--- a/ci/cached-builds/make_test.py
+++ b/ci/cached-builds/make_test.py
@@ -37,12 +37,19 @@ def run_tests(target: str) -> None:
     pod = prefix + "-notebook-0"  # `$(kubectl get statefulset -o name | head -n 1)` would work too
     namespace = "ns-" + prefix
 
-    if target.startswith("runtime-"):
+    if target == "runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12":
+        deploy = "deploy9"
+        deploy_target = "runtimes-cuda-pytorch+llmcompressor-ubi9-python-3.12"
+    elif target.startswith("runtime-"):
         deploy = "deploy9"
         deploy_target = target.replace("runtime-", "runtimes-")
     elif target.startswith("rocm-runtime-"):
         deploy = "deploy9"
         deploy_target = target.replace("rocm-runtime-", "runtimes-rocm-")
+
+    elif target == "cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12":
+        deploy = "deploy9"
+        deploy_target = "cuda-jupyter-pytorch+llmcompressor-ubi9-python-3.12"
     elif target.startswith("rocm-jupyter-"):
         deploy = "deploy9"
         deploy_target = target.replace("rocm-jupyter-", "jupyter-rocm-")
@@ -247,6 +254,24 @@ class TestMakeTest(unittest.TestCase):
         assert "make deploy9-runtimes-rocm-pytorch-ubi9-python-3.11" in commands
         assert "make validate-runtime-image image=runtime-rocm-pytorch-ubi9-python-3.11" in commands
         assert "make undeploy9-runtimes-rocm-pytorch-ubi9-python-3.11" in commands
+
+    @unittest.mock.patch(target)
+    def test_make_commands_llmcompressor(self, mock_execute: unittest.mock.Mock) -> None:
+        """Compares the commands with what we had in the openshift/release yaml"""
+        run_tests("cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12")
+        commands: list[str] = [c[0][1][0] for c in mock_execute.call_args_list]
+        assert "make deploy9-cuda-jupyter-pytorch+llmcompressor-ubi9-python-3.12" in commands
+        assert "make test-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12" in commands
+        assert "make undeploy9-cuda-jupyter-pytorch+llmcompressor-ubi9-python-3.12" in commands
+
+    @unittest.mock.patch(target)
+    def test_make_commands_llmcompressor_runtime(self, mock_execute: unittest.mock.Mock) -> None:
+        """Compares the commands with what we had in the openshift/release yaml"""
+        run_tests("runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12")
+        commands: list[str] = [c[0][1][0] for c in mock_execute.call_args_list]
+        assert "make deploy9-runtimes-cuda-pytorch+llmcompressor-ubi9-python-3.12" in commands
+        assert "make validate-runtime-image image=runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12" in commands
+        assert "make undeploy9-runtimes-cuda-pytorch+llmcompressor-ubi9-python-3.12" in commands
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

## Description

```
# Deploying notebook from runtimes/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base directory...

arg=ghcr.io/opendatahub-io/notebooks/workbench-images bin/yq e -i '.images[].newName = strenv(arg)' runtimes/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml
arg=runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12-_8adf444fa4f489cd5b34d7fce14f94795812393b bin/yq e -i '.images[].newTag = strenv(arg)' runtimes/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml
bin/kubectl apply -k runtimes/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base
+ arg=ghcr.io/opendatahub-io/notebooks/workbench-images
+ bin/yq e -i '.images[].newName = strenv(arg)' runtimes/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml
Error: stat runtimes/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml: no such file or directory
```

https://github.com/opendatahub-io/notebooks/actions/runs/18656507192/job/53186868578#step:36:1

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/18660442091

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for new deployment and runtime variants with CUDA-enabled configurations and llmcompressor support, verifying deployment, validation, and cleanup commands execute as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->