### PR TITLE
RHAIENG-1254: Add command to check Feast package version installed

### DIFF
--- a/ci/check-software-versions.py
+++ b/ci/check-software-versions.py
@@ -173,6 +173,7 @@ def process_dependency_item(item, container_id, annotation_type):
         "Sklearn-onnx": ["/bin/bash", "-c", "pip show skl2onnx | grep 'Version: '"],
         "MySQL Connector/Python": ["/bin/bash", "-c", "pip show mysql-connector-python | grep 'Version: '"],
         "Nvidia-CUDA-CU12-Bundle": ["/bin/bash", "-c", "pip show nvidia-cuda-runtime-cu12 | grep 'Version: '"],
+        "Feast": ["/bin/bash", "-c", "pip show feast | grep 'Version: '"],
         "Python": ["/bin/bash", "-c", "python --version"],
         "CUDA": ["/bin/bash", "-c", "nvcc --version"],
     }


### PR DESCRIPTION
Add validation to our CI tests to ensure that the Feast package is being tested as well with running the `--version` command.

## Description
Our build process executes some test commands to ensure that packages are installed properly. These commands are only executed if the package is listed on the ImageStream manifest file, so if the package is not there, the command will be skipped.

This PR aims to add the `pip show feast | grep --version` command to the CI tests, to ensure that the package is installed properly where applicable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the software version verification to include Feast in the list of dependencies checked in the container environment. This adds Feast to the runtime checks alongside existing tools, improving consistency of dependency reporting and helping surface version information during build and release processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->