### PR TITLE
RHOAIENG-43410: chore(dependencies): bump `codeflare-sdk` to version `0.33.1` across all relevant configurations

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -670,10 +670,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
-    "codeflare-sdk~=0.33.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
+    "codeflare-sdk~=0.33.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "feast~=0.58.0",
 
     # DB connectors

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -677,10 +677,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "kubeflow-training==1.9.3",
     "feast~=0.58.0",
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -677,10 +677,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "kubeflow-training==1.9.3",
     "feast~=0.58.0",
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -663,10 +663,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "kubeflow-training==1.9.3",
 
     # DB connectors

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -684,10 +684,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "feast~=0.58.0",
 
     # DB connectors

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -656,10 +656,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
+    "codeflare-sdk~=0.33.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "kubeflow-training==1.9.3",
 
     # DB connectors

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -580,10 +580,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
+    "codeflare-sdk~=0.33.1; platform_machine != 's390x' and platform_machine != 'ppc64le'",
     "feast~=0.58.0",
 
     # DB connectors

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -587,10 +587,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "feast~=0.58.0",
 
     # DB connectors

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -587,10 +587,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "feast~=0.58.0",
 
     # DB connectors

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -566,10 +566,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8ee
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorful"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -594,10 +594,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc
 
 [[packages]]
 name = "codeflare-sdk"
-version = "0.33.0"
+version = "0.33.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e6/27b0e645b5f0fd81171bce6e9ccf1613dd62cc9c2451b977efe44224a0a8/codeflare_sdk-0.33.0.tar.gz", upload-time = 2025-12-08T10:21:46Z, size = 154082, hashes = { sha256 = "a8d0a838b4ec197e91a547b8011425c1b1af8768f8cf2346365adfa24622ed48" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/44/4915baa541355d9247d9fa9239e374e56ff0e665f1e167a8f53dcb40821e/codeflare_sdk-0.33.0-py3-none-any.whl", upload-time = 2025-12-08T10:21:45Z, size = 222827, hashes = { sha256 = "3cd834410053e745ad1afa1edba7577a9ea909690c00b6e724d63f64b83f9ca2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/91/38/59cbc979ba26cb8b3a0a9b2cc74d76c06af45848c3a0c2d6b5df97e770e5/codeflare_sdk-0.33.1.tar.gz", upload-time = 2026-01-06T09:22:53Z, size = 156028, hashes = { sha256 = "ad41ec5260217fd030904fb4b9fe62e26c3f51ac7999a5d607eb4b1359edd5e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9c/db/f2cd11b6e68dc6e82b7f17eb04a88fe6946296ed3336cb9f7b33614b7b0a/codeflare_sdk-0.33.1-py3-none-any.whl", upload-time = 2026-01-06T09:22:51Z, size = 224774, hashes = { sha256 = "6622a73edde5042455ae7d76279a5279c55db4950533ea7f12aac2fc51d49bb8" } }]
 
 [[packages]]
 name = "colorama"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
-    "codeflare-sdk~=0.33.0",
+    "codeflare-sdk~=0.33.1",
     "feast~=0.58.0",
 
     # DB connectors


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-43410

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated codeflare-sdk from version 0.33.0 to 0.33.1 across all datascience, PyTorch, TensorFlow, and ROCm runtime environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->