### PR TITLE
Test: Use zstd:chunked base images to measure GHA build speedup

### DIFF
--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:e5bf9d9494b6c4ed7b5639f8d9a6203c889bc7f187147a0082a8940c36c23870
 PYLOCK_FLAVOR=cpu

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:e5bf9d9494b6c4ed7b5639f8d9a6203c889bc7f187147a0082a8940c36c23870

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
 # Base Image   : c9s with Python 3.12 (zstd:chunked from PR 2868)
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:e5bf9d9494b6c4ed7b5639f8d9a6203c889bc7f187147a0082a8940c36c23870
 PYLOCK_FLAVOR=cpu

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,3 @@
 # zstd:chunked from PR 2868 (cuda-13-0, closest available)
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:2a4cb3a49e11bc58548a55720060de0cc72387c88adc9b3354785fc1522bca44
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:4a25b4b40bb1e1c6a0dc222668bfcf41e45586c6a9e2f675684b7db0a30f47dc
 PYLOCK_FLAVOR=cuda

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,3 @@
 # zstd:chunked from PR 2868 (rocm-6-4)
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:f76c06cbc7ed4e653d2f925e4a906b60bab34c4b8d55874bc91bb3f7074d0cd8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:23ecb27da253e2ecd4e33240879abafbd15cd77202b8ba8e042dacc04daabe40
 PYLOCK_FLAVOR=rocm

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:2a4cb3a49e11bc58548a55720060de0cc72387c88adc9b3354785fc1522bca44
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:4a25b4b40bb1e1c6a0dc222668bfcf41e45586c6a9e2f675684b7db0a30f47dc

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:2a4cb3a49e11bc58548a55720060de0cc72387c88adc9b3354785fc1522bca44
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:4a25b4b40bb1e1c6a0dc222668bfcf41e45586c6a9e2f675684b7db0a30f47dc

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:f76c06cbc7ed4e653d2f925e4a906b60bab34c4b8d55874bc91bb3f7074d0cd8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:23ecb27da253e2ecd4e33240879abafbd15cd77202b8ba8e042dacc04daabe40

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:f76c06cbc7ed4e653d2f925e4a906b60bab34c4b8d55874bc91bb3f7074d0cd8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:23ecb27da253e2ecd4e33240879abafbd15cd77202b8ba8e042dacc04daabe40

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:2a4cb3a49e11bc58548a55720060de0cc72387c88adc9b3354785fc1522bca44
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:4a25b4b40bb1e1c6a0dc222668bfcf41e45586c6a9e2f675684b7db0a30f47dc

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:e5bf9d9494b6c4ed7b5639f8d9a6203c889bc7f187147a0082a8940c36c23870

--- a/rstudio/c9s-python-3.12/build-args/cuda.conf
+++ b/rstudio/c9s-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:2a4cb3a49e11bc58548a55720060de0cc72387c88adc9b3354785fc1522bca44
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:4a25b4b40bb1e1c6a0dc222668bfcf41e45586c6a9e2f675684b7db0a30f47dc

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:e5bf9d9494b6c4ed7b5639f8d9a6203c889bc7f187147a0082a8940c36c23870
 PYLOCK_FLAVOR=cpu

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:e5bf9d9494b6c4ed7b5639f8d9a6203c889bc7f187147a0082a8940c36c23870

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9@sha256:7032289e42fd53b65b0a71008cc4ad21f9db8f00dcb421128904a939da5bb16e
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9@sha256:0aa9a69ea58171f77ab1956e6270c89a68c1854f44771515be7f65a8110ef6b7

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9@sha256:7032289e42fd53b65b0a71008cc4ad21f9db8f00dcb421128904a939da5bb16e
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9@sha256:0aa9a69ea58171f77ab1956e6270c89a68c1854f44771515be7f65a8110ef6b7

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-ubi9@sha256:13f2bc5bde88770ff8ad446114274e97668575bf41095915529fe9958f97c0bb
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-ubi9@sha256:dcfba31b80513284fe1d6cc0ad0f8867161a37e143d46fc84ed0d07c85e807a9

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:f76c06cbc7ed4e653d2f925e4a906b60bab34c4b8d55874bc91bb3f7074d0cd8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:23ecb27da253e2ecd4e33240879abafbd15cd77202b8ba8e042dacc04daabe40

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9@sha256:7032289e42fd53b65b0a71008cc4ad21f9db8f00dcb421128904a939da5bb16e
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9@sha256:0aa9a69ea58171f77ab1956e6270c89a68c1854f44771515be7f65a8110ef6b7


### PR DESCRIPTION
## Description

This test branch uses the **zstd:chunked** compressed base images built in PR #2868 to measure whether GHA builds are faster with the new compression format.

## Base Images Updated

All 19 `.conf` files in `build-args/` directories updated to use digest-pinned zstd:chunked images:

| Image Type | Digest |
|------------|--------|
| CPU C9S | `sha256:2580cb333113ae2e04a813dbea318ddc9c8e3f68e724f42c0d3d4f83ac35abd0` |
| CUDA C9S (13.0) | `sha256:2a4cb3a49e11bc58548a55720060de0cc72387c88adc9b3354785fc1522bca44` |
| CUDA UBI9 (12.8) | `sha256:7032289e42fd53b65b0a71008cc4ad21f9db8f00dcb421128904a939da5bb16e` |
| ROCm C9S (6.4) | `sha256:f76c06cbc7ed4e653d2f925e4a906b60bab34c4b8d55874bc91bb3f7074d0cd8` |
| ROCm UBI9 (6.4) | `sha256:13f2bc5bde88770ff8ad446114274e97668575bf41095915529fe9958f97c0bb` |

## Expected Improvements

Based on [benchmark results](https://github.com/opendatahub-io/notebooks/actions/runs/21541929282):

| Metric | Improvement |
|--------|-------------|
| CUDA image pulls | ~53% faster |
| CUDA builds | ~64% faster |
| CPU image pulls | ~18% faster |

## Test Plan

- [ ] Compare GHA workflow run times against a baseline run with gzip base images
- [ ] Monitor build times for jupyter-minimal, jupyter-datascience, runtimes

## Related

- Parent PR: #2868 (zstd:chunked compression for base images)
- Benchmark report: `docs/benchmark-zstd-chunked-results.md`

Made with [Cursor](https://cursor.com)