### PR TITLE
RHAIENG-3065: chore(dependencies): bump `micropipenv` to 1.10.0 and `uv` to 0.9.28 across all Dockerfiles

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -116,7 +116,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -48,7 +48,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -47,7 +47,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -45,7 +45,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -66,7 +66,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -66,7 +66,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -64,7 +64,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -64,7 +64,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -66,7 +66,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -90,7 +90,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -21,7 +21,7 @@ ENV UV_DEFAULT_INDEX=https://pypi.org/simple
 ### END RHAIENG-2189: this is AIPCC migration phase 1.5
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 # OS Packages needs to be installed as root

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -51,7 +51,7 @@ RUN dnf install -y mesa-libGL && dnf clean all && rm -rf /var/cache/yum
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -47,7 +47,7 @@ RUN dnf install -y perl mesa-libGL && dnf clean all && rm -rf /var/cache/yum
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -47,7 +47,7 @@ RUN dnf install -y perl mesa-libGL && dnf clean all && rm -rf /var/cache/yum
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -122,7 +122,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -59,7 +59,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -47,7 +47,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -47,7 +47,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -45,7 +45,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -45,7 +45,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -49,7 +49,7 @@ EOF
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 ### BEGIN Install the oc client

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -81,7 +81,7 @@ def main():
             EOF
 
         """)),
-        "Install micropipenv and uv to deploy packages from requirements.txt": '''RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.9.0" "uv==0.9.6"''',
+        "Install micropipenv and uv to deploy packages from requirements.txt": '''RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.9.28"''',
         "Install the oc client": textwrap.dedent(r"""
             RUN /bin/bash <<'EOF'
             set -Eeuxo pipefail


### PR DESCRIPTION
Discussed on slack https://redhat-internal.slack.com/archives/C096ZR053RQ/p1770110533316759?thread_ts=1770099414.491409&cid=C096ZR053RQ

https://issues.redhat.com/browse/RHAIENG-3045

## Description

* https://github.com/opendatahub-io/notebooks/pull/2899

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package management tools in container images across multiple environments and configurations. Upgraded micropipenv to version 1.10.0 and uv to version 0.9.28 to improve package deployment and dependency resolution in containerized environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->