### PR TITLE
RHAIENG-948: fix(jupyter datascience on IBM/Power): build failure due to AIPCC base (missing curl and openssl -devel packages) and AIPCC wheels (some prereqs are missing)

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -398,6 +398,9 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
 
     # required to compile maturin
     openssl-devel
+
+    # required to compile scikit-learn
+    gcc-gfortran
   )
   dnf install -y "${packages[@]}"
 fi


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-32541
https://issues.redhat.com/browse/RHAIENG-948

## Description

* https://github.com/red-hat-data-services/notebooks/pull/1697

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration for CPU-based images to optimize dependency resolution and support for multiple processor architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->