### PR TITLE
RHAIENG-1602: fix(Dockerfile.rocm): create *.so symbolic links for ROCm 6.3.4 TensorFlow compatibility

### DIFF
--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -158,4 +158,9 @@ RUN echo "Installing softwares and packages" && \
 
 COPY ${JUPYTER_REUSABLE_UTILS}/usercustomize.pth ${JUPYTER_REUSABLE_UTILS}/monkey_patch_protobuf_6x.py /opt/app-root/lib/python3.12/site-packages/
 
+USER 0
+COPY ${TENSORFLOW_SOURCE_CODE}/utils/link-solibs.sh /tmp/link-solibs.sh
+RUN /tmp/link-solibs.sh && rm /tmp/link-solibs.sh
+USER 1001
+
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/utils/link-solibs.sh
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/utils/link-solibs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# TensorFlow-ROCm wants to link with `*.so` libraries without version suffixes.
+# This would require us to install the -devel packages, but that's cumbersome with AIPCC bases.
+# Therefore, simply create symlinks to the versioned libraries and (IMPORTANT!) run ldconfig afterwards.
+
+ROCM_PATH=/opt/rocm-6.3.4
+find "$ROCM_PATH/lib" -name '*.so.*' -type f -print0 |
+while IFS= read -r -d '' f; do
+  dir=${f%/*}                       # /opt/rocm-6.3.4/lib  (or sub-dir)
+  bn=${f##*/}                       # libMIOpen.so.1.0.60304
+  base=${bn%%.so*}                  # libMIOpen
+  soname=$base.so                   # libMIOpen.so
+  link=$dir/$soname                 # /opt/rocm-6.3.4/lib/libMIOpen.so
+  [[ -e $link ]] && continue
+  echo "ln -s $bn  →  $link"
+  ln -s "$bn" "$link"
+done
+
+# Run ldconfig to update the cache.
+ldconfig


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1602

## Description

This is a better approach than
* https://github.com/opendatahub-io/notebooks/pull/2610

because it is also applicable with AIPCC bases

## How Has This Been Tested?

```
sh-5.1# podman pull quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9:rhoai-3.0
Trying to pull quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9:rhoai-3.0...
Getting image source signatures
Copying blob 028a24e51342 done   | 
Copying blob 3a376e2ec371 done   | 
Copying blob ea465c0aa532 done   | 
Copying blob 3bcc3478f335 done   | 
Copying blob f70201c29128 done   | 
Copying blob 1d77b0681676 done   | 
Copying config 05f4757d58 done   | 
Writing manifest to image destination
05f4757d580399c163b9e874c74baf9d3914f05be3a1dbae1cce613a42e9d616

sh-5.1# podman run --rm -it --device /dev/kfd --device /dev/dri --entrypoint /bin/bash --user 0 quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9:rhoai-3.0

(app-root) ~$ python -c "import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; print(tf.config.list_physical_devices('GPU'))"
2025-10-23 16:11:53.049448: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512_VNNI AVX512_BF16 AVX512_FP16 AVX_VNNI AMX_TILE AMX_INT8 AMX_BF16 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2025-10-23 16:11:55.943322: W tensorflow/core/common_runtime/gpu/gpu_device.cc:2343] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.
Skipping registering GPU devices...
[]

(app-root) ~$ ld
ld        ldattach  ld.bfd    ldconfig  ldd       ld.gold   ld.so     

(app-root) ~$ ldconfig 

(app-root) ~$ python -c "import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; print(tf.config.list_physical_devices('GPU'))"
2025-10-23 16:12:05.270028: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512_VNNI AVX512_BF16 AVX512_FP16 AVX_VNNI AMX_TILE AMX_INT8 AMX_BF16 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2025-10-23 16:12:07.974094: W tensorflow/core/common_runtime/gpu/gpu_device.cc:2343] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.
Skipping registering GPU devices...
[]

(app-root) ~$ dnf install rocblas-devel rocsolver-devel rocfft-devel rocrand-devel rocsparse-devel miopen-hip-devel rccl-devel hipblas-devel hipblaslt-devel hipfft-devel hipsparse-devel hiprand-devel hipsolver-devel
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Red Hat Universal Base Image 9 (RPMs) - BaseOS                                                         7.8 MB/s | 531 kB     00:00    
Red Hat Universal Base Image 9 (RPMs) - AppStream                                                       22 MB/s | 2.4 MB     00:00    
Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder                                              4.8 MB/s | 287 kB     00:00    
No match for argument: rocblas-devel
No match for argument: rocsolver-devel
No match for argument: rocfft-devel
No match for argument: rocrand-devel
No match for argument: rocsparse-devel
No match for argument: miopen-hip-devel
No match for argument: rccl-devel
No match for argument: hipblas-devel
No match for argument: hipblaslt-devel
No match for argument: hipfft-devel
No match for argument: hipsparse-devel
No match for argument: hiprand-devel
No match for argument: hipsolver-devel
Error: Unable to find a match: rocblas-devel rocsolver-devel rocfft-devel rocrand-devel rocsparse-devel miopen-hip-devel rccl-devel hipblas-devel hipblaslt-devel hipfft-devel hipsparse-devel hiprand-devel hipsolver-devel

(app-root) ~$ ls -l /opt/rocm-6.3.4/lib/librocsolver.so*
lrwxrwxrwx. 1 root root         25 Feb 21  2025 /opt/rocm-6.3.4/lib/librocsolver.so.0 -> librocsolver.so.0.3.60304
-rwxr-xr-x. 1 root root 1710130472 Feb 21  2025 /opt/rocm-6.3.4/lib/librocsolver.so.0.3.60304

(app-root) ~$ ROCM_PATH=/opt/rocm-6.3.4
find "$ROCM_PATH/lib" -name '*.so.*' -type f -print0 |
while IFS= read -r -d '' f; do
  dir=${f%/*}                       # /opt/rocm-6.3.4/lib  (or sub-dir)
  bn=${f##*/}                       # libMIOpen.so.1.0.60304
  base=${bn%%.so*}                  # libMIOpen
  soname=$base.so                   # libMIOpen.so
  link=$dir/$soname                 # /opt/rocm-6.3.4/lib/libMIOpen.so
  [[ -e $link ]] && continue
  echo "ln -s $bn  →  $link"
  ln -s "$bn" "$link"
done
ln -s libMIOpen.so.1.0.60304  →  /opt/rocm-6.3.4/lib/libMIOpen.so
ln -s libhipblas.so.2.3.60304  →  /opt/rocm-6.3.4/lib/libhipblas.so
ln -s libhipblaslt.so.0.10.60304  →  /opt/rocm-6.3.4/lib/libhipblaslt.so
ln -s libhipfft.so.0.1.60304  →  /opt/rocm-6.3.4/lib/libhipfft.so
ln -s libhiprand.so.1.1.60304  →  /opt/rocm-6.3.4/lib/libhiprand.so
ln -s libhipsolver.so.0.3.60304  →  /opt/rocm-6.3.4/lib/libhipsolver.so
ln -s libhipsparse.so.1.1.0.60304  →  /opt/rocm-6.3.4/lib/libhipsparse.so
ln -s libhipsparselt.so.0.2.60304  →  /opt/rocm-6.3.4/lib/libhipsparselt.so
ln -s libhiptensor.so.0.1.60304  →  /opt/rocm-6.3.4/lib/libhiptensor.so
ln -s librccl.so.1.0.60304  →  /opt/rocm-6.3.4/lib/librccl.so
ln -s librocalution.so.1.0.60304  →  /opt/rocm-6.3.4/lib/librocalution.so
ln -s librocalution_hip.so.1.0.0.60304  →  /opt/rocm-6.3.4/lib/librocalution_hip.so
ln -s librocblas.so.4.3.60304  →  /opt/rocm-6.3.4/lib/librocblas.so
ln -s librocfft.so.0.1.60304  →  /opt/rocm-6.3.4/lib/librocfft.so
ln -s librocrand.so.1.1.60304  →  /opt/rocm-6.3.4/lib/librocrand.so
ln -s librocsolver.so.0.3.60304  →  /opt/rocm-6.3.4/lib/librocsolver.so
ln -s librocsparse.so.1.0.60304  →  /opt/rocm-6.3.4/lib/librocsparse.so
ln -s libroctracer64.so.4.1.60304  →  /opt/rocm-6.3.4/lib/libroctracer64.so
ln -s libroctx64.so.4.1.60304  →  /opt/rocm-6.3.4/lib/libroctx64.so

(app-root) ~$ python -c "import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; print(tf.config.list_physical_devices('GPU'))"
2025-10-23 16:15:03.889601: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512_VNNI AVX512_BF16 AVX512_FP16 AVX_VNNI AMX_TILE AMX_INT8 AMX_BF16 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2025-10-23 16:15:06.580625: W tensorflow/core/common_runtime/gpu/gpu_device.cc:2343] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.
Skipping registering GPU devices...
[]

(app-root) ~$ ldconfig 

(app-root) ~$ python -c "import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; print(tf.config.list_physical_devices('GPU'))"
2025-10-23 16:15:10.790646: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512_VNNI AVX512_BF16 AVX512_FP16 AVX_VNNI AMX_TILE AMX_INT8 AMX_BF16 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU'), PhysicalDevice(name='/physical_device:GPU:1', device_type='GPU'), PhysicalDevice(name='/physical_device:GPU:2', device_type='GPU'), PhysicalDevice(name='/physical_device:GPU:3', device_type='GPU'), PhysicalDevice(name='/physical_device:GPU:4', device_type='GPU'), PhysicalDevice(name='/physical_device:GPU:5', device_type='GPU'), PhysicalDevice(name='/physical_device:GPU:6', device_type='GPU')]
(app-root) ~$ 
```

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a build-time initialization step that creates missing unversioned library links and refreshes the system linker cache.
  * Ensures the ROCm TensorFlow image correctly resolves runtime shared libraries during startup for more reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->