### PR TITLE
RHOAIENG-32156: tests(containers/): verify the trash extension is correctly installed in all the jupyterlab Images

### DIFF
--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -58,13 +58,13 @@ class TestJupyterLabImage:
     @allure.description("Check that Trash Cleanup extension is installed and enabled")
     def test_trash_cleanup_installed(self, jupyterlab_image: conftest.Image) -> None:
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
-        extension_check_pattern = r"odh-jupyter-trash-cleanup.*enabled.*OK"
+        extension_check_pattern = r"^\s*odh-jupyter-trash-cleanup[^\n]*enabled[^\n]*OK"
         try:
             container.start(wait_for_readiness=False)
             exit_code, output = container.exec(["jupyter", "labextension", "list"])
             result_output = output.decode(errors="replace")
             assert exit_code == 0, f"`jupyter labextension list` failed:\n{result_output}"
-            assert re.search(extension_check_pattern, result_output) is not None, (
+            assert re.search(extension_check_pattern, result_output, re.MULTILINE) is not None, (
                 "Trash Cleanup extension not reported as enabled/OK:\n" + result_output
             )
         finally:


### PR DESCRIPTION
## Description
This is a test to verify that the Trash Cleanup extension was correctly installed and enabled.

## How Has This Been Tested?

Build the minimal image with Jupyter:
```
make jupyter-minimal-ubi9-python-3.12 -e  IMAGE_REGISTRY=quay.io/wsiqueir/workbench-images  -e  RELEASE=TRASH_TEST
```
Then I ran the test locally using: 

```
DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock uv run pytest ./tests/containers/workbenches/jupyterlab/jupyterlab_test.py::TestJupyterLabImage::test_trash_cleanup_installed -m 'not openshift and not cuda and not rocm' --image 530c1d85f7aa
```

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying the Trash Cleanup JupyterLab extension is installed and enabled by listing extensions and matching output; runs inside a container with specific user/group settings and ensures container teardown to avoid resource leaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->