### PR TITLE
RHAIENG-2458: fix(ppc64le): update ONNX version to 1.20.1 in Dockerfiles to match pylock.toml

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -229,7 +229,7 @@ EOF
 #######################################################
 FROM common-builder AS onnx-builder
 ARG TARGETARCH
-ARG ONNX_VERSION=v1.20.0
+ARG ONNX_VERSION=v1.20.1
 WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -87,7 +87,7 @@ if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFIL
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.0
+export ONNX_VERSION=1.20.1
 export PYARROW_VERSION=21.0.0
 export PATH="$HOME/.cargo/bin:$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
@@ -276,7 +276,7 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.0
+ENV ONNX_VERSION=1.20.1
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 


### PR DESCRIPTION
## Description

Problem
-------
ppc64le builds were failing with:

    CMake Error: Could NOT find Python3
    (missing: Python3_INCLUDE_DIRS Development.Module Development.SABIModule)
    (found version "3.9.25")

This occurred when uv tried to build onnx from source during the datascience/runtime image builds on ppc64le.

Root Cause
----------
Version mismatch between pre-built wheel and lockfile requirement:

| Source                      | ONNX Version |
|-----------------------------|--------------|
| Dockerfile.cpu onnx-builder | 1.20.0       |
| pylock.toml                 | 1.20.1       |

The onnx-builder stage successfully built onnx 1.20.0 for ppc64le, but pylock.toml required onnx 1.20.1 (as a transitive dependency of skl2onnx).

When uv installed dependencies, it couldn't use the 1.20.0 wheel and attempted to build 1.20.1 from source. The source build failed because CMake found Python 3.9 (system default) instead of Python 3.12, and Python 3.9 lacked development headers.

Solution
--------
Update ONNX_VERSION from 1.20.0 to 1.20.1 in all Dockerfiles:

- jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu (onnx-builder ARG)
- runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu (ppc64le profile)
- runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu (onnx-builder ENV)

This ensures the pre-built wheel matches what pylock.toml requires, eliminating the need to build onnx from source on ppc64le.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ONNX runtime library version to v1.20.1 in data science platform configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->