### PR TITLE
fix(manifests): revert accidental N-1 version changes for Pyodbc and Psycopg

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -74,10 +74,10 @@ spec:
             {"name": "Scipy", "version": "1.15"},
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
-            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
-            {"name": "Psycopg", "version": "3.3"},
+            {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -83,10 +83,10 @@ spec:
             {"name": "Scipy", "version": "1.15"},
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
-            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
-            {"name": "Psycopg", "version": "3.3"},
+            {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -79,10 +79,10 @@ spec:
             {"name": "Scipy", "version": "1.15"},
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
-            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
-            {"name": "Psycopg", "version": "3.3"},
+            {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -77,10 +77,10 @@ spec:
             {"name": "Scipy", "version": "1.15"},
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
-            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.17"},
-            {"name": "Psycopg", "version": "3.3"},
+            {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -84,10 +84,10 @@ spec:
             {"name": "Scipy", "version": "1.15"},
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
-            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
-            {"name": "Psycopg", "version": "3.3"},
+            {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -83,10 +83,10 @@ spec:
             {"name": "Scipy", "version": "1.15"},
             {"name": "Odh-Elyra", "version": "4.2"},
             {"name": "PyMongo", "version": "4.11"},
-            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Pyodbc", "version": "5.2"},
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
-            {"name": "Psycopg", "version": "3.3"},
+            {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.3"},
             {"name": "Kubeflow-Training", "version": "1.9"}
           ]


### PR DESCRIPTION
## Summary

Fixes accidental N-1 version changes introduced in commit f3f84d7c1 (#2884).

When updating package versions for AIPCC compatibility, the search/replace for Pyodbc (5.2→5.3) and Psycopg (3.2→3.3) accidentally matched in N-1 sections since they had the same version numbers as the N sections being updated.

N-1 sections should remain frozen with the versions that shipped in that release.

### Changes

Reverts in N-1 sections of 6 imagestream files:
- Pyodbc: 5.3 → 5.2
- Psycopg: 3.3 → 3.2

### Affected Files

- jupyter-datascience-notebook-imagestream.yaml
- jupyter-pytorch-notebook-imagestream.yaml
- jupyter-tensorflow-notebook-imagestream.yaml
- jupyter-trustyai-notebook-imagestream.yaml
- jupyter-rocm-pytorch-notebook-imagestream.yaml
- jupyter-rocm-tensorflow-notebook-imagestream.yaml

## Test plan

- [ ] Verify N-1 sections now show correct frozen versions
- [ ] Verify N sections are unchanged (still have updated versions)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded Pyodbc to version 5.2 across all Jupyter notebook images.
  * Downgraded Psycopg to version 3.2 across all Jupyter notebook images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->