### PR TITLE
NO-JIRA: enhance(pylocks): add `--quiet` flag to suppress unnecessary output in `pylocks_generator.sh` script

### DIFF
--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -193,6 +193,7 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
       --python-version="$PYTHON_VERSION" \
       --universal \
       --no-annotate \
+      --quiet \
       $index
     local status=$?
     set -e


### PR DESCRIPTION
## Description

This prints so much output for the unrelated images that I can't see the failures when there are any.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced output verbosity during dependency lock file generation for cleaner build logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->