### PR TITLE
RHAIENG-1965: chore(cli): introduce Download Elyra Bootstrapper template and subscription-manager refresh template

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -84,6 +84,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -40,13 +40,6 @@ EOF
 # cpu-base         #
 ####################
 FROM ${BASE_IMAGE} AS cpu-base
-USER 0
-RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
-fi
-EOF
 
 WORKDIR /opt/app-root/bin
 
@@ -60,6 +53,14 @@ ARG TARGETARCH
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -22,6 +22,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -24,6 +24,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -22,6 +22,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -40,6 +40,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -40,6 +40,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -38,6 +38,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -38,6 +38,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -40,6 +40,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -63,6 +63,14 @@ USER root
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -20,6 +20,14 @@ RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "mic
 USER root
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -16,6 +16,14 @@ WORKDIR /opt/app-root/bin
 USER root
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -24,6 +24,8 @@ USER root
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 COPY --from=ubi-repos /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
@@ -31,7 +33,6 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-### BEGIN upgrade first to avoid fixable vulnerabilities
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -24,6 +24,8 @@ USER root
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 COPY --from=ubi-repos /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
@@ -31,7 +33,6 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-### BEGIN upgrade first to avoid fixable vulnerabilities
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -26,6 +26,14 @@ COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 ARG TARGETARCH
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -22,6 +22,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -24,6 +24,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -24,6 +24,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -22,6 +22,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -22,6 +22,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -26,6 +26,14 @@ USER 0
 COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
+# If we have a Red Hat subscription prepared, refresh it
+RUN /bin/bash <<'EOF'
+set -Eeuxo pipefail
+if command -v subscription-manager &> /dev/null; then
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+fi
+EOF
+
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
 # Solution: --best --skip-broken does not work either, so use --nobest

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -35,6 +35,14 @@ def main():
 
         replacements = {
             "upgrade first to avoid fixable vulnerabilities": textwrap.dedent(r"""
+                # If we have a Red Hat subscription prepared, refresh it
+                RUN /bin/bash <<'EOF'
+                set -Eeuxo pipefail
+                if command -v subscription-manager &> /dev/null; then
+                  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+                fi
+                EOF
+
                 # Problem: The operation would result in removing the following protected packages: systemd
                 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
                 # Solution: --best --skip-broken does not work either, so use --nobest


### PR DESCRIPTION
## Description

* https://github.com/opendatahub-io/notebooks/pull/2682

https://issues.redhat.com/browse/RHAIENG-1965

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional Red Hat subscription refresh during image build preparation. When available, subscriptions are automatically refreshed to ensure package management systems are current and functional before package updates proceed.

* **Chores**
  * Enhanced build structure organization with explicit section markers for clarity and maintainability. Build steps are now clearly delineated with structural markers across multiple container image variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->