### PR TITLE
NO-JIRA: chore(docs/adr): document language preference for Python, Go, and TypeScript

### DIFF
--- a/docs/architecture/decisions/0003-prefer-python-go-and-typescript-in-this-order.md
+++ b/docs/architecture/decisions/0003-prefer-python-go-and-typescript-in-this-order.md
@@ -31,9 +31,13 @@ It does not have proper runtime types (everything in Bash is a string, or possib
 it does not even have proper value-returning functions!
 
 There are efforts to level up Bash scripting, such as the `set -Eeuxo pipefail`, but it has
-[problems of its own](https://www.reddit.com/r/bash/comments/mivbcm/comment/gt8harr/):
+[problems](https://mywiki.wooledge.org/BashPitfalls#set_-euo_pipefail)
+[of](https://lobste.rs/s/gwzjjw/modern_bash_scripting)
+[its](https://www.mulle-kybernetik.com/modern-bash-scripting/)
+[own](https://www.reddit.com/r/bash/comments/mivbcm/comment/gt8harr/):
 
-> `errexit`, `nounset` and `pipefail` are imperfect implementations of otherwise sane ideas, and unfortunately they often amount to being unreliable interfaces that are less familiar and less understood than simply living without them. It's perfectly fine to want them to work as advertised, and I think we all would like that, but they don't, so shouldn't be recommended so blindly, nor advertised as a "best practice"—they aren't.
+> `errexit`, `nounset` and `pipefail` are imperfect implementations of otherwise sane ideas, and unfortunately they often amount to being unreliable interfaces that are less familiar and less understood than simply living without them.
+> It's perfectly fine to want them to work as advertised, and I think we all would like that, but they don't, so shouldn't be recommended so blindly, nor advertised as a "best practice"—they aren't.
 
 There is also the [bats](https://github.com/bats-core/bats-core) testing framework which does show promise if forced to live with a Bash codebase.
 


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/pull/858

https://redhat-internal.slack.com/archives/C0961HQ858Q/p1761933985263029?thread_ts=1761328992.287889&cid=C0961HQ858Q

## Description

I fully admit this is less than half-baked at this point, but I believe the core idea of committing to use Python, Go, and TypeScript is already something we can discuss. The decision has been [originally made back in Adriel's team](https://issues.redhat.com/browse/RHOAIENG-14780?focusedId=25998005&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-25998005), but we never wrote it down back then, besides in that Jira comment.

## How Has This Been Tested?

Some time ago we abandoned [skodjob/odh-e2e](https://github.com/skodjob/odh-e2e) because it was written in Java and we decided not to do Java. That's the Jira I linked above.

Given the teams [experience and preferences spreadsheet](https://docs.google.com/spreadsheets/d/1bEIPH61Og17EsvU86fqk2OHCkcE17wHijbUynXt0pRw/edit?gid=0#gid=0), Python, Go, and TypeScript seem reasonable choices.

## Ergo

<img width="391" height="199" alt="Screenshot 2025-12-20 at 12 10 59 AM" src="https://github.com/user-attachments/assets/087a7135-716c-4762-9e3f-e7c4fd4d7dff" />

* https://github.com/search?q=repo%3Aopendatahub-io%2Fnotebooks++language%3AShell&type=code

<details>

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an official architecture decision documenting a preferred language order (Python, Go, TypeScript). Includes rationale, consequences, phased migration guidance, type-checking and editor support recommendations, and language-specific notes. No functional or code changes were introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->