### PR TITLE
RHOAIENG-38634: sync(rstudio): comment out R packages installation same as we do in rhds/notebooks

### DIFF
--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -171,9 +171,10 @@ COPY ${RSTUDIO_SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 # # https://cran.r-project.org/web/packages
 # COPY ${RSTUDIO_SOURCE_CODE}/install_packages.R ./
 # RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-R -f ./install_packages.R
-#     rm ./install_packages.REOF
+# set -Eeuxo pipefail
+# R -f ./install_packages.R
+# rm ./install_packages.R
+# EOF
 
 ENV APP_ROOT=/opt/app-root
 

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -185,9 +185,10 @@ COPY ${RSTUDIO_SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 # # https://cran.r-project.org/web/packages
 # COPY ${RSTUDIO_SOURCE_CODE}/install_packages.R ./
 # RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-R -f ./install_packages.R
-#     rm ./install_packages.REOF
+# set -Eeuxo pipefail
+# R -f ./install_packages.R
+# rm ./install_packages.R
+# EOF
 
 ENV APP_ROOT=/opt/app-root
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-38634

## Description

rstudio minimal image should not install this many packages

cherry-picked from
* https://github.com/red-hat-data-services/notebooks/pull/1624

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled R package installation during RStudio RHEL 9 Python 3.12 image builds (CPU and CUDA variants). The original installation steps are preserved as comments for reference. As a result, R packages will no longer be installed during the image build process, affecting the contents of the produced images and reducing build-time package execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->