### PR TITLE
fix(ci): use three-dot diff to detect only PR changes in build workflow

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -22,9 +22,12 @@ def get_github_token() -> str:
 def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     logging.debug("Getting list of changed files from git diff")
 
+    # Use three-dot diff to show changes from merge-base to to_ref
+    # This correctly shows only changes introduced by the PR, regardless of how much from_ref has advanced
+    # See: https://github.com/opendatahub-io/notebooks/issues/2875
     # https://github.com/red-hat-data-services/notebooks/pull/361: add -- in case to_ref matches a file name in the repo
     files = subprocess.check_output(
-        ["git", "diff", "--name-only", from_ref, to_ref, "--"], encoding="utf-8"
+        ["git", "diff", "--name-only", f"{from_ref}...{to_ref}", "--"], encoding="utf-8"
     ).splitlines()
 
     logging.debug(f"Determined {len(files)} changed files: {files[:100]} (..., printing up to 100 files)")


### PR DESCRIPTION
Fix CI workflow git diff logic to correctly detect only files changed by a PR, preventing false-positive build triggers when main advances after PR creation.

## Problem

PR #2874 only changed 2 files but CI detected 20 changed files and triggered builds for all workbench images.

## Root Cause

The file ci/cached-builds/gha_pr_changed_files.py used two-dot diff which shows ALL differences between branches. When main advances after PR creation, this includes files changed in main.

## Solution

Use three-dot diff which shows only changes from merge-base to PR branch.

## Testing

All 4 unit tests pass. Verified with PR #2874: detects 2 files instead of 20.

* Fixes #2875

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to align with Python 3.12 target environment.

* **Chores**
  * Enhanced PR change detection mechanism to more accurately identify modified files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->