### PR TITLE
RHAIENG-2042: chore(base-images): add `ppc64le` (and `s390x` todo later) architectures to `odh-base-image-cpu-py312-c9s`

### DIFF
--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -38,6 +38,9 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+    - linux/ppc64le
+    # TODO(jdanek): Enable s390x once it is supported in the base image.
+    #- linux/s390x
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -36,6 +36,9 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+    - linux/ppc64le
+    # TODO(jdanek): Enable s390x once it is supported in the base image.
+    #- linux/s390x
   pipelineRef:
     name: multiarch-push-pipeline
   taskRunTemplate:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-2042

## Description

Enablement work for
* https://github.com/opendatahub-io/notebooks/pull/2687

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added PowerPC 64-bit (ppc64le) to the build platforms, expanding multi-architecture build coverage alongside x86_64 and ARM64.
  * Support for s390x remains pending (commented/out and marked TODO); not yet enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->