### PR TITLE
RHELAI-2417, RHELAI-1720: fix(base-images): add `LD_PRELOAD` workaround for PyArrow TLS block issue in CUDA and ROCm images

### DIFF
--- a/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
@@ -59,6 +59,10 @@ ENV VIRTUAL_ENV=${APP_ROOT} \
     PS1="(app-root) \w\$ "
 ### END AIPCC pip and uv config files
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
+++ b/base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
@@ -131,6 +131,10 @@ ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 RUN dnf -y install cuda-toolkit-12-6 && \
     dnf -y clean all --enablerepo="*"
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
@@ -131,6 +131,10 @@ ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 RUN dnf -y install cuda-toolkit-12-6 && \
     dnf -y clean all --enablerepo="*"
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
@@ -127,6 +127,10 @@ RUN dnf install -y \
 # Set this flag so that libraries can find the location of CUDA
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
@@ -152,6 +152,10 @@ RUN dnf -y install dnf-plugins-core && \
     snappy \
     && dnf -y clean all --enablerepo="*"
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
@@ -144,6 +144,10 @@ RUN dnf -y install \
 # RHEL entitlements. Adding CentOS Stream 9 repos would work but mixing distro repos
 # is not a good practice to promote. The c9s variant of this image has these installed.
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -178,6 +178,10 @@ ENV VIRTUAL_ENV=${APP_ROOT} \
     PS1="(app-root) \w\$ "
 ### END AIPCC pip and uv config files
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
@@ -80,6 +80,10 @@ EOF
 
 RUN ldconfig
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
@@ -80,6 +80,10 @@ EOF
 
 RUN ldconfig
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
@@ -80,6 +80,10 @@ EOF
 
 RUN ldconfig
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
@@ -80,6 +80,10 @@ EOF
 
 RUN ldconfig
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
@@ -123,6 +123,10 @@ ENV VIRTUAL_ENV=${APP_ROOT} \
     PS1="(app-root) \w\$ "
 ### END AIPCC pip and uv config files
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src

--- a/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
@@ -118,6 +118,10 @@ ENV VIRTUAL_ENV=${APP_ROOT} \
     PS1="(app-root) \w\$ "
 ### END AIPCC pip and uv config files
 
+# RHELAI-2417, RHELAI-1720: workaround for PyArrow
+# libjemalloc.so.2: cannot allocate memory in static TLS block
+ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.2
+
 # Restore user workspace
 USER 1001
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-allocation stability for PyArrow across CPU, CUDA (12.6/12.8/13.0) and ROCm (6.2/6.3/6.4) base images by introducing a runtime preload to reduce allocation/runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->