### PR TITLE
RHAIENG-2111: chore(trustyai): clean up temporary build files

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -196,6 +196,9 @@ if [[ $(uname -m) == "ppc64le" ]] || [[ $(uname -m) == "s390x" ]]; then
 
     uv pip list
     cd ${CURDIR}
+
+    # cleanup temporary build files
+    rm -rf ${TMP}
 else
     # only for mounting on non-ppc64le and non-s390x
     mkdir -p /root/OpenBLAS/

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -27,14 +27,21 @@ fi
 echo "Installing TexLive to allow PDf export from Notebooks"
 curl -fL https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -o install-tl-unx.tar.gz
 zcat < install-tl-unx.tar.gz | tar xf -
-cd install-tl-2*
+rm install-tl-unx.tar.gz
+pushd install-tl-2*
 perl ./install-tl --no-interaction --scheme=scheme-small --texdir=/usr/local/texlive
+popd
+rm -rf install-tl-2*
 mv /usr/local/texlive/bin/"$(uname -m)-linux" /usr/local/texlive/bin/linux
-cd /usr/local/texlive/bin/linux
+pushd /usr/local/texlive/bin/linux
 ./tlmgr install tcolorbox pdfcol adjustbox titling enumitem soul ucs collection-fontsrecommended
+popd
 
 # pandoc installation
 curl -fL "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-linux-${ARCH}.tar.gz"  -o /tmp/pandoc.tar.gz
 mkdir -p /usr/local/pandoc
 tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/pandoc/
 rm -f /tmp/pandoc.tar.gz
+
+# clean up /tmp
+rm -rf /tmp/* /tmp/.[!.]*


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-2111

## Description

## How Has This Been Tested?
* https://github.com/opendatahub-io/notebooks/actions/runs/19769826625/job/56651412462?pr=2740

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved temporary file cleanup during build processes
  * Optimized directory navigation during installation procedures
  * Enhanced removal of temporary build artifacts and installer files
  * Refined temporary directory management for build environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->