### PR TITLE
NO-JIRA: chore(ci): add SC3041 and SC3020 to hadolint ignore list

### DIFF
--- a/ci/hadolint-config.yaml
+++ b/ci/hadolint-config.yaml
@@ -28,6 +28,10 @@ ignored:
   - DL3007
   # SC3060 warning: In POSIX sh, string replacement is undefined.
   - SC3060
+  # SC3041 warning: In POSIX sh, set flag -E is undefined. (bash-specific ERR trap)
+  - SC3041
+  # SC3020 warning: In POSIX sh, &> is undefined. (bash-specific redirect operator)
+  - SC3020
   # SC2086 info: Double quote to prevent globbing and word splitting.
   - SC2086
   # SC2046 warning: Quote this to prevent word splitting.


### PR DESCRIPTION
These warnings are suppressed because:

* Bash is available in RHEL base images
* The codebase uses bash-specific features

This avoids modifying multiple Dockerfiles
Hadolint will no longer report these warnings for the RStudio Dockerfiles. The warnings were about POSIX sh compatibility, but since bash is guaranteed in these images, suppressing them is acceptable.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->