### PR TITLE
RHAIENG-1649: feat: add automated dependency lock generation script

### DIFF
--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -53,6 +53,10 @@ warn()  { echo -e "⚠️  \033[1;33m$1\033[0m"; }
 error() { echo -e "❌ \033[1;31m$1\033[0m"; }
 ok()    { echo -e "✅ \033[1;32m$1\033[0m"; }
 
+uppercase() {
+  echo "$1" | tr '[:lower:]' '[:upper:]'
+}
+
 # ----------------------------
 # PRE-FLIGHT CHECK
 # ----------------------------
@@ -169,8 +173,8 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
     else
       mkdir -p uv.lock
       output="uv.lock/pylock.${flavor}.toml"
-      desc="${flavor^^} lock file"
-      echo "➡️ Generating ${flavor^^} lock file..."
+      desc="$(uppercase "$flavor") lock file"
+      echo "➡️ Generating $(uppercase "$flavor") lock file..."
     fi
 
     set +e
@@ -194,7 +198,7 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
       if [[ "$INDEX_MODE" == "public-index" ]]; then
         ok "pylock.toml generated successfully."
       else
-        ok "${flavor^^} lock generated successfully."
+        ok "$(uppercase "$flavor") lock generated successfully."
       fi
     fi
   }
@@ -240,4 +244,5 @@ if [ ${#FAILED_DIRS[@]} -gt 0 ]; then
     echo "  • $d"
     echo "Please comment out the missing package to continue and report the missing package to aipcc"
   done
+  exit 1
 fi

--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ----------------------------
+# CONFIGURATION
+# ----------------------------
+CPU_INDEX="--index-url=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.0/cpu-ubi9/simple/"
+CUDA_INDEX="--index-url=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.0/cuda-ubi9/simple/"
+ROCM_INDEX="--index-url=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.0/rocm-ubi9/simple/"
+
+MAIN_DIRS=("jupyter" "runtimes" "rstudio" "codeserver")
+
+# ----------------------------
+# HELPER FUNCTIONS
+# ----------------------------
+info()  { echo -e "🔹 \033[1;34m$1\033[0m"; }
+warn()  { echo -e "⚠️  \033[1;33m$1\033[0m"; }
+error() { echo -e "❌ \033[1;31m$1\033[0m"; }
+ok()    { echo -e "✅ \033[1;32m$1\033[0m"; }
+
+# ----------------------------
+# PRE-FLIGHT CHECK
+# ----------------------------
+if ! command -v uv &>/dev/null; then
+  error "uv command not found. Please install uv: https://github.com/astral-sh/uv"
+  exit 1
+fi
+
+# (Optional) check uv version (requires version >= 0.4.0)
+UV_MIN_VERSION="0.4.0"
+UV_VERSION=$(uv --version 2>/dev/null | awk '{print $2}' || echo "0.0.0")
+
+version_ge() {
+  # returns 0 if $1 >= $2
+  [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]
+}
+
+if ! version_ge "$UV_VERSION" "$UV_MIN_VERSION"; then
+  error "uv version $UV_VERSION found, but >= $UV_MIN_VERSION is required."
+  error "Please upgrade uv: https://github.com/astral-sh/uv"
+  exit 1
+fi
+
+# ----------------------------
+# GET TARGET DIRECTORIES
+# ----------------------------
+if [ $# -gt 0 ]; then
+  TARGET_DIRS=("$1")
+else
+  info "Scanning main directories for Python projects..."
+  TARGET_DIRS=()
+  for base in "${MAIN_DIRS[@]}"; do
+    if [ -d "$base" ]; then
+      while IFS= read -r -d '' pyproj; do
+        TARGET_DIRS+=("$(dirname "$pyproj")")
+      done < <(find "$base" -type f -name "pyproject.toml" -print0)
+    fi
+  done
+fi
+
+if [ ${#TARGET_DIRS[@]} -eq 0 ]; then
+  error "No directories containing pyproject.toml were found."
+  exit 1
+fi
+
+# ----------------------------
+# MAIN LOOP
+# ----------------------------
+FAILED_DIRS=()
+SUCCESS_DIRS=()
+
+for TARGET_DIR in "${TARGET_DIRS[@]}"; do
+  echo
+  echo "==================================================================="
+  info "Processing directory: $TARGET_DIR"
+  echo "==================================================================="
+
+  cd "$TARGET_DIR" || continue
+  mkdir -p uv.lock
+  PYTHON_VERSION="${PWD##*-}"
+
+  # Validate Python version extraction
+  if [[ ! "$PYTHON_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    warn "Could not extract valid Python version from directory name: $PWD"
+    warn "Expected directory format: .../ubi9-python-X.Y"
+    cd - >/dev/null
+    continue
+  fi
+
+  # Detect available Dockerfiles (flavors)
+  HAS_CPU=false
+  HAS_CUDA=false
+  HAS_ROCM=false
+  [ -f "Dockerfile.cpu" ] && HAS_CPU=true
+  [ -f "Dockerfile.cuda" ] && HAS_CUDA=true
+  [ -f "Dockerfile.rocm" ] && HAS_ROCM=true
+
+  if ! $HAS_CPU && ! $HAS_CUDA && ! $HAS_ROCM; then
+    warn "No Dockerfiles found in $TARGET_DIR (cpu/cuda/rocm). Skipping."
+    cd - >/dev/null
+    continue
+  fi
+
+  echo "📦 Python version: $PYTHON_VERSION"
+  echo "🧩 Detected flavors:"
+  $HAS_CPU && echo "  • CPU"
+  $HAS_CUDA && echo "  • CUDA"
+  $HAS_ROCM && echo "  • ROCm"
+  echo
+
+  DIR_SUCCESS=true
+
+  run_lock() {
+    local flavor="$1"
+    local index="$2"
+    local output="uv.lock/pylock.${flavor}.toml"
+
+    echo "➡️ Generating ${flavor^^} lock file..."
+    set +e
+    uv pip compile pyproject.toml \
+      --output-file "$output" \
+      --format pylock.toml \
+      --generate-hashes \
+      --emit-index-url \
+      --python-version="$PYTHON_VERSION" \
+      --python-platform linux \
+      --no-annotate \
+      $index
+    local status=$?
+    set -e
+
+    if [ $status -ne 0 ]; then
+      warn "${flavor^^} lock failed in $TARGET_DIR"
+      rm -f "$output"
+      DIR_SUCCESS=false
+    else
+      ok "${flavor^^} lock generated successfully."
+    fi
+  }
+
+  $HAS_CPU && run_lock "cpu" "$CPU_INDEX"
+  $HAS_CUDA && run_lock "cuda" "$CUDA_INDEX"
+  $HAS_ROCM && run_lock "rocm" "$ROCM_INDEX"
+
+  if $DIR_SUCCESS; then
+    SUCCESS_DIRS+=("$TARGET_DIR")
+  else
+    FAILED_DIRS+=("$TARGET_DIR")
+  fi
+
+  cd - >/dev/null
+done
+
+# ----------------------------
+# SUMMARY
+# ----------------------------
+echo
+echo "==================================================================="
+ok "Lock generation complete."
+echo "==================================================================="
+
+if [ ${#SUCCESS_DIRS[@]} -gt 0 ]; then
+  echo "✅ Successfully generated locks for:"
+  for d in "${SUCCESS_DIRS[@]}"; do
+    echo "  • $d"
+  done
+fi
+
+if [ ${#FAILED_DIRS[@]} -gt 0 ]; then
+  echo
+  warn "Failed lock generation for:"
+  for d in "${FAILED_DIRS[@]}"; do
+    echo "  • $d"
+    echo "Please comment out the missing package to continue and report the missing package to aipcc"
+  done
+fi


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHAIENG-1489 
and partially to: https://issues.redhat.com/browse/RHAIENG-1649 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR introduces `pylock_generator.sh`, a Bash automation tool that generates
`uv` lock files (`pylock.toml`) for all supported notebook image flavors and runtimes.

Key features:
- Supports targeted mode (specific directory) and automatic mode (repo-wide)
- Detects available Dockerfiles (CPU, CUDA, ROCm) and locks accordingly
- Supports two modes of indexes. `aipcc-index` → Uses internal Red Hat AIPCC wheel indexes and generates per-flavor locks (uv.lock/pylock.<flavor>.toml). And `public-index` → Uses public PyPI index and updates pylock.toml in-place in the project directory. This Index is currently by default as our odh images are not yet ready to use aipcc wheels. Once ready we can simply tune the to INDEX_MODE=aipcc-index. 
- Includes detailed progress and error reporting
- Reduces duplication and complexity in the Makefile

## How can be used

Using the makefile recipe or run the script directly.

Modes: 
1. Run for in automatic mode (repo-wide) 
via makefile: `gmake refresh-lock-files` Or the script like: `bash scripts/pylocks_generator.sh`

2. Specify the index you desire (for now default is the public pypi)
`gmake refresh-lock-files INDEX_MODE=aipcc-index` or `bash scripts/pylocks_generator.sh aipcc-index`

3. Lock using public index and specific directory:

`gmake refresh-lock-files INDEX_MODE=aipcc-index DIR=jupyter/minimal/ubi9-python-3.12` or `bash scripts/pylocks_generator.sh public-index jupyter/minimal/ubi9-python-3.12`

--
**NOTE:** If there is a missing package on `pyproject.toml` it will produces the following(for example):

```
  × No solution found when resolving dependencies:
  ╰─▶ Because kubeflow-training was not found in the package registry and datascience-notebook depends on kubeflow-training==1.9.3, we can conclude that your requirements are unsatisfiable.
 ``` 
so in this case you can comment out problematic package in the above case the kubeflow-training,  and run it again, and probably it will print another missing package, and so on. **So these missing packages should be reported to AIPCC team.**

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automation to generate per-target Python dependency lock files for multiple hardware flavors (CPU, CUDA, ROCm) with selectable index modes (public-index vs aipcc-index).
  * Validates and skips non-conforming targets, records per-target successes/failures, cleans up on failure, prints remediation guidance, and returns a non-zero exit on any failure.
  * Exposed a new INDEX_MODE variable and streamlined build target to invoke the lock-generation workflow; supports optional per-directory invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->