### PR TITLE
RHOAIENG-42342: update to Elyra 4.3.2

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -2909,10 +2909,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -3252,10 +3252,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -3068,10 +3068,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -2930,10 +2930,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2600,10 +2600,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -3125,10 +3125,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -2676,10 +2676,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df83
 
 [[packages]]
 name = "odh-elyra"
-version = "4.3.1"
+version = "4.3.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f4/6be53ca16125e7d3ca6cb86aa8f001ebe200977e429bedb4b6467e692328/odh_elyra-4.3.1.tar.gz", upload-time = 2025-10-09T14:53:22Z, size = 2196705, hashes = { sha256 = "522c85c647d97d3a5317389dc106452fdebf48f95ecbdea3db0aef1b43192475" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b3/7a/009a5eb3e872330c22155928ffd3dcb8f139385b7de2a7540cad714be9bd/odh_elyra-4.3.1-py3-none-any.whl", upload-time = 2025-10-09T14:53:20Z, size = 4352762, hashes = { sha256 = "ae1008e0329e14d45a4c31b5436b00e732dcaa201cae15adb7f502249bf9d7a8" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c7/0dc3a7827b166b052f66dc6619b81122979669970507493f0b53bb3c9469/odh_elyra-4.3.2.tar.gz", upload-time = 2025-12-17T19:54:01Z, size = 2196786, hashes = { sha256 = "be25cf3199f7d4de0489bc085dc16eb5c746e5f3fb9a2a17a6dd71dfffaefde5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/a1/d312dfa66495995682c0a95b172f3796270a18bdff85cb03306645a9f291/odh_elyra-4.3.2-py3-none-any.whl", upload-time = 2025-12-17T19:53:59Z, size = 4352744, hashes = { sha256 = "854ae74994a0e4bbcc86ead10b7218c3b10348c4f3537d776801f3650ab02afa" } }]
 
 [[packages]]
 name = "odh-jupyter-trash-cleanup"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "mysql-connector-python~=9.4.0",
 
     # JupyterLab packages
-    "odh-elyra==4.3.1",
+    "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
     "jupyterlab==4.4.9",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-42342

Update to Elyra 4.3.2. This is expected to fix [Elyra Build Constraint](https://issues.redhat.com/browse/RHOAIENG-39611) issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `odh-elyra` package from version 4.3.1 to 4.3.2 across all Jupyter environments and configurations, including DataScience, PyTorch, TensorFlow, ROCm, and TrustyAI stacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->