### PR TITLE
Add additional ARGS for pylock locations and names

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -2,6 +2,8 @@
 # configuration args    #
 #########################
 ARG BASE_IMAGE
+ARG PYLOCK_PATH
+ARG PYLOCK_NAME
 
 # External image alias for UBI repository configuration
 FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
@@ -66,6 +68,8 @@ FROM cpu-base AS jupyter-minimal
 
 ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
+ARG PYLOCK_PATH
+ARG PYLOCK_NAME
 
 LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.12" \
     summary="Minimal Jupyter notebook image for ODH notebooks" \
@@ -91,15 +95,16 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}${PYLOCK_PATH} ./${PYLOCK_NAME}
+COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh .
 
-# Install Python dependencies from requirements.txt file
+# Install Python dependencies from pylock file
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./${PYLOCK_NAME}
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -4,6 +4,8 @@ ARG TARGETARCH
 # configuration args    #
 #########################
 ARG BASE_IMAGE
+ARG PYLOCK_PATH
+ARG PYLOCK_NAME
 
 ####################
 # cuda-base        #
@@ -65,6 +67,8 @@ FROM cuda-base AS cuda-jupyter-minimal
 
 ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
+ARG PYLOCK_PATH
+ARG PYLOCK_NAME
 
 LABEL name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12" \
     summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \
@@ -90,15 +94,16 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}${PYLOCK_PATH} ./${PYLOCK_NAME}
+COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh .
 
-# Install Python dependencies from requirements.txt file
+# Install Python dependencies from pylock file
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./${PYLOCK_NAME}
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -2,6 +2,8 @@
 # configuration args    #
 #########################
 ARG BASE_IMAGE
+ARG PYLOCK_PATH
+ARG PYLOCK_NAME
 
 ####################
 # rocm-base        #
@@ -63,6 +65,8 @@ FROM rocm-base AS rocm-jupyter-minimal
 
 ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
+ARG PYLOCK_PATH
+ARG PYLOCK_NAME
 
 LABEL name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12" \
     summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \
@@ -88,15 +92,16 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}${PYLOCK_PATH} ./${PYLOCK_NAME}
+COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh .
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from pylock file
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./${PYLOCK_NAME}
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,4 @@
 # Base Image   : c9s with Python 3.12
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
+PYLOCK_PATH=/pylock.toml
+PYLOCK_NAME=pylock.toml

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,3 @@
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.8
+PYLOCK_PATH=/pylock.toml
+PYLOCK_NAME=pylock.toml

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,3 @@
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.3
+PYLOCK_PATH=/pylock.toml
+PYLOCK_NAME=pylock.toml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR prepares the ground for: https://issues.redhat.com/browse/RHAIENG-1650 as i need to specify different locations for pylocks on the konflux flavors that introduced on https://github.com/red-hat-data-services/notebooks/pull/1668 

## Description
<!--- Describe your changes in detail -->
Add additional ARGS for pylock locations and names


Related to: https://issues.redhat.com/browse/RHAIENG-2096

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local `gmake cuda-jupyter-minimal-ubi9-python-3.12` completed successfully (for all the flavors cpu/cuda/rocm). 


Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker build configs for Jupyter updated to support configurable dependency lockfile path and name across CPU, CUDA, and ROCm images.
  * Dependency installation now uses the configurable lockfile name instead of a hardcoded filename.
  * Notebook startup script handling preserved and aligned with the new configurable lockfile behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->