### PR TITLE
NO-JIRA: chore(docs/adr): document onboarding onto all possible test execution platforms for evaluation

### DIFF
--- a/docs/architecture/decisions/0002-onboard-onto-all-possible-test-execution-platforms-available.md
+++ b/docs/architecture/decisions/0002-onboard-onto-all-possible-test-execution-platforms-available.md
@@ -26,7 +26,7 @@ This will provide us with sufficient knowledge to talk to Red Hat DevTestOps tea
 * Testing-Farm.io nested virtualization
 * <https://github.com/jiridanek/rhoai-in-kind>
 * Hydra trigger such as /test-e2e that will run something on Red Hat internal CI
-* Machine under @jiridanek's table in Brno
+* Machine under @jiridanek's desk in Brno
 * Virtual machines under our management on ITUP.scale platform in Red Hat
 
 ## Consequences


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/issues/1389

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record that formalizes onboarding and maintaining quick-start tests across multiple test execution platforms (CI providers, partner queues, nested virtualization, internal triggers and local options). Specifies owner responsibilities, lists platforms to consider, notes expected ongoing maintenance and criteria for offboarding unused platforms, and references an evaluation process for selecting the preferred E2E testing platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->