### PR TITLE
RHAIENG-2460: Update x86_64 to amd64

### DIFF
--- a/.tekton/multiarch-pull-request-pipeline.yaml
+++ b/.tekton/multiarch-pull-request-pipeline.yaml
@@ -90,7 +90,7 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array

--- a/.tekton/multiarch-push-pipeline.yaml
+++ b/.tekton/multiarch-push-pipeline.yaml
@@ -112,7 +112,7 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array

--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -36,7 +36,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -34,7 +34,7 @@ spec:
     - latest
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-base-image-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-ubi9-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -36,7 +36,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   pipelineRef:
     name: multiarch-pull-request-pipeline

--- a/.tekton/odh-base-image-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-ubi9-push.yaml
@@ -30,7 +30,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   pipelineRef:
     name: multiarch-push-pipeline

--- a/.tekton/odh-base-image-cuda-12-8-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-8-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,12 +35,30 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-12-8-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-8-py312-c9s-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge
     - linux-d160-m2xlarge/arm64
   - name: path-context
     value: .

--- a/.tekton/odh-base-image-cuda-12-8-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-8-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda

--- a/.tekton/odh-base-image-cuda-12-8-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-8-py312-ubi9-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/.tekton/odh-base-image-cuda-py311-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py311-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,12 +35,30 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux/arm64
+    - linux-d160-m4xlarge/amd64
+    - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-py311-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-py311-c9s-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/.tekton/odh-base-image-cuda-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-m2xlarge/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda

--- a/.tekton/odh-base-image-cuda-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-py312-c9s-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/.tekton/odh-base-image-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,12 +35,30 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-cuda-py312-ubi9-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/.tekton/odh-base-image-rocm-6-3-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-6-3-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,11 +35,29 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-3-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-6-3-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,11 +35,29 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-4-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,11 +35,29 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-4-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,11 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
   - name: path-context

--- a/.tekton/odh-base-image-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,11 +35,29 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/ppc64le
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -43,6 +43,24 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -34,15 +34,32 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: build-platforms
-    value:
-    # Increase build resources to use m2xlarge machines, avoid OOM
-    - linux/x86_64
+    value:    
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,30 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
   - name: dockerfile
     value: rstudio/c9s-python-3.12/Dockerfile.cpu
   - name: path-context
     value: .
   - name: build-args-file
     value: rstudio/c9s-python-3.12/build-args/cpu.conf
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-pull-request.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
   - name: dockerfile
     value: rstudio/rhel9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: rstudio/c9s-python-3.12/Dockerfile.cuda
   - name: path-context

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-pull-request.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,13 +37,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: rstudio/rhel9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: rstudio/rhel9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Description
Update ./tekton yaml files from linux/x86_64 to linux/amd64 to take advantage of the available larger resources.

## How Has This Been Tested?

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized build-platform identifiers for multi-arch CI runs to updated amd64 host types.
  * Increased pipeline timeouts from 3h to 6h to accommodate longer builds.
  * Raised compute for security scan and preflight tasks (clair-scan, ecosystem-cert-preflight-checks) to 8 CPU / 32Gi memory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->