### PR TITLE
RHAIENG-1758- Revise Tests for 2025b Onboarding: PandocMissing

### DIFF
--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -57,12 +57,13 @@ class TestJupyterLabImage:
     @allure.description("Check that PDF export is working correctly")
     def test_pdf_export(self, jupyterlab_image: conftest.Image) -> None:
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
-        # Skip if we're running on s390x architecture
+        # Skip if we're running architectures where PDF export is not supported
         container.start(wait_for_readiness=False)
         try:
             exit_code, arch_output = container.exec(["uname", "-m"])
-            if exit_code == 0 and arch_output.decode().strip() == "s390x":
-                pytest.skip("PDF export functionality is not supported on s390x architecture")
+            arch = arch_output.decode().strip()
+            if exit_code == 0 and arch in ("s390x", "ppc64le"):
+                pytest.skip("PDF export functionality is not supported on s390x/ppc64le architecture")
         finally:
             docker_utils.NotebookContainer(container).stop(timeout=0)
         test_file_name = "test.ipybn"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes for https://issues.redhat.com/browse/RHAIENG-1758
## Description
<!--- Describe your changes in detail -->
Updated GA with missing Pandoc 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the PDF export test to better detect CPU architecture and skip execution on s390x and ppc64le systems; skip messaging updated for clarity to reflect these additional excluded architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->