### PR TITLE
RHAIENG-948: chore(rstudio): add npm installation to support cve_remediation when using AIPCC base image lacking npm by default

### DIFF
--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -151,6 +151,8 @@ mkdir -p /usr/share/doc/R
 # package installation
 # install necessary texlive-framed package to make Knit R markup to PDF rendering possible
 dnf install -y libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed
+# install npm to run cve_remediation script
+dnf install -y npm
 dnf clean all
 rm -rf /var/cache/yum
 (cd /tmp/utils && ./cve_remediation.sh)

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -165,6 +165,8 @@ mkdir -p /usr/share/doc/R
 # package installation
 # install necessary texlive-framed package to make Knit R markup to PDF rendering possible
 dnf install -y libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed
+# install npm to run cve_remediation script
+dnf install -y npm
 dnf clean all
 rm -rf /var/cache/yum
 (cd /tmp/utils && ./cve_remediation.sh)


### PR DESCRIPTION


```
+ ./cve_remediation.sh
++ uname -m
+ rm /usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild
+ npm ci
./cve_remediation.sh: line 7: npm: command not found
```

## Description

follows up on
* https://github.com/opendatahub-io/notebooks/pull/2670
* https://github.com/opendatahub-io/notebooks/pull/2671

https://issues.redhat.com/browse/RHAIENG-948

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/19304675491

Tried this out first in

* https://github.com/red-hat-data-services/notebooks/pull/1689

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container images to include npm, ensuring all necessary dependencies are available during the build process for the Python 3.12 RHEL9 environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->