### PR TITLE
RHOAIENG-38634: add `latest` additional tags for c9s Docker base image

### DIFF
--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -28,6 +28,10 @@ spec:
     value: base-images/cpu/c9s-python-3.12/Dockerfile.cpu
   - name: path-context
     value: .
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+    - latest
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-38634

## Description

So that I can reference `:latest` in
* https://github.com/opendatahub-io/notebooks/pull/2664

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to apply additional tags to container images, enabling easier identification by branch revision and latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->