### PR TITLE
NO-JIRA: refactor(jupyter/minimal/Dockerfile.cpu): wrap multiple RUN commands with bash for improved readability and error handling

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -34,7 +34,12 @@ EOF
 # upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
-RUN dnf install -y perl mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+dnf install -y perl mesa-libGL skopeo
+dnf clean all
+rm -rf /var/cache/yum
+EOF
 
 # Other apps and tools installed as default user
 USER 1001
@@ -89,21 +94,24 @@ USER 1001
 COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
 # Install Python dependencies from requirements.txt file
-RUN echo "Installing softwares and packages" && \
-    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
-    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
-    # Disable announcement plugin of jupyterlab \
-    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
-    # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \
-    sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json && \
-    # copy jupyter configuration
-    cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter && \
-    # Fix permissions to support pip in Openshift environments \
-    chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
-    fix-permissions /opt/app-root -P && \
-    # Apply JupyterLab addons \
-    /opt/app-root/bin/utils/addons/apply.sh
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+echo "Installing softwares and packages"
+# This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+#  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+# Disable announcement plugin of jupyterlab
+jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+# Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
+sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
+# copy jupyter configuration
+cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# Fix permissions to support pip in Openshift environments
+chmod -R g+w /opt/app-root/lib/python3.12/site-packages
+fix-permissions /opt/app-root -P
+# Apply JupyterLab addons
+/opt/app-root/bin/utils/addons/apply.sh
+EOF
 
 WORKDIR /opt/app-root/src
 


### PR DESCRIPTION
Carrying on with

* https://github.com/opendatahub-io/notebooks/pull/2645
* https://github.com/opendatahub-io/notebooks/pull/2647

## Description

Reformat inline bash commands into HEREDOC blocks, so they can be later extracted to separate script files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored Docker build process to improve error handling and build reliability through enhanced command sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->