### PR TITLE
RHAIENG-3072: Update build-args to use c9s bases with CUDA 12.9, ROCm 6.4

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.8"},
+            {"name": "CUDA", "version": "12.9"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -19,7 +19,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.8"},
+            {"name": "CUDA", "version": "12.9"},
             {"name": "Python", "version": "v3.12"},
             {"name": "PyTorch", "version": "2.9"},
             {"name": "LLM-Compressor", "version": "0.9"}

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.8"},
+            {"name": "CUDA", "version": "12.9"},
             {"name": "Python", "version": "v3.12"},
             {"name": "PyTorch", "version": "2.9"}
           ]

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.8"},
+            {"name": "CUDA", "version": "12.9"},
             {"name": "Python", "version": "v3.12"},
             {"name": "TensorFlow", "version": "2.20"}
           ]

--- a/manifests/base/rstudio-gpu-notebook-imagestream.yaml
+++ b/manifests/base/rstudio-gpu-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.8"},
+            {"name": "CUDA", "version": "12.9"},
             {"name": "R", "version": "v4.5"},
             {"name": "Python", "version": "v3.12"}
           ]

--- a/rstudio/c9s-python-3.12/build-args/cuda.conf
+++ b/rstudio/c9s-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.8
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9:v12.6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9:v12.6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-ubi9:v6.2
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
 PYLOCK_FLAVOR=rocm

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-ubi9:v12.6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9


### PR DESCRIPTION
## Summary

Update workbench and runtime build configurations to use CentOS Stream 9 (c9s) base images with:
- **CUDA 12.9** (upgraded from 12.6/12.8)
- **ROCm 6.4** (for runtimes/rocm-pytorch)

This aligns ODH notebooks with AIPCC base image versions and ensures compatibility with the latest GPU library requirements.

## Why CentOS Stream 9 over UBI9?

UBI9 (Red Hat Universal Base Image) has a limited package set compared to CentOS Stream 9. Several runtime dependencies required by PyTorch packages are **not available in UBI9 repos** without RHEL entitlements.

### Missing packages in UBI9

The following packages are required for PyTorch runtime but unavailable in UBI9:

| Library | Package | Purpose |
|---------|---------|---------|
| `libmpi_cxx.so` | `openmpi` | MPI C++ bindings for distributed training |
| `libqhull_r.so` | `libqhull_r` | Computational geometry (scipy dependency) |
| `libsnappy.so` | `snappy` | Fast compression library |

Plus the c9s has latex for JupyterLab PDF export. Honestly I'm wondering how the ubi9-based cuda's did do pdf export until now. This is ODH consideration.

### Code comparison

**UBI9 base image** (`base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm`):
```dockerfile
# Runtime dependencies for PyTorch packages (libmpi_cxx.so, libqhull_r.so, libsnappy.so)
# These packages (openmpi, libqhull_r, snappy) are not available in UBI9 repos without
# RHEL entitlements. Adding CentOS Stream 9 repos would work but mixing distro repos
# is not a good practice to promote. The c9s variant of this image has these installed.

# Restore user workspace
USER 1001
```

**CentOS Stream 9 base image** (`base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm`):
```dockerfile
# Runtime dependencies for PyTorch packages (libmpi_cxx.so, libqhull_r.so, libsnappy.so)
# libqhull_r is in CRB (Code Ready Builder) repo
RUN dnf -y install dnf-plugins-core && \
    dnf config-manager --set-enabled crb && \
    dnf -y install \
    openmpi \
    libqhull_r \
    snappy \
    && dnf -y clean all --enablerepo="*"
```

The c9s image has access to the full CentOS Stream 9 package set including the **CRB (Code Ready Builder)** repository, making it possible to install all required dependencies.

## Changes

### build-args/*.conf updates

| File | Change |
|------|--------|
| `jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf` | v12.8 → v12.9, c9s base |
| `jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf` | v12.8 → v12.9, c9s base |
| `jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf` | v12.8 → v12.9, c9s base |
| `jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf` | v12.8 → v12.9, c9s base |
| `rstudio/c9s-python-3.12/build-args/cuda.conf` | v12.8 → v12.9 |
| `runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf` | ubi9:v12.6 → c9s:v12.9 |
| `runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf` | ubi9:v12.6 → c9s:v12.9 |
| `runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf` | ubi9:v12.6 → c9s:v12.9 |
| `runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf` | ubi9:v6.2 → c9s:v6.4 |

### Manifest updates (N version / 3.4 tag)

Updated CUDA version from 12.8 to 12.9 in imagestream annotations:
- `jupyter-minimal-gpu-notebook-imagestream.yaml`
- `jupyter-pytorch-notebook-imagestream.yaml`
- `jupyter-pytorch-llmcompressor-imagestream.yaml`
- `jupyter-tensorflow-notebook-imagestream.yaml`
- `rstudio-gpu-notebook-imagestream.yaml`

## Note on CUDA 13

We are **not yet decided on CUDA 13**. The base-images directory contains a `cuda/13.0` folder for exploration, but this PR focuses on stabilizing CUDA 12.9 for the 3.4 release. CUDA 13 adoption will be evaluated separately based on:
- PyTorch/TensorFlow compatibility
- Driver requirements
- AIPCC timeline

## Test Plan

- [ ] Verify base images build successfully with c9s
- [ ] Run `test_elf_files_can_link_runtime_libs` to confirm all GPU libraries are present
- [ ] Test PyTorch and TensorFlow workbenches on GPU nodes
- [ ] Validate ROCm PyTorch runtime with AMD GPUs

## Related Issues

- [RHAIENG-3072](https://issues.redhat.com/browse/RHAIENG-3072): Add CUDA 12.9 base image to ODH notebooks
- [RHAIENG-2787](https://issues.redhat.com/browse/RHAIENG-2787): Upgrade ROCm workbench and runtime images to RHOAI 3.4-EA1

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated CUDA runtime from version 12.8 to 12.9 across all notebook and runtime configurations.
* Updated ROCm GPU support from version 6.2 to 6.4.
* Updated base image dependencies for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->