### PR TITLE
NO-JIRA: manifests: update orders of Image Streams

### DIFF
--- a/ci/package_versions_selftestdata.py
+++ b/ci/package_versions_selftestdata.py
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Minimal Python"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "1"
+    opendatahub.io/notebook-image-order: "4"
   name: jupyter-minimal-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/codeserver"
     opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
-    opendatahub.io/notebook-image-order: "19"
+    opendatahub.io/notebook-image-order: "14"
   name: code-server-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "3"
+    opendatahub.io/notebook-image-order: "5"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-minimal-gpu-notebook
 spec:

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
-    opendatahub.io/notebook-image-order: "1"
+    opendatahub.io/notebook-image-order: "4"
   name: jupyter-minimal-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch+llmcompressor/ubi9-python-3.12"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch LLM Compressor | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch LLM Compressor libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "10"
+    opendatahub.io/notebook-image-order: "9"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-llmcompressor
 spec:

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/pytorch"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "9"
+    opendatahub.io/notebook-image-order: "8"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-notebook
 spec:

--- a/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm"
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "5"
+    opendatahub.io/notebook-image-order: "6"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-minimal
 spec:

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm/pytorch"
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "12"
+    opendatahub.io/notebook-image-order: "10"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-pytorch
 spec:

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/rocm/tensorflow"
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized TensorFlow notebook image for ODH notebooks."
-    opendatahub.io/notebook-image-order: "16"
+    opendatahub.io/notebook-image-order: "12"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-tensorflow
 spec:

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/blob/main/jupyter/tensorflow"
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-    opendatahub.io/notebook-image-order: "14"
+    opendatahub.io/notebook-image-order: "11"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-tensorflow-notebook
 spec:

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai"
     opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
-    opendatahub.io/notebook-image-order: "17"
+    opendatahub.io/notebook-image-order: "13"
   name: jupyter-trustyai-notebook
 spec:
   lookupPolicy:

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
     opendatahub.io/notebook-image-name: "RStudio | Minimal | CUDA | R 4.5"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
-    opendatahub.io/notebook-image-order: "22"
+    opendatahub.io/notebook-image-order: "16"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: rstudio-gpu-notebook
 spec:

--- a/manifests/base/rstudio-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-notebook-imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
     opendatahub.io/notebook-image-name: "RStudio | Minimal | CPU | R 4.5"
     opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
-    opendatahub.io/notebook-image-order: "21"
+    opendatahub.io/notebook-image-order: "15"
   name: rstudio-notebook
 spec:
   lookupPolicy:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated image order numbers to start from 4, making room for the new universal training images (CUDA, ROCm, CPU) to appear at the top of the workbench dropdown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized notebook image display ordering to improve user navigation and experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->