### PR TITLE
RHOAIENG-42632, RHOAIENG-42630: chore(tests): validate RHDS Tekton pipelines use appropriate `konflux` build arguments

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -399,14 +399,16 @@ def test_rhds_pipelines_use_rhds_args(subtests: pytest_subtests.plugin.SubTests)
                 if param["name"] == "build-args-file":
                     build_args_file_param = pathlib.Path(param["value"])
 
-            assert dockerfile_param is not None
+            assert dockerfile_param is not None, (
+                f"Pipeline {file.relative_to(PROJECT_ROOT)} is missing the required 'dockerfile' parameter"
+            )
 
             if not dockerfile_param.name.startswith("Dockerfile.konflux"):
                 continue
 
             assert build_args_file_param is not None, (
-                f"Pipeline {file.relative_to(PROJECT_ROOT)} is missing required parameters: "
-                f"dockerfile={dockerfile_param}, build-args-file={build_args_file_param}"
+                f"Pipeline {file.relative_to(PROJECT_ROOT)} builds a konflux Dockerfile ({dockerfile_param.name}) "
+                f"but is missing the required 'build-args-file' parameter"
             )
 
             assert build_args_file_param.name.startswith("konflux."), (


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-42632
https://issues.redhat.com/browse/RHOAIENG-42630

## Description

Pipelines under .tekton/ that build `^Dockerfile\.konflux.*` dockerfiles have to use `^konflux\..*` args files. For example, this would be a violation of the rule:

```
    - name: dockerfile
      value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
    - name: build-args-file
      value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pipeline validation test that scans pipeline YAMLs and enforces naming conventions between Dockerfiles and their corresponding build-args files.
  * The test reports issues per file for clearer diagnostics.
  * Note: the test was inadvertently added twice (duplicate insertion).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->