### PR TITLE
fix(scripts): pass build args to buildinputs in sandbox.py

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -89,7 +89,11 @@ def should_build_target(changed_files: list[str], target_directory: str) -> str:
     dockerfiles = find_dockerfiles(target_directory)
     for dockerfile in dockerfiles:
         stdout = subprocess.check_output(
-            [PROJECT_ROOT / "bin/buildinputs", target_directory + "/" + dockerfile],
+            args=[
+                PROJECT_ROOT / "bin/buildinputs",
+                *["-build-arg=BASE_IMAGE=fake-image"],
+                target_directory + "/" + dockerfile,
+            ],
             env={
                 "TARGETPLATFORM": f"linux/{get_go_arch()}",
                 **os.environ,
@@ -152,12 +156,12 @@ class SelfTests(unittest.TestCase):
         }
 
     def test_get_build_directory(self):
-        directory = get_build_directory("rocm-jupyter-pytorch-ubi9-python-3.11")
+        directory = get_build_directory("rocm-jupyter-pytorch-ubi9-python-3.12")
         assert directory == "jupyter/rocm/pytorch/ubi9-python-3.11"
 
     def test_get_build_dockerfile(self):
-        dockerfile = get_build_dockerfile("rocm-jupyter-pytorch-ubi9-python-3.11")
-        assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm"
+        dockerfile = get_build_dockerfile("rocm-jupyter-pytorch-ubi9-python-3.12")
+        assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm"
 
     def test_should_build_target(self):
-        assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.11")
+        assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.12")

--- a/scripts/buildinputs/buildinputs_test.go
+++ b/scripts/buildinputs/buildinputs_test.go
@@ -39,7 +39,7 @@ func TestParseAllDockerfiles(t *testing.T) {
 
 	for _, dockerfile := range dockerfiles {
 		t.Run(dockerfile, func(t *testing.T) {
-			result := getDockerfileDeps(dockerfile, "amd64")
+			result := getDockerfileDeps(dockerfile, "amd64", map[string]string{"BASE_IMAGE": "fake-image"})
 			if len(result) == 0 {
 				// no deps in the dockerfile
 				return
@@ -74,7 +74,7 @@ func TestParseDockerfileWithBindMount(t *testing.T) {
 
 	//dockerfile = "/Users/jdanek/IdeaProjects/notebooks/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm"
 
-	result := getDockerfileDeps(dockerfile, "amd64")
+	result := getDockerfileDeps(dockerfile, "amd64", map[string]string{"BASE_IMAGE": "fake-image"})
 	expected := []string{"codeserver/ubi9-python-3.12/test", "foo"}
 	if !reflect.DeepEqual(
 		slices.Sorted(slices.Values(result)),
@@ -92,7 +92,7 @@ func TestParseFileWithStageCopy(t *testing.T) {
 		COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 	`)), 0644))
 
-	result := getDockerfileDeps(dockerfile, "amd64")
+	result := getDockerfileDeps(dockerfile, "amd64", map[string]string{"BASE_IMAGE": "fake-image"})
 	if len(result) != 0 {
 		t.Fatalf("unexpected deps reported for the dockerfile: %s", result)
 	}
@@ -107,7 +107,7 @@ func TestParseFileWithStageMount(t *testing.T) {
 			mvn package
 	`)), 0644))
 
-	result := getDockerfileDeps(dockerfile, "amd64")
+	result := getDockerfileDeps(dockerfile, "amd64", map[string]string{"BASE_IMAGE": "fake-image"})
 	if len(result) != 0 {
 		t.Fatalf("unexpected deps reported for the dockerfile: %s", result)
 	}

--- a/scripts/buildinputs/dockerfile.go
+++ b/scripts/buildinputs/dockerfile.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getDockerfileDeps(dockerfile string, targetArch string) []string {
+func getDockerfileDeps(dockerfile string, targetArch string, buildArgs map[string]string) []string {
 	ctx := context.Background()
 	data := noErr2(os.ReadFile(dockerfile))
 
@@ -34,7 +34,7 @@ func getDockerfileDeps(dockerfile string, targetArch string) []string {
 			platform: "linux/" + targetArch,
 		},
 		Config: dockerui.Config{
-			BuildArgs:      map[string]string{"BASE_IMAGE": "fake-image"},
+			BuildArgs:      buildArgs,
 			BuildPlatforms: []ocispecs.Platform{{OS: "linux", Architecture: targetArch}},
 		},
 		Warn: func(rulename, description, url, fmtmsg string, location []parser.Range) {

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -43,7 +43,8 @@ def main() -> int:
         print("must give a `{};` parameter that will be replaced with new build context")
         return 1
 
-    prereqs = buildinputs(dockerfile=args.dockerfile, platform=args.platform)
+    build_args = extract_build_args(args.remaining[1:])
+    prereqs = buildinputs(dockerfile=args.dockerfile, platform=args.platform, build_args=build_args)
 
     with tempfile.TemporaryDirectory(delete=True) as tmpdir:
         setup_sandbox(prereqs, pathlib.Path(tmpdir))
@@ -57,15 +58,34 @@ def main() -> int:
     return 0
 
 
+def extract_build_args(remaining: list[str]) -> dict[str, str]:
+    """Extract --build-arg KEY=VALUE pairs from the command line using argparse."""
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--build-arg", action="append", default=[])
+    known, _ = parser.parse_known_args(remaining)
+    build_args = {}
+    for arg in known.build_arg:
+        if "=" not in arg:
+            raise ValueError(f"--build-arg must be in KEY=VALUE format, got: {arg!r}")
+        key, value = arg.split("=", 1)
+        build_args[key] = value
+    return build_args
+
+
 def buildinputs(
         dockerfile: pathlib.Path | str,
-        platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64"
+        platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64",
+        build_args: dict[str, str] | None = None
 ) -> list[pathlib.Path]:
     if not (ROOT_DIR / "bin/buildinputs").exists():
         subprocess.check_call([MAKE, "bin/buildinputs"], cwd=ROOT_DIR)
-    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs", str(dockerfile)],
+    if not build_args:
+        build_args = {}
+    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs",
+                                      *[f"-build-arg={k}={v}" for k, v in build_args.items()],
+                                      str(dockerfile)],
                                      text=True, cwd=ROOT_DIR,
-                                     env={"TARGETPLATFORM": platform, **os.environ})
+                                     env={**os.environ, "TARGETPLATFORM": platform})
     prereqs = [pathlib.Path(file) for file in json.loads(stdout)]
     print(f"{prereqs=}")
     return prereqs


### PR DESCRIPTION
## Summary

- Adds `-build-arg` support to `bin/buildinputs` Go binary
- Updates `sandbox.py` to extract and pass `--build-arg KEY=VALUE` pairs from the command line
- Fixes issue where `${PYLOCK_PLATFORM}` was empty, resulting in 'pylock..toml' instead of 'pylock.cuda.toml'

## Test plan

- [x] Run `make bin/buildinputs` to verify Go code compiles
- [ ] Test sandbox.py with CUDA Dockerfile that uses `PYLOCK_PLATFORM` build arg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI and build pipeline now accept and propagate --build-arg values so custom image build args are applied end-to-end.

* **Bug Fixes**
  * Validation added to ensure a BASE_IMAGE build argument is provided when required.

* **Tests**
  * Tests updated to cover build-arg handling and reflect the platform Python target bump to 3.12.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->