### PR TITLE
chore(makefile): improve macOS compatibility for `.RECIPEPREFIX`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# On macOS, the default /usr/bin/make is GNU Make 3.81 which doesn't support .RECIPEPREFIX.
+# Transparently re-exec with gmake if available.
+ifeq ($(origin .RECIPEPREFIX), undefined)
+	ifeq ($(shell command -v gmake 2>/dev/null),)
+		$(error This Make does not support .RECIPEPREFIX. If on macOS, install GNU Make 4.0+ (`gmake`) via 'brew install make')
+	endif
+.DEFAULT:
+	@exec gmake $(MAKECMDGOALS)
+endif
+
 # https://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 SELF ::= $(firstword $(MAKEFILE_LIST))
@@ -13,9 +23,6 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
 # todo: leave the default recipe prefix for now
-ifeq ($(origin .RECIPEPREFIX), undefined)
-$(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later)
-endif
 .RECIPEPREFIX =
 
 IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images


### PR DESCRIPTION
## Description

Added automatic fallback to `gmake` on macOS if the default `make` version does not support `.RECIPEPREFIX`. Simplified error handling and eliminated redundancy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system compatibility across macOS and systems without certain GNU Make versions
  * Enhanced build reliability with stricter shell execution standards and improved environment detection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->