### PR TITLE
CI: Allow test stages to run independently when earlier tests fail

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -283,6 +283,8 @@ jobs:
         run: uv sync --locked
 
       - name: Run Testcontainers container tests (in PyTest)
+        id: pytest-testcontainers
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           set -Eeuxo pipefail
           uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
@@ -298,9 +300,11 @@ jobs:
 
       - name: "Check if we have tests or not"
         id: have-tests
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: "ci/cached-builds/has_tests.py --target ${{ inputs.target }}"
 
       - name: "Change pull policy to IfNotPresent"
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           set -Eeuxo pipefail
 
@@ -312,7 +316,7 @@ jobs:
       # Deploying notebook from runtimes/rocm/tensorflow/ubi9-python-3.11/kustomize/base directory...
       # sed: can't read runtimes/rocm/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml: No such file or directory
       - name: "Fixup paths that prevent us from running rocm tests"
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' && steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
 
@@ -321,13 +325,15 @@ jobs:
           ln -s ../rocm-pytorch runtimes/rocm/pytorch
 
       - name: Provision K8s cluster
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
+        id: provision-k8s
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' && steps.have-tests.outputs.tests == 'true' }}
         uses: ./.github/actions/provision-k8s
 
       - name: "Run image tests"
+        id: makefile-tests
         # skip on s390x because we are unable to install requirements-elyra.txt that's installed by runtime image tests
         # https://raw.githubusercontent.com/opendatahub-io/elyra/refs/heads/main/etc/generic/requirements-elyra.txt
-        if: ${{ steps.have-tests.outputs.tests == 'true' && !contains(fromJSON('["linux/s390x"]'), inputs.platform) }}
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' && steps.provision-k8s.outcome == 'success' && !contains(fromJSON('["linux/s390x"]'), inputs.platform) }}
         run: python3 ci/cached-builds/make_test.py --target ${{ inputs.target }}
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
@@ -337,7 +343,8 @@ jobs:
       # endregion
 
       - name: Run OpenShift container tests (in PyTest)
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
+        id: pytest-openshift
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' && steps.provision-k8s.outcome == 'success' && steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
           uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
@@ -410,12 +417,14 @@ jobs:
       # region check-payload for FIPS compliance
 
       - id: check-payload-vars
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           echo "GOPATH=${{ github.workspace }}/go-check-payload" >> "$GITHUB_OUTPUT"
         working-directory: scripts/check-payload
 
       # for https://github.com/openshift/check-payload to cache the built binary
       - uses: actions/setup-go@v6
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         with:
           cache-dependency-path: "scripts/check-payload/go.sum"
         env:
@@ -423,6 +432,7 @@ jobs:
 
       # F0512 15:43:03.219076 21568 main.go:294] Error: exec: "oc": executable file not found in $PATH
       - name: Install oc client
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           # Install the oc client
           curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/openshift-client-linux.tar.gz
@@ -441,6 +451,8 @@ jobs:
       # and use --preserve-env=PATH to avoid
       #  F0512 16:31:58.425584    9911 main.go:294] Error: exec: "podman": executable file not found in $PATH
       - name: Check image with check-payload for FIPS compliance
+        id: fips-check
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           set -Eeuxo pipefail
           # resolve podman under current user, not under sudo/root


### PR DESCRIPTION
## Summary

- Enable all test stages to run independently after image build succeeds, even when earlier tests fail
- Add `if: !cancelled() && steps.make-target.outcome == 'success'` conditions to test steps
- Add precise dependency tracking for K8s-dependent tests using `steps.provision-k8s.outcome == 'success'`

Closes #2900

## Problem

When an early test step (like "Run Testcontainers container tests") fails, all subsequent test stages are skipped. This prevents getting feedback from Trivy scans, FIPS compliance checks, Playwright tests, and other validations that could run independently.

### Example

In [PR #2880 run #3545](https://github.com/opendatahub-io/notebooks/actions/runs/21588878722/job/62203828121?pr=2880), the `rocm-runtime-pytorch-ubi9-python-3.12` job failed at step 24 with 428 failed subtests. As a result, the following steps were **skipped**:
- K8s cluster provisioning and Makefile-based image tests
- OpenShift container tests (PyTest)
- Trivy vulnerability scan
- FIPS compliance check (check-payload)
- Playwright browser tests

## Solution

Add `if: !cancelled() && steps.make-target.outcome == 'success'` conditions to all test-related steps. This ensures:
1. **Tests only run if the image build succeeded** - No point running tests on a failed build
2. **Tests continue running even if previous tests fail** - Get feedback from all independent validations
3. **The job still reports overall failure** - Any test failure marks the job as failed

## Design Choice: Why `if: !cancelled()` instead of `continue-on-error: true`?

| Approach | Pros | Cons |
|----------|------|------|
| `continue-on-error: true` | Simple to add | Step shows as "success" even when failing; misleading |
| `if: !cancelled()` | Preserves accurate pass/fail status per step | Slightly more verbose |
| Separate parallel jobs | Maximum isolation | Major workflow restructure; increased complexity |

We chose `if: !cancelled()` because it's minimally invasive, preserves accurate pass/fail status, and is easy to understand.

## Changes Made

### Phase 1: Independent Test Steps
| Step | Changes |
|------|---------|
| Testcontainers pytest | Added `id: pytest-testcontainers` and `if` condition |
| check-payload-vars | Added `if` condition |
| setup-go for check-payload | Added `if` condition |
| Install oc client | Added `if` condition |
| Check image with check-payload | Added `id: fips-check` and `if` condition |

### Phase 2: K8s-Dependent Test Chain
| Step | Changes |
|------|---------|
| Check if we have tests or not | Added `if` condition (preserved existing `id: have-tests`) |
| Change pull policy to IfNotPresent | Added `if` condition |
| Fixup paths for rocm tests | Updated to include `!cancelled()` |
| Provision K8s cluster | Added `id: provision-k8s` and updated condition |
| Run image tests | Added `id: makefile-tests` and condition checking `steps.provision-k8s.outcome` |
| Run OpenShift container tests | Added `id: pytest-openshift` and condition checking `steps.provision-k8s.outcome` |

### Phase 3: Verification
- Trivy scan and Playwright tests already had correct `!cancelled()` conditions - no changes needed

## Test Flow After Change

```
Build Image (success)
    |
    +---> Testcontainers pytest (can fail)
    |         |
    |         v (failure does NOT block)
    +---> K8s Cluster Setup
    |         |
    |         +---> Makefile Tests
    |         +---> OpenShift pytest  
    |
    +---> Trivy Scan
    +---> FIPS Compliance Check
    +---> Playwright Tests (if codeserver)
```

All branches run independently after the build succeeds.

## Test plan

- [x] Verify workflow syntax is valid
- [x] Test with a PR that has a failing Testcontainers test to confirm other tests still run
- [x] Confirm job still reports overall failure when any test fails

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline robustness with improved execution controls to prevent cascading failures and ensure more reliable build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->