### PR TITLE
RHAIENG-287: fix(kustomization.yaml): abbreviate namePrefix to resolve Kubernetes label character limit issue

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml
@@ -1,7 +1,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namePrefix: jupyter-pytorch-llmcompressor-ubi9-python-3-12-
+# have to abbreviate the prefix, otherwise we'd go over the 63 character limit
+# > Pod "jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-0" is invalid: metadata.labels: Invalid value: "jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-7d69c59fc6": must be no more than 63 characters
+namePrefix: jupyter-pt-llmcompress-ubi9-python-3-12-
 labels:
   - includeSelectors: true
     pairs:

--- a/scripts/test_jupyter_with_papermill.sh
+++ b/scripts/test_jupyter_with_papermill.sh
@@ -346,6 +346,9 @@ function _get_notebook_id() {
         *${jupyter_pytorch_notebook_id}-*)
             notebook_id="${accelerator:+$accelerator/}${jupyter_pytorch_notebook_id}"
             ;;
+        *${jupyter_pytorch_llmcompressor_notebook_shortened_id}-*)
+            notebook_id="${accelerator:+$accelerator/}${jupyter_pytorch_llmcompressor_notebook_full_id}"
+            ;;
         *)
             printf '%s\n' "No matching condition found for ${notebook_workload_name}."
             exit 1
@@ -387,6 +390,8 @@ jupyter_datascience_notebook_id='datascience'
 jupyter_trustyai_notebook_id='trustyai'
 jupyter_pytorch_notebook_id='pytorch'
 jupyter_tensorflow_notebook_id='tensorflow'
+jupyter_pytorch_llmcompressor_notebook_shortened_id='pt-llmcompress'
+jupyter_pytorch_llmcompressor_notebook_full_id="pytorch-llmcompressor"
 
 notebook_name=$( _get_notebook_name "${test_target}" )
 python_flavor="python-${test_target//*-python-/}"  # <-- python-3.11


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-287

```
kubernetes namespace events
  [INFO] Running command (('kubectl get events',), {'shell': True})
  LAST SEEN   TYPE      REASON         OBJECT                                                                MESSAGE
  71s         Warning   FailedCreate   statefulset/jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook   create Pod jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-0 in StatefulSet jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook failed error: Pod "jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-0" is invalid: metadata.labels: Invalid value: "jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-7d69c59fc6": must be no more than 63 characters
```

## Description

* https://github.com/opendatahub-io/notebooks/issues/2616

## How Has This Been Tested?

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Shortened deployment name prefix to meet naming limits and updated image tag for the PyTorch LLM Compressor Jupyter environment.
  * Added service and stateful set resources to improve deployment resource management.
* **Bug Fixes**
  * Acceptance of a shortened notebook identifier during test runs by mapping it to the full notebook ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->