### PR TITLE
chore(dockerfile): comment out `CUDA_MODULE_LOADING` for better error discovery during tests in CUDA 12.9 base images

### DIFF
--- a/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
@@ -87,7 +87,11 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 ENV CUDA_CACHE_DISABLE=1
 
 # Load kernels on demand for faster startup
-ENV CUDA_MODULE_LOADING=LAZY
+# With CUDA_MODULE_LOADING=LAZY:
+# - A simple import torch; torch.cuda.is_available() won't catch all issues
+# Eager loading for tests - Override during test:
+#     CUDA_MODULE_LOADING=EAGER python -c "import torch; ..."
+#ENV CUDA_MODULE_LOADING=LAZY
 
 # Install CUDA runtime from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.9.1/ubi9/runtime/Dockerfile

--- a/base-images/cuda/12.9/ubi9-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.9/ubi9-python-3.12/Dockerfile.cuda
@@ -87,7 +87,11 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 ENV CUDA_CACHE_DISABLE=1
 
 # Load kernels on demand for faster startup
-ENV CUDA_MODULE_LOADING=LAZY
+# With CUDA_MODULE_LOADING=LAZY:
+# - A simple import torch; torch.cuda.is_available() won't catch all issues
+# Eager loading for tests - Override during test:
+#     CUDA_MODULE_LOADING=EAGER python -c "import torch; ..."
+#ENV CUDA_MODULE_LOADING=LAZY
 
 # Install CUDA runtime from:
 # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.9.1/ubi9/runtime/Dockerfile


### PR DESCRIPTION
## Description

* https://github.com/opendatahub-io/notebooks/issues/2896

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Changed default CUDA kernel loading behavior from lazy to eager in base container images, removing automatic lazy loading configuration while providing documentation on test-specific overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->