### PR TITLE
[RHAIENG-2893] CVE-2026-0897: Update keras to 3.13.2 for CVE mitigation

### DIFF
--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1737,10 +1737,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/0f/61/22e778f642465a1
 
 [[packages]]
 name = "keras"
-version = "3.12.1"
+version = "3.13.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/85/1d/b64986120f5de68b921aa9bc2b69cb53ad20c1a6ebe5431a73def28525ef/keras-3.12.1.tar.gz", upload-time = 2026-01-30T18:28:57Z, size = 1127003, hashes = { sha256 = "3cb760b3fec105db4d893dd717daafdd0e35457a8201502c1ba8bedfaf334a71" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/13/7a/40096b1e1c29ffa830497a80800775ada5ba93f15cd52e0f1a84b4f22cd4/keras-3.12.1-py3-none-any.whl", upload-time = 2026-01-30T18:28:54Z, size = 1475784, hashes = { sha256 = "c340f8a25362398b20500c64e290f6ee280c6aeec51e1044eb8d759b32dc272a" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/09/e9/400582e5f3dbd815d2a373f7de7717dd1bc8349274e9ac1b9ac47410b123/keras-3.13.2.tar.gz", upload-time = 2026-01-30T00:35:13Z, size = 1155875, hashes = { sha256 = "62f0123488ac87c929c988617e14f293f7bc993811837d08bb37eff77adc85a9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/28/b5/ea85873abc99dc64a7a27ff1a8dbfdc7dbb57d4e5d1a423abc11217af4f1/keras-3.13.2-py3-none-any.whl", upload-time = 2026-01-30T00:35:09Z, size = 1513769, hashes = { sha256 = "14b2afc0f9c636cc295d28efc36aae42fc52e7b892c950eec33f3befe4d22fb5" } }]
 
 [[packages]]
 name = "kfp"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -53,7 +53,7 @@ odh-notebooks-meta-workbench-datascience-deps = { path = "../../../../dependenci
 override-dependencies = [
     # tf2onnx has pinned protobuf version, that causes conflict with other packages
     "protobuf==6.31.1",
-    "keras~=3.12.0",
+    "keras~=3.13.2",
     # RHAIENG-2458: CVE-2025-66418 urllib3 - override needed because odh-elyra pulls in
     # appengine-python-standard which has an obnoxious urllib3<2 constraint
     "urllib3>=2.6.0",

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1903,10 +1903,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/0f/61/22e778f642465a1
 
 [[packages]]
 name = "keras"
-version = "3.12.1"
+version = "3.13.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/85/1d/b64986120f5de68b921aa9bc2b69cb53ad20c1a6ebe5431a73def28525ef/keras-3.12.1.tar.gz", upload-time = 2026-01-30T18:28:57Z, size = 1127003, hashes = { sha256 = "3cb760b3fec105db4d893dd717daafdd0e35457a8201502c1ba8bedfaf334a71" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/13/7a/40096b1e1c29ffa830497a80800775ada5ba93f15cd52e0f1a84b4f22cd4/keras-3.12.1-py3-none-any.whl", upload-time = 2026-01-30T18:28:54Z, size = 1475784, hashes = { sha256 = "c340f8a25362398b20500c64e290f6ee280c6aeec51e1044eb8d759b32dc272a" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/09/e9/400582e5f3dbd815d2a373f7de7717dd1bc8349274e9ac1b9ac47410b123/keras-3.13.2.tar.gz", upload-time = 2026-01-30T00:35:13Z, size = 1155875, hashes = { sha256 = "62f0123488ac87c929c988617e14f293f7bc993811837d08bb37eff77adc85a9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/28/b5/ea85873abc99dc64a7a27ff1a8dbfdc7dbb57d4e5d1a423abc11217af4f1/keras-3.13.2-py3-none-any.whl", upload-time = 2026-01-30T00:35:09Z, size = 1513769, hashes = { sha256 = "14b2afc0f9c636cc295d28efc36aae42fc52e7b892c950eec33f3befe4d22fb5" } }]
 
 [[packages]]
 name = "kfp"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -51,7 +51,7 @@ odh-notebooks-meta-workbench-datascience-deps = { path = "../../../dependencies/
 override-dependencies = [
     # tf2onnx has pinned protobuf version, that causes conflict with other packages
     "protobuf==6.31.1",
-    "keras~=3.12.0",
+    "keras~=3.13.2",
     # RHAIENG-2458: CVE-2025-66418 urllib3 - override needed because odh-elyra pulls in
     # appengine-python-standard which has an obnoxious urllib3<2 constraint
     "urllib3>=2.6.0",

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -1320,10 +1320,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/0f/61/22e778f642465a1
 
 [[packages]]
 name = "keras"
-version = "3.12.1"
+version = "3.13.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/85/1d/b64986120f5de68b921aa9bc2b69cb53ad20c1a6ebe5431a73def28525ef/keras-3.12.1.tar.gz", upload-time = 2026-01-30T18:28:57Z, size = 1127003, hashes = { sha256 = "3cb760b3fec105db4d893dd717daafdd0e35457a8201502c1ba8bedfaf334a71" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/13/7a/40096b1e1c29ffa830497a80800775ada5ba93f15cd52e0f1a84b4f22cd4/keras-3.12.1-py3-none-any.whl", upload-time = 2026-01-30T18:28:54Z, size = 1475784, hashes = { sha256 = "c340f8a25362398b20500c64e290f6ee280c6aeec51e1044eb8d759b32dc272a" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/09/e9/400582e5f3dbd815d2a373f7de7717dd1bc8349274e9ac1b9ac47410b123/keras-3.13.2.tar.gz", upload-time = 2026-01-30T00:35:13Z, size = 1155875, hashes = { sha256 = "62f0123488ac87c929c988617e14f293f7bc993811837d08bb37eff77adc85a9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/28/b5/ea85873abc99dc64a7a27ff1a8dbfdc7dbb57d4e5d1a423abc11217af4f1/keras-3.13.2-py3-none-any.whl", upload-time = 2026-01-30T00:35:09Z, size = 1513769, hashes = { sha256 = "14b2afc0f9c636cc295d28efc36aae42fc52e7b892c950eec33f3befe4d22fb5" } }]
 
 [[packages]]
 name = "kiwisolver"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 override-dependencies = [
     # tf2onnx has pinned protobuf version, that causes conflict with other packages
     "protobuf==6.31.1",
-    "keras~=3.12.0"
+    "keras~=3.13.2"
 ]
 
 constraint-dependencies = [

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1507,10 +1507,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/0f/61/22e778f642465a1
 
 [[packages]]
 name = "keras"
-version = "3.12.1"
+version = "3.13.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/85/1d/b64986120f5de68b921aa9bc2b69cb53ad20c1a6ebe5431a73def28525ef/keras-3.12.1.tar.gz", upload-time = 2026-01-30T18:28:57Z, size = 1127003, hashes = { sha256 = "3cb760b3fec105db4d893dd717daafdd0e35457a8201502c1ba8bedfaf334a71" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/13/7a/40096b1e1c29ffa830497a80800775ada5ba93f15cd52e0f1a84b4f22cd4/keras-3.12.1-py3-none-any.whl", upload-time = 2026-01-30T18:28:54Z, size = 1475784, hashes = { sha256 = "c340f8a25362398b20500c64e290f6ee280c6aeec51e1044eb8d759b32dc272a" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/09/e9/400582e5f3dbd815d2a373f7de7717dd1bc8349274e9ac1b9ac47410b123/keras-3.13.2.tar.gz", upload-time = 2026-01-30T00:35:13Z, size = 1155875, hashes = { sha256 = "62f0123488ac87c929c988617e14f293f7bc993811837d08bb37eff77adc85a9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/28/b5/ea85873abc99dc64a7a27ff1a8dbfdc7dbb57d4e5d1a423abc11217af4f1/keras-3.13.2-py3-none-any.whl", upload-time = 2026-01-30T00:35:09Z, size = 1513769, hashes = { sha256 = "14b2afc0f9c636cc295d28efc36aae42fc52e7b892c950eec33f3befe4d22fb5" } }]
 
 [[packages]]
 name = "kiwisolver"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 override-dependencies = [
     # tf2onnx has pinned protobuf version, that causes conflict with other packages
     "protobuf==6.31.1",
-    "keras~=3.12.0"
+    "keras~=3.13.2"
 ]
 
 environments = [


### PR DESCRIPTION
## Description
- Bump keras override to 3.13.2 in TensorFlow runtime and workbench configs to address the CVE
- Regenerate lockfiles

## How Has This Been Tested?
- The image was built for the ARM64 architecture using: `gmake BUILD_ARCH=linux/arm64 cuda-jupyter-tensorflow-ubi9-python-3.12 -e IMAGE_REGISTRY="quay.io/mtchoumi-aaet/workbench-images"`
- Security Verification: Confirmed via Quay Security Scan that the vulnerabilities related to Keras is no longer present
Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Keras dependency from 3.12.x to 3.13.2 across Python 3.12 build/runtime configurations and lockfiles.
  * Associated package metadata and download references refreshed to reflect the new Keras release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->