### PR TITLE
RHOAIENG-24702, RHOAIENG-38121: add AI Pipelines exceptions to check-payload

### DIFF
--- a/scripts/check-payload/config.toml
+++ b/scripts/check-payload/config.toml
@@ -170,6 +170,36 @@ dirs = ["/assets/downloads/cli"]
 error = "ErrGoMissingTag"
 dirs = ["/assets/downloads/cli"]
 
+# AI Pipelines override (RHOAIENG-24702 and RHOAIENG-38121)
+# When FIPS is enabled, /usr/bin/argoexec-fips is used. /usr/bin/argoexec is
+# only used for portability reasons in non-FIPS environments.
+[[payload.odh-data-science-pipelines-argo-argoexec-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/argoexec"]
+
+[[payload.odh-data-science-pipelines-argo-argoexec-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/argoexec"]
+
+[[payload.odh-data-science-pipelines-argo-argoexec-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/argoexec"]
+
+# AI Pipelines override (RHOAIENG-24702 and RHOAIENG-38121)
+# When FIPS is enabled, /usr/bin/launcher-v2-fips is used. /usr/bin/launcher-v2 is
+# only used for portability reasons in non-FIPS environments.
+[[payload.odh-ml-pipelines-launcher-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/launcher-v2"]
+
+[[payload.odh-ml-pipelines-launcher-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/launcher-v2"]
+
+[[payload.odh-ml-pipelines-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/launcher-v2"]
+
 # Temporary supprsssions for workbenches
 # https://github.com/openshift/check-payload/blob/main/internal/types/errors.go
 


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C09GK0M9YKD/p1762444060933119?thread_ts=1762370844.652579&cid=C09GK0M9YKD

## Description

These exceptions are required because AI Pipelines uses two different binaries when in FIPS mode vs non-FIPS mode. The reason is that these binaries are copied to the user's provided base image and in FIPS mode, this means the OpenSSL version must match (e.g. UBI 9). In non-FIPS mode, we leverage the builtin Go crypto so that the binaries are portable.

Relates:
https://issues.redhat.com/browse/RHOAIENG-24702
https://issues.redhat.com/browse/RHOAIENG-38121

## How Has This Been Tested?

I ran check-payload on the latest released RHOAI images.

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added new ignore rules for certain pipeline container checks, covering both FIPS and non‑FIPS variants to align configuration across deployment profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->