### PR TITLE
RHAIENG-948: update subscription value to "true" in build-notebooks-pr-aipcc workflow and when building on push in rhds/notebooks

### DIFF
--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -89,6 +89,6 @@ jobs:
       python: "${{ matrix.python }}"
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
-      # AIPCC base images are RHEL-based, subscription is good for them
+      # rhds/notebooks builds from AIPCC base images that are RHEL-based
       subscription: "true"
     secrets: inherit

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -53,5 +53,6 @@ jobs:
       python: "${{ matrix.python }}"
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
-      subscription: "${{ matrix.subscription }}"
+      # rhds/notebooks builds from AIPCC base images that are RHEL-based
+      subscription: "${{ matrix.subscription || (github.repository == 'red-hat-data-services/notebooks') }}"
     secrets: inherit


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/RHAIENG-948

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/19299930162

Tried this out first in
* https://github.com/red-hat-data-services/notebooks/pull/1689

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows for notebook builds to refine subscription configuration handling across pull request validation and main branch deployment scenarios, with improved repository-aware logic for optimized build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->