### PR TITLE
RHAIENG-1643: fix Pyarrow build for s390x

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -135,6 +135,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         git clone --depth 1 --branch "apache-arrow-17.0.0" https://github.com/apache/arrow.git && \
         cd arrow/cpp && \
         mkdir release && cd release && \
+        ARROW_S3_FLAG="" && \
+        if [ "$TARGETARCH" != "s390x" ]; then ARROW_S3_FLAG="-DARROW_S3=ON"; fi && \
         cmake -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=/usr/local \
               -DARROW_PYTHON=ON \
@@ -148,7 +150,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
               -DARROW_WITH_LZ4=OFF \
               -DARROW_WITH_ZSTD=OFF \
               -DARROW_WITH_SNAPPY=OFF \
-              -DARROW_S3=ON \
+              ${ARROW_S3_FLAG} \
               -DARROW_SUBSTRAIT=ON \
               -DARROW_BUILD_TESTS=OFF \
               -DARROW_BUILD_BENCHMARKS=OFF \


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1643

## Description

The s390x architecture (Big Endian) fails during Apache Arrow build when
AWS S3 support is enabled because AWS LC (libcrypto) dependency does not
support Big Endian architectures. The build fails with:

CMake Error:

```
  -- Configuring incomplete, errors occurred!
  
  -- stderr output is:
  libunwind not found. Disabling unwind tests.
  CMake Error at CMakeLists.txt:631 (message):
    Big Endian is not supported.
```

Solution: Conditionally disable ARROW_S3 for s390x architecture only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Docker image build configuration to make Arrow S3 support architecture-dependent, with support enabled for most systems and disabled on s390x architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->