### PR TITLE
RHAIENG-2043: chore(base-images): apply `fix-permissions` to `${APP_ROOT}` across CUDA, ROCm, and CPU Dockerfiles

### DIFF
--- a/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 # Restore user workspace

--- a/base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
+++ b/base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001

--- a/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
@@ -20,6 +20,7 @@ RUN \
 /bin/bash <<'EOF'
 set -Eeuxo pipefail
 /mnt/aipcc.sh
+fix-permissions ${APP_ROOT} -P
 EOF
 
 USER 1001


### PR DESCRIPTION
## Description

Fixup for
* https://github.com/opendatahub-io/notebooks/pull/2840/changes

## How Has This Been Tested?

Build was failing because /opt/app-root venv was owned by root.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple base image configurations across CPU, CUDA (versions 12.6, 12.8, 13.0), and ROCm (versions 6.2, 6.3, 6.4) with varying Python versions to ensure proper directory permissions are established during the image build process. Updates applied consistently across all supported platform variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->