### PR TITLE
reapply RHOAIENG-32541: fix(subscription): remove `subscription-manager.*register` from Dockerfiles to have Konflux do it for us (#2686)

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -83,7 +83,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -49,7 +49,7 @@ ARG TARGETARCH
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -29,7 +29,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -28,7 +28,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -26,7 +26,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -36,7 +36,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -36,7 +36,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -34,7 +34,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -34,7 +34,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -36,7 +36,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -60,7 +60,7 @@ USER root
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -32,7 +32,7 @@ USER root
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -28,7 +28,7 @@ USER root
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -27,7 +27,7 @@ USER root
 # If we have a Red Hat subscription prepared, refresh it
 RUN set -Eeuxo pipefail && \
     if command -v subscription-manager &> /dev/null; then \
-        subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."; \
+        subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."; \
     fi
 
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -27,7 +27,7 @@ USER root
 # If we have a Red Hat subscription prepared, refresh it
 RUN set -Eeuxo pipefail && \
     if command -v subscription-manager &> /dev/null; then \
-        subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."; \
+        subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."; \
     fi
 
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -30,7 +30,7 @@ ARG TARGETARCH
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -26,7 +26,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -20,7 +20,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -20,7 +20,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -18,7 +18,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -18,7 +18,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -22,7 +22,7 @@ USER 0
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
-  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+  subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
 fi
 EOF
 

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -55,7 +55,7 @@ def main():
         RUN /bin/bash <<'EOF'
         set -Eeuxo pipefail
         if command -v subscription-manager &> /dev/null; then
-          subscription-manager identity &>/dev/null && subscription-manager refresh || echo "Not registered, skipping refresh."
+          subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."
         fi
         EOF
     """)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,28 @@ if TYPE_CHECKING:
 MAKE = shutil.which("gmake") or shutil.which("make")
 
 
+def test_dockerfiles_unintended_subscription_manager_pattern():
+    """Konflux will not `subscription-manager register --org --activationkey` if the pattern matches.
+    Because it is easy to be matched by mistake (e.g. in a string/comment on the same line), add a check.
+
+    See the buildah task definition in https://github.com/konflux-ci/build-definitions for more details."""
+
+    # https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.6/buildah.yaml#L795-L813
+    pattern = re.compile(r"^[^#]*subscription-manager.[^#]*register")
+
+    for file in PROJECT_ROOT.glob("**/Dockerfile*"):
+        if file.is_dir():
+            continue
+        if file.is_relative_to(PROJECT_ROOT / "rstudio/rhel9-python-3.12"):
+            continue  # Skip RStudio Dockerfiles
+        with open(file, "r") as f:
+            for line_no, line in enumerate(f, start=1):
+                assert not pattern.match(line), (
+                    f"Undesirable subscription-manager pattern that disables Konflux subscription found in {file}:{line_no}."
+                    f" Modify the test if this is intended behaviour. But it is very reasonable to assume it is a mistake."
+                )
+
+
 def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests):
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):
         logging.info(file)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized subscription-manager fallback message across container images to: "No identity, skipping refresh." for clearer build/runtime output.

* **Tests**
  * Added a validation test that scans container definitions to detect unintended subscription-manager registration patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->