### PR TITLE
NO-JIRA: chore(docker): add `mongocli-builder` stage into dockerfile_fragments.py templates

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,7 @@
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage with s390x support
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -32,6 +33,8 @@ else
     CGO_ENABLED=1 GOOS=linux GOARCH=${arch} GO111MODULE=on go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 fi
 EOF
+
+### END mongocli-builder stage with s390x support
 
 ####################
 # cpu-base         #
@@ -337,8 +340,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,7 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -20,6 +21,8 @@ unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/
 CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 EOF
+
+### END mongocli-builder stage
 
 ####################
 # cuda-base        #
@@ -125,8 +128,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,7 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -20,6 +21,8 @@ unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/
 CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 EOF
+
+### END mongocli-builder stage
 
 ####################
 # cuda-base        #
@@ -125,8 +128,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,7 @@
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -18,6 +19,8 @@ unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/
 CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 EOF
+
+### END mongocli-builder stage
 
 ####################
 # rocm-base        #
@@ -131,8 +134,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,7 @@
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -18,6 +19,8 @@ unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/
 CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 EOF
+
+### END mongocli-builder stage
 
 ####################
 # rocm-base        #
@@ -131,8 +134,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,7 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -20,6 +21,8 @@ unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/
 CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 EOF
+
+### END mongocli-builder stage
 
 ####################
 # cuda-base        #
@@ -133,8 +136,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,7 @@
 #########################
 ARG BASE_IMAGE
 
+### BEGIN mongocli-builder stage
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -18,6 +19,8 @@ unzip ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip
 cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/
 CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/
 EOF
+
+### END mongocli-builder stage
 
 ####################
 # wheel-cache-base #
@@ -149,8 +152,10 @@ dnf clean all
 rm -rf /var/cache/yum
 EOF
 
+### BEGIN Copy mongocli from builder
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
+### END Copy mongocli from builder
 
 # Other apps and tools installed as default user
 USER 1001


### PR DESCRIPTION
* https://github.com/red-hat-data-services/notebooks/pull/1834

## Description

Successfully integrated mongocli compilation stages into the templating system managed by [`scripts/dockerfile_fragments.py`](scripts/dockerfile_fragments.py:1).

Added three new templates to [`dockerfile_fragments.py`](scripts/dockerfile_fragments.py:63):
- **`mongocli-builder stage`**: Simple mongocli builder for most images
- **`mongocli-builder stage with s390x support`**: Advanced builder with s390x architecture handling for datascience images
- **`Copy mongocli from builder`**: Template for copying the compiled binary

Created [`scripts/add_mongocli_markers.py`](scripts/add_mongocli_markers.py:1) to automatically add BEGIN/END markers to all Dockerfile.* files containing mongocli stages.

Successfully applied templates to **16 Dockerfiles** across:
- jupyter/pytorch (cuda, konflux.cuda)
- jupyter/pytorch+llmcompressor (cuda, konflux.cuda)
- jupyter/tensorflow (cuda, konflux.cuda)
- jupyter/trustyai (cpu, konflux.cpu, cowsay.cpu)
- jupyter/rocm/pytorch (rocm, konflux.rocm)
- jupyter/rocm/tensorflow (rocm, konflux.rocm)
- jupyter/datascience (cpu, konflux.cpu, cpu.j2, mongocli-builder)

- **Centralized Management**: All mongocli build stages now managed from a single location
- **Consistency**: Ensures identical mongocli compilation across all images
- **Easy Updates**: Future changes to mongocli version or build process only need to be made in [`dockerfile_fragments.py`](scripts/dockerfile_fragments.py:1)
- **Maintainability**: Reduces code duplication and potential for drift between Dockerfiles

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mongocli tool to Docker images for data science environments.

* **Chores**
  * Optimized Docker build process using multi-stage compilation for improved efficiency and faster image generation across CPU, CUDA, and ROCm deployment configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->