### PR TITLE
fix(trustyai): filter out lintrunner from PyTorch requirements for uv compatibility

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -133,7 +133,9 @@ if [[ $(uname -m) == "ppc64le" ]] || [[ $(uname -m) == "s390x" ]]; then
     else
 	git clone --depth 1 --branch "v${TORCH_VERSION}" --recurse-submodules --shallow-submodules https://github.com/pytorch/pytorch.git
         cd pytorch
-        uv pip install -r requirements.txt
+        # Filter out lintrunner - it's a dev tool for linting, not needed for building PyTorch
+        # uv cannot parse lintrunner's pyproject.toml (missing project.version)
+        grep -v lintrunner requirements.txt | uv pip install -r /dev/stdin
         python setup.py develop
         rm -f dist/torch*+git*whl
         MAX_JOBS=${MAX_JOBS:-$(nproc)} \


### PR DESCRIPTION
## Summary

- Filter out `lintrunner` from PyTorch's `requirements.txt` during ppc64le build to fix uv compatibility issue
- lintrunner is a development tool for linting PyTorch source code, not needed for building the wheel

## Problem

Building PyTorch from source on ppc64le fails with uv because lintrunner's `pyproject.toml` is missing the required `dynamic = ["version"]` field:

```
× Failed to download and build `lintrunner==0.12.11`
├─▶ Failed to parse: `.../pyproject.toml`
╰─▶ TOML parse error at line 5, column 1
    `pyproject.toml` is using the `[project]` table, but the required
    `project.version` field is neither set nor present in the
    `project.dynamic` list
```

## Solution

Filter out lintrunner before passing PyTorch's requirements.txt to uv. This is safe because lintrunner is only used for linting PyTorch's source code during development, not for building the wheel.

Upstream issue filed: https://github.com/suo/lintrunner/issues/99

## Test plan

- [x] Verify ppc64le TrustyAI build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved development environment setup to enhance dependency installation handling on non-s390x architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->