### PR TITLE
RHAIENG-948: chore(rstudio): add conditional `subscription-manager refresh`

### DIFF
--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -24,6 +24,13 @@ USER root
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 COPY --from=ubi-repos /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -24,6 +24,13 @@ USER root
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 COPY --from=ubi-repos /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)


### PR DESCRIPTION
follows up on
* https://github.com/opendatahub-io/notebooks/pull/2670

https://issues.redhat.com/browse/RHAIENG-948

## Description

we may have c9s, ubi9, as well as rhel9, either already subscribed or not; every case must be handled

when there is subscription-manager present, we need to then check if we are pre-subscribed or not, and if we are, we refresh the subscription

it is a mistake trying to run subscription-manger on c9s (binary not present) or when we are not pre-subscribed (refresh fails)

this should be the universal pattern applicable in odh-io as well as rhods

```
[2/3] STEP 6/10: RUN /bin/bash <<'EOF' (set -Eeuxo pipefail...)
+ dnf -y upgrade --refresh --nobest --skip-broken --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0
Red Hat Enterprise Linux 9 for x86_64 - AppStre 6.5 kB/s | 473  B     00:00
Errors during downloading metadata for repository 'rhel-9-for-x86_64-appstream-eus-rpms':
  - Status code: 403 for https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/repomd.xml (IP: 23.60.144.251)
Error: Failed to download metadata for repo 'rhel-9-for-x86_64-appstream-eus-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
Error: building at STEP "RUN /bin/bash <<'EOF'": while running runtime: exit status 1
```

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/19303608633

Tried this out first in

* https://github.com/red-hat-data-services/notebooks/pull/1689

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CPU and CUDA Docker image builds with conditional subscription-manager checks that gracefully handle environments where the manager is unavailable or unregistered, improving build robustness across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->