### PR TITLE
RHAIENG-2453: chore(pyproject.toml): bump Feast version to 0.58.0 across all applicable configurations

### DIFF
--- a/codeserver/ubi9-python-3.12/pylock.toml
+++ b/codeserver/ubi9-python-3.12/pylock.toml
@@ -396,10 +396,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/25/c5/8a5231197b81943
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "skl2onnx~=1.19.1; platform_machine != 's390x'",
     "ipykernel~=6.30.1",
     "kubeflow-training==1.9.3",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # Some extra useful packages
     "opencensus~=0.11.4",

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -946,10 +946,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
     "codeflare-sdk~=0.33.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -924,10 +924,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -953,10 +953,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.33.0",
     "kubeflow-training==1.9.3",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -953,10 +953,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.33.0",
     "kubeflow-training==1.9.3",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -960,10 +960,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.33.0",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -37,7 +37,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.33"},
-            {"name": "Feast", "version": "0.56"},
+            {"name": "Feast", "version": "0.58"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -43,7 +43,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.33"},
-            {"name": "Feast", "version": "0.56"},
+            {"name": "Feast", "version": "0.58"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.33"},
-            {"name": "Feast", "version": "0.56"},
+            {"name": "Feast", "version": "0.58"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -40,7 +40,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.33"},
-            {"name": "Feast", "version": "0.56"},
+            {"name": "Feast", "version": "0.58"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -43,7 +43,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.33"},
-            {"name": "Feast", "version": "0.56"},
+            {"name": "Feast", "version": "0.58"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"}

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -842,10 +842,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.33.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -745,10 +745,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -849,10 +849,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.33.0",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -849,10 +849,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.33.0",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -856,10 +856,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.56.0"
+version = "0.58.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/db9614909f9a6fccaa9e25feda473cdf01db2b99b218cf5998d4c0d64b6f/feast-0.56.0.tar.gz", upload-time = 2025-10-27T20:38:58Z, size = 6263885, hashes = { sha256 = "285bebf226890513446e88e670ea5cda0a56599cede4998f9037cb1b458d28f4" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/58/b7/e9b7c29b9ca330fd3e758cf3ffd3f0b7156598b983041426fb3607c4f3e2/feast-0.56.0-py2.py3-none-any.whl", upload-time = 2025-10-27T20:38:56Z, size = 7743359, hashes = { sha256 = "faca34103b4ec115f4f933b7438db030d11c1b6e0fdfac8933f1275a5b4a58b0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
     "codeflare-sdk~=0.33.0",
-    "feast~=0.56.0",
+    "feast~=0.58.0",
 
     # DB connectors
     "pymongo~=4.15.3",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-2453

## Description

https://redhat-internal.slack.com/archives/C08GHG424KW/p1765870985595739

Previous update:

* https://github.com/opendatahub-io/notebooks/pull/2702

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the Feast dependency from 0.56.0 to 0.58.0 across all runtime environments, Jupyter variants, and image configurations (datascience, PyTorch, TensorFlow, ROCm, etc.), updating associated distribution metadata so all images use the new package release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->