### PR TITLE
RHAIENG-1625, RHAIENG-3047, RHAIENG-3048: bump codeserver IDE version and python and jupyterlab extensions

### DIFF
--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -36,9 +36,8 @@ spec:
   - name: build-platforms
     value:
     # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
-    - linux-extra-fast/amd64
-    - linux-m2xlarge/arm64
-    - linux/ppc64le
+    - linux-d160-m4xlarge/amd64
+    - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: codeserver/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
     # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
     - linux-d160-m4xlarge/amd64
     - linux-d160-m4xlarge/arm64
+    - linux/ppc64le
   - name: dockerfile
     value: codeserver/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -38,7 +38,6 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
     - linux-d160-m4xlarge/arm64
-    - linux/ppc64le
   pipelineRef:
     name: multiarch-push-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -36,8 +36,9 @@ spec:
     - 3.4_ea1-v1.41
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
-    - linux-m2xlarge/arm64
+    - linux-d160-m4xlarge/amd64
+    - linux-d160-m4xlarge/arm64
+    - linux/ppc64le
   pipelineRef:
     name: multiarch-push-pipeline
   taskRunTemplate:

--- a/codeserver/Extensions.md
+++ b/codeserver/Extensions.md
@@ -40,6 +40,15 @@ Extension packages (`.vsix` files) vendored into this repository are automatical
 
 When adding or updating extensions, place the downloaded `.vsix` artifacts under the appropriate `codeserver/ubiX-python-Y/utils/` directory. Commit them normally; they will be stored as LFS objects.
 
+### Current versions
+
+For `codeserver/ubi9-python-3.12`, the image expects these `.vsix` files in `utils/`:
+
+- **ms-python.python** 2026.0.0: <https://open-vsx.org/api/ms-python/python/2026.0.0/file/ms-python.python-2026.0.0.vsix>
+- **ms-toolsai.jupyter** 2025.9.1: <https://open-vsx.org/api/ms-toolsai/jupyter/2025.9.1/file/ms-toolsai.jupyter-2025.9.1.vsix>
+
+Download with `curl -o <filename> <url>` and place under `codeserver/ubi9-python-3.12/utils/`.
+
 ## Troubleshooting
 
 - If you see errors like "End of central directory record signature not found" when installing `.vsix` files, it usually means LFS pointers were checked out instead of the actual binaries.

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -187,7 +187,7 @@ COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 mkdir -p /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2026.0.1.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2026.0.0.vsix --extensions-dir /opt/app-root/extensions-temp
 code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.9.1.vsix --extensions-dir /opt/app-root/extensions-temp
 EOF
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -187,8 +187,8 @@ COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 mkdir -p /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.14.0.vsix --extensions-dir /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.8.0.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2026.0.1.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.9.1.vsix --extensions-dir /opt/app-root/extensions-temp
 EOF
 
 # Install NGINX to proxy code-server and pass probes check

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -17,10 +17,8 @@ ENV HOME=/root
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
-ARG NODE_VERSION=22.18.0
-
-ARG CODESERVER_VERSION=v4.104.0
-
+ARG NODE_VERSION=22.21.1
+ARG CODESERVER_VERSION=v4.106.3
 COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
 
 # create dummy file to ensure this stage is awaited before installing rpm
@@ -134,7 +132,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
-ARG CODESERVER_VERSION=v4.104.0
+ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.12" \

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -20,8 +20,8 @@ ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
 if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" || "$ARCH" == "ppc64le" || "$ARCH" == "s390x" ]]; then
 
 	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
-	export NODE_VERSION=${NODE_VERSION:-22.18.0}
-	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.104.0}
+	export NODE_VERSION=${NODE_VERSION:-22.21.1}
+	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.106.3}
 
 	export NVM_DIR=/root/.nvm VENV=/opt/.venv
 	export PATH=${VENV}/bin:$PATH

--- a/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.14.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.14.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d561d57f5820c0bdbc2b822f417e524afba256c60b28a9a1670f7923b1bddabc
-size 6771811

--- a/codeserver/ubi9-python-3.12/utils/ms-python.python-2026.0.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.python-2026.0.0.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e396d253fc3ef967bd11b1df5e827c2cbb6b30af6e7f56c1a0cfa5f933410465
+size 6810600

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.8.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.8.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e0373fe1b309660e6e53189ab7ad34f7e374d3c7a76b8e4621d6a5b93d4caae
-size 12619222

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.9.1.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.9.1.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:110660656944c4ab0ff687db488c2e8c59c67ec121dcf09bcaa54b6edd9ce71f
+size 12619012

--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -8,185 +8,185 @@ requires-python = ">=3.12"
 name = "annotated-doc"
 version = "0.0.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/annotated_doc-0.0.4-2-py3-none-any.whl", hashes = { sha256 = "76decc1d1a4a6abe8df74feeaf16efcf8aa82fd0f3d836a0c0f30242b6b8bb4e" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/annotated_doc-0.0.4-2-py3-none-any.whl", hashes = { sha256 = "4a13057c82b5f5b1824a779530c0670abe1e250cab87a63496a50660f548c299" } }]
 
 [[packages]]
 name = "annotated-types"
 version = "0.7.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/annotated_types-0.7.0-2-py3-none-any.whl", hashes = { sha256 = "b680e61f604ef055a77fd965e0b7cd0259111c9c3f1abf144f74e62c7e136cd3" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/annotated_types-0.7.0-2-py3-none-any.whl", hashes = { sha256 = "87e8bbd41b7572a6722813786075b4b2f5973a1eb0bc467713dba87f9d9a3d18" } }]
 
 [[packages]]
 name = "anyio"
 version = "4.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/anyio-4.12.1-2-py3-none-any.whl", hashes = { sha256 = "93458bf75282426f7e4f905928b86e5d07589f028e578627b867cf3c048b2735" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/anyio-4.12.1-2-py3-none-any.whl", hashes = { sha256 = "267dd7f9871a944c7ee481ce7d54d7ef41f7b0901beffff905572d19a08c39c3" } }]
 
 [[packages]]
 name = "asttokens"
 version = "3.0.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/asttokens-3.0.1-2-py3-none-any.whl", hashes = { sha256 = "d702a7f4d5dce346f01401bfe71a4b64bfea95be7504a7366fb062895abfde8d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/asttokens-3.0.1-2-py3-none-any.whl", hashes = { sha256 = "82a416f0b13d0e50d9a2579f51f0eb6bba1ea3c9b90e2bb56dc3376fb9c1f603" } }]
 
 [[packages]]
 name = "attrs"
 version = "25.4.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "5e085aec729524ce11be9fe4843015f43c213475c2295c1711f98b0d1fea817d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "244f7a736edda821f3a02073308d5924882422ce641055105739ae31905d65ca" } }]
 
 [[packages]]
 name = "bigtree"
 version = "1.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/bigtree-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "3dab35b0472f4fff31c1ccfcadbb8cdf4b6cf012c786e38a05205abec979ebd8" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/bigtree-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "056f6f8383312fc0ded4dd178039ed4a1cede5536a7310e3e0827bef3c5db72a" } }]
 
 [[packages]]
 name = "boto3"
 version = "1.42.29"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/boto3-1.42.29-2-py3-none-any.whl", hashes = { sha256 = "b01a7e3496e304274eba0a666ff43f00490b77273a84358cd76a2ed655789cc9" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/boto3-1.42.29-2-py3-none-any.whl", hashes = { sha256 = "271d7eea8375d6ca4dd85622c6db4f6bafd0cc4254b9b4b80c7597e61809c307" } }]
 
 [[packages]]
 name = "botocore"
 version = "1.42.29"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/botocore-1.42.29-2-py3-none-any.whl", hashes = { sha256 = "21fcf1c7780f5cd922f3e62c64c61223a890d3e2c3c2935e6f00f535b8a207b6" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/botocore-1.42.29-2-py3-none-any.whl", hashes = { sha256 = "2f2f5abd2f09d401368331638cf7005af295edd37ebd57ff8a081def1ab40538" } }]
 
 [[packages]]
 name = "certifi"
 version = "2026.1.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/certifi-2026.1.4-2-py3-none-any.whl", hashes = { sha256 = "7537a11f21081e197a039bef140918f65bfa91c589bca74ec3455e34ebbad268" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/certifi-2026.1.4-2-py3-none-any.whl", hashes = { sha256 = "b95074c6f3437cf73c11aee9aa7ca595c69b61bb88b87e623524503c28b50c32" } }]
 
 [[packages]]
 name = "charset-normalizer"
 version = "3.4.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/charset_normalizer-3.4.4-2-py3-none-any.whl", hashes = { sha256 = "f4a9b098a4b36e6a3bf22c5a757424c8c7084f94e31b047ebbeaf27d10ee522e" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/charset_normalizer-3.4.4-2-py3-none-any.whl", hashes = { sha256 = "9ef0c1bdf6d733aada9c05b7de35b712cbdab0bf9f523c3c5bf765d97d2ce8d7" } }]
 
 [[packages]]
 name = "click"
 version = "8.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/click-8.3.1-2-py3-none-any.whl", hashes = { sha256 = "e34d5a937cb7e46d820377e362870fa383d2806d3b9d0695799e0d51ec345f42" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/click-8.3.1-2-py3-none-any.whl", hashes = { sha256 = "7148bc8108bfeb0021bc1c8514aa738702d7f3ddb063b2895850b2c74d9f74bd" } }]
 
 [[packages]]
 name = "cloudpickle"
 version = "3.1.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/cloudpickle-3.1.2-2-py3-none-any.whl", hashes = { sha256 = "10330d899d609d8b008c1fb016cd75f784adb47e05b3f950c01ac2f141657b8c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/cloudpickle-3.1.2-2-py3-none-any.whl", hashes = { sha256 = "4b27aa3e751a1173084b52f30d80d86b9d99d14f624b5b69854e57640c97d3ec" } }]
 
 [[packages]]
 name = "colorama"
 version = "0.4.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/colorama-0.4.6-2-py2.py3-none-any.whl", hashes = { sha256 = "6a666a04575143daff7ee645ed455ecd7b108f1a1e2bb8afd24e0e58dc7a7969" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/colorama-0.4.6-2-py2.py3-none-any.whl", hashes = { sha256 = "585e10bf52cbfabe1b73adfec16718a282bc62412325048f4b7328e47140e194" } }]
 
 [[packages]]
 name = "comm"
 version = "0.2.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/comm-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "b1c4907c5e0a1b5c2fc1aee28a43c32c72c7d52db77def960acaf11e2453456a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/comm-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "0df571138a8cade162d1b2951baaf02b48d38300b3a057219a6faa83762a7a3c" } }]
 
 [[packages]]
 name = "contourpy"
 version = "1.3.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "522aacb85ec6054bfad9a210c23fff0788fa712b2f6f80551e36f80853db6980" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "95db72c6a7abd099d3b2c1f7ed2c2c51fad1cec425f9077cf0b46d7491870713" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "8b843bd39c5967c3b8c6ae1357a831bd2fbfac1540a9c8427d41d95fd6fc9b84" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "5262edbcd8ac663b5d555fdd183d615a2e23fb0c7ce7906683ebf06cd149e964" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "59ac7ffc014a54edf9e60182ea4a1de8923c7adc5272decbf3c36e70efbee075" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8832f31917d7272e11746a4c06c531532973c55b365b14eeeb5b0fa7e569c807" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e289b658f94e13d79ca1fb798eb1d0586e6f74b210a1ed6894eb7d8235b50640" } },
 ]
 
 [[packages]]
 name = "cycler"
 version = "0.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/cycler-0.12.1-2-py3-none-any.whl", hashes = { sha256 = "c208eacb836c3db8d1e13d146b1d40326e1b1aa36e0ffaa341f4d25f2f4f8dc0" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/cycler-0.12.1-2-py3-none-any.whl", hashes = { sha256 = "8fd4987794a2f551b628d28f563ca7b5acca635399edaf487cf88b2ab6f84755" } }]
 
 [[packages]]
 name = "dask"
 version = "2026.1.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/dask-2026.1.1-2-py3-none-any.whl", hashes = { sha256 = "ee61d1efa7964d1263e65dc683cd6aa733cbb3083547e2da1fea9b4438f7e7fd" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/dask-2026.1.1-2-py3-none-any.whl", hashes = { sha256 = "e4460b252abb574d9f56ad4f4266313ae195b3ca4fb59e2b140cd16e0f220e8f" } }]
 
 [[packages]]
 name = "debugpy"
 version = "1.8.19"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "954325ad41afc1b790ff2cc1c972932cf54513ebe6eed6cb19ea4434ebfdf2cd" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "f8f63c99967d3298c71bd4be03d6982509c2c090b1cd8ea745d6316a6b96c5cd" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bd0a48692fb8e1ab47a6f133f863d77d5f7580aa9435581302f56e553b1c37fd" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9ded32a0414f66a6a422b964b6ade6924fef530777215d470a5918ed1239dda6" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "14200aa00a2221e5a54ef4daa102f8534742f0f03f436483f130951d0cc49876" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "cb4df6be43489a21d7ed58712a9cd1c65ed63aa5a6773c8d17bc75e19fd147fd" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/debugpy-1.8.19-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "42318e7baaaef84c513748af6ce64919f3c15eb79d42792f1ccb707cd8f51ffb" } },
 ]
 
 [[packages]]
 name = "decorator"
 version = "5.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/decorator-5.2.1-2-py3-none-any.whl", hashes = { sha256 = "e1035a58414b10aa6081e3f29eb7e5424613c173bd705931d1c99b42cc62edce" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/decorator-5.2.1-2-py3-none-any.whl", hashes = { sha256 = "d0af9d86522d514999673fd1b20c3c1ee6ca61a4d5659b1c4408bc01d0c57dcb" } }]
 
 [[packages]]
 name = "dill"
 version = "0.3.9"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/dill-0.3.9-2-py3-none-any.whl", hashes = { sha256 = "219ba5a31614d4f79277a5410269ef0e6fbf1b58b11e98da58497ca502ec92b0" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/dill-0.3.9-2-py3-none-any.whl", hashes = { sha256 = "33a6db05874742426cbb107a97150e8ab3d288b1683729ec8624cdf809260092" } }]
 
 [[packages]]
 name = "distlib"
 version = "0.4.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/distlib-0.4.0-2-py2.py3-none-any.whl", hashes = { sha256 = "4805851bad31ce109d59f45482b2e75ec467886a48cfdf4d9c79ddde0ae6825c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/distlib-0.4.0-2-py2.py3-none-any.whl", hashes = { sha256 = "5a7d73702145d13bfb93edebda8b03234ae59919a39ec46ebfdedd894cabbdcb" } }]
 
 [[packages]]
 name = "docstring-parser"
 version = "0.17.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/docstring_parser-0.17.0-2-py3-none-any.whl", hashes = { sha256 = "2d0ee2d81d830560e9a84fcfa858ca82568a59404d74568eed518a8ebf0f11f9" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/docstring_parser-0.17.0-2-py3-none-any.whl", hashes = { sha256 = "ba3c51de09fcb52ef881ab103f45465576f9f77d10dd5a00c0cfb0e646a464bf" } }]
 
 [[packages]]
 name = "durationpy"
 version = "0.10"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/durationpy-0.10-2-py3-none-any.whl", hashes = { sha256 = "dd5707ee0a90db67aba4dfc8105d0c5fb84f0b821cf64b8bbb64ea920c75f44e" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/durationpy-0.10-2-py3-none-any.whl", hashes = { sha256 = "609bf63b7b7488798a2f32bb7bf2578326fda6baa63062bdb8c7d113f824eac6" } }]
 
 [[packages]]
 name = "executing"
 version = "2.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/executing-2.2.1-2-py2.py3-none-any.whl", hashes = { sha256 = "909133bdef9adfb927156970917908ba5d99511b92e495d3144bc07913d92634" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/executing-2.2.1-2-py2.py3-none-any.whl", hashes = { sha256 = "6f682e536de9e9514a8b02e93c2e0e2e0acc1df64f68242a45823a2f671157ec" } }]
 
 [[packages]]
 name = "fastapi"
 version = "0.128.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/fastapi-0.128.0-2-py3-none-any.whl", hashes = { sha256 = "3516fcbecaff8648293f2ce16643e3e255ab816fd3162095122061157bb3478a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/fastapi-0.128.0-2-py3-none-any.whl", hashes = { sha256 = "6048960a9d7ec34e020ece119f2d39da776d91593b43367ca011d1f69611596a" } }]
 
 [[packages]]
 name = "feast"
 version = "0.58.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/feast-0.58.0-2-py2.py3-none-any.whl", hashes = { sha256 = "d649fb352d4afeee9022e7a82052eb11dd42f5a61e075eebe46fb938d93f99ba" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/feast-0.58.0-2-py2.py3-none-any.whl", hashes = { sha256 = "1170d65abd3f8414bc3a0cbdc3ed626926e84f3374c77965916eac38a5e59d58" } }]
 
 [[packages]]
 name = "filelock"
 version = "3.20.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/filelock-3.20.3-2-py3-none-any.whl", hashes = { sha256 = "34f06e548fefa091653ff531971bd4a0d794ece3d1f97d8bb7dcb734e422e0de" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/filelock-3.20.3-2-py3-none-any.whl", hashes = { sha256 = "629985c06d17c9c9e011c6fd68f28d854943f512501ca6203b2dbc6f9527df41" } }]
 
 [[packages]]
 name = "fonttools"
 version = "4.61.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/fonttools-4.61.1-2-py3-none-any.whl", hashes = { sha256 = "4da98f0f5ae7a78c070cabc5732fe33258534b1c6103daf144e4b00ddab8e4a0" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/fonttools-4.61.1-2-py3-none-any.whl", hashes = { sha256 = "6be606533544178d0468c1780f702114bf4ee267109e1c86a435ea44e54de0c6" } }]
 
 [[packages]]
 name = "fsspec"
 version = "2026.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/fsspec-2026.1.0-2-py3-none-any.whl", hashes = { sha256 = "ff3b89ed0bd246b77b95e93b89fdab753feef5a898bbd20236bad12cad6a24c4" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/fsspec-2026.1.0-2-py3-none-any.whl", hashes = { sha256 = "9d63b889e8306e0bd5d86f2222ee1a12ac2278bb3cdfb116e98d14d1d1b229e6" } }]
 
 [[packages]]
 name = "google-api-core"
@@ -198,13 +198,13 @@ wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai
 name = "google-auth"
 version = "2.47.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_auth-2.47.0-2-py3-none-any.whl", hashes = { sha256 = "be86255289fd20db8377f7dd8651ae8202d4615c11bc2f498f35f5fa2cb24e83" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_auth-2.47.0-2-py3-none-any.whl", hashes = { sha256 = "3b87a08681cfcd29962312ed620356950095ac6152cdf8f2874754a49e607dd9" } }]
 
 [[packages]]
 name = "google-cloud-core"
 version = "2.5.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_cloud_core-2.5.0-2-py3-none-any.whl", hashes = { sha256 = "6fbf78b1f08be891d896310309e576f66565a19a79334575db9cececde4fe948" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_cloud_core-2.5.0-2-py3-none-any.whl", hashes = { sha256 = "71ff58f0fa71327571388a46f51121ae982ecc9bf086b7d0c5fe00978ddaac66" } }]
 
 [[packages]]
 name = "google-cloud-storage"
@@ -216,48 +216,48 @@ wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai
 name = "google-crc32c"
 version = "1.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_crc32c-1.8.0-2-py3-none-any.whl", hashes = { sha256 = "aa358fd96bbc33eddfccd794e8bf77b7cd1b02b5b857518139dcc0b328392cf6" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_crc32c-1.8.0-2-py3-none-any.whl", hashes = { sha256 = "e540e24fca27095890292f016e7b447050b2125f78adbcd8ebc44d944e26edee" } }]
 
 [[packages]]
 name = "google-resumable-media"
 version = "2.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_resumable_media-2.8.0-2-py3-none-any.whl", hashes = { sha256 = "bdf13a0ceec8ba97622165ceeb789e6f0fb7c1614665be246b819811ca661f9c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/google_resumable_media-2.8.0-2-py3-none-any.whl", hashes = { sha256 = "afe6808cff743f0aac707a62f31019494a6497ed56a9c3ab5b340ee0542f8d4a" } }]
 
 [[packages]]
 name = "googleapis-common-protos"
 version = "1.72.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/googleapis_common_protos-1.72.0-2-py3-none-any.whl", hashes = { sha256 = "b530c484aa7341cab24eda0b801abc608c85da52ff9002d8a485e2f9d9d302c5" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/googleapis_common_protos-1.72.0-2-py3-none-any.whl", hashes = { sha256 = "d597f6fbb0c87d6b1ff53fdc34775d2e71dcc32680a52c7fb974aa38e16554a9" } }]
 
 [[packages]]
 name = "greenlet"
 version = "3.3.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/greenlet-3.3.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "84530bec1ac96afb5dafc470fe08df38e75db27b5095a6cccb31fe8d9b141ad8" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/greenlet-3.3.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "abe1d8550fe0d3d4c10015c1ff4d9bdaef7ee3faec63b2c8f5490ab5d31b888c" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/greenlet-3.3.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "800a297bc20e8fbe0f8543294453bcf2093eacca86d012ea8026976bd693fe46" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/greenlet-3.3.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3df6261acc22326f757c53a36ac1f4bc6be2b30e0256d8f19f4971e3cfa0d638" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/greenlet-3.3.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c5054ad06269fa8941c1b28688df2de61efbee9c37d36a49c36c15bd2ae108d2" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/greenlet-3.3.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "18a9b8887018150e6c1cd54938b0ea57981b554213f67022b75a1d625f45b92c" } },
 ]
 
 [[packages]]
 name = "gunicorn"
 version = "23.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/gunicorn-23.0.0-2-py3-none-any.whl", hashes = { sha256 = "40c0557d2b8888ce68c8ca6abf4f25be052dab6614d21d2c1c36acd1aad86c3b" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/gunicorn-23.0.0-2-py3-none-any.whl", hashes = { sha256 = "e865e650864d289500c7b202db9f4ba5bb9fc87b7bd195139fe7dd8ac86c5aec" } }]
 
 [[packages]]
 name = "h11"
 version = "0.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/h11-0.16.0-2-py3-none-any.whl", hashes = { sha256 = "0ca942b873cebeba04728f11b317165fd9f6c0350ae97134b5d4735c9dd626d7" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/h11-0.16.0-2-py3-none-any.whl", hashes = { sha256 = "48c48b16ee4d9c1ef58128b93b0355c2d2d0559e9a31c4d8457830f486f38fc2" } }]
 
 [[packages]]
 name = "httptools"
 version = "0.7.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "640ebb19879127b4ff6f9eec280177ca66cfd60568c49eed63bfb089d886e811" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "6c0ebdd1962220c6b9a34efe7c6d80e99f7a3a189819f388750d594e47ad74ad" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "0281398ff5447d3f5506f103895f2b05d6f175219e82ac894965b954a3118d58" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "2f03a543635892efd57736ba224e6b374159dc7dbdb25ab150950c078ff923e6" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "34c950d984527c2472105a4a44087ae1edaa2849aac80af0f9674581a018c2e4" } },
@@ -267,120 +267,120 @@ wheels = [
 name = "idna"
 version = "3.11"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/idna-3.11-2-py3-none-any.whl", hashes = { sha256 = "c7e033ce11af6f5ec2efa2df1c7a91c1789646bdf11dd9609756fa76314f95d4" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/idna-3.11-2-py3-none-any.whl", hashes = { sha256 = "6e43f2c725e73dd787cb4d33c37384a48c6e4dc0cf65ea182c39525923d596b7" } }]
 
 [[packages]]
 name = "ipykernel"
 version = "7.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ipykernel-7.1.0-2-py3-none-any.whl", hashes = { sha256 = "4f8727d25cf2211fb7084b3381c531a86484a09f36b2511f6617d641db4438d5" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ipykernel-7.1.0-2-py3-none-any.whl", hashes = { sha256 = "a3e3f693eb22a3cc4426f6b06270ae46051b455f0e749ed467368f9898533328" } }]
 
 [[packages]]
 name = "ipython"
 version = "9.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ipython-9.9.0-2-py3-none-any.whl", hashes = { sha256 = "69f612373f595c46cbf26e57889b9cdf917cf776cf1c70f2c6d19c11fb9c201a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ipython-9.9.0-2-py3-none-any.whl", hashes = { sha256 = "a008ee8b95d3d82975c7eddd25a29e2edcaee8e05fc5365d265727e4f9a407dc" } }]
 
 [[packages]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ipython_pygments_lexers-1.1.1-2-py3-none-any.whl", hashes = { sha256 = "c5e8b5429e04dfee8f20e683f4215ae7987e77427bab47ce08dc7cdba3ba54f3" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ipython_pygments_lexers-1.1.1-2-py3-none-any.whl", hashes = { sha256 = "2058e4dfaa28e31459b40669b2125ed658eecc06080570fef310fb6c46b088c9" } }]
 
 [[packages]]
 name = "jedi"
 version = "0.19.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jedi-0.19.2-2-py2.py3-none-any.whl", hashes = { sha256 = "7316e55ee5bfc463d60d52c5dfe89eedb966bf36214dbca32571a495e1978e39" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jedi-0.19.2-2-py2.py3-none-any.whl", hashes = { sha256 = "5405276df27fc82e508e58028ba28b3ddaaedfb530d160450215a70eb1a81468" } }]
 
 [[packages]]
 name = "jinja2"
 version = "3.1.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jinja2-3.1.6-2-py3-none-any.whl", hashes = { sha256 = "99bd1d524e9ac6f085e6e99cff4a88207a42fa94b36b1a302a2edbbd7bd102fd" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jinja2-3.1.6-2-py3-none-any.whl", hashes = { sha256 = "83efe090bafd6fbb24bcd52e61008bdd74dfbbb107e053f0981e248ad920f5da" } }]
 
 [[packages]]
 name = "jmespath"
 version = "1.0.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jmespath-1.0.1-2-py3-none-any.whl", hashes = { sha256 = "b37aa0e072345500720b21a9845bc787e7e0829cb3f83a270ee94fbe2a7a6127" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jmespath-1.0.1-2-py3-none-any.whl", hashes = { sha256 = "ac1c9fee7ce0a3af45e6d3204a06022b32fa0ed97505c8c0089e78b6d38f651e" } }]
 
 [[packages]]
 name = "joblib"
 version = "1.5.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/joblib-1.5.3-2-py3-none-any.whl", hashes = { sha256 = "13c52f2daf15b9d43787421b3de27d1c6ff2e73665508ac82d588d25859a2992" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/joblib-1.5.3-2-py3-none-any.whl", hashes = { sha256 = "e37dd95ac13d39435b465702e1f0aed216a9fffeff99a9f76347acdb93a81070" } }]
 
 [[packages]]
 name = "jsonschema"
 version = "4.26.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jsonschema-4.26.0-2-py3-none-any.whl", hashes = { sha256 = "76a7a9dda3cc509aaa712f14b7b65425f6b5fcae4ade9d56561f1d70693f296f" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jsonschema-4.26.0-2-py3-none-any.whl", hashes = { sha256 = "e05f7d4fd2b5ebc8243d9df2ba14a12abdca7bec6b67f34fc5e435982f7f1991" } }]
 
 [[packages]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jsonschema_specifications-2025.9.1-2-py3-none-any.whl", hashes = { sha256 = "ebae37a275d883a3380ea32169885fdf222231d974f8f0a58cbaef8e9bc4461d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jsonschema_specifications-2025.9.1-2-py3-none-any.whl", hashes = { sha256 = "9d3e48772a1de7b4749272f83f6dad3d75d02b0a43ecd972a250157cac897444" } }]
 
 [[packages]]
 name = "jupyter-client"
 version = "8.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jupyter_client-8.8.0-2-py3-none-any.whl", hashes = { sha256 = "1ef0a8ccf9120f552a77d10224db0233212a14c07cb1992496009686b042538c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jupyter_client-8.8.0-2-py3-none-any.whl", hashes = { sha256 = "5a5eea009ec64dbb9a3106b1fa42fb8317d7f149de6819cb35f09984a17ac18a" } }]
 
 [[packages]]
 name = "jupyter-core"
 version = "5.9.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jupyter_core-5.9.1-2-py3-none-any.whl", hashes = { sha256 = "0b5f0dd7adf6bc20180248128036931ff349ef5f279e7b79848c731751a1f4a0" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/jupyter_core-5.9.1-2-py3-none-any.whl", hashes = { sha256 = "08bde68faac29eda7c3dd336af3648317b060e105ecfad316f5cb408d9557e69" } }]
 
 [[packages]]
 name = "kafka-python-ng"
 version = "2.2.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kafka_python_ng-2.2.3-2-py2.py3-none-any.whl", hashes = { sha256 = "faf759a5b161ba764ae3229f6dd6af94610104a1dd02b34a7d998c72543152f4" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kafka_python_ng-2.2.3-2-py2.py3-none-any.whl", hashes = { sha256 = "6efaa2ecbb0a0f5b747b176f8f66feb15467286c7d022510750d7c791fbbdf38" } }]
 
 [[packages]]
 name = "kfp"
 version = "2.15.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kfp-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "f3c99cf16542fc694943d5e0f06b333c537d6151eafa4ccf938926a2ee84d17f" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kfp-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "827de3c8d355810dfe02b994d59836c6db57632366c243d10e05843af38953f6" } }]
 
 [[packages]]
 name = "kfp-pipeline-spec"
 version = "2.15.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "587040b1de8c4a3a86d4e36f25d204a7e4af52b7b363b4f2260c65abdbecc44b" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "0c2203ca37eb461bb6577826c93a18e1d772880bb601ea7e3f3f549f85cf416b" } }]
 
 [[packages]]
 name = "kfp-server-api"
 version = "2.15.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "01dc12f5a9961bebed492e752df4de25e668e971100aa939835534f1e2fb4eb2" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "8684eead4328d67ef944e344e428e1570724009318bac6fcc515faeeca0b5fd0" } }]
 
 [[packages]]
 name = "kiwisolver"
 version = "1.4.9"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "b2013a40d0e0ab40d3a471cf28e0adacab2bc42eacdc2798be964b2ca7eed4ae" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c88d271dddaca3abaac19482139d94dcce506b0850edc859ce0b20edb19b8284" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a1e3dd2249f92043c9d6eecbc92f6c1415797bb5a7e1ddae2d697208d8d838ff" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "8f7b81c7eab41665ac3b7a43231a615e6e1eb11ef8d0b7ea02ffbbac715c1421" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "b2e1754db8c5073af409aa8d2ebed60f27a64ba2e024a97bffe53053f66e9406" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5d8c1b557ea0ecd21e4390190f17811f85125f72884a031501d2780b3048bd71" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8152e8d44517346e4c56cab276827d7e74480a51431febe36923f68cbe1f4a54" } },
 ]
 
 [[packages]]
 name = "kubeflow-training"
 version = "1.9.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kubeflow_training-1.9.3-2-py3-none-any.whl", hashes = { sha256 = "bf0b7fda112b8a280fce461a06d034d5833840def7c88f83ca6e7ceda920313f" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kubeflow_training-1.9.3-2-py3-none-any.whl", hashes = { sha256 = "5cf130ac503908bb0268a4e3a6eb2ab3c22deb923da6b8817cd7d429f0d8a53a" } }]
 
 [[packages]]
 name = "kubernetes"
 version = "35.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kubernetes-35.0.0-2-py3-none-any.whl", hashes = { sha256 = "52bb4f4bfc761e3765bcfd11f72edf3e0a44575c8aacc25ff3d3757f352cd642" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/kubernetes-35.0.0-2-py3-none-any.whl", hashes = { sha256 = "6687040c72d5d370d18b052d3365374c74202c13522d4ca5d5288a9229e9cbdc" } }]
 
 [[packages]]
 name = "librt"
@@ -397,17 +397,17 @@ wheels = [
 name = "locket"
 version = "1.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/locket-1.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "65208d374c03928accf2b503abc00048726e45fae2e7dd864836d3ecba87ddf7" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/locket-1.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "cd8c0e0b5e8e393ae8c70c594739c9e483639671c833312c76a35606a3abd4ed" } }]
 
 [[packages]]
 name = "markupsafe"
 version = "3.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1253952645ec5ce6186bc4427b68455e007039866f4409e22ccbece3b55d4cbb" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "88280d27b669634ea58880fc3606c6f68b2cad337665e6943a7e02deba02d762" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "b475ac04ed3df9c59074bb6cf9cd4d4dd1875b6241778cf9b0e1f3eded182353" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "dd3b9a761522a111e053fd57b214372557669a94837f7d6677e20e09c7f11138" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "a8dd475b5e29530eebd4bd9ce4ece30fb390fa00246138f327d10253cf57194a" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "f1ecf5d2dc2f76deb93a44b0ca90ba3cf4dae76788c32a8890da2f817a9d9dd5" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "43847cd32191f9d1ae4213c1b2ef6a7b802f9c39e8c9cacfa0ceadb409f157a6" } },
 ]
 
 [[packages]]
@@ -415,17 +415,17 @@ name = "matplotlib"
 version = "3.10.8"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "784f6530e4021cf84a9a8dbf332e2d0dd59ba748fc72221147241658a33d3ab8" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "14431e4b44512343d26a1deba5363026344eb146856765853914ec9b27237f8b" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "9df32ef063b9b526fa1d489cd0b48eafbf9ea1df92e4ba4234f77afe736acb18" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "6ec6ca79f07e59e3d0b89bdd203e44ba1ef1ad15a583b784fe6e9688a63e49b3" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "eccbffef192e6bbc0dfae03cfd65e6cc9ecbcc06da533194a142afb06f900435" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "0e4a5e410dc42c88c8a3cfc950169e7700092b9650150564fc607bf4372311a7" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c8342f877591b8382ab419dd1aa7baf1fd4591c2ba5d323a5bccca6a0cdba54f" } },
 ]
 
 [[packages]]
 name = "matplotlib-inline"
 version = "0.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib_inline-0.2.1-2-py3-none-any.whl", hashes = { sha256 = "62dff47eb7fb419385e2ae1913a618d9e2a7c6655f9f965139b2ee2aab46550c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/matplotlib_inline-0.2.1-2-py3-none-any.whl", hashes = { sha256 = "e2d1781820cce9816b942a18b064ec7bf3909d65b35e27b821c733b1ad1e5ecb" } }]
 
 [[packages]]
 name = "ml-dtypes"
@@ -453,42 +453,42 @@ wheels = [
 name = "mypy"
 version = "1.19.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/mypy-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "538920cf785012607cf8e2a74e4412549e18a6b202cf8791e0e04ec160d312d5" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/mypy-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "22f92f16ed36f38ebf35cd767463cc985020a74cfb8d9f5bbe94461b377f70b4" } }]
 
 [[packages]]
 name = "mypy-extensions"
 version = "1.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/mypy_extensions-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "bb890d9a82b49ad57fa31c0db47b5a0f05e3de3dcc7063d1d2730094bf00e426" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/mypy_extensions-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "c0f493713632febd9eb23b8d8282ac84269a263473776ae8ef1ce34dfd57d586" } }]
 
 [[packages]]
 name = "narwhals"
 version = "2.15.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/narwhals-2.15.0-2-py3-none-any.whl", hashes = { sha256 = "9b3e76c864511215c1d290b83123fce79c8758096ed6c06770d4a0835aa814ec" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/narwhals-2.15.0-2-py3-none-any.whl", hashes = { sha256 = "243275c60ae2f7fe2da9683e2a5d1265c1a331b996fe4b5d227cd17477f969ac" } }]
 
 [[packages]]
 name = "nest-asyncio"
 version = "1.6.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/nest_asyncio-1.6.0-2-py3-none-any.whl", hashes = { sha256 = "ab67a9ff26b136cf9ca834d88e020f54d3e1d8dd2ef9a05d88e8e4ad0837dd4a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/nest_asyncio-1.6.0-2-py3-none-any.whl", hashes = { sha256 = "28a0c4e5840c55c27cc47b8ad47ad6a78dbfc1fdda2ab5bc4e2945775654b35c" } }]
 
 [[packages]]
 name = "numpy"
 version = "2.4.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "159e7fa128c21efe8f43528e28775cf6ecd8d6a8b9b9df710f3e3bde073a11cc" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "2a4b37c4c587ef73900058539ad368a8347b8366ab4cc1fb9a0f75a9871f6474" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "818ca656ef92e6b20780d1df02abb50dfbf3bdd9927327acfd2825e5a582dd52" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cb9515497b013e15b984449cf1831c6ce5543c87367db87ecd358bc2eb4ba217" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "a921976f95847953784216ad5dac506dccefea21fcf250fdecf14c185cf3b5ba" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5acd97d0a371b41e3045150b5c56404bf5bfedccff4ac7c76b2f585047bcadf3" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/numpy-2.4.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3a247fe82d8fe4c61c235290d71e40803a6559bd763d49bc27b65590297cb897" } },
 ]
 
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/oauthlib-3.3.1-2-py3-none-any.whl", hashes = { sha256 = "fe665914e774fb8aa1d831e6b376559e5895897819cbcaa50e57f9d71892ea9a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/oauthlib-3.3.1-2-py3-none-any.whl", hashes = { sha256 = "d17c9c14346d43efeeae6c26478545c627825a2dd3af8cd0d80789169cea40cf" } }]
 
 [[packages]]
 name = "onnx"
@@ -509,83 +509,83 @@ wheels = [
 name = "onnxconverter-common"
 version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/onnxconverter_common-1.16.0-4-py2.py3-none-any.whl", hashes = { sha256 = "9456985526ab1df117185a2b8316f539fb1c98c97d54d7e8e203f3e6befe7076" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/onnxconverter_common-1.16.0-4-py2.py3-none-any.whl", hashes = { sha256 = "9dc7c7b29832e60e6f124dab5d318ad6f5a828d84c70b1bc0a7e56a47f65a264" } }]
 
 [[packages]]
 name = "opencensus"
 version = "0.11.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/opencensus-0.11.4-2-py2.py3-none-any.whl", hashes = { sha256 = "7d616f71ddea53a83a79f5c63a6d3f73f4a2ae375841f5ffea8d7d0779ed226d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/opencensus-0.11.4-2-py2.py3-none-any.whl", hashes = { sha256 = "3fcd8f273b16e03d76a425d0079cb2f3b2f7cedf1af8558b73db770d0e8b402a" } }]
 
 [[packages]]
 name = "opencensus-context"
 version = "0.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/opencensus_context-0.1.3-2-py2.py3-none-any.whl", hashes = { sha256 = "9a47e8c5a9ebd966b4ead540f1cf13d5bf352a22d9be9d34abc16b83f01c9eca" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/opencensus_context-0.1.3-2-py2.py3-none-any.whl", hashes = { sha256 = "dc2b500c3e48986bdad94a6b65d2a112a368f141418600019cdb82ca386f85ba" } }]
 
 [[packages]]
 name = "packaging"
 version = "25.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/packaging-25.0-2-py3-none-any.whl", hashes = { sha256 = "a6c930a466d6cfba1d72761288723a647c2376ddd6c9365c326b78ad2b03c2de" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/packaging-25.0-2-py3-none-any.whl", hashes = { sha256 = "2fc032cd32dd97facb902fb89f41e1e984e792d9dbe5d29d8e2713b56a0026b1" } }]
 
 [[packages]]
 name = "pandas"
 version = "2.3.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a94c0d82be1a08ef192bf5e35e61a292fcf0873e9e17161c2d31175a98bff518" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "8eb6188d36679a8b34131a5dbcef17089963ddf5244fc644e7892a049acbed65" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7333eefc03e19b5147a408a596a0e200a6ff6e00f7a670708e58a9cc08e69395" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "f2752b81a987ebef19aa4e603747ce38c744bd40a4d93c5b32334d14a88f9167" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "308c8ca6262e058136d91a7d4d2bd84dd02e65caf60340fefd20bcf26b97e819" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d7372bbc64fb3d31d594c97a65c8b4e5c02640f94f600eaeae6219625e0edda0" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8797b74457575c7fc82b26a55854c6a1b3e6346b9caf1b56c31e99af20ca5ff8" } },
 ]
 
 [[packages]]
 name = "parso"
 version = "0.8.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/parso-0.8.5-2-py2.py3-none-any.whl", hashes = { sha256 = "f62c1b5b8b96be77fca5bd68ef3604a3621c4a8b39b2c8b5ba9a8bfa6679c70a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/parso-0.8.5-2-py2.py3-none-any.whl", hashes = { sha256 = "93ea28b8281c62fb4955f0a8a706139d070e8f78cd10a4e1419ef484562f7c93" } }]
 
 [[packages]]
 name = "partd"
 version = "1.4.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/partd-1.4.2-2-py3-none-any.whl", hashes = { sha256 = "22fe682c04b3659d754fa3ffad8e952e8c3050406bf2e951eb7b500ff61d8d90" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/partd-1.4.2-2-py3-none-any.whl", hashes = { sha256 = "cbf45bc7f66a54ef7ccdfa17c1f4100c41c258f49be64d1c008c946f86358525" } }]
 
 [[packages]]
 name = "pathspec"
 version = "1.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pathspec-1.0.3-2-py3-none-any.whl", hashes = { sha256 = "4ea6eae6ef0b4d842f42964f625c213133c6e67d7cb2db5277e9f90d6d295aa2" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pathspec-1.0.3-2-py3-none-any.whl", hashes = { sha256 = "7d961dd6dd7127641698015562acf664516c0a33a0152ae04c807ff8d5e69496" } }]
 
 [[packages]]
 name = "pexpect"
 version = "4.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pexpect-4.9.0-2-py2.py3-none-any.whl", hashes = { sha256 = "f5d10add9ec19699078789187278f04c35326b1f42019cb57883d8751aad8a49" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pexpect-4.9.0-2-py2.py3-none-any.whl", hashes = { sha256 = "cc67218e75303519689a360356e6c65663db164abd3926cdfa157db20a157b5e" } }]
 
 [[packages]]
 name = "pillow"
 version = "12.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "14e2a2af2355707041a5020c726473bd5b2a13c1c71db675fb63852b89ee23ea" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9d74a26d533429efd059923286faddcbaf8b2f4160ea8ae7f3a00f2263f1470c" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "d37bf8ca616f3f2a60317bb5f57fe8ce1121695ff2136693475f8825e6ad8bed" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "316e4d8d399907d4d0f17ac06b7fe7808892bb5b0e56cbbb0aad01edf6bc794f" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "70ef2aa5cd788e9de636eca6c5d3f2189b12f1c52aae7fdda59f3de76cf4e5f9" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4c2ba725b0b86d4fce216f98cd25a38d213f421af450843fe23c0fef4b0d82ca" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5a540b5d18d929892c25bc769f1170f51cb0cdcc9f7840a62d4bd3e7e7da5cb8" } },
 ]
 
 [[packages]]
 name = "platformdirs"
 version = "4.5.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/platformdirs-4.5.1-2-py3-none-any.whl", hashes = { sha256 = "147c9be80904af69cbe33be1c645738a00abdd9ba616acd7e25c4cb7694b4290" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/platformdirs-4.5.1-2-py3-none-any.whl", hashes = { sha256 = "7077bfc7555fa5ad69a5d62c1f910db73da928275b6aa0dae7329b9e0840758e" } }]
 
 [[packages]]
 name = "plotly"
 version = "6.5.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/plotly-6.5.2-2-py3-none-any.whl", hashes = { sha256 = "ca6b27a8afbbe155c82681b3f9363a3baa8207099880941291fdc26f771680c3" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/plotly-6.5.2-2-py3-none-any.whl", hashes = { sha256 = "d94031eb11e791bc3a65e9ae283fc269741b3155a4cb2d61de0f1467bb674fa6" } }]
 
 [[packages]]
 name = "prometheus-client"
@@ -597,23 +597,23 @@ wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai
 name = "prompt-toolkit"
 version = "3.0.52"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/prompt_toolkit-3.0.52-2-py3-none-any.whl", hashes = { sha256 = "16cf95c87770bb067fec4607d68085ee530b91f4e1fbbed831b0bba08e796e93" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/prompt_toolkit-3.0.52-2-py3-none-any.whl", hashes = { sha256 = "58048a19cf801c4baab8ff5308464383c53187e90473fe951003dddf541d0fb6" } }]
 
 [[packages]]
 name = "proto-plus"
 version = "1.27.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/proto_plus-1.27.0-2-py3-none-any.whl", hashes = { sha256 = "43de14d5a8365e8273ac1cc67bf1e842d0c944d76cbcf74016a1a8a45b7f2a3d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/proto_plus-1.27.0-2-py3-none-any.whl", hashes = { sha256 = "24625628a7354c21977943d20e42ea091e06da738460e9f21ab58b7f27e02c6f" } }]
 
 [[packages]]
 name = "protobuf"
 version = "6.33.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ca8df84cfb4566d2cf6b469d903bffdd04023e6aaf63d9ebbaa726ee0949da4a" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "44f3f2b99c8de02515ff279a60c74c10843fd5bfdbb284fc8ce8544c8dfe53ed" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "f1d0521dc235d614f78c5e1b2afea1b0575820257d08fd4b68b73638d2aff5cf" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "1c6a79d3579f9acb5bdcdb2e585d7791a38c9319a8a9efa138e59772700e1197" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "0b6c8459ecd3b4e67e2bb7c1a0716b837b4191e2129f5d8f8ef4dfb334142dc4" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1da2c5a996a9b17835a27c79fb154f27006b511ebde788f1125b9d0f61544383" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/protobuf-6.33.4-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "88f8b54959de17b6ebe6e12801eb4e8f88b009261063dbfc5475fbb836c91ffb" } },
 ]
 
 [[packages]]
@@ -621,23 +621,23 @@ name = "psutil"
 version = "7.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_aarch64.whl", hashes = { sha256 = "6cb46b8790dc30e1a696216e5c9938f76a6b0e7d2ffc26eb49107671a2a71776" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_ppc64le.whl", hashes = { sha256 = "6a103f616f337a35a8d8946aa6eca55326f1332a0ecb43c776046c42cd378c27" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_aarch64.whl", hashes = { sha256 = "c47d196f69c582fef94159396ab8c2a077faf5953dc4509c0d5a7e0357d9d11c" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_ppc64le.whl", hashes = { sha256 = "231eaa20f4fdcaf8362195de934e6c3e55b0a507ecd308173da7e8b8c2175aff" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_s390x.whl", hashes = { sha256 = "15d460c954f134d5506d3d937e8e015de3f2d7877adcba4df1005be817187304" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_x86_64.whl", hashes = { sha256 = "adab85c06c12a7cd4c483d337a2388c192b99c9ef07cb89db74bef05b3882b95" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/psutil-7.2.1-2-cp36-abi3-linux_x86_64.whl", hashes = { sha256 = "f2bc3b5a86ea973916d2522fd53d402376343a305fd3d5f0085d88d28dff19b0" } },
 ]
 
 [[packages]]
 name = "ptyprocess"
 version = "0.7.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ptyprocess-0.7.0-2-py2.py3-none-any.whl", hashes = { sha256 = "3d538b98d81df3b9e9f308020f43105d243e90e65bd19e36cfad20993eb2635c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/ptyprocess-0.7.0-2-py2.py3-none-any.whl", hashes = { sha256 = "016d70f91c0a76d568a91632550e2e04c000ce5118e12eee4704efd43741037c" } }]
 
 [[packages]]
 name = "pure-eval"
 version = "0.2.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pure_eval-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "ef797056cd413abccc89b270557656ddc6ad111340bae06f551e1640a5ad6aa3" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pure_eval-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "7c5de7ae24b7aa030372533e3177f587197dd25fd3b02d6d543f01948ddde15d" } }]
 
 [[packages]]
 name = "py-spy"
@@ -669,70 +669,70 @@ wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai
 name = "pyasn1-modules"
 version = "0.4.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyasn1_modules-0.4.2-2-py3-none-any.whl", hashes = { sha256 = "989a78025c4b440ea6259457ee55570157476890c743a714042f1a201b239341" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyasn1_modules-0.4.2-2-py3-none-any.whl", hashes = { sha256 = "bcc06d3e698e3db6af58a24e89848a1a8f02232664212313629fab89941074a9" } }]
 
 [[packages]]
 name = "pydantic"
 version = "2.12.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic-2.12.5-2-py3-none-any.whl", hashes = { sha256 = "605aecb7a0e2ad5b3993076f35fba4434b03a66b7f7d92df394a26e50724f275" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic-2.12.5-2-py3-none-any.whl", hashes = { sha256 = "f2144e486ddf97b22f779c0f63e1303ae1a98b643807f5c908c804938ed864fa" } }]
 
 [[packages]]
 name = "pydantic-core"
 version = "2.41.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "34d7bc2b0d4f82efc6ac121aab4e1d38dce95b0bc582e70829e3857d28790c35" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "d411aaf3ee5208191ce470b0d117171f161079d897e51ebcef22df04fe9e7623" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "6e53c1956a182c586c3edafcb31fceb540867c076f13c24c23b7a585a86f5a1e" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "5a7a65087bcf423ed6e467308cff36b76fa3c65aff71d80fea899a34fa021fe1" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "41f74ba1ea18462d7cc27155581a9b23165adc7b009c6d467542274d63db163c" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d2b97f4ae24d62a8e2f350b40d44b8da8bcf30cc670af787590208cf9c32c713" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3526190a442c2065b875790a6c11d568dd097369de8000196042584f506665aa" } },
 ]
 
 [[packages]]
 name = "pygments"
 version = "2.19.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pygments-2.19.2-2-py3-none-any.whl", hashes = { sha256 = "ffba36e668551ae05bbf9b29f29479d0867791b2f709916cbf885db17f1fbabc" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pygments-2.19.2-2-py3-none-any.whl", hashes = { sha256 = "29c80feca98b2603538c50c4615036baa795df38d3c9cfaaaf2158c866947fe8" } }]
 
 [[packages]]
 name = "pyjwt"
 version = "2.10.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyjwt-2.10.1-2-py3-none-any.whl", hashes = { sha256 = "7605c665f70ac69384a99fa842d6bfe713315048cd4517c53d0d87c62ac99511" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyjwt-2.10.1-2-py3-none-any.whl", hashes = { sha256 = "198e5add6826896765fff1bf30b456959ef4df11c5a811b9b1f6a2fe96f598bf" } }]
 
 [[packages]]
 name = "pyparsing"
 version = "3.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyparsing-3.3.1-2-py3-none-any.whl", hashes = { sha256 = "6c4d01e2d8a23bfbf6d4632072a802ab064c3d7de283219b559e47c2691a970f" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyparsing-3.3.1-2-py3-none-any.whl", hashes = { sha256 = "9e189216a26d479669e2919f04a796955083ec135079998865ab89ad7a691384" } }]
 
 [[packages]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/python_dateutil-2.9.0.post0-2-py2.py3-none-any.whl", hashes = { sha256 = "717dc4f89c79cba1892e15bd9c124ce047b558af1a94840e116c3d0279da42b4" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/python_dateutil-2.9.0.post0-2-py2.py3-none-any.whl", hashes = { sha256 = "a0ffc6b63e7230c3852e65a05374f7e53ab8c1c137218338934b87606936016b" } }]
 
 [[packages]]
 name = "python-dotenv"
 version = "1.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/python_dotenv-1.2.1-2-py3-none-any.whl", hashes = { sha256 = "cb19f8951d392b45101c688fb36de310e92f88a807d718ef5d64ce0e2cfbb1a1" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/python_dotenv-1.2.1-2-py3-none-any.whl", hashes = { sha256 = "c16256aacbcfc3cbaf8adcc26b6f0201a25fd8c70b5d7a7e863c26b6acdfbfba" } }]
 
 [[packages]]
 name = "pytz"
 version = "2025.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pytz-2025.2-2-py3-none-any.whl", hashes = { sha256 = "b49a3b3c1ee39245fe7bb7749d04e5100f96013fd5be6b385e9b502b6e35fda1" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pytz-2025.2-2-py3-none-any.whl", hashes = { sha256 = "f0677996b3ddb76418d5895849636c7b3fc96e884b7a57839809d301393a8e38" } }]
 
 [[packages]]
 name = "pyyaml"
 version = "6.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bdac389772b9c54af198c33625065f8761ee92ca66b9d134f0575629a6b4463d" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "b02c03953ff93508bb1b0d7e6ad4919804e854510ade829d50953681a5ce0fed" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1d3a0379b054a47186ce23849f4af79eba777459b83f515b98aad8c38b6f90ab" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "fcf56448388ac1f8ca4e84f77efffeba308a8059cb92521a114649481be0edb5" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "d122b1f987c23385d9600d211475f765fcb59a2fff150c5e6036293196df5b80" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e2c1473ef2501aceaf28fb72ab431a259a12e4e3863ae98151c65936e50e6b69" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7bdf2ffe391589ce212f27f76c39d46fb7bc72d92b9a5e0771ee14c0518a8b0c" } },
 ]
 
 [[packages]]
@@ -740,74 +740,74 @@ name = "pyzmq"
 version = "27.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "56dc41d18e2245fd61679aefbf606c771574f0aedddbb7d2e82807c91cc776fa" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "447146ee06c273ab0184b8dec263e6e56922f1f6edf486288f77ad105a356a22" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "695b4d4ab299d7238466b0a8b18bcf3243d8ab82ef34ca893ac8824b889c97e4" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "73a18e52ca005923fc91120990a6656f2ceb966e3758f559469711b94aedcef1" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "4f4ab47c56cbd5369c6f7c1056b5376926e932a378729f008c765ff89be91d80" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "68d6e9539c236194aef5915f1f3e5599b715f191a9b59f4749c42bdb9f95a107" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8156ee1f2b97c066c6d6dec19d5ed6af18d8edfada57067729c697537953f320" } },
 ]
 
 [[packages]]
 name = "referencing"
 version = "0.37.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/referencing-0.37.0-2-py3-none-any.whl", hashes = { sha256 = "0e74fdf278ee083212f766ccf656e8838332e196dcd23a482cd2ce62a2c5ee88" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/referencing-0.37.0-2-py3-none-any.whl", hashes = { sha256 = "3cbbaccb79aa3fe2ea00af59d9a196d2bdeb2f066406fc80425f3de7537bb86d" } }]
 
 [[packages]]
 name = "requests"
 version = "2.32.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/requests-2.32.5-2-py3-none-any.whl", hashes = { sha256 = "3f8fd741e14a68bc07f2d3721103f80f874b087d18248bfe69ef79399ddc68bb" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/requests-2.32.5-2-py3-none-any.whl", hashes = { sha256 = "bf6d784e03074d6828963b46c2ddcdc3b1fd5a4e438c0907596f1b7fa7365e7e" } }]
 
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/requests_oauthlib-2.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "2607ae5482a90cb6e3d456781c89ca75908065ba5be57d0dee7d23b1baeccc43" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/requests_oauthlib-2.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "d8584f638392e44d56505ba4e7ac90cc1680ac08897e205424c77d4572e48c4d" } }]
 
 [[packages]]
 name = "requests-toolbelt"
 version = "1.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/requests_toolbelt-1.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "22a60a783ab26d3df6befcc4072204aa1dfad65802da16186fe97852df6e352c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/requests_toolbelt-1.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "6f3aab02c52fe4773201d6d24f23ae29cc61be84d8c0e7cb2925c1b2bbbc7168" } }]
 
 [[packages]]
 name = "retrying"
 version = "1.4.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/retrying-1.4.2-2-py3-none-any.whl", hashes = { sha256 = "2d5203c0e6f6d9a481599267e5360587480bbdcdc00c5609d0f659bdbf9f4fc2" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/retrying-1.4.2-2-py3-none-any.whl", hashes = { sha256 = "80aea987b24701be1e4774cac9c94c64d97109856ab2e7161df4a3bcb5783c87" } }]
 
 [[packages]]
 name = "rpds-py"
 version = "0.30.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "080800aca5c7d42653cee4e3a1bb6993457acddb45b2d55894e81d3b184a54b8" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "403ef61929054aca5969fb6ee2c541cf39b264436134734bd48b0e7b31986cdf" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "0a43ccc040ca38740fb5b0966871542df53b050437b8a4e0aa2da43bccd273c0" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "25be4254b360114f21066c09f82c146aa2be890675983ef0d1b70caa2f72ac26" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "6c94c5f1c2501e50c22b7c993b083aeef4d342974d3058763296fb4646d8a059" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "25245c2a9756f5b991f56de8f426030f150d0d5376a59c59162012b63ade03f0" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a786e62cbc067d8a17f2356a8b76bcf8cc312ed432cb0411c115ab8c478c9145" } },
 ]
 
 [[packages]]
 name = "rsa"
 version = "4.9.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rsa-4.9.1-2-py3-none-any.whl", hashes = { sha256 = "e99a1595448fca5aa05b904c3cd945d8c9bc49f496befce4fa9f9f5ee957ec94" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/rsa-4.9.1-2-py3-none-any.whl", hashes = { sha256 = "c94d965d3fbcdad641019043aa8e8410587e52bd83c70028475fcc444ebef922" } }]
 
 [[packages]]
 name = "s3transfer"
 version = "0.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/s3transfer-0.16.0-2-py3-none-any.whl", hashes = { sha256 = "0f14cc204604ae60c84aa2a6179dca77d5355b778f85245031a5c3db4fcf012d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/s3transfer-0.16.0-2-py3-none-any.whl", hashes = { sha256 = "aa184352af4aa047a3894b9981cc9df98a7b5205de0e52df30581b6db856d109" } }]
 
 [[packages]]
 name = "scikit-learn"
 version = "1.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "9cf93043ee87bcd11a0d2277739e895361aed833e07eaf1a349cb2e751541678" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "6229bf71a25367106cf475119463648355ad43f1d8534310ec3adcef62d89577" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "10735fab772d6d6a4e401b9c6e766279ae0c4a1ff3df0e64e049905449e0aafe" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "f77447d46e7193fd6b7d32a736d30975615af8dda80866e71738a63db422cf9a" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "5d27f41e0a981a58fcc00f09ef9c00fd68a2e13c218768d0ed69c1a247c8855f" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "896aa3aa094121b2d2827939efa1efe659a1d651f6678e048c712e8b416694f4" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8f0e5b049d897177e7e73d229dc3a6a8ac8d6ffd42aed29de3f8033d7df9731f" } },
 ]
 
 [[packages]]
@@ -815,160 +815,160 @@ name = "scipy"
 version = "1.16.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "62931eadda568e23f428b322bfe7ff5e1353c916d543b23ba1aac09b9e681a54" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "45ae5a3a655bdb6f20e8b76c894a6a083cdf131246e5d0abb4719925c9c58b82" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "f89c4827bd7b85064ec3bd118adbf697b8c7e9ee898c4208fc23204d48d29f1e" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "daaecb02cfebaa3fb760565be0bbf7428a0facf3022a78250a0fa378dac9eb3d" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "98726415e1374d7c748627df0967bf25379d8bc23c2092d4bf9abc435d032941" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "97ffb922d5a22b8257d3524a23643b8eec8577cb3b57ba27d8b550c692118f61" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ed3bb6c66045eb3f86b8d93b263900554b47bd355850cf3ec5aff8330c59ad44" } },
 ]
 
 [[packages]]
 name = "setuptools"
 version = "80.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/setuptools-80.9.0-2-py3-none-any.whl", hashes = { sha256 = "31a48be74efc8e45de1ca096c088b4f15f13c52a1f33c84df7eb5ee0d75b74d5" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/setuptools-80.9.0-2-py3-none-any.whl", hashes = { sha256 = "c1b3024f48febd9cbe6e44f0692fcb9888322d3fcbc1108023ed841eb40e9293" } }]
 
 [[packages]]
 name = "six"
 version = "1.17.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/six-1.17.0-2-py2.py3-none-any.whl", hashes = { sha256 = "4f61a04f75640c6de3a8d935e9d1c9b4e110edaa293016f85873b220ff4eae5c" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/six-1.17.0-2-py2.py3-none-any.whl", hashes = { sha256 = "39736e2b04013f8c6f9550ea406aedbad35a55f48699e19317ddd4e9b94a5e8b" } }]
 
 [[packages]]
 name = "skl2onnx"
 version = "1.19.1"
 marker = "implementation_name == 'cpython' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/skl2onnx-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "9db9df1b9976550fa7c39b61c1de059d8b5789d1da3f1ec625386836f5630723" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/skl2onnx-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "c60118c28a074a461f4f8ac1161572550169a3cd33fda5774f0cce2618f50550" } }]
 
 [[packages]]
 name = "smart-open"
 version = "7.5.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/smart_open-7.5.0-2-py3-none-any.whl", hashes = { sha256 = "14ac0d2519550744417d8953da61bc7ae2d726f524b0f413efccee3dd59fad13" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/smart_open-7.5.0-2-py3-none-any.whl", hashes = { sha256 = "722d0a1fe530ed17336e9abc9e81f27330459b1599704b7c199fa8f52d3740d1" } }]
 
 [[packages]]
 name = "sqlalchemy"
 version = "2.0.45"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "b936bbdfb3c1eff6bdbcdd69f07205201d7d564bc13304b17e39b4233a35b902" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c1b127cc6ec20ef7b7abb3a4f807222725720d62a62b46b5e274f6c9fa91dade" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "9ace8d1610b1c094e715734834334192c32435af57b3eef20662e51242bb6459" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "45cbaa3efdb87f3a03b64d2236719241597081b2021bb0ab183f1a742dd52d84" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "69ada3936fac5c0c15e765e71fae9b1177c9c957eb7fbd5210f63d7c05aa26c3" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "92d36fba7314fb3eebfe5fd795e0fa410111dca19ab2b7015455578bf8d13c4d" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/sqlalchemy-2.0.45-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "88a614ec2a2e897e6e609f6c823eb4667d4d64e96d6e43cbcb6759b82935f0a4" } },
 ]
 
 [[packages]]
 name = "stack-data"
 version = "0.6.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/stack_data-0.6.3-2-py3-none-any.whl", hashes = { sha256 = "1ca71aebc35ac04c7870966bacd99ecc7c2d5a699e447d22b680a5803b75247a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/stack_data-0.6.3-2-py3-none-any.whl", hashes = { sha256 = "79a7ae7aebcf04ed01e453da86f240f74f9fc1c3f8f530c9b1b134ac79108cfa" } }]
 
 [[packages]]
 name = "starlette"
 version = "0.50.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/starlette-0.50.0-2-py3-none-any.whl", hashes = { sha256 = "b0ba74e54decd3b70de172de85f7ae253fa664113dc4f8e46a8c6f83525ca914" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/starlette-0.50.0-2-py3-none-any.whl", hashes = { sha256 = "d66627be3d0e555e1f1b91fcf0b7d992315ec45b31e99adf230418aa440d06c4" } }]
 
 [[packages]]
 name = "tabulate"
 version = "0.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tabulate-0.9.0-2-py3-none-any.whl", hashes = { sha256 = "28773355dc0a6cde36d5fbff57e559d7d24b792cd376f568bf874a66c42415a6" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tabulate-0.9.0-2-py3-none-any.whl", hashes = { sha256 = "f66663802de50df413f85f805cf3b2c862e92252ec83b8d99c94db13d7e9db5d" } }]
 
 [[packages]]
 name = "tenacity"
 version = "8.5.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tenacity-8.5.0-2-py3-none-any.whl", hashes = { sha256 = "ce44af751f0c027d2d884fb4e43bb21bceb2b6e45122de6f38bc49ab2789e7c3" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tenacity-8.5.0-2-py3-none-any.whl", hashes = { sha256 = "5a2c48d0fd170b2811ab5cce7574be19afde39d3d1954222666c262768d67683" } }]
 
 [[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/threadpoolctl-3.6.0-2-py3-none-any.whl", hashes = { sha256 = "21d9d8f6a6b16987c0f1865e501018865f14663accdbd2f739c6706fdc41a608" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/threadpoolctl-3.6.0-2-py3-none-any.whl", hashes = { sha256 = "6b09b92b78b144e8600fee2ffca27347d2d6ac9cb9a7941ac72fb04be3571e14" } }]
 
 [[packages]]
 name = "toml"
 version = "0.10.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/toml-0.10.2-2-py2.py3-none-any.whl", hashes = { sha256 = "87d5414dc64dd5911c30a8a652686e8ae24f77e95dfe8dec938976edf4b7c3f1" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/toml-0.10.2-2-py2.py3-none-any.whl", hashes = { sha256 = "06dcaa70faa3e6b6d4e4bc0b9ecf95853f159ca2e028735b2d3d1d843ba2720e" } }]
 
 [[packages]]
 name = "toolz"
 version = "1.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/toolz-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "dfacd79c4364c17f42ae3a2aff104df306cc6be8d84272ce41066845773cc066" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/toolz-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "fd74cb5d43a68d7f1f0059258cf65b4f3895b0a54f3e72139c7efa5411e36047" } }]
 
 [[packages]]
 name = "tornado"
 version = "6.5.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "b31a589e6b32a372c1aacb3472436ff0b7d6b72f24f67dbc99c021d61c880c45" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "65f33175c6e77a4c2a2c94a5e693d9cacc425c152d00ca055c590816b481df85" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "b7ab5f99ebd7f97cf2b961de506913cdab5df1ef1b21196c6112f3ea6193c02d" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "b85c57576abfa99427f39fced4f0f18528643be099a4426f3bf0093f99f66bf2" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "a4a68ff2f1bafbb720bf36673a038e87de1541bc58eec7ce9b8c76d5eb45278a" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "c9234785ccdb81308a1a02e7d85eb5f327be4c99b03c406fb0fede1e691366ed" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "35272bf48611b7d47591b310eb58592371f7f21b055f5fd07688e49e0472d23f" } },
 ]
 
 [[packages]]
 name = "tqdm"
 version = "4.67.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tqdm-4.67.1-2-py3-none-any.whl", hashes = { sha256 = "760916a7d3df8f90b4cdb5da8629249849483c5affde787f264cc7dc63d1576d" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tqdm-4.67.1-2-py3-none-any.whl", hashes = { sha256 = "5da86edadf3e45383e2a50ebd4e2dc5072087ea6db4bdc37884dbb6f629fc6e6" } }]
 
 [[packages]]
 name = "traitlets"
 version = "5.14.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/traitlets-5.14.3-2-py3-none-any.whl", hashes = { sha256 = "641a69e188101848f44e6f9469c09843098494f20fa1414c3531402ac633be4a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/traitlets-5.14.3-2-py3-none-any.whl", hashes = { sha256 = "30744e92b64acf510e2b13304af5bb6a1c949a97931e2df773042981c4be3801" } }]
 
 [[packages]]
 name = "typeguard"
 version = "4.4.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/typeguard-4.4.4-2-py3-none-any.whl", hashes = { sha256 = "6c4bfbc28ce5d0e115d67b27e76a1796f709ba8ee1bee26212493395a6eb63fd" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/typeguard-4.4.4-2-py3-none-any.whl", hashes = { sha256 = "88abb52b28c7aab8dcca4407f4f47b3e7608160dc4a58d0c706ab1bde3ca85c2" } }]
 
 [[packages]]
 name = "typing-extensions"
 version = "4.15.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/typing_extensions-4.15.0-2-py3-none-any.whl", hashes = { sha256 = "b36d96989e4f2bda2c8f049e643779967c9e49a7f56cf5d1edcc92769b8b0616" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/typing_extensions-4.15.0-2-py3-none-any.whl", hashes = { sha256 = "523aaa2153f7f55f600823f12aa585d416969c616f49f35281713f3ea616e07c" } }]
 
 [[packages]]
 name = "typing-inspection"
 version = "0.4.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/typing_inspection-0.4.2-2-py3-none-any.whl", hashes = { sha256 = "03b66b8f89a2e393fcbe541aefc6b8d985264358acdf5a008ad31d27ae96381a" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/typing_inspection-0.4.2-2-py3-none-any.whl", hashes = { sha256 = "97026619e7fb8d752b17d6b4d5e078e724eba268c4666faf1af2b916a8369125" } }]
 
 [[packages]]
 name = "tzdata"
 version = "2025.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tzdata-2025.3-2-py2.py3-none-any.whl", hashes = { sha256 = "be583c19929f5b63960a7dace4d0b93767187d039ec7d6100d4b1fa52dea79f7" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/tzdata-2025.3-2-py2.py3-none-any.whl", hashes = { sha256 = "1474da003273cc0336e98056ec5bcc070d3430a563185641e14d8b6c920cae0e" } }]
 
 [[packages]]
 name = "urllib3"
 version = "2.6.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/urllib3-2.6.3-2-py3-none-any.whl", hashes = { sha256 = "163e0df1c66cf453ae46017841d4c062b731ffa4d8b208f23a5d8d660657e0a2" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/urllib3-2.6.3-2-py3-none-any.whl", hashes = { sha256 = "affe057780f8099a26ca3bdbce966a3ede78da9fa04fae81711240515940ad00" } }]
 
 [[packages]]
 name = "uvicorn"
 version = "0.34.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvicorn-0.34.0-2-py3-none-any.whl", hashes = { sha256 = "a3a3601e530b6c908d7c06077f2cfc2e5663452badabc8704bc42c7ff9f0b7dd" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvicorn-0.34.0-2-py3-none-any.whl", hashes = { sha256 = "962505e72d6b241897b36a42c64fdfc2c132e13043a862e23dc62c40ea7c50b6" } }]
 
 [[packages]]
 name = "uvicorn-worker"
 version = "0.3.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvicorn_worker-0.3.0-3-py3-none-any.whl", hashes = { sha256 = "4cccd3f042f5309efd166819e0503401e59ba10776c7a889e0da1a7530b037bb" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvicorn_worker-0.3.0-3-py3-none-any.whl", hashes = { sha256 = "52e2fbc1775a212281d90880e7224f034b3f2ad947be8730761951907d897c06" } }]
 
 [[packages]]
 name = "uvloop"
 version = "0.22.1"
 marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "8e469d30efa0e158b189168c69204fad1632d8ccfff24d9942cbc2a4cca6cd37" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c436a69182a3a153a52ac0ed7d168051c36384926abfed2a507dda417f9ff1b8" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "0d2cb14881104d4aaab82b96f33b684e5c62824db9557d502f126a3ce1c329d3" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "80fced95437c2c310f8af2e5f3bc9891429cf8d0b897038d4d03540cce8dfac3" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "63c81125d54cc50934c5c682909532fc4062e36828eeee3fcdcff1c6abdfefd5" } },
@@ -985,7 +985,7 @@ name = "watchfiles"
 version = "1.1.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "f7ea2e7538fc5bf379a4227019c0d96751e120c83aa13c0ebf01216a44907d79" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "f42848cfed712e2e2d11841e0cc017f3f61ccc4c05c8cf1168532793c0d749f4" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "a6f7a83448f22648ae83c20f4d0a4601fc2a8702d62b92ca406a7a22d4884fae" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "23ebacba0aa8acd30d6d1e39959c3cb78feb3cc161d4fffdee73b6478efd3899" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "f7ea582505704a0a9bf1c4bc09b147f373d1ef2a4a376b60ca9e6dd041e6bdfe" } },
@@ -995,20 +995,20 @@ wheels = [
 name = "wcwidth"
 version = "0.2.14"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wcwidth-0.2.14-2-py3-none-any.whl", hashes = { sha256 = "fddfb3320277f071135c89249083a69bfae61662915fcb4006b289b6a768f967" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wcwidth-0.2.14-2-py3-none-any.whl", hashes = { sha256 = "094585a550ada3af1edb47e0d44c1204d9b3e7d245d3bd3ebf06073801d05aa1" } }]
 
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websocket_client-1.9.0-2-py3-none-any.whl", hashes = { sha256 = "0b729d37e7f11f2020a9480f7b41cd48687f23499037e504183ba32d80342c6b" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websocket_client-1.9.0-2-py3-none-any.whl", hashes = { sha256 = "0bdd8b077202b6c6707af0f1200b9bbd0592a35df22c072fc59b1ae457267e1b" } }]
 
 [[packages]]
 name = "websockets"
 version = "16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ce197dcedda9544ac8382046f6dc74b52005732dc6f36105f9c9f4c20088614b" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c54016bbb76f4f4e5a3c5cf02cec2638eb188ba277d3f427ed197725ac50e231" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "0e67eeda5d16502a8d25d6204ea8bb311d94d345490920d020683707877ddfab" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "8c407d9d309aaa92db557a52a766921781f07d038e766f2a9ea42bac1ac05e39" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "365156c45502ba46ba062e513a7710b7da3eaf83936f2706cd7899fbafcd43f7" } },
@@ -1018,15 +1018,15 @@ wheels = [
 name = "wheel"
 version = "0.45.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wheel-0.45.1-2-py3-none-any.whl", hashes = { sha256 = "0534e552602421d105e15a73d8a57de96c989e315fdb87cbcbbf44b2e579bbdb" } }]
+wheels = [{ url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wheel-0.45.1-2-py3-none-any.whl", hashes = { sha256 = "6ff7fa44b6f5906a51c8fdb270b2189621a4cef8867e1c8979c6b0a5754a38aa" } }]
 
 [[packages]]
 name = "wrapt"
 version = "2.0.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wrapt-2.0.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "466229adc17bb3c63def42271818fe554253acdf0fd2d800ed140341f1b6a907" } },
-    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wrapt-2.0.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "74c5d68fc21975f75465843bed7084d0081c63b7faefeca287d4c926b4e6b822" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wrapt-2.0.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7a2cbf6f2752995c9782279d16604958b88178b14df29981805fac86593d0e54" } },
+    { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wrapt-2.0.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "b2d61285ea3ad1f4713adcb727418e844d49199ce600bad5a4ed8f3bf7886e41" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wrapt-2.0.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "896d4a83c844d8d0bbabe4a5e6fd65c9a085223250adccb69a267b528e57e6a8" } },
     { url = "https://console.redhat.com/api/pulp-content/public-rhai/rhoai/3.3/cpu-ubi9/wrapt-2.0.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "10643c37f9263078f20c2d70a8696f6d1d418cc7aa01f6f960ec68d950aa1ef2" } },
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: 
1. https://issues.redhat.com/browse/RHAIENG-1625
2. https://issues.redhat.com/browse/RHAIENG-3048
3. https://issues.redhat.com/browse/RHAIENG-3047
## Description

<!--- Describe your changes in detail -->

## Description
<!--- Describe your changes in detail -->
Bump codeserver IDE version from 4.104 to 4.106 and python and jupyterlab extensions


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with : `quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:on-pr-db0017607d17ca2ee41ab6093ab7be6f02ec4fdd-linux-d160-m4xlarge-arm64`

Pipeline build: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-release/pipelineruns/odh-workbench-codeserver-datascience-cpu-py312-ubi9-on-pulgzg54 

<img width="2549" height="1284" alt="Screenshot 2026-02-04 at 08 47 37" src="https://github.com/user-attachments/assets/7ab8d59e-e0b4-498e-a59a-16f4320f2fa8" />


Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js from 22.18.0 to 22.21.1
  * Updated code-server from v4.104.0 to v4.106.3
  * Updated Python extension from 2025.14.0 to 2026.0.0
  * Updated Jupyter extension from 2025.8.0 to 2025.9.1
  * Adjusted CI build platforms used for image builds

* **Documentation**
  * Added extension version reference and download/setup guidance; expanded troubleshooting for Git LFS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->