### PR TITLE
NO-JIRA: tests(pytest): speed up pytest collection by limiting search paths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,8 +14,15 @@ addopts =
 testpaths = tests ntb
 collect_ignore = ["tests/containers"]
 
+# Test discovery patterns (explicit defaults for documentation)
+python_files = test_*.py *_test.py
+python_classes = Test*
+python_functions = test_*
+
 # https://docs.pytest.org/en/stable/example/pythoncollection.html#changing-directory-recursion
 norecursedirs = .git .venv tmp node_modules __pycache__
+
+cache_dir = .pytest_cache
 
 # pytest-subtest plugin is built-in since pytest 9.0: https://docs.pytest.org/en/stable/how-to/subtests.html
 required_plugins =


### PR DESCRIPTION
## Description

Test collection was taking 8-10 seconds, even for just 36 tests. This made the edit-test cycle unnecessarily slow.

Investigation:
- Ran 'pytest --collect-only' with various --ignore flags to isolate cause
- Found that '--doctest-modules' was scanning ALL Python files in the repo
- With '-p no:doctest', collection dropped from ~6s to ~0.4s
- jdanek's checkout of the repo contains ~6700 Python files (many in tmp/, scripts/, etc.)
- The --ignore flags only excluded ci, codeserver, jupyter, rstudio
- This left many directories being scanned unnecessarily

Root cause:
The --doctest-modules option scans every .py file looking for doctests. Without explicit testpaths, pytest starts from the root directory and walks through everything not in norecursedirs or --ignore.

Solution:
- Add 'testpaths = tests ntb' to explicitly define test directories
- Remove --ignore flags from addopts (now redundant with testpaths)
- Expand norecursedirs to include .venv, tmp, node_modules, __pycache__

Result:
- Collection time: 8-10s -> 2s (4-5x improvement)
- All 36 tests still collected correctly
- Doctest in ntb/strings.py still runs

Additional improvements:

- Add testpaths to explicitly define test directories (tests, ntb)
- Add collect_ignore to skip tests/containers by default (imports heavy modules like docker, kubernetes, testcontainers that slow collection)
- Expand norecursedirs to exclude .venv, tmp, node_modules, __pycache__

Container tests can still be run explicitly:
  pytest tests/containers --image=...

Collection time improved from ~8s to ~0.5s.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Streamlined test discovery and collection configuration for better organization across test directories
  * Enhanced logging and diagnostic capabilities to improve troubleshooting and debugging
  * Added test markers for platform-specific environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->