### PR TITLE
fix(manifests): align Numpy version to 2.4 in pytorch and rocm-pytorch imagestreams

### DIFF
--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -36,7 +36,7 @@ spec:
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Kfp", "version": "2.15"},
             {"name": "Matplotlib", "version": "3.10"},
-            {"name": "Numpy", "version": "2.3"},
+            {"name": "Numpy", "version": "2.4"},
             {"name": "Pandas", "version": "2.3"},
             {"name": "Scikit-learn", "version": "1.8"},
             {"name": "Scipy", "version": "1.16"},

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -34,7 +34,7 @@ spec:
             {"name": "Tensorboard", "version": "2.20"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.10"},
-            {"name": "Numpy", "version": "2.3"},
+            {"name": "Numpy", "version": "2.4"},
             {"name": "Pandas", "version": "2.3"},
             {"name": "Scikit-learn", "version": "1.8"},
             {"name": "Scipy", "version": "1.16"},

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -555,11 +555,11 @@ wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai
 
 [[packages]]
 name = "numpy"
-version = "2.3.5"
+version = "2.4.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cuda12.9-ubi9/numpy-2.3.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "2a50b6870027eed0561f786f4e99829b5be5f5207dd7bff73bbf6c34a455fe41" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cuda12.9-ubi9/numpy-2.3.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "6595ca2ddf1e0e7973ca407c9b7b52b90bdce94806b165a77b88e21ce3a83cc5" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cuda12.9-ubi9/numpy-2.4.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "652b84c2b07e25503593821eaaaff70088744a421428b1202975c759901d54b8" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cuda12.9-ubi9/numpy-2.4.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1ef16da95f8cac46f7a6fe521257cb93dfd4857ee0e9bdff1d849a4873e11596" } },
 ]
 
 [[packages]]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -504,9 +504,9 @@ wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai
 
 [[packages]]
 name = "numpy"
-version = "2.3.5"
+version = "2.4.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/rocm6.4-ubi9/numpy-2.3.5-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "444849e76d8cfd9171c6d109600cc90a0af9b7bc84c33b77d1c8ffde181d6203" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/rocm6.4-ubi9/numpy-2.4.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b0766dfc70962b7d1ce395b3a5c833ccd5e62165684b808cb8b81dcad10f8bb2" } }]
 
 [[packages]]
 name = "onnx"


### PR DESCRIPTION
fix(manifests): align Numpy version to 2.4 in pytorch and rocm-pytorch imagestreams

## Description
Pylock pins Numpy 2.4.1; manifest declared 2.3, causing test_image_pyprojects to fail. Update notebook-python-dependencies to Numpy 2.4 for jupyter-pytorch and jupyter-rocm-pytorch imagestreams.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Numpy dependency from version 2.3 to 2.4 in PyTorch and ROCm PyTorch notebook images for the 2025.2 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->