### PR TITLE
RHAIENG-2813: Externalize indexes outside pylock_generator script for better maintenance and flexibility

### DIFF
--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,3 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,3 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : c9s with Python 3.12
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/rocm6.4-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
 PYLOCK_FLAVOR=rocm

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/rocm6.4-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
 PYLOCK_FLAVOR=rocm

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/rocm6.4-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+PYLOCK_FLAVOR=rocm

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
+PYLOCK_FLAVOR=cuda

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,2 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
-PYLOCK_FLAVOR=cpu

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,1 +1,3 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
+PYLOCK_FLAVOR=cpu

--- a/rstudio/c9s-python-3.12/build-args/cpu.conf
+++ b/rstudio/c9s-python-3.12/build-args/cpu.conf
@@ -1,1 +1,2 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s

--- a/rstudio/c9s-python-3.12/build-args/cuda.conf
+++ b/rstudio/c9s-python-3.12/build-args/cuda.conf
@@ -1,1 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
+

--- a/rstudio/rhel9-python-3.12/build-args/cpu.conf
+++ b/rstudio/rhel9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 # Base Image   : RHEL 9 with Python 3.12
 # Architectures: linux/arm64, linux/x86_64
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=registry.redhat.io/rhel9/python-312:latest
+

--- a/rstudio/rhel9-python-3.12/build-args/cuda.conf
+++ b/rstudio/rhel9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,6 @@
 # Base Image   : RHEL 9 with Python 3.12
 # Architectures: linux/arm64, linux/x86_64
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=registry.redhat.io/rhel9/python-312:latest

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,3 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,2 +1,3 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,2 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/rocm6.4-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
 PYLOCK_FLAVOR=rocm

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,1 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/rocm6.4-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+PYLOCK_FLAVOR=rocm

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,1 +1,5 @@
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/
+# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
+CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
+PYLOCK_FLAVOR=cuda

--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -41,16 +41,6 @@ set -euo pipefail
 # ----------------------------
 # CONFIGURATION
 # ----------------------------
-# https://redhat-internal.slack.com/archives/C079FE5H94J/p1768855783394919?thread_ts=1767789190.424899&cid=C079FE5H94J
-CPU_INDEX_URL="https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cpu-ubi9/simple/"
-CUDA_INDEX_URL="https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/cuda12.9-ubi9/simple/"
-ROCM_INDEX_URL="https://console.redhat.com/api/pypi/public-rhai/rhoai/3.3/rocm6.4-ubi9/simple/"
-
-CPU_INDEX="--default-index=${CPU_INDEX_URL}"
-# TODO(RHAIENG-3071): Add CPU index as fallback for packages not available in CUDA/ROCm indexes
-# (e.g., kfp-pipeline-spec, kfp-server-api, google-cloud-storage, requests-toolbelt)
-CUDA_INDEX="--default-index=${CUDA_INDEX_URL} --index=${CUDA_INDEX_URL} --index=${CPU_INDEX_URL}"
-ROCM_INDEX="--default-index=${ROCM_INDEX_URL} --index=${ROCM_INDEX_URL} --index=${CPU_INDEX_URL}"
 PUBLIC_INDEX="--default-index=https://pypi.org/simple"
 
 MAIN_DIRS=("jupyter" "runtimes" "rstudio" "codeserver")
@@ -70,6 +60,26 @@ ok()    { echo -e "✅ \033[1;32m$1\033[0m"; }
 
 uppercase() {
   echo "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+read_conf_value() {
+  local conf_file="$1"
+  local key="$2"
+
+  awk -F= -v key="$key" '
+    /^[[:space:]]*#/ { next }
+    NF < 2 { next }
+    {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1)
+      if ($1 == key) {
+        $1=""
+        sub(/^=/, "", $0)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+        print $0
+        exit
+      }
+    }
+  ' "$conf_file"
 }
 
 # ----------------------------
@@ -194,6 +204,62 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
   info "Effective mode for this directory: $EFFECTIVE_MODE"
 
   DIR_SUCCESS=true
+  CONF_DIR="build-args"
+  CPU_INDEX_URL=""
+
+  if [[ -f "${CONF_DIR}/cpu.conf" ]]; then
+    CPU_INDEX_URL=$(read_conf_value "${CONF_DIR}/cpu.conf" "INDEX_URL")
+  fi
+
+  get_index_flags() {
+    local flavor="$1"
+    local conf_file="${CONF_DIR}/${flavor}.conf"
+    local index_url
+    local index_flags
+    local cpu_index_url
+
+    if [[ ! -f "$conf_file" ]]; then
+      warn "Missing build-args config for ${flavor}: $conf_file"
+      return 1
+    fi
+
+    index_url=$(read_conf_value "$conf_file" "INDEX_URL")
+    if [[ -z "$index_url" ]]; then
+      warn "INDEX_URL not found in $conf_file"
+      return 1
+    fi
+
+    index_flags="--default-index=${index_url}"
+
+    if [[ "$flavor" != "cpu" ]]; then
+      index_flags+=" --index=${index_url}"
+
+      cpu_index_url=$(read_conf_value "$conf_file" "CPU_INDEX_URL")
+      if [[ -z "$cpu_index_url" && -n "$CPU_INDEX_URL" ]]; then
+        cpu_index_url="$CPU_INDEX_URL"
+      fi
+
+      if [[ -n "$cpu_index_url" ]]; then
+        index_flags+=" --index=${cpu_index_url}"
+      else
+        warn "CPU_INDEX_URL not found for $conf_file; using ${flavor} index only."
+      fi
+    fi
+
+    echo "$index_flags"
+  }
+
+  run_flavor_lock() {
+    local flavor="$1"
+    local index_flags
+
+    if ! index_flags=$(get_index_flags "$flavor"); then
+      DIR_SUCCESS=false
+      return
+    fi
+
+    run_lock "$flavor" "$index_flags" "$EFFECTIVE_MODE"
+  }
 
   run_lock() {
     local flavor="$1"
@@ -267,9 +333,9 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
   if [[ "$EFFECTIVE_MODE" == "public-index" ]]; then
     run_lock "cpu" "$PUBLIC_INDEX" "$EFFECTIVE_MODE"
   else
-    $HAS_CPU && run_lock "cpu" "$CPU_INDEX" "$EFFECTIVE_MODE"
-    $HAS_CUDA && run_lock "cuda" "$CUDA_INDEX" "$EFFECTIVE_MODE"
-    $HAS_ROCM && run_lock "rocm" "$ROCM_INDEX" "$EFFECTIVE_MODE"
+    $HAS_CPU && run_flavor_lock "cpu"
+    $HAS_CUDA && run_flavor_lock "cuda"
+    $HAS_ROCM && run_flavor_lock "rocm"
   fi
 
   if $DIR_SUCCESS; then

--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -54,9 +54,9 @@ CVE_CONSTRAINTS_FILE="$ROOT_DIR/dependencies/cve-constraints.txt"
 # HELPER FUNCTIONS
 # ----------------------------
 info()  { echo -e "🔹 \033[1;34m$1\033[0m"; }
-warn()  { echo -e "⚠️  \033[1;33m$1\033[0m" >&2; }
-error() { echo -e "❌ \033[1;31m$1\033[0m"; >&2; }
-ok()    { echo -e "✅ \033[1;32m$1\033[0m"; >&2; }
+warn()  { echo -e "⚠️ \033[1;33m$1\033[0m" >&2; }
+error() { echo -e "❌ \033[1;31m$1\033[0m" >&2; }
+ok()    { echo -e "✅ \033[1;32m$1\033[0m" >&2; }
 
 uppercase() {
   echo "$1" | tr '[:lower:]' '[:upper:]'

--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -54,9 +54,9 @@ CVE_CONSTRAINTS_FILE="$ROOT_DIR/dependencies/cve-constraints.txt"
 # HELPER FUNCTIONS
 # ----------------------------
 info()  { echo -e "🔹 \033[1;34m$1\033[0m"; }
-warn()  { echo -e "⚠️  \033[1;33m$1\033[0m"; }
-error() { echo -e "❌ \033[1;31m$1\033[0m"; }
-ok()    { echo -e "✅ \033[1;32m$1\033[0m"; }
+warn()  { echo -e "⚠️  \033[1;33m$1\033[0m" >&2; }
+error() { echo -e "❌ \033[1;31m$1\033[0m"; >&2; }
+ok()    { echo -e "✅ \033[1;32m$1\033[0m"; >&2; }
 
 uppercase() {
   echo "$1" | tr '[:lower:]' '[:upper:]'
@@ -232,8 +232,6 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
     index_flags="--default-index=${index_url}"
 
     if [[ "$flavor" != "cpu" ]]; then
-      index_flags+=" --index=${index_url}"
-
       cpu_index_url=$(read_conf_value "$conf_file" "CPU_INDEX_URL")
       if [[ -z "$cpu_index_url" && -n "$CPU_INDEX_URL" ]]; then
         cpu_index_url="$CPU_INDEX_URL"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://issues.redhat.com/browse/RHAIENG-2813

## Description
<!--- Describe your changes in detail -->
Externalize indexes outside pylock_generator script for better maintenance and flexibility, especially if we have different base cuda versions per image. 

As the plan is to start with the minimal image on CUDA 13 and then gradually move the other images to CUDA 13 across 3.4 EA2 and GA (where supported).
Given that, keeping the script in its current form will make day-to-day work difficult. This PR is a good example of the issue: https://github.com/opendatahub-io/notebooks/pull/2919/changes
The minimal image should be locked to the CUDA 13 index, while the remaining images should stay on 12.9, Therefore, the developer should change the value back to 12.9 for the rest. Then in an upcoming automated pylock PR like this one: https://github.com/opendatahub-io/notebooks/pull/2915 the minimal lock will be reverted to 12.9 again...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-flavor package index support for CUDA/ROCm/CPU, enabling flavor-specific package resolution and a CPU fallback for lock generation.

* **Chores**
  * Added INDEX_URL/CPU_INDEX_URL and PYLOCK_FLAVOR entries across build-arg configs.
  * Lock-generation flow updated to use per-flavor index settings and emit warnings when index configs are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->