### PR TITLE
RHAIENG-495: fix(Dockerfile.cpu): add `gettext` for required `envsubst` usage in `run-nginx.sh`

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -139,7 +139,17 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Install useful OS packages
-RUN dnf install -y jq git-lfs libsndfile && dnf clean all && rm -rf /var/cache/dnf
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+PACKAGES=(
+    jq git-lfs libsndfile
+    # provides envsubst which is required by run-nginx.sh
+    gettext
+)
+dnf install -y "${PACKAGES[@]}"
+dnf clean all
+rm -rf /var/cache/dnf
+EOF
 
 # wait for rpm-base stage (rpm builds for ppc64le and s390x)
 COPY --from=rpm-base /tmp/control /dev/null


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-495

## Description

```
Debug: '/opt/app-root/src/.vscode/launch.json' file created.
/opt/app-root/etc/generate_container_user: line 6: envsubst: command not found
ERROR: ld.so: object 'libnss_wrapper.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```

https://github.com/red-hat-data-services/notebooks/pull/1633#pullrequestreview-3350386165

Followup to previous PR that added this only for build stage
* https://github.com/opendatahub-io/notebooks/pull/2419

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized image build process with a consolidated, more robust package installation flow.
  * Added runtime system packages (jq, git-lfs, libsndfile, gettext) to support additional tooling.
  * Enabled stricter shell error handling during build for more reliable and debuggable builds.
  * Preserved and improved package cache cleanup to keep images lean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->