### PR TITLE
RHOAIENG-45474: Updated feast to 0.59.0

### DIFF
--- a/codeserver/ubi9-python-3.12/pylock.toml
+++ b/codeserver/ubi9-python-3.12/pylock.toml
@@ -389,10 +389,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b09354
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "skl2onnx~=1.19.1; platform_machine != 's390x'",
     "ipykernel~=6.30.1",
     "kubeflow-training==1.9.3",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # Some extra useful packages
     "opencensus~=0.11.4",

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -966,10 +966,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
     "codeflare-sdk~=0.34.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -924,10 +924,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -973,10 +973,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "kubeflow-training==1.9.3",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -973,10 +973,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "kubeflow-training==1.9.3",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -980,10 +980,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -37,7 +37,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.34"},
-            {"name": "Feast", "version": "0.58"},
+            {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -43,7 +43,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.34"},
-            {"name": "Feast", "version": "0.58"},
+            {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.34"},
-            {"name": "Feast", "version": "0.58"},
+            {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -40,7 +40,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.34"},
-            {"name": "Feast", "version": "0.58"},
+            {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"},

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -43,7 +43,7 @@ spec:
             {"name": "PyMongo", "version": "4.15"},
             {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.34"},
-            {"name": "Feast", "version": "0.58"},
+            {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.4"}

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -862,10 +862,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -752,10 +752,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -869,10 +869,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -869,10 +869,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "skl2onnx~=1.19.1",
     "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -876,10 +876,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "feast"
-version = "0.58.0"
+version = "0.59.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/28/d9/42ed92e83aefa74b8ce6f690f6c262e00a5bd0f89a22c326c78b8cd041e0/feast-0.58.0.tar.gz", upload-time = 2025-12-16T18:28:14Z, size = 6365517, hashes = { sha256 = "8d01b2a8f2247db0a36ee566c4c4aa76e50626e26ab8be89a54dfa9f97601e56" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8c/20/faa43a06673692578dd2188f07c612b474ecdd31e9fb04ebf952aa2c9f0f/feast-0.58.0-py2.py3-none-any.whl", upload-time = 2025-12-16T18:28:11Z, size = 7848416, hashes = { sha256 = "c199788cbc1e9ece638bbf22b01267a2eeb9954d545ce9e05c07a36dd0550b3c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/03/22/bbfe21b719e8d278d2e1d4a09542beff84c05f169b434fab40778c01316c/feast-0.59.0.tar.gz", upload-time = 2026-01-16T21:21:14Z, size = 6392725, hashes = { sha256 = "f4a09733ca8a2967495d95230d0e433ff8c9b1181ef0bf9a92729f69f74ac606" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/7b/ad8e7872733636e70123e679f229fac0b9c23703604f05c16b11c67b47bb/feast-0.59.0-py2.py3-none-any.whl", upload-time = 2026-01-16T21:21:12Z, size = 7876795, hashes = { sha256 = "7e5e8d14bf651c4d4cc621793d33a22ddb86decbb74677eb7020abb8812cd7d2" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "onnxconverter-common~=1.13.0",
     "codeflare-sdk~=0.34.0",
-    "feast~=0.58.0",
+    "feast~=0.59.0",
 
     # DB connectors
     "pymongo~=4.15.3",


### PR DESCRIPTION
## Description
RHOAIENG-45474: Updated feast to 0.59.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Feast library dependency from version 0.58.0 to 0.59.0 across all Jupyter notebook environments (DataScience, PyTorch, PyTorch with LLM Compressor, ROCm, and TensorFlow) and runtime configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->