### PR TITLE
RHAIENG-2187: chore(.github): specify platform in build-notebooks workflow for `subscription-manager register`

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -104,6 +104,7 @@ jobs:
           mkdir entitlement
           mkdir consumer
           docker run \
+            --platform=${{ inputs.platform }} \
             -v ${PWD}/entitlement:/etc/pki/entitlement:Z \
             -v ${PWD}/consumer:/etc/pki/consumer:Z \
             --rm -t registry.access.redhat.com/ubi9/ubi \


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-2187

## Description

It looks like the subscription data are platform-dependent, and we need to subscribe on the same architecture as we later use the subscription certs from.

## How Has This Been Tested?
* https://github.com/red-hat-data-services/notebooks/actions/runs/20239754756/job/58104257583

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration for improved cross-platform compatibility in CI/CD workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->