### PR TITLE
NO-JIRA: tests(containers): fix a wrongly applied ruff autofix for pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,13 @@ ignore = [
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
+# Don't suggest moving types used in Pydantic models into `if TYPE_CHECKING` import blocks
+# https://docs.astral.sh/ruff/settings/#lint_flake8-type-checking_runtime-evaluated-base-classes
+flake8-type-checking.runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+# https://docs.astral.sh/ruff/settings/#lint_pep8-naming_classmethod-decorators
+pep8-naming.classmethod-decorators = ["pydantic.validator"]
+
 # https://docs.astral.sh/ruff/formatter
 [tool.ruff.format]
 line-ending = "lf"

--- a/tests/containers/pydantic_schemas/podman_machine_inspect.py
+++ b/tests/containers/pydantic_schemas/podman_machine_inspect.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from datetime import datetime
 
 from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    from datetime import datetime
 
 
 class ConfigDir(BaseModel):


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/issues/2747

## Description

I broke this in

* https://github.com/opendatahub-io/notebooks/pull/2733

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality and type-checking configuration standards.

* **Tests**
  * Improved internal test infrastructure for better type annotation support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->