### PR TITLE
fix(base-images): use custom `fix-permissions` script in all Dockerfiles

### DIFF
--- a/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
@@ -55,7 +55,7 @@ ENV CNB_USER_ID=1001 \
 RUN useradd -u ${CNB_USER_ID} -g ${CNB_GROUP_ID} -d ${HOME} -K HOME_MODE=0770 -K UMASK=0007 -m -s /bin/bash -c "Default Application User" default \
     && mkdir -m 770 "${HOME}/.cache"
 
-# permission fixer from github.com/sclorg
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
 COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \

--- a/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/ubi9-python-3.12/Dockerfile.cpu
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM registry.access.redhat.com/ubi9/python-312:latest AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
+++ b/base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.11
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.8/ubi9-python-3.12/Dockerfile.cuda
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.3/c9s-python-3.12/Dockerfile.rocm
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.3/ubi9-python-3.12/Dockerfile.rocm
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM quay.io/centos/centos:stream9 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \

--- a/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
@@ -2,6 +2,7 @@ ARG TARGETARCH
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
+COPY base-images/utils/fix-permissions /mnt/usr/bin/
 
 ####################
 # base             #
@@ -13,6 +14,13 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV PYTHON=python3.12
 ENV VIRTUAL_ENV=/opt/app-root/
+
+# OpenShift s2i / Cloud Native Buildpack user
+ENV CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0
+
+# Custom fix-permissions script that extends sclorg version with chown to UID 1001
+COPY --from=buildscripts /mnt/usr/bin/ /usr/bin/
 
 RUN \
 --mount=from=buildscripts,source=/mnt,target=/mnt \


### PR DESCRIPTION
## Description

The UBI and sclorg base images include a built-in fix-permissions script from github.com/sclorg that only adjusts group ownership and permissions for OpenShift compatibility. However, our custom fix-permissions script (in base-images/utils/) additionally runs:

    find ... -exec chown ${CNB_USER_ID} {} +

This ensures files in /opt/app-root are owned by the 'default' user (UID 1001) rather than root. Without this, files installed as root remain owned by root, even though they are group-writable.

Investigation showed that quay.io/opendatahub/odh-base-image-cpu-py312-c9s correctly has files owned by 'default:root' because cpu/c9s-python-3.12 already used the custom script. Other base images (UBI9, c9s with sclorg python base) were using the upstream fix-permissions which lacks the chown command.

This change ensures consistent file ownership across all base images by:
1. Copying our custom fix-permissions to /mnt/usr/bin/ in buildscripts
2. Installing it to /usr/bin/ to override the base image's version

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced permission management across base container images (CPU, CUDA, ROCm variants) for Python 3.11/3.12: added a permissions-fix utility to images, ensured it runs during image setup, and introduced CNB user/group environment configuration for consistent OpenShift/Cloud Native Buildpack behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->