### PR TITLE
RHAIENG-495: feat(base-images/cpu): give ourselves zeromq in base image

### DIFF
--- a/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
@@ -1,0 +1,22 @@
+ARG TARGETARCH
+
+FROM quay.io/sclorg/python-312-c9s:c9s AS buildscripts
+COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+
+####################
+# base             #
+####################
+FROM quay.io/sclorg/python-312-c9s:c9s AS base
+
+USER 0
+
+RUN \
+--mount=from=buildscripts,source=/mnt,target=/mnt \
+--mount=type=cache,sharing=locked,id=dnf-c9s,target=/var/cache/dnf \
+/bin/bash <<'EOF'
+/mnt/aipcc.sh
+EOF
+
+# Restore user workspace
+USER 1001
+WORKDIR /opt/app-root/src

--- a/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
@@ -1,0 +1,22 @@
+ARG TARGETARCH
+
+FROM registry.access.redhat.com/ubi9/python-312:latest AS buildscripts
+COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+
+####################
+# base             #
+####################
+FROM registry.access.redhat.com/ubi9/python-312:latest AS base
+
+USER 0
+
+RUN \
+--mount=from=buildscripts,source=/mnt,target=/mnt \
+--mount=type=cache,sharing=locked,id=dnf-ubi9,target=/var/cache/dnf \
+/bin/bash <<'EOF'
+/mnt/aipcc.sh
+EOF
+
+# Restore user workspace
+USER 1001
+WORKDIR /opt/app-root/src

--- a/base-images/utils/aipcc.sh
+++ b/base-images/utils/aipcc.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+DNF_OPTS=(-y --nodocs --setopt=install_weak_deps=False --setopt=keepcache=True)
+
+function install_epel() {
+    dnf install "${DNF_OPTS[@]}" https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+}
+
+function uninstall_epel() {
+    dnf remove "${DNF_OPTS[@]}" epel-release
+}
+
+function main() {
+    install_epel
+    trap uninstall_epel EXIT
+
+    dnf install "${DNF_OPTS[@]}" zeromq
+    if ! test -f /usr/lib64/libzmq.so.5; then
+        echo "Error: libzmq.so.5 was not found after installation"
+        exit 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-495

## Description
> Runtime Dependency Failure: Upstream fails due to missing system library (libzmq.so.5) because "codeready-builder" is not enabled in standard UBI.

## How Has This Been Tested?
```
❯ podman build -f base-images/cpu/ubi9-python-3.12/Dockerfile.cpu .
❯ podman build -f base-images/cpu/c9s-python-3.12/Dockerfile.cpu . 
```

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced updated multi-stage builds for Python 3.12 base images to streamline image creation.
  * Added an installation script to enable EPEL and install ZeroMQ, providing messaging library support.
  * Ensured container runs as a non-root user and refined package installation for improved security and reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->