### PR TITLE
RHOAIENG-46777: fix(ci): set explicit persist-credentials in checkout actions

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -76,6 +76,7 @@ jobs:
         if: ${{ fromJson(inputs.github).event_name != 'pull_request_target' }}
         with:
           lfs: ${{ contains(inputs.target, 'codeserver') }}
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
       # we need to checkout the pr branch, not pr target (the default for pull_request_target)
       # user access check is done in calling workflow
       - uses: actions/checkout@v6
@@ -83,6 +84,7 @@ jobs:
         with:
           ref: "refs/pull/${{ fromJson(inputs.github).event.number }}/merge"
           lfs: ${{ contains(inputs.target, 'codeserver') }}
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       # https://github.com/docker/setup-qemu-action?tab=readme-ov-file#about
       # https://www.itix.fr/blog/qemu-user-static-with-podman/

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -54,8 +54,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
       - uses: actions/checkout@v6
         if: ${{ github.event_name != 'pull_request_target' }}
+        with:
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -52,8 +52,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
       - uses: actions/checkout@v6
         if: ${{ github.event_name != 'pull_request_target' }}
+        with:
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -29,6 +29,8 @@ jobs:
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/notebooks-digest-updater.yaml
+++ b/.github/workflows/notebooks-digest-updater.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.BRANCH_NAME }}
+          persist-credentials: true
 
       - name: Create a new branch
         run: |
@@ -65,6 +66,7 @@ jobs:
         with:
           ref: ${{ env.TMP_BRANCH }}
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Invoke ci/sha-digest-updater.sh script to handle the updates
         shell: bash

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -65,6 +65,7 @@ jobs:
         with:
           ref: ${{ env.BRANCH }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
+          persist-credentials: true
 
       - name: Configure Git
         run: |

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.BRANCH_NAME }}
+          persist-credentials: true
 
       # Create a new branch
       - name: Create a new branch
@@ -92,6 +93,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.SEC_SCAN_BRANCH }}
+          persist-credentials: true
 
       - name: setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/update-buildconfigs.yaml
+++ b/.github/workflows/update-buildconfigs.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Configure Git
         run: |

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Update manifests/base/commit-latest.env
         id: update_env

--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Detect and replace tags in .tekton and params-latest.env files
         id: replace


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-46777

## Summary

- Set `persist-credentials: false` for PR build workflows that don't need git push (with reference to actions/checkout#2312)
- Set `persist-credentials: true` for automation workflows that need git push

## Test plan

- [x] Verify PR build workflows still work correctly
- [ ] Verify automation workflows (piplock-renewal, digest-updater, etc.) can still push commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated credential handling configuration across multiple automated build and deployment workflows to ensure secure and appropriate credential management during CI/CD operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->