### PR TITLE
RHAIENG-2816, RHAIENG-948: chore(dependencies): upgrade JupyterLab version to 4.5.2 across manifests and lockfiles

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -1786,10 +1786,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/minimal/ubi9-python-3.12/pylock.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pylock.toml
@@ -852,10 +852,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/minimal/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     # JupyterLab packages
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",
     "jupyter-server-terminals~=0.5.3",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -1780,10 +1780,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -1793,10 +1793,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -1793,10 +1793,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1716,10 +1716,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1870,10 +1870,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=4.0.5",
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -1712,10 +1712,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/07/2d/2b32cdbe8d2a602
 
 [[packages]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", upload-time = 2025-09-26T17:28:20Z, size = 22966654, hashes = { sha256 = "ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", upload-time = 2025-09-26T17:28:15Z, size = 12292552, hashes = { sha256 = "394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/93/dc/2c8c4ff1aee27ac999ba04c373c5d0d7c6c181b391640d7b916b884d5985/jupyterlab-4.5.2.tar.gz", upload-time = 2026-01-12T12:27:08Z, size = 23990371, hashes = { sha256 = "c80a6b9f6dace96a566d590c65ee2785f61e7cd4aac5b4d453dcc7d0d5e069b7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/78/7e455920f104ef2aa94a4c0d2b40e5b44334ee7057eae1aa1fb97b9631ad/jupyterlab-4.5.2-py3-none-any.whl", upload-time = 2026-01-12T12:27:03Z, size = 12385807, hashes = { sha256 = "76466ebcfdb7a9bb7e2fbd6459c0e2c032ccf75be673634a84bee4b3e6b13ab6" } }]
 
 [[packages]]
 name = "jupyterlab-git"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "odh-elyra==4.3.2",
     "odh-jupyter-trash-cleanup==0.1.1",
 
-    "jupyterlab==4.4.9",
+    "jupyterlab==4.5.2",
     "jupyter-bokeh~=3.0.5", # trustyai 0.6.1 depends on jupyter-bokeh~=3.0.5
     "jupyter-server~=2.17.0",
     "jupyter-server-proxy~=4.4.0",

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "Boto3", "version": "1.40"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Kfp", "version": "2.14"},

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -26,7 +26,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab", "version": "4.4"}
+            {"name": "JupyterLab", "version": "4.5"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"}
+            {"name": "JupyterLab","version": "4.5"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -27,7 +27,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "PyTorch", "version": "2.7"},
             {"name": "LLM-Compressor", "version": "0.9"},
             {"name": "Tensorboard", "version": "2.20"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -27,7 +27,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "PyTorch", "version": "2.7"},
             {"name": "Tensorboard", "version": "2.20"},
             {"name": "Boto3", "version": "1.40"},

--- a/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -26,7 +26,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab", "version": "4.4"}
+            {"name": "JupyterLab", "version": "4.5"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -27,7 +27,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "ROCm-PyTorch", "version": "2.7"},
             {"name": "Tensorboard", "version": "2.20"},
             {"name": "Kafka-Python-ng", "version": "2.2"},

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -27,7 +27,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "TensorFlow-ROCm", "version": "2.18"},
             {"name": "Tensorboard", "version": "2.18"},
             {"name": "Kafka-Python-ng", "version": "2.2"},

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -27,7 +27,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "TensorFlow", "version": "2.20"},
             {"name": "Tensorboard", "version": "2.20"},
             {"name": "Nvidia-CUDA-CU12-Bundle", "version": "12.9"},

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.4"},
+            {"name": "JupyterLab","version": "4.5"},
             {"name": "TrustyAI", "version": "0.6"},
             {"name": "Transformers", "version": "4.56"},
             {"name": "Datasets", "version": "4.0"},


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-2816

## Summary

- Upgrade JupyterLab from 4.4.9 to 4.5.2 across all Jupyter notebook images
- Update pyproject.toml and pylock.toml files for all notebook flavors
- Update manifests/imagestreams to reflect the new version

AIPCC index for RHOAI 3.3 does not carry JupyterLab 4.4.9 any more, so we upgrade to version 4.5.2 which is available.

Related to #2836 (same AIPCC migration workstream).

## Test plan

- [ ] Verify JupyterLab starts correctly with version 4.5.2
- [ ] Test notebook creation and execution
- [ ] Confirm no regressions in JupyterLab functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped JupyterLab from 4.4.9 to 4.5.2 across all notebook Python environments (datascience, minimal, PyTorch, ROCm, TensorFlow, TrustyAI).
  * Updated image stream manifests to reference JupyterLab 4.5 for the latest image variants, ensuring released images use the newer JupyterLab build.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->