### PR TITLE
RHAIENG-1650: chore(build): update pylock-generator: auto mode now always uses AIPCC index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ RELEASE_PYTHON_VERSION	 ?= 3.12
 CONTAINER_BUILD_CACHE_ARGS ?= --no-cache
 # whether to push the images to a registry as they are built
 PUSH_IMAGES ?= yes
-# INDEX_MODE: auto (default), public-index, or aipcc-index - controls lock file generation
+# INDEX_MODE: auto (default), public-index, or rh-index - controls lock file generation
 INDEX_MODE ?= auto
 
 # OS dependant: Generate date, select appropriate cmd to locate container engine

--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -5,26 +5,26 @@ set -euo pipefail
 # pylocks_generator.sh
 #
 # This script generates Python dependency lock files (pylock.toml) for multiple
-# directories using either internal AIPCC wheel indexes or the public PyPI index.
+# directories using either internal Red Hat wheel indexes or the public PyPI index.
 #
 # Features:
 #   • Supports multiple Python project directories, detected by pyproject.toml.
-#   • Detects available Dockerfile flavors (CPU, CUDA, ROCm) for AIPCC index mode.
+#   • Detects available Dockerfile flavors (CPU, CUDA, ROCm) for rh-index mode.
 #   • Validates Python version extracted from directory name (expects format .../ubi9-python-X.Y).
-#   • Generates per-flavor locks in 'uv.lock.d/' for AIPCC index mode.
+#   • Generates per-flavor locks in 'uv.lock.d/' for rh-index mode.
 #   • Overwrites existing pylock.toml in-place for public PyPI index mode.
 #
 # Index Modes:
-#   • auto (default) -> Uses AIPCC index if uv.lock.d/ exists, public PyPI index otherwise.
-#   • aipcc-index    -> Uses internal Red Hat AIPCC wheel indexes. Generates uv.lock.d/pylock.<flavor>.toml .
+#   • auto (default) -> Uses rh-index if uv.lock.d/ exists, public-index otherwise.
+#   • rh-index    -> Uses internal Red Hat wheel indexes. Generates uv.lock.d/pylock.<flavor>.toml .
 #   • public-index   -> Uses public PyPI index and updates pylock.toml in place.
 #
 # Usage:
 #   1. Lock using auto mode (default) for all projects in MAIN_DIRS:
 #        bash pylocks_generator.sh
 #
-#   2. Lock using AIPCC index for a specific directory:
-#        bash pylocks_generator.sh aipcc-index jupyter/minimal/ubi9-python-3.12
+#   2. Lock using rh-index for a specific directory:
+#        bash pylocks_generator.sh rh-index jupyter/minimal/ubi9-python-3.12
 #
 #   3. Lock using public index for a specific directory:
 #        bash pylocks_generator.sh public-index jupyter/minimal/ubi9-python-3.12
@@ -87,8 +87,8 @@ INDEX_MODE="${1:-auto}"
 TARGET_DIR_ARG="${2:-}"
 
 # Validate mode
-if [[ "$INDEX_MODE" != "auto" && "$INDEX_MODE" != "aipcc-index" && "$INDEX_MODE" != "public-index" ]]; then
-  error "Invalid mode '$INDEX_MODE'. Valid options: auto, aipcc-index, public-index"
+if [[ "$INDEX_MODE" != "auto" && "$INDEX_MODE" != "rh-index" && "$INDEX_MODE" != "public-index" ]]; then
+  error "Invalid mode '$INDEX_MODE'. Valid options: auto, rh-index, public-index"
   exit 1
 fi
 info "Using index mode: $INDEX_MODE"
@@ -162,7 +162,7 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
   # Resolve effective mode for this directory
   if [[ "$INDEX_MODE" == "auto" ]]; then
     if [[ -d "uv.lock.d" ]]; then
-      EFFECTIVE_MODE="aipcc-index"
+      EFFECTIVE_MODE="rh-index"
     else
       EFFECTIVE_MODE="public-index"
     fi
@@ -262,7 +262,7 @@ if [ ${#FAILED_DIRS[@]} -gt 0 ]; then
   warn "Failed lock generation for:"
   for d in "${FAILED_DIRS[@]}"; do
     echo "  • $d"
-    echo "Please comment out the missing package to continue and report the missing package to aipcc"
+    echo "Please comment out the missing package to continue and report the missing package to the RH index maintainers"
   done
   exit 1
 fi


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-1650

We want the ability to have some images using PyPI and some images be already on AIPCC.

Therefore, for as long as this situation lasts, it would make sense to have an auto value for INDEX_MODE that can make choice automatically.

Uv is unhappy with a directory named `uv.lock` because some uv subcommands expect a file of that name. So rename the directory.

## Summary

- Introduced `auto` as the default value for `INDEX_MODE` in the Makefile and scripts
- Adjusted lockfile directory from `uv.lock/` to `uv.lock.d/` for `aipcc-index` mode
- Enhanced `auto` mode to switch between AIPCC and public PyPI based on `uv.lock.d/` directory presence
- Updated RHAI repository index URLs to 3.3 version (AIPCC started versioning their index based on cuda/rocm version)

## Test plan

- [x] Verify `make` commands work with the new `auto` index mode
- [x] Test lockfile generation with both AIPCC and PyPI modes
- [x] Confirm builds succeed with the updated index URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default package index mode changed to "auto": selects RH index when a local per-flavor lock directory exists, otherwise falls back to the public PyPI index.
  * Per-flavor lock outputs now write to a dedicated lock directory for non-public modes.
  * Validation, messages, and help text updated to recognize and describe the new "auto", "rh-index", and "public-index" modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->