### PR TITLE
RHAIENG-3039: deps(datascience): re-enable codeflare-sdk

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -5,8 +5,7 @@ requires-python = "==3.12.*"
 
 dependencies = [
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
-    #"codeflare-sdk~=0.34.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
+    "codeflare-sdk~=0.34.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "feast~=0.59.0",
     "skl2onnx~=1.19.1",
     "odh-notebooks-meta-workbench-datascience-deps",

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -22,6 +22,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "aiohttp-cors"
+version = "0.8.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/aiohttp_cors-0.8.1-2-py3-none-any.whl", hashes = { sha256 = "09d9788a297cc86c79f6c81fab24b986a3997ea31c08628a28a0c4d76f6b2dae" } }]
+
+[[packages]]
 name = "aiosignal"
 version = "1.4.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -111,6 +117,15 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/babel-2.18.0-2-py3-none-any.whl", hashes = { sha256 = "09a3d6613999eac4892b21b7b6bc97bcb86a7e6312cf53d89b3c43f6be8faf8d" } }]
 
 [[packages]]
+name = "bcrypt"
+version = "5.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/bcrypt-5.0.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1d58417375b2a499fabc20a59fabdf7a8dbf0f58ab5ce8ca6075d477152443a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/bcrypt-5.0.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "282f033262dddc92da5432ab56d3c20651e82ab74ae1cabb6125e450046afaf7" } },
+]
+
+[[packages]]
 name = "beautifulsoup4"
 version = "4.14.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -188,10 +203,22 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cloudpickle-3.1.2-2-py3-none-any.whl", hashes = { sha256 = "7d49d126993f7e9f5e5ad945bc232fab0274339cadc6c2a5b453ee21fa2228e2" } }]
 
 [[packages]]
+name = "codeflare-sdk"
+version = "0.34.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/codeflare_sdk-0.34.0-2-py3-none-any.whl", hashes = { sha256 = "ec51d64bb15b5fa8cc3fcbce309a2c5bda3a8be3e3fc6e306c0a0a36a1d84082" } }]
+
+[[packages]]
 name = "colorama"
 version = "0.4.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/colorama-0.4.6-2-py2.py3-none-any.whl", hashes = { sha256 = "6b4a8e5d766a573b0ff926b3f946f064d6ff1fbf81c5942d176f3c34e683d511" } }]
+
+[[packages]]
+name = "colorful"
+version = "0.5.8"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/colorful-0.5.8-2-py2.py3-none-any.whl", hashes = { sha256 = "0f48b3d8a3914477d56c59ddd37075046dca749ad94db8b9dd16f88017ebb27c" } }]
 
 [[packages]]
 name = "comm"
@@ -212,13 +239,13 @@ wheels = [
 
 [[packages]]
 name = "cryptography"
-version = "46.0.4"
+version = "46.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.4-2-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "0cecc7cb9880de1c61c9ac614e30d656bc7663b00999d29ff9cbc56e873ddac1" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.4-2-cp312-abi3-linux_ppc64le.whl", hashes = { sha256 = "541de6f6db7fe5539b5857cbfec902744c2993ebae33b2441e6ec32edf738391" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.4-2-cp312-abi3-linux_s390x.whl", hashes = { sha256 = "ececca50e3e724e0778cf9880f2b8461b4465dc72cda3af4120c5c24004da5a9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.4-2-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "641e9f655b62e29f53ff2233c3e33f33fc969adc3341aa3913656ae9be82d706" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "1b90ebf281100bae06c6a7378ca6c79aeb0d44b59be760d43c683c394fc82983" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_ppc64le.whl", hashes = { sha256 = "35137a6f487c8786015f5f5434985109d7482af44377ff4e76ff34a1ddcee62e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_s390x.whl", hashes = { sha256 = "c03d4649d24ebaa00a388b22f4e9b8f9d8a301fe354c1cb4c9d160639b219ae3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "96522b9276c0ee070aad5df9721e09efee85c565005970acb1ebc67251291fe8" } },
 ]
 
 [[packages]]
@@ -269,6 +296,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/dill-0.3.9-2-py3-none-any.whl", hashes = { sha256 = "1ac03aa46a9699d4bc68f52c2986eb7d8ea8696e0ade30a6b1f645df1e203e46" } }]
 
 [[packages]]
+name = "distlib"
+version = "0.4.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/distlib-0.4.0-2-py2.py3-none-any.whl", hashes = { sha256 = "a587b9426e6cf59e6116e6d329150e4e45b08211f1892e1cf100c16a41f8e9b8" } }]
+
+[[packages]]
 name = "dnspython"
 version = "2.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -300,9 +333,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "executing"
-version = "2.2.1"
+version = "1.2.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/executing-2.2.1-2-py2.py3-none-any.whl", hashes = { sha256 = "d72048a79b547d5f3c2fe6fb84d2982568dc0fbe168b35f8b04eb9545167bce1" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/executing-1.2.0-2-py2.py3-none-any.whl", hashes = { sha256 = "6f897666cb8e2381e182753f062b82516c66b8aaa9ae30fe389f00f0f5e0fb4c" } }]
 
 [[packages]]
 name = "fastapi"
@@ -321,6 +354,12 @@ name = "feast"
 version = "0.59.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/feast-0.59.0-2-py2.py3-none-any.whl", hashes = { sha256 = "a8df1c93bb5b479c3096b521ca9a7de7e5f6051e7b6fed1dea4610e83a175591" } }]
+
+[[packages]]
+name = "filelock"
+version = "3.20.3"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/filelock-3.20.3-2-py3-none-any.whl", hashes = { sha256 = "ea920484a56693a87027eb8d173059eda17fe42a4fbad454e2052b20394d0648" } }]
 
 [[packages]]
 name = "fonttools"
@@ -427,6 +466,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "grpcio"
+version = "1.76.0"
+marker = "python_full_version >= '3.10' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1c13ca5a1d07f3f393f666e5129e58c80d6a35cb4795e129b7a7edbb86c16ae2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c0e341e292abe4050d370613bdb874e109a461bf34a8daa19af5db78b2d9245b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "bdcd2330da7345993c2499536fd5c8f5e9c01f1c46029d4ac9d40805fdf1bc34" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "26c2a2851ed27d19da340ed570f36a880afe6c97fa573175cb17053faaa35538" } },
+]
+
+[[packages]]
 name = "gunicorn"
 version = "25.0.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -474,6 +524,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/importlib_metadata-8.7.1-2-py3-none-any.whl", hashes = { sha256 = "2fbfff013f23963bc75c3e3a395efa3e1646e97cf4195cd7dae8a720a458b9b6" } }]
 
 [[packages]]
+name = "invoke"
+version = "2.2.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/invoke-2.2.1-2-py3-none-any.whl", hashes = { sha256 = "e205c890426bce76ca97f59c5e0dd1820bb413144e4d354c39af0545c5754172" } }]
+
+[[packages]]
 name = "ipykernel"
 version = "7.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -493,9 +549,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ipywidgets"
-version = "8.1.8"
+version = "8.1.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipywidgets-8.1.8-2-py3-none-any.whl", hashes = { sha256 = "2d1b7666b75e8a3d21024ecbe65e7e5c3de05bb7ad0c429f094a31eb58dfaf1e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipywidgets-8.1.2-2-py3-none-any.whl", hashes = { sha256 = "9782495bd3206441caace2f592d0587fc22f1afc0631f4ea7a4f9ed5982dec06" } }]
 
 [[packages]]
 name = "isoduration"
@@ -736,6 +792,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/locket-1.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "94bd944f1ebb1ed06f9d1f51abc4b9170b297d34e2a3675057bb94222e42173e" } }]
 
 [[packages]]
+name = "markdown-it-py"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/markdown_it_py-4.0.0-2-py3-none-any.whl", hashes = { sha256 = "7987a41d387448523e90cb6b1089dae47dc95eaed7c1e3147037c16211c82b86" } }]
+
+[[packages]]
 name = "markupsafe"
 version = "3.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -762,6 +824,12 @@ name = "matplotlib-inline"
 version = "0.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/matplotlib_inline-0.2.1-2-py3-none-any.whl", hashes = { sha256 = "6a1b97fed26c7c7452c3357db29aa75e0298b1c8e0a4cb8e42220e68cb28b4cf" } }]
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mdurl-0.1.2-2-py3-none-any.whl", hashes = { sha256 = "4daacaef45c8a39e6074ed339bb654fd52aa6bec1109a7906dcb9fde4cb60319" } }]
 
 [[packages]]
 name = "minio"
@@ -802,6 +870,17 @@ name = "mock"
 version = "5.2.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mock-5.2.0-2-py3-none-any.whl", hashes = { sha256 = "4d708afc977756a718ed120d6ecd033d7f336299812d9d8bdd1f6390e064f6c1" } }]
+
+[[packages]]
+name = "msgpack"
+version = "1.1.2"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "976dc988e95242953c8be444b3e536f4d1416210cb7af13f578a501188e5fdb4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "b40a93f9aeeca86d6d0ac69a1baea430030f0a25d96172dbce6a3a73ee483276" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9087e44d1e86a8c3813be7b4ce1d618ff81577d6370893572ec22e8c2969c830" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "29ce7557d122e3c00cf95eb41870adb924c0149311a122724c33b85a6bc78c8e" } },
+]
 
 [[packages]]
 name = "multidict"
@@ -938,6 +1017,54 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/onnxconverter_common-1.16.0-4-py2.py3-none-any.whl", hashes = { sha256 = "2aff3ae28278509da839634c226265f78075654c210d36a3fc5058db375e4156" } }]
 
 [[packages]]
+name = "opencensus"
+version = "0.11.4"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opencensus-0.11.4-2-py2.py3-none-any.whl", hashes = { sha256 = "eedbd569b2a359c36e1b287de65950c4fe78b19f89af2c1c61c74a4a08617ac4" } }]
+
+[[packages]]
+name = "opencensus-context"
+version = "0.1.3"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opencensus_context-0.1.3-2-py2.py3-none-any.whl", hashes = { sha256 = "086e9c1c3c52ac92a6a1f48ae1cf75856683fc5235fadfd1032a1d4f6a082ad5" } }]
+
+[[packages]]
+name = "openshift-client"
+version = "1.0.18"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/openshift_client-1.0.18-2-py2.py3-none-any.whl", hashes = { sha256 = "8935aec9161a05d1c620a7a3d6a22d8f7ef3e057ffe9293ff5eca78031aca892" } }]
+
+[[packages]]
+name = "opentelemetry-api"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_api-1.39.1-2-py3-none-any.whl", hashes = { sha256 = "9e806ddae59651ca5ba8ca35066c80afd8cae466349991a8d1ff710791bff3f1" } }]
+
+[[packages]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_exporter_prometheus-0.60b1-2-py3-none-any.whl", hashes = { sha256 = "b11e5a92dc44d82b648694d72b282177601f90422b90cd98c1608f6f407a022d" } }]
+
+[[packages]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_proto-1.39.1-2-py3-none-any.whl", hashes = { sha256 = "55a0a6703776a71f81eb20ecf129ceeb979f7222c78b96c3a7e65bc6eb40d114" } }]
+
+[[packages]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_sdk-1.39.1-2-py3-none-any.whl", hashes = { sha256 = "2ecc0a8a97572a91e0f42fb2d411e5f8fed192e01ccfaa52eeb912714b16f479" } }]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_semantic_conventions-0.60b1-2-py3-none-any.whl", hashes = { sha256 = "bfab6bd416479400e40a8363e5dd8a813b33b0e82182d684f35865fde2dbca79" } }]
+
+[[packages]]
 name = "packaging"
 version = "26.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -965,6 +1092,12 @@ name = "papermill"
 version = "2.6.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/papermill-2.6.0-2-py3-none-any.whl", hashes = { sha256 = "f7e33f1ba5bc85b7b7d2e060386d5f6399c31063deff17f4a46bf8d085f3fb91" } }]
+
+[[packages]]
+name = "paramiko"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/paramiko-4.0.0-2-py3-none-any.whl", hashes = { sha256 = "2ec2a7c40df0a6cb368fd891f5133beeaf623eaa7fe6402d4659185d441e33b0" } }]
 
 [[packages]]
 name = "parso"
@@ -1087,6 +1220,15 @@ name = "pure-eval"
 version = "0.2.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pure_eval-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "69ca56a05367fa5b08de38f76c9fa60637ebc5ef32726337b3a63732fd53aad9" } }]
+
+[[packages]]
+name = "py-spy"
+version = "0.4.1"
+marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/py_spy-0.4.1-2-py3-none-linux_aarch64.whl", hashes = { sha256 = "632a990ddd5394d1360f4736790daa336a4412ae5d448b71eb1f092e61d46220" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/py_spy-0.4.1-2-py3-none-linux_x86_64.whl", hashes = { sha256 = "ba03163b955927082e19509a9d79a647d3ce782b97f8f343df4f160b562ec9ff" } },
+]
 
 [[packages]]
 name = "pyarrow"
@@ -1278,6 +1420,15 @@ wheels = [
 ]
 
 [[packages]]
+name = "ray"
+version = "2.52.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_aarch64.whl", hashes = { sha256 = "08eb8f5fd55292ba6bee363a32491136a5e54af54e007f81e0603986fbea41a4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_x86_64.whl", hashes = { sha256 = "843c0108ad72bb7fc6c23a22e29e6099546a5eaad3ad675c78a146d9080f6ec6" } },
+]
+
+[[packages]]
 name = "referencing"
 version = "0.37.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1324,6 +1475,12 @@ name = "rfc3987-syntax"
 version = "1.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/rfc3987_syntax-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "269579adbbeab3df1cd5f9667fd0035635494789ca8159c8ecae2c4c7687d4a6" } }]
+
+[[packages]]
+name = "rich"
+version = "13.9.4"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/rich-13.9.4-2-py3-none-any.whl", hashes = { sha256 = "ec8ad7c9c333b8a2b249eb68864faecf4e87519e6ae2c8e88de5fada449245e2" } }]
 
 [[packages]]
 name = "rpds-py"
@@ -1405,6 +1562,12 @@ name = "skl2onnx"
 version = "1.19.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/skl2onnx-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "a0512e099edfa89622c5c9f55ac0e17b43584bbfef79984ce131ac9c3852e12d" } }]
+
+[[packages]]
+name = "smart-open"
+version = "7.5.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/smart_open-7.5.0-2-py3-none-any.whl", hashes = { sha256 = "19448cb2f668050aa732246762c4196ec285dd0efedd9b169238f2201b8096d4" } }]
 
 [[packages]]
 name = "smmap"
@@ -1589,6 +1752,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "virtualenv"
+version = "20.36.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/virtualenv-20.36.1-2-py3-none-any.whl", hashes = { sha256 = "63c660e83c7cb19846fd4f91d6a92dd557179d7706f3d20c28ebe1f386eae927" } }]
+
+[[packages]]
 name = "watchdog"
 version = "6.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1651,6 +1820,17 @@ name = "widgetsnbextension"
 version = "4.0.15"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/widgetsnbextension-4.0.15-2-py3-none-any.whl", hashes = { sha256 = "cfea2d2409a3249b3217c12c2449ffe51417894f6b2f5f7b5401cac21840712e" } }]
+
+[[packages]]
+name = "wrapt"
+version = "2.1.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0e6baa9cfa6d2aab49306b73e139162cf7a25444ff676a25dc80333a1398239" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "7e3fd8324db491cd99350a48a8fbb9c888ee825f94b4eec456916e0689470ade" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "284004f82045f055f77ab79361126742ca11090f0ffe4ea899442dffe1014f97" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "2117b8745946ad08dbf96ed4106bb867e554a869e294f028f2707288aaaacff3" } },
+]
 
 [[packages]]
 name = "xyzservices"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -10,8 +10,7 @@ dependencies = [
     "torchvision==0.24.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
-    # "codeflare-sdk~=0.34.0",
+    "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
     "skl2onnx~=1.19.1",
     "odh-notebooks-meta-workbench-datascience-deps",

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -26,6 +26,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "aiohttp-cors"
+version = "0.8.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/aiohttp_cors-0.8.1-8-py3-none-any.whl", hashes = { sha256 = "8e7369a0d75b345d83f596071807f5621519a96f5d29a90fba3d240dc9490e5a" } }]
+
+[[packages]]
 name = "aiosignal"
 version = "1.4.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -113,6 +119,15 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/babel-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "be3485e1e7f083386b0e09643561b33b372428dd7373923c7363766dec49b299" } }]
 
 [[packages]]
+name = "bcrypt"
+version = "5.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/bcrypt-5.0.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "daa11e64ff8863d9c97864a11f782281083d37b358adfd24a8f93c72d8561be9" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/bcrypt-5.0.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9afdfc5bc2b65bf5660e4848cbd7fd3091bd5f1ba846fba3f3f283e22ec3e2a6" } },
+]
+
+[[packages]]
 name = "beautifulsoup4"
 version = "4.14.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -188,10 +203,22 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cloudpickle-3.1.2-8-py3-none-any.whl", hashes = { sha256 = "a9c9dba766e2288e12bd9f26435a5a3cf3f022d7ee048c6f0c5ba05b796b1cd2" } }]
 
 [[packages]]
+name = "codeflare-sdk"
+version = "0.34.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/codeflare_sdk-0.34.0-8-py3-none-any.whl", hashes = { sha256 = "9ef6b583ee00f04df8199aafb800ea8a6d7eb56dd3f97b1287e6c939d32faf4d" } }]
+
+[[packages]]
 name = "colorama"
 version = "0.4.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/colorama-0.4.6-8-py2.py3-none-any.whl", hashes = { sha256 = "08c8b3038b633a70557d54797563b6f1f0fab174e97939ad5459d0479ff628c6" } }]
+
+[[packages]]
+name = "colorful"
+version = "0.5.8"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/colorful-0.5.8-8-py2.py3-none-any.whl", hashes = { sha256 = "9ba8514681b0a1accb47bd0263d94e8fbcad90e58e4fd6feafa3efe0710cd351" } }]
 
 [[packages]]
 name = "comm"
@@ -210,11 +237,11 @@ wheels = [
 
 [[packages]]
 name = "cryptography"
-version = "46.0.4"
+version = "46.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cryptography-46.0.4-8-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "640a3979b159ca4f9454ed26b8b016f7d6703b0442a027088262d4d279945497" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cryptography-46.0.4-8-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "625066533ca6ecfac0f31b974a629903899467053f8593b57ea1fa69b57ba3c3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cryptography-46.0.3-8-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "8c308ee0475994bf9cd3cff12515e78f8a24e4bc15f28b5b7c973d3cbf1505f2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cryptography-46.0.3-8-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "597b2688ec213512f8bd2596e92c72d86600e0ff132f453baf8d45876a97f364" } },
 ]
 
 [[packages]]
@@ -263,6 +290,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/dill-0.3.9-8-py3-none-any.whl", hashes = { sha256 = "10f14f67e7fb824cf1f0c771fc709be3404ee0a3506e385aad9aadd1fca48453" } }]
 
 [[packages]]
+name = "distlib"
+version = "0.4.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/distlib-0.4.0-8-py2.py3-none-any.whl", hashes = { sha256 = "6c00e3348021f675262a7bbece9e56562060dba095acebd59db743b9c482c939" } }]
+
+[[packages]]
 name = "dnspython"
 version = "2.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -294,9 +327,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "executing"
-version = "2.2.1"
+version = "1.2.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/executing-2.2.1-8-py2.py3-none-any.whl", hashes = { sha256 = "2f6db4d258b4375ffcbff9bd4a35c8e7ad883d724fd246221f234116134caf00" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/executing-1.2.0-8-py2.py3-none-any.whl", hashes = { sha256 = "e763ca4ee97f6fe04c08c95f2c1afbcdc1b2197e8bdadb32405e57a3aa47e2b1" } }]
 
 [[packages]]
 name = "fastapi"
@@ -476,6 +509,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/importlib_metadata-8.7.1-8-py3-none-any.whl", hashes = { sha256 = "9438c2c8582fae36d4d851f9c02aa8e327e14a77738d9f1f8a6f7e9bfa3ea908" } }]
 
 [[packages]]
+name = "invoke"
+version = "2.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/invoke-2.2.1-8-py3-none-any.whl", hashes = { sha256 = "05412facff8cf1c8bb9ddc0e0bbc37d64e33318886855bf2876e32e68ad9cf00" } }]
+
+[[packages]]
 name = "ipykernel"
 version = "7.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -495,9 +534,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ipywidgets"
-version = "8.1.8"
+version = "8.1.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipywidgets-8.1.8-8-py3-none-any.whl", hashes = { sha256 = "f84784cc7dce51f234dda0464acafa722f9351250d58ab9fb248f0001e8f589c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipywidgets-8.1.2-8-py3-none-any.whl", hashes = { sha256 = "4f78c5242b754eba22ae1fa04f5db458e3e562e33ed702c705e9bc5b74af6071" } }]
 
 [[packages]]
 name = "isoduration"
@@ -740,6 +779,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/markdown-3.10.1-8-py3-none-any.whl", hashes = { sha256 = "817a697ce457f652cb368a14b9eaf9c62f02b0243468204bd49c618904f6e012" } }]
 
 [[packages]]
+name = "markdown-it-py"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/markdown_it_py-4.0.0-8-py3-none-any.whl", hashes = { sha256 = "2e63f1744bd8d809a002f68dddd01956ffc12964c15397dcdd492aa4bae11bb9" } }]
+
+[[packages]]
 name = "markupsafe"
 version = "3.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -762,6 +807,12 @@ name = "matplotlib-inline"
 version = "0.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/matplotlib_inline-0.2.1-8-py3-none-any.whl", hashes = { sha256 = "a439bba0219798e3bb1123bc378f673df65fc1e7ddb59ddbce8155cb9ac45114" } }]
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mdurl-0.1.2-8-py3-none-any.whl", hashes = { sha256 = "45c663f9c94351ece0ba397babc5bc2131de528d527821321c4267c8e8c0b484" } }]
 
 [[packages]]
 name = "minio"
@@ -804,6 +855,15 @@ name = "mpmath"
 version = "1.3.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mpmath-1.3.0-8-py3-none-any.whl", hashes = { sha256 = "b321f4f60780963fc0f5a27c61aa0ae7925818535564526855f0874302b9e73b" } }]
+
+[[packages]]
+name = "msgpack"
+version = "1.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/msgpack-1.1.2-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "70a36b2a556ca5261a866ad6fcc6a63bf26be77a66d5e1ed3a9fb1282a8722a3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/msgpack-1.1.2-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "73d2c1e7da99fec6486f18169ec2d4dbb7ea32e41fa06285fc071159436751bb" } },
+]
 
 [[packages]]
 name = "multidict"
@@ -932,6 +992,54 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/onnxconverter_common-1.16.0-10-py2.py3-none-any.whl", hashes = { sha256 = "e10b80b7d24d4dfae295d1a872bb0046b9a095a58aadf06c2ff03bb7424e34e5" } }]
 
 [[packages]]
+name = "opencensus"
+version = "0.11.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opencensus-0.11.4-8-py2.py3-none-any.whl", hashes = { sha256 = "4be45e7b357769afbeb34d576a05997af19e663c5c210b9d27cbc3c0d0970b80" } }]
+
+[[packages]]
+name = "opencensus-context"
+version = "0.1.3"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opencensus_context-0.1.3-8-py2.py3-none-any.whl", hashes = { sha256 = "6cbc534d5bb803948f575da1b555c0344df7148cd3adebfc71c377b58ce1932a" } }]
+
+[[packages]]
+name = "openshift-client"
+version = "1.0.18"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/openshift_client-1.0.18-8-py2.py3-none-any.whl", hashes = { sha256 = "4a5cb57fb2f2ef3372b504797bed19a9dd75ca93168ec93b7012cbc0b60c7fb0" } }]
+
+[[packages]]
+name = "opentelemetry-api"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_api-1.39.1-8-py3-none-any.whl", hashes = { sha256 = "892530d3de2309f4c7ea86c895fafd5e9d489545db928510efca294bcb7e8610" } }]
+
+[[packages]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_exporter_prometheus-0.60b1-8-py3-none-any.whl", hashes = { sha256 = "94d5b62023f659b091bb5e48818412b2fc9a21e164bece9fbe8a698342410c1e" } }]
+
+[[packages]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_proto-1.39.1-8-py3-none-any.whl", hashes = { sha256 = "bb5b3235b7fb2414378ae1c906e6b4751acc424c37b590336fc4d2850e4a4da5" } }]
+
+[[packages]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_sdk-1.39.1-8-py3-none-any.whl", hashes = { sha256 = "2286f30340a77ade25238fa4c60a3d69a7161a6c4a35fac1c81649792c63fe64" } }]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_semantic_conventions-0.60b1-8-py3-none-any.whl", hashes = { sha256 = "908640a7c0bf479a1bdbbad21561d895f9a227bd3ea606fdbb686159eb059864" } }]
+
+[[packages]]
 name = "packaging"
 version = "26.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -957,6 +1065,12 @@ name = "papermill"
 version = "2.6.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/papermill-2.6.0-8-py3-none-any.whl", hashes = { sha256 = "fbca5b662c14f7127390597bc7a967a1a745fde51efee097c592dcc8b57a193e" } }]
+
+[[packages]]
+name = "paramiko"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/paramiko-4.0.0-8-py3-none-any.whl", hashes = { sha256 = "1d168b4631018edf5bc438dce290503b82fdb7c288935e0513a8f7bbf57b2acc" } }]
 
 [[packages]]
 name = "parso"
@@ -1071,6 +1185,15 @@ name = "pure-eval"
 version = "0.2.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pure_eval-0.2.3-8-py3-none-any.whl", hashes = { sha256 = "2fdc667e87f14de1c0e961c1288dbb4a0f97ce82c41756c47521c9ab86e794b1" } }]
+
+[[packages]]
+name = "py-spy"
+version = "0.4.1"
+marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/py_spy-0.4.1-8-py3-none-linux_aarch64.whl", hashes = { sha256 = "cb40c2741f7ecf0b63812353e81c7f356f00a5aa6fcfe0c4f41f3d755d0f7bc6" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/py_spy-0.4.1-8-py3-none-linux_x86_64.whl", hashes = { sha256 = "5fe3ae248e1cd1c07939b228f9b5f563c1bdbe0ad5c2b908588e9ceac5c42bbb" } },
+]
 
 [[packages]]
 name = "pyarrow"
@@ -1244,6 +1367,15 @@ wheels = [
 ]
 
 [[packages]]
+name = "ray"
+version = "2.52.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_aarch64.whl", hashes = { sha256 = "08eb8f5fd55292ba6bee363a32491136a5e54af54e007f81e0603986fbea41a4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_x86_64.whl", hashes = { sha256 = "843c0108ad72bb7fc6c23a22e29e6099546a5eaad3ad675c78a146d9080f6ec6" } },
+]
+
+[[packages]]
 name = "referencing"
 version = "0.37.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1290,6 +1422,12 @@ name = "rfc3987-syntax"
 version = "1.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/rfc3987_syntax-1.1.0-8-py3-none-any.whl", hashes = { sha256 = "bf5ef1cefcc974e2bf90eb9746ae79ff7d3734905ca0c41f86e601d992bcc596" } }]
+
+[[packages]]
+name = "rich"
+version = "13.9.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/rich-13.9.4-8-py3-none-any.whl", hashes = { sha256 = "9f582115c023367d33d9f44df636ad1c037dc540d5fd971e8526b11ea83f33e8" } }]
 
 [[packages]]
 name = "rpds-py"
@@ -1365,6 +1503,12 @@ name = "skl2onnx"
 version = "1.19.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/skl2onnx-1.19.1-8-py3-none-any.whl", hashes = { sha256 = "fd966002d2b0620765e4597b807e03f777e674c852f7739b98fbc12b81f5c264" } }]
+
+[[packages]]
+name = "smart-open"
+version = "7.5.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/smart_open-7.5.0-8-py3-none-any.whl", hashes = { sha256 = "b28e557ee2c0e112c46247620c46bae12472a0dcc2f0ca2c9ae2f2fea0f18a3f" } }]
 
 [[packages]]
 name = "smmap"
@@ -1586,6 +1730,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "virtualenv"
+version = "20.36.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/virtualenv-20.36.1-8-py3-none-any.whl", hashes = { sha256 = "a4ed3477e28d87de9c6e12c4e1d69ee61897ded82f247b108319c2fa565f24cd" } }]
+
+[[packages]]
 name = "watchdog"
 version = "6.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1650,6 +1800,15 @@ name = "widgetsnbextension"
 version = "4.0.15"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/widgetsnbextension-4.0.15-8-py3-none-any.whl", hashes = { sha256 = "397974e955b5e21d84621ec82b001b9fed3bbc3562c8a59a04e737dee630f4a2" } }]
+
+[[packages]]
+name = "wrapt"
+version = "2.1.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/wrapt-2.1.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "612384476b9d11027d318ee601249fa9505397d877d109e724d06a1afd69078e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/wrapt-2.1.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "70cd59427a242e29fbd842b7614d04dcdeac38120bff169caa4902a43691aead" } },
+]
 
 [[packages]]
 name = "xyzservices"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -11,8 +11,7 @@ dependencies = [
     "triton~=3.5.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
-    # "codeflare-sdk~=0.34.0",
+    "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
     "skl2onnx~=1.19.1",
     "odh-notebooks-meta-workbench-datascience-deps",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -23,6 +23,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/aiohttp-3.13.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1cbefc6957ffe41e6e08aa24b5065c874357f9cc7aa375a1a1af3aa2c5a88c34" } }]
 
 [[packages]]
+name = "aiohttp-cors"
+version = "0.8.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/aiohttp_cors-0.8.1-12-py3-none-any.whl", hashes = { sha256 = "f82e739a4997d7b774043a577395ecc6f410c1f8ad7a9ce82128c36aa4c9cf82" } }]
+
+[[packages]]
 name = "aiosignal"
 version = "1.4.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -107,6 +113,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/babel-2.18.0-12-py3-none-any.whl", hashes = { sha256 = "a4b0aecf820ba18611184ea37557ebf9c02574142383c176c9301b63b9121dcf" } }]
 
 [[packages]]
+name = "bcrypt"
+version = "5.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/bcrypt-5.0.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "068ff31f8734dd984ee7780ec66c7b63e16a04d97cbb083ec7af9662eefecab8" } }]
+
+[[packages]]
 name = "beautifulsoup4"
 version = "4.14.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -179,10 +191,22 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cloudpickle-3.1.2-12-py3-none-any.whl", hashes = { sha256 = "d333edb233fa3c1ea649de041c997b55ed2ee51756f62b92ce03d2601ad04976" } }]
 
 [[packages]]
+name = "codeflare-sdk"
+version = "0.34.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/codeflare_sdk-0.34.0-12-py3-none-any.whl", hashes = { sha256 = "5e33e402326260bf4468f5d0477d081de447b806e643cd202f3f25f4323b79d5" } }]
+
+[[packages]]
 name = "colorama"
 version = "0.4.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/colorama-0.4.6-12-py2.py3-none-any.whl", hashes = { sha256 = "ce49679c36d7cba422c64ef88bff417a5148fcf5bb008fa612a1c63b4f560e5f" } }]
+
+[[packages]]
+name = "colorful"
+version = "0.5.8"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/colorful-0.5.8-12-py2.py3-none-any.whl", hashes = { sha256 = "bbe0a47c0d11451b0ed8ebe96ed0329d3df2c563ca7e52c45cd03fc401510fd6" } }]
 
 [[packages]]
 name = "comm"
@@ -198,9 +222,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "cryptography"
-version = "46.0.4"
+version = "46.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cryptography-46.0.4-12-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "45b984be13954dff282ca5b04c4b19fc69e8d34fe28b9698a080058742b0c246" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cryptography-46.0.3-12-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "49e8e68a2886c9774bcded159876a7fd1571594cda62e0d4b456d38820e55e15" } }]
 
 [[packages]]
 name = "cycler"
@@ -245,6 +269,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/dill-0.3.9-12-py3-none-any.whl", hashes = { sha256 = "a3b61f5d01365991bd13ae167992e7cdbe3defdcce4604af16fdc73ef949c69c" } }]
 
 [[packages]]
+name = "distlib"
+version = "0.4.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/distlib-0.4.0-12-py2.py3-none-any.whl", hashes = { sha256 = "9893c8d3ae9adc621ca561f101f46815ed4b928ccf8a7d5eb88f923ee4b8a2b4" } }]
+
+[[packages]]
 name = "dnspython"
 version = "2.8.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -276,9 +306,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "executing"
-version = "2.2.1"
+version = "1.2.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/executing-2.2.1-12-py2.py3-none-any.whl", hashes = { sha256 = "4f6b4754388c66c50d266bf6cc2d36fd30a4282fb8e0cf7cf3536b333bdf233c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/executing-1.2.0-12-py2.py3-none-any.whl", hashes = { sha256 = "493e100dd9835dbfbe2e552bcf854fd5155be133a0f21aac5c17ce030cf7f76d" } }]
 
 [[packages]]
 name = "fastapi"
@@ -443,6 +473,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/importlib_metadata-8.7.1-12-py3-none-any.whl", hashes = { sha256 = "f852453a394808c9913e78d92a3779a1e2483c7793f533d66fc00c55933bb9a1" } }]
 
 [[packages]]
+name = "invoke"
+version = "2.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/invoke-2.2.1-12-py3-none-any.whl", hashes = { sha256 = "59bcacd733ad8eba1763240ad52cf0ead14cedd8857acdfec1c8cd2d3ec375c9" } }]
+
+[[packages]]
 name = "ipykernel"
 version = "7.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -462,9 +498,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ipywidgets"
-version = "8.1.8"
+version = "8.1.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipywidgets-8.1.8-12-py3-none-any.whl", hashes = { sha256 = "08102cc83df8f470bbdf61ddfd7e9b7a1c861406e844e0d1ed86c1fbee223883" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipywidgets-8.1.2-12-py3-none-any.whl", hashes = { sha256 = "b6f5cd501b328012abfc07afc02c2a3712e387eb3df4ef562108a33b63c7f0cd" } }]
 
 [[packages]]
 name = "isoduration"
@@ -701,6 +737,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/markdown-3.10.1-12-py3-none-any.whl", hashes = { sha256 = "ba04ed8d42fe1acfb83d543719efb3ebb6e03363756528468c48c2d01ae0f398" } }]
 
 [[packages]]
+name = "markdown-it-py"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/markdown_it_py-4.0.0-12-py3-none-any.whl", hashes = { sha256 = "afb3064e67dfe1384935f0dd8c854008d2b960c75323274da77e88a0e07dd338" } }]
+
+[[packages]]
 name = "markupsafe"
 version = "3.0.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -717,6 +759,12 @@ name = "matplotlib-inline"
 version = "0.2.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/matplotlib_inline-0.2.1-12-py3-none-any.whl", hashes = { sha256 = "11ee58c96d1d18f23eb05797db8f9e4e06b29a35439e99058c5f53b7d49fa724" } }]
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mdurl-0.1.2-12-py3-none-any.whl", hashes = { sha256 = "e2894d70e354c982d72ab3dcd21762bef602816c40aa1f7e90e5329d194a8d2f" } }]
 
 [[packages]]
 name = "minio"
@@ -753,6 +801,12 @@ name = "mpmath"
 version = "1.3.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mpmath-1.3.0-12-py3-none-any.whl", hashes = { sha256 = "c508c340bce1fe5ef512f2fc2d07c0ebd2279e4b8140f46e40063f69b544bdd7" } }]
+
+[[packages]]
+name = "msgpack"
+version = "1.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/msgpack-1.1.2-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "53c2cbd4ff9f9d2b6546e9953c728bd42037938b4bb583fab999bc15461ed610" } }]
 
 [[packages]]
 name = "multidict"
@@ -869,6 +923,54 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/onnxconverter_common-1.16.0-14-py2.py3-none-any.whl", hashes = { sha256 = "c631a0fcd6c333ad685c7441e62f1b11a38d1309ccae7386e0b72db2ede4c696" } }]
 
 [[packages]]
+name = "opencensus"
+version = "0.11.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opencensus-0.11.4-12-py2.py3-none-any.whl", hashes = { sha256 = "f0c5f4db0985af9f1fa3ceb701ebd0414f1c38b4076b343fe126c0729ec82a5d" } }]
+
+[[packages]]
+name = "opencensus-context"
+version = "0.1.3"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opencensus_context-0.1.3-12-py2.py3-none-any.whl", hashes = { sha256 = "b22604c803332a64f8bce6c242b82901fc9055c8dd0316dba84965d337593cfe" } }]
+
+[[packages]]
+name = "openshift-client"
+version = "1.0.18"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/openshift_client-1.0.18-12-py2.py3-none-any.whl", hashes = { sha256 = "0410a0dc421bdec9aca784173d888d7d4af814c97013f1e4c066159c7461dbe7" } }]
+
+[[packages]]
+name = "opentelemetry-api"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_api-1.39.1-12-py3-none-any.whl", hashes = { sha256 = "6e88b9a64b2da4c537f875687b7f05bbf4bb7c93bc33fe59abebdd0e41145a82" } }]
+
+[[packages]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_exporter_prometheus-0.60b1-12-py3-none-any.whl", hashes = { sha256 = "edc6a6ee983f0ac4246120b8d5dc8c69f5d77c59b5b905e71077e084224f4a0a" } }]
+
+[[packages]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_proto-1.39.1-12-py3-none-any.whl", hashes = { sha256 = "42a18b22245e3952aa71588991dde856ac5449d7bc9a3e25a70b02aa409da7b7" } }]
+
+[[packages]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_sdk-1.39.1-12-py3-none-any.whl", hashes = { sha256 = "ca6c04a79a5b986fc0ca5b1a3f76a027c19e1d6d0bc2e0457e5b4ad905e7a83d" } }]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_semantic_conventions-0.60b1-12-py3-none-any.whl", hashes = { sha256 = "cf7ad2af9a289cbbc2655cf09d9f1228a0f6d7ee717b5cc2354765ec8b512bc4" } }]
+
+[[packages]]
 name = "packaging"
 version = "26.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -891,6 +993,12 @@ name = "papermill"
 version = "2.6.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/papermill-2.6.0-12-py3-none-any.whl", hashes = { sha256 = "92aaf5d27574a22c70ca765f38264cffffbf840ef90fe2da847c664a37e2087b" } }]
+
+[[packages]]
+name = "paramiko"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/paramiko-4.0.0-12-py3-none-any.whl", hashes = { sha256 = "a92d81be86d0da61f621da8c22e2b5b607531fe0e2382c67ea0491e83b357ef9" } }]
 
 [[packages]]
 name = "parso"
@@ -993,6 +1101,12 @@ name = "pure-eval"
 version = "0.2.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pure_eval-0.2.3-12-py3-none-any.whl", hashes = { sha256 = "7ba9e6e92265ed12ed058e7ed509f326161f9b67ee8b5fea1414309bc661809b" } }]
+
+[[packages]]
+name = "py-spy"
+version = "0.4.1"
+marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/py_spy-0.4.1-12-py3-none-linux_x86_64.whl", hashes = { sha256 = "63a33198cc171606d75f0046d206bef939393e07418a98a7dcbf6180ca9fe762" } }]
 
 [[packages]]
 name = "pyarrow"
@@ -1139,6 +1253,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyzmq-27.1.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "44942ecaed93c35cc75eade17abe3c6c666d45c1a396ede980145151f37ac03c" } }]
 
 [[packages]]
+name = "ray"
+version = "2.52.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_x86_64.whl", hashes = { sha256 = "843c0108ad72bb7fc6c23a22e29e6099546a5eaad3ad675c78a146d9080f6ec6" } }]
+
+[[packages]]
 name = "referencing"
 version = "0.37.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1185,6 +1305,12 @@ name = "rfc3987-syntax"
 version = "1.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/rfc3987_syntax-1.1.0-12-py3-none-any.whl", hashes = { sha256 = "f06537eceafa64ee6e749d465ec1900a764a72ad40bf27fa7572e2d6931bf85e" } }]
+
+[[packages]]
+name = "rich"
+version = "13.9.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/rich-13.9.4-12-py3-none-any.whl", hashes = { sha256 = "7db784f6a28ce6c156c6ecd19131c71b5dca11a02ebc81e13ef48b934217c812" } }]
 
 [[packages]]
 name = "rpds-py"
@@ -1251,6 +1377,12 @@ name = "skl2onnx"
 version = "1.19.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/skl2onnx-1.19.1-12-py3-none-any.whl", hashes = { sha256 = "a96c4aa294741d40d05bd0fd3229668c16541ff5977d5b0da2bebc424c483e99" } }]
+
+[[packages]]
+name = "smart-open"
+version = "7.5.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/smart_open-7.5.0-12-py3-none-any.whl", hashes = { sha256 = "67e757cc65fa8d6c84a3747c6a0464c1f580d2f90a6ce2990ef3d8edee5a8aed" } }]
 
 [[packages]]
 name = "smmap"
@@ -1451,6 +1583,12 @@ marker = "implementation_name == 'cpython' and platform_python_implementation !=
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/uvloop-0.22.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c230e833b138292b354138a1b8b5198aaf612d003f0169b692a09c698c658e96" } }]
 
 [[packages]]
+name = "virtualenv"
+version = "20.36.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/virtualenv-20.36.1-12-py3-none-any.whl", hashes = { sha256 = "b6ec6193977ec45105dc89bed001497d7902d444954d603f586d0ae8cb625e1a" } }]
+
+[[packages]]
 name = "watchdog"
 version = "6.0.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1509,6 +1647,12 @@ name = "widgetsnbextension"
 version = "4.0.15"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/widgetsnbextension-4.0.15-12-py3-none-any.whl", hashes = { sha256 = "91f19d95e76c52a6fd3ecf262b4bb7241f2d5f88938f51969d595c4a1e356aa7" } }]
+
+[[packages]]
+name = "wrapt"
+version = "2.1.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/wrapt-2.1.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5f9f90c9580b0b68eb65c4a167de1f2c7696ba7fb583b27d3c7422fd4ac110ca" } }]
 
 [[packages]]
 name = "xyzservices"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "tensorboard~=2.18.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
     "codeflare-sdk~=0.34.0",
     "skl2onnx~=1.19.1",
     "odh-notebooks-meta-workbench-datascience-deps",

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "tensorboard~=2.20.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
     "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
     "skl2onnx~=1.19.1",

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "trustyai~=0.6.3",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
     "codeflare-sdk~=0.34.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "skl2onnx~=1.19.1",
     "odh-notebooks-meta-workbench-datascience-deps",

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -21,8 +21,6 @@ spec:
           [
             {"name": "Python", "version": "v3.12"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -38,6 +36,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},

--- a/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -24,8 +24,6 @@ spec:
             {"name": "PyTorch", "version": "2.9"},
             {"name": "LLM-Compressor", "version": "0.9"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -44,6 +42,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -24,8 +24,6 @@ spec:
             {"name": "Python", "version": "v3.12"},
             {"name": "PyTorch", "version": "2.9"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -43,6 +41,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},

--- a/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -24,8 +24,6 @@ spec:
             {"name": "Python", "version": "v3.12"},
             {"name": "ROCm-PyTorch", "version": "2.9"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -41,6 +39,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},

--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -24,8 +24,6 @@ spec:
             {"name": "Python", "version": "v3.12"},
             {"name": "TensorFlow-ROCm", "version": "2.18"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -41,6 +39,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.5"}

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -24,8 +24,6 @@ spec:
             {"name": "Python", "version": "v3.12"},
             {"name": "TensorFlow", "version": "2.20"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -44,6 +42,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -21,8 +21,6 @@ spec:
           [
             {"name": "Python", "version": "v3.12"}
           ]
-        # TODO(RHAIENG-3039): Re-enable Codeflare-SDK before RHOAI 3.4 GA
-        # {"name": "Codeflare-SDK", "version": "0.34"}
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
@@ -43,6 +41,7 @@ spec:
             {"name": "Odh-Elyra", "version": "4.3"},
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.5"},

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -5,8 +5,7 @@ requires-python = "==3.12.*"
 
 dependencies = [
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
-    # "codeflare-sdk~=0.34.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
+    "codeflare-sdk~=0.34.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
     "feast~=0.59.0",
     "odh-notebooks-meta-runtime-datascience-deps",
 

--- a/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -7,13 +7,13 @@ requires-python = ">=3.12"
 [[packages]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/aiohappyeyeballs-2.6.1-2-py3-none-any.whl", hashes = { sha256 = "09998e59de786f50a7d37d0d0e691f29fd252befb8aae9cba6f0875a9e915b7d" } }]
 
 [[packages]]
 name = "aiohttp"
 version = "3.13.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/aiohttp-3.13.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1827889cf3dc03eb2ad7b599761946e0b816a64c32a67bac62e2c523e9e85cc2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/aiohttp-3.13.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "8c4910fe93ae3afacb4b77134903afc8df193e1cfa350fc555a6b3a70505793b" } },
@@ -22,45 +22,51 @@ wheels = [
 ]
 
 [[packages]]
+name = "aiohttp-cors"
+version = "0.8.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/aiohttp_cors-0.8.1-2-py3-none-any.whl", hashes = { sha256 = "09d9788a297cc86c79f6c81fab24b986a3997ea31c08628a28a0c4d76f6b2dae" } }]
+
+[[packages]]
 name = "aiosignal"
 version = "1.4.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/aiosignal-1.4.0-2-py3-none-any.whl", hashes = { sha256 = "a0d5f83b87383308dbb36b8b791f31a5a9d877f974d027b2dc0134d849802b91" } }]
 
 [[packages]]
 name = "annotated-doc"
 version = "0.0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/annotated_doc-0.0.4-2-py3-none-any.whl", hashes = { sha256 = "e313f1ebf34a5d9c95c172ddc561af3453158e7c9cb3a7c7224c80d96edd5454" } }]
 
 [[packages]]
 name = "annotated-types"
 version = "0.7.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/annotated_types-0.7.0-2-py3-none-any.whl", hashes = { sha256 = "0b4f2636b9768e864eceeb8e8ea986b4363b280559f0de3a07c5703da7cda06b" } }]
 
 [[packages]]
 name = "ansicolors"
 version = "1.1.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ansicolors-1.1.8-2-py3-none-any.whl", hashes = { sha256 = "893f9d31b149d95d81bb1fd27dfd04b7e76b5f80e5c47a230d8625007937f2c0" } }]
 
 [[packages]]
 name = "anyio"
 version = "4.12.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/anyio-4.12.1-2-py3-none-any.whl", hashes = { sha256 = "778891010e52a0ea96916cdfd962ae4698486ef5f7a324e9c35f73f1ac69f56c" } }]
 
 [[packages]]
 name = "argon2-cffi"
 version = "25.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/argon2_cffi-25.1.0-2-py3-none-any.whl", hashes = { sha256 = "11f9fcd2fee71e388452e5c3b80650a228b0f30027ed1ee1ac7543dec7097eb9" } }]
 
 [[packages]]
 name = "argon2-cffi-bindings"
 version = "25.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/argon2_cffi_bindings-25.1.0-2-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "cf53e6c6f921a638850ce712ec08a6f257e1489043f15ea6207f63bfb5e724c0" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/argon2_cffi_bindings-25.1.0-2-cp312-abi3-linux_ppc64le.whl", hashes = { sha256 = "8c379eb7f877cf5a8c7a7d13ad3e91cdd49d3b420f673e680248162436c8f5da" } },
@@ -71,55 +77,64 @@ wheels = [
 [[packages]]
 name = "asttokens"
 version = "3.0.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/asttokens-3.0.1-2-py3-none-any.whl", hashes = { sha256 = "b73d3ab8d1af0fc803933f0b4f86def33b1a3b44111cbeda1d41b68a17cf7d06" } }]
 
 [[packages]]
 name = "attrs"
 version = "25.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "278ad9ce90064af2b877c7217db6d1c4331d6b43308a174aa3725c0a75548922" } }]
+
+[[packages]]
+name = "bcrypt"
+version = "5.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/bcrypt-5.0.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1d58417375b2a499fabc20a59fabdf7a8dbf0f58ab5ce8ca6075d477152443a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/bcrypt-5.0.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "282f033262dddc92da5432ab56d3c20651e82ab74ae1cabb6125e450046afaf7" } },
+]
 
 [[packages]]
 name = "beautifulsoup4"
 version = "4.14.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/beautifulsoup4-4.14.3-2-py3-none-any.whl", hashes = { sha256 = "05ea2e1cf7fc98ce0fca4085813713588a3d369f320c990f4bfa3c4ef6eb7e5e" } }]
 
 [[packages]]
 name = "bigtree"
 version = "1.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/bigtree-1.3.0-2-py3-none-any.whl", hashes = { sha256 = "f17475ea80e7ebd3aa1ef7c0cf63860124a9d94af3df0cfa8a67f2d2f6a8c595" } }]
 
 [[packages]]
 name = "bleach"
 version = "6.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/bleach-6.3.0-2-py3-none-any.whl", hashes = { sha256 = "1d18b19334fb55ef66b71142d8fefef18fa5f4c13ba7f3979da9c87da490c796" } }]
 
 [[packages]]
 name = "boto3"
 version = "1.42.40"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/boto3-1.42.40-2-py3-none-any.whl", hashes = { sha256 = "dec411effc25c73baa2e4fa7a30e5e260220d9c4ca05b580035ce29989758d0f" } }]
 
 [[packages]]
 name = "botocore"
 version = "1.42.40"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/botocore-1.42.40-2-py3-none-any.whl", hashes = { sha256 = "4a6f198923cb925471fa1abfc9b06411abdd97fe5f2ab13899f806b411bdfae7" } }]
 
 [[packages]]
 name = "certifi"
 version = "2026.1.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/certifi-2026.1.4-2-py3-none-any.whl", hashes = { sha256 = "3a21348b3c8e2722ddc07887f13f9b957bce49a5c508fa432d1e64afd0633189" } }]
 
 [[packages]]
 name = "cffi"
 version = "2.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cffi-2.0.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "6422df588b9ebd82b7730192a75cd52c15ee475da8940cdb42a2c3999dd0b19a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cffi-2.0.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "00c3435e836d3cc68b477ca65e0a71f66eba70ee1c573b3c8da2e80d10c1be7d" } },
@@ -130,37 +145,49 @@ wheels = [
 [[packages]]
 name = "charset-normalizer"
 version = "3.4.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/charset_normalizer-3.4.4-2-py3-none-any.whl", hashes = { sha256 = "8e2d00f3a069ba1d4308ca758da519b41ba69bf5c2230a4d114ddc9c6b8d0d37" } }]
 
 [[packages]]
 name = "click"
-version = "8.3.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/click-8.3.1-2-py3-none-any.whl", hashes = { sha256 = "8a04874d43b415abb3eeaf003ea3f2ae1b6e502f34c6c17100bee9770e0d0855" } }]
+version = "8.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/click-8.2.1-2-py3-none-any.whl", hashes = { sha256 = "874adfd8369280a1d454c62a4284a87d42b5e9529b51c263d900f8d86b92d755" } }]
 
 [[packages]]
 name = "cloudpickle"
 version = "3.1.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cloudpickle-3.1.2-2-py3-none-any.whl", hashes = { sha256 = "7d49d126993f7e9f5e5ad945bc232fab0274339cadc6c2a5b453ee21fa2228e2" } }]
+
+[[packages]]
+name = "codeflare-sdk"
+version = "0.34.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/codeflare_sdk-0.34.0-2-py3-none-any.whl", hashes = { sha256 = "ec51d64bb15b5fa8cc3fcbce309a2c5bda3a8be3e3fc6e306c0a0a36a1d84082" } }]
 
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/colorama-0.4.6-2-py2.py3-none-any.whl", hashes = { sha256 = "6b4a8e5d766a573b0ff926b3f946f064d6ff1fbf81c5942d176f3c34e683d511" } }]
+
+[[packages]]
+name = "colorful"
+version = "0.5.8"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/colorful-0.5.8-2-py2.py3-none-any.whl", hashes = { sha256 = "0f48b3d8a3914477d56c59ddd37075046dca749ad94db8b9dd16f88017ebb27c" } }]
 
 [[packages]]
 name = "comm"
 version = "0.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/comm-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "d11d5eb9a6bc83c49b622e5382985e78da0e1c801c68102e016e2bafe873a4c6" } }]
 
 [[packages]]
 name = "contourpy"
 version = "1.3.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "8469ae6cc3fe7df1cdb4a045c5f6de4d51b13f92693ec25f163b4b2c4c784019" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/contourpy-1.3.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "8c347f7b9ce74908500fd815d1c2573d90f81fc4302d1508984cfd0a2cd6a4fb" } },
@@ -169,21 +196,32 @@ wheels = [
 ]
 
 [[packages]]
+name = "cryptography"
+version = "46.0.3"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "1b90ebf281100bae06c6a7378ca6c79aeb0d44b59be760d43c683c394fc82983" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_ppc64le.whl", hashes = { sha256 = "35137a6f487c8786015f5f5434985109d7482af44377ff4e76ff34a1ddcee62e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_s390x.whl", hashes = { sha256 = "c03d4649d24ebaa00a388b22f4e9b8f9d8a301fe354c1cb4c9d160639b219ae3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cryptography-46.0.3-2-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "96522b9276c0ee070aad5df9721e09efee85c565005970acb1ebc67251291fe8" } },
+]
+
+[[packages]]
 name = "cycler"
 version = "0.12.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/cycler-0.12.1-2-py3-none-any.whl", hashes = { sha256 = "578089e91a06aa4be4eb6c1d2199f869d74301b272b8847bdb7fbadf8667a061" } }]
 
 [[packages]]
 name = "dask"
 version = "2026.1.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/dask-2026.1.2-2-py3-none-any.whl", hashes = { sha256 = "47bf96d4cb3b3c31e71cedd18739ac4c07ed191960d64b76cfec74f3bcbe00f9" } }]
 
 [[packages]]
 name = "debugpy"
 version = "1.8.20"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/debugpy-1.8.20-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "fd0257b951293cdfbd069b6caf8630af172ab9b7fb41c37445b7152025084703" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/debugpy-1.8.20-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "02f1afad493434b5655dd8913c3dd40fa7272fa08d68753628d5d0fc83581c44" } },
@@ -194,67 +232,85 @@ wheels = [
 [[packages]]
 name = "decorator"
 version = "5.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/decorator-5.2.1-2-py3-none-any.whl", hashes = { sha256 = "483506902081a5b9f3a2a13b93f1e11b4e9a773d650525c37794dfc28311aa45" } }]
 
 [[packages]]
 name = "defusedxml"
 version = "0.7.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/defusedxml-0.7.1-2-py2.py3-none-any.whl", hashes = { sha256 = "7199e2d15afbf4e247efb6db37bb37c429107de7e053cbbf9f3440ce897939c9" } }]
 
 [[packages]]
 name = "dill"
 version = "0.3.9"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/dill-0.3.9-2-py3-none-any.whl", hashes = { sha256 = "1ac03aa46a9699d4bc68f52c2986eb7d8ea8696e0ade30a6b1f645df1e203e46" } }]
+
+[[packages]]
+name = "distlib"
+version = "0.4.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/distlib-0.4.0-2-py2.py3-none-any.whl", hashes = { sha256 = "a587b9426e6cf59e6116e6d329150e4e45b08211f1892e1cf100c16a41f8e9b8" } }]
 
 [[packages]]
 name = "dnspython"
 version = "2.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/dnspython-2.8.0-2-py3-none-any.whl", hashes = { sha256 = "e3dbc30b9e9a9d9b9de46847b87a989441dba745176b03a0c5ab5f722bc0737e" } }]
+
+[[packages]]
+name = "durationpy"
+version = "0.10"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/durationpy-0.10-2-py3-none-any.whl", hashes = { sha256 = "dc904bb9882e53d3b2c02e0d61a4475c2ef4717d7d593636996c1ce2862ce4c2" } }]
 
 [[packages]]
 name = "entrypoints"
 version = "0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/entrypoints-0.4-2-py3-none-any.whl", hashes = { sha256 = "ed3e8ee54774abf84aa608ec4265cc94854b800a7de4a8097878da5a3c8e7613" } }]
 
 [[packages]]
 name = "executing"
-version = "2.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/executing-2.2.1-2-py2.py3-none-any.whl", hashes = { sha256 = "d72048a79b547d5f3c2fe6fb84d2982568dc0fbe168b35f8b04eb9545167bce1" } }]
+version = "1.2.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/executing-1.2.0-2-py2.py3-none-any.whl", hashes = { sha256 = "6f897666cb8e2381e182753f062b82516c66b8aaa9ae30fe389f00f0f5e0fb4c" } }]
 
 [[packages]]
 name = "fastapi"
 version = "0.128.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/fastapi-0.128.0-2-py3-none-any.whl", hashes = { sha256 = "aa44c45b7a9297b81b15ed283d15efe6c479d7c433f3291943309ac842b974be" } }]
 
 [[packages]]
 name = "fastjsonschema"
 version = "2.21.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/fastjsonschema-2.21.2-2-py3-none-any.whl", hashes = { sha256 = "80a4fb48e3bace4a8ecdc25872db7b33ff7d25a9924fc77a5b17abdb457e2e5b" } }]
 
 [[packages]]
 name = "feast"
 version = "0.59.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/feast-0.59.0-2-py2.py3-none-any.whl", hashes = { sha256 = "a8df1c93bb5b479c3096b521ca9a7de7e5f6051e7b6fed1dea4610e83a175591" } }]
+
+[[packages]]
+name = "filelock"
+version = "3.20.3"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/filelock-3.20.3-2-py3-none-any.whl", hashes = { sha256 = "ea920484a56693a87027eb8d173059eda17fe42a4fbad454e2052b20394d0648" } }]
 
 [[packages]]
 name = "fonttools"
 version = "4.61.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/fonttools-4.61.1-2-py3-none-any.whl", hashes = { sha256 = "5020171c7aab8256034ca74ec45682707faae7f0d5193d3026225be5c123cdd9" } }]
 
 [[packages]]
 name = "frozenlist"
 version = "1.8.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/frozenlist-1.8.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "280743fbfb0aa946d6f8bf6eeb4e40a6c13c9166e202dda77cdf8494b02b44a9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/frozenlist-1.8.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "17d8b764d76ada313e66ec744255549889fcfdadcbc91c3069e22d03d3755180" } },
@@ -265,13 +321,31 @@ wheels = [
 [[packages]]
 name = "fsspec"
 version = "2026.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/fsspec-2026.1.0-2-py3-none-any.whl", hashes = { sha256 = "54a6fa32a68e743176fd422dc0ce8e8818f289f74246c54be76836e767f8d964" } }]
+
+[[packages]]
+name = "google-api-core"
+version = "2.29.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/google_api_core-2.29.0-2-py3-none-any.whl", hashes = { sha256 = "b53ae99a823e1c7e02925a156367db84f23637a5fc66bdec6c0d00161cd30b5e" } }]
+
+[[packages]]
+name = "google-auth"
+version = "2.48.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/google_auth-2.48.0-2-py3-none-any.whl", hashes = { sha256 = "ac62d2a52b59f3ff27deb36036a25d31cc5d6f91f35b192556505500c953fad1" } }]
+
+[[packages]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/googleapis_common_protos-1.72.0-2-py3-none-any.whl", hashes = { sha256 = "45a4a645393bb9b9c4658017a19a483b11bffbbced740ecc2123652f9121f581" } }]
 
 [[packages]]
 name = "greenlet"
 version = "3.3.1"
-marker = "(python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+marker = "(implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/greenlet-3.3.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "24edd58f59cfafffc0e87738beb981b5f4723df347b0743a9143d06bd46e8882" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/greenlet-3.3.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "eeab02f043e10f97b3b4f444e6e6ec4ea892fae8dd37613664ad795e5f15e1e8" } },
@@ -279,21 +353,32 @@ wheels = [
 ]
 
 [[packages]]
+name = "grpcio"
+version = "1.76.0"
+marker = "python_full_version >= '3.10' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1c13ca5a1d07f3f393f666e5129e58c80d6a35cb4795e129b7a7edbb86c16ae2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c0e341e292abe4050d370613bdb874e109a461bf34a8daa19af5db78b2d9245b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "bdcd2330da7345993c2499536fd5c8f5e9c01f1c46029d4ac9d40805fdf1bc34" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/grpcio-1.76.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "26c2a2851ed27d19da340ed570f36a880afe6c97fa573175cb17053faaa35538" } },
+]
+
+[[packages]]
 name = "gunicorn"
 version = "25.0.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/gunicorn-25.0.1-2-py3-none-any.whl", hashes = { sha256 = "301e2f2ed18c1d3595cb1c1e8de6a7c6c43aa554ea206a8827c3666dd3520ac0" } }]
 
 [[packages]]
 name = "h11"
 version = "0.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/h11-0.16.0-2-py3-none-any.whl", hashes = { sha256 = "a6ea88ccc48bdf70fc193707ac0761eced8e30f45132a07a181ff8170a15901b" } }]
 
 [[packages]]
 name = "httptools"
 version = "0.7.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "763f5a67f822dd8dacd0ca09a85caa46d595e91b792774ce8758ccb4a4f8f109" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/httptools-0.7.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "194fad05c00c061242d910da6cbeae7d85a73c8afde93303cc8f42e4102da9ea" } },
@@ -304,97 +389,121 @@ wheels = [
 [[packages]]
 name = "idna"
 version = "3.11"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/idna-3.11-2-py3-none-any.whl", hashes = { sha256 = "c649c08ebd979268bffb0e7ac1cf9169bac80a95767505b69dd5197af4f0f5e0" } }]
+
+[[packages]]
+name = "importlib-metadata"
+version = "8.7.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/importlib_metadata-8.7.1-2-py3-none-any.whl", hashes = { sha256 = "2fbfff013f23963bc75c3e3a395efa3e1646e97cf4195cd7dae8a720a458b9b6" } }]
+
+[[packages]]
+name = "invoke"
+version = "2.2.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/invoke-2.2.1-2-py3-none-any.whl", hashes = { sha256 = "e205c890426bce76ca97f59c5e0dd1820bb413144e4d354c39af0545c5754172" } }]
 
 [[packages]]
 name = "ipykernel"
 version = "7.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipykernel-7.1.0-2-py3-none-any.whl", hashes = { sha256 = "d0dd6cc41024482cce8fefdc7d63bd115eace79d0e363c9a6ecd41da1a162091" } }]
 
 [[packages]]
 name = "ipython"
 version = "9.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipython-9.9.0-2-py3-none-any.whl", hashes = { sha256 = "c8708eec8f2f25eea37d55abd6c981023bd9cac07379821340fd19978e6c5d2b" } }]
 
 [[packages]]
 name = "ipython-genutils"
 version = "0.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipython_genutils-0.2.0-2-py2.py3-none-any.whl", hashes = { sha256 = "4b72f0a6d19176e276bbc3bc3da48a998aa3e0d0520e6ec6fce36a82f07c4eff" } }]
 
 [[packages]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipython_pygments_lexers-1.1.1-2-py3-none-any.whl", hashes = { sha256 = "a5a812d0c0c28edef983e7931a257908f5383d5746a567f52e10fafc7924c4d2" } }]
+
+[[packages]]
+name = "ipywidgets"
+version = "8.1.2"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ipywidgets-8.1.2-2-py3-none-any.whl", hashes = { sha256 = "9782495bd3206441caace2f592d0587fc22f1afc0631f4ea7a4f9ed5982dec06" } }]
 
 [[packages]]
 name = "jedi"
 version = "0.19.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jedi-0.19.2-2-py2.py3-none-any.whl", hashes = { sha256 = "4815e61b5edd92ff5e30ee0faa3c08acb54aaffce40372b6045723b043946a6b" } }]
 
 [[packages]]
 name = "jinja2"
 version = "3.1.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jinja2-3.1.6-2-py3-none-any.whl", hashes = { sha256 = "8538159cdbb2c2d4c14777f4a64426d25c947033b7e556ab3ee24cda29e63ec2" } }]
 
 [[packages]]
 name = "jmespath"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jmespath-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "b935c0e0488a86998683927afb3273d62048c0a4ab2903bafe3455c36c275d56" } }]
 
 [[packages]]
 name = "joblib"
 version = "1.5.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/joblib-1.5.3-2-py3-none-any.whl", hashes = { sha256 = "ac0416208abbaa6ce8362539091d1341a5b794a6f6a4ae03cc3fb7ed65126172" } }]
 
 [[packages]]
 name = "jsonschema"
 version = "4.26.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jsonschema-4.26.0-2-py3-none-any.whl", hashes = { sha256 = "3250059c36324159412eea15b11ecee94fe6be09f38d8c7e02767bcdd712bc53" } }]
 
 [[packages]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jsonschema_specifications-2025.9.1-2-py3-none-any.whl", hashes = { sha256 = "48ee20e787525846e5091d539a8b4f108306f28af05aae7ee0f7310fbabe5c43" } }]
 
 [[packages]]
 name = "jupyter-client"
 version = "8.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jupyter_client-8.8.0-2-py3-none-any.whl", hashes = { sha256 = "df922f8cd3c9ae7726dfbc9f38da6b53bd77d305d79aba8a667387da5be5ee55" } }]
 
 [[packages]]
 name = "jupyter-core"
 version = "5.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jupyter_core-5.9.1-2-py3-none-any.whl", hashes = { sha256 = "14eadf9c6454e91add55d3104b3a6eac53490c3401fa5be81df98f885ac901dc" } }]
 
 [[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jupyterlab_pygments-0.3.0-3-py3-none-any.whl", hashes = { sha256 = "f6869cb9618aba7c2a62a8700656c157ae648506289a3eb803a82a17db7c5800" } }]
+
+[[packages]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/jupyterlab_widgets-3.0.16-2-py3-none-any.whl", hashes = { sha256 = "1e3c9f5a50b8963a519d6b9090ba954cf7c28fd58f47161292b2a573dfeee7a4" } }]
 
 [[packages]]
 name = "kafka-python-ng"
 version = "2.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/kafka_python_ng-2.2.3-2-py2.py3-none-any.whl", hashes = { sha256 = "c84c3248b88c194ce55e8fd6d7447b690d7be806a511c6a42be0e28b99313b70" } }]
 
 [[packages]]
 name = "kiwisolver"
 version = "1.4.9"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "9a5f9313b897290fa5cab2de1d42eb24d43e89d599f56aed07c9b13df04d90e6" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/kiwisolver-1.4.9-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "dbe3b766e873691141b25e4a403988be08a351c8017853460a174d2d925c2e1b" } },
@@ -403,9 +512,15 @@ wheels = [
 ]
 
 [[packages]]
+name = "kubernetes"
+version = "35.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/kubernetes-35.0.0-2-py3-none-any.whl", hashes = { sha256 = "46baed613ea13516eb95834fd146f18680ce5adb391e499decd67128ab0330b4" } }]
+
+[[packages]]
 name = "librt"
 version = "0.7.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/librt-0.7.8-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5705f57d5d5fcb3b4faa8a171bb999d7473e8ec88e78c4e1b7e49ea3ecd500dd" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/librt-0.7.8-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "ec99c7fb2d4fe6e816afef02ab4905a3ecdb509249781d4d605286833fb44524" } },
@@ -416,13 +531,19 @@ wheels = [
 [[packages]]
 name = "locket"
 version = "1.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/locket-1.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "94bd944f1ebb1ed06f9d1f51abc4b9170b297d34e2a3675057bb94222e42173e" } }]
+
+[[packages]]
+name = "markdown-it-py"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/markdown_it_py-4.0.0-2-py3-none-any.whl", hashes = { sha256 = "7987a41d387448523e90cb6b1089dae47dc95eaed7c1e3147037c16211c82b86" } }]
 
 [[packages]]
 name = "markupsafe"
 version = "3.0.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "be9085c1d5d30211587cea5c20975258e7b6c494e4e17400e1b13b163f171d5d" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/markupsafe-3.0.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "f7f5244c8cc33750d2d763872c0ca0e9e281a6224eb49b0acd4f084ff09e16aa" } },
@@ -433,7 +554,7 @@ wheels = [
 [[packages]]
 name = "matplotlib"
 version = "3.10.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "77b447234996332569eb0b88ce49d8bb9c44b232343c919309fe7a1f0ca4274a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/matplotlib-3.10.8-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "be6c38957d7eeaf1e2fdfd02a58278ef03f820f80d86cadbe1955fa008826a82" } },
@@ -444,25 +565,31 @@ wheels = [
 [[packages]]
 name = "matplotlib-inline"
 version = "0.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/matplotlib_inline-0.2.1-2-py3-none-any.whl", hashes = { sha256 = "6a1b97fed26c7c7452c3357db29aa75e0298b1c8e0a4cb8e42220e68cb28b4cf" } }]
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mdurl-0.1.2-2-py3-none-any.whl", hashes = { sha256 = "4daacaef45c8a39e6074ed339bb654fd52aa6bec1109a7906dcb9fde4cb60319" } }]
 
 [[packages]]
 name = "minio"
 version = "7.2.20"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/minio-7.2.20-2-py3-none-any.whl", hashes = { sha256 = "c2a7630478adea0e2f498fe964b8d4b346abf8882590989b44ca6dac7197c93b" } }]
 
 [[packages]]
 name = "mistune"
 version = "3.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mistune-3.2.0-2-py3-none-any.whl", hashes = { sha256 = "8a6211444e44fa67af0af0c37da41155f3f8ca9c7a9d279d37c3eb03af27c509" } }]
 
 [[packages]]
 name = "ml-dtypes"
 version = "0.5.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ml_dtypes-0.5.4-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c017e0ea0689b170958967d96754946c07d396280c51d9ae201d83a9a599469e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ml_dtypes-0.5.4-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "2fce8e1e21bd26d18d4254336e17f7f2f132dbca77b4b3fe89da25ab5a3d87eb" } },
@@ -473,7 +600,7 @@ wheels = [
 [[packages]]
 name = "mmh3"
 version = "5.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mmh3-5.2.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a0f623387e12ac34c60cc90c8ed9664c7bd61927441e7c6b010e352a61a66a40" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mmh3-5.2.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "14f33a4ce72edcd47eea68a67602587ceab99073292cf779bbfae53fcd4db01a" } },
@@ -482,9 +609,20 @@ wheels = [
 ]
 
 [[packages]]
+name = "msgpack"
+version = "1.1.2"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "976dc988e95242953c8be444b3e536f4d1416210cb7af13f578a501188e5fdb4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "b40a93f9aeeca86d6d0ac69a1baea430030f0a25d96172dbce6a3a73ee483276" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9087e44d1e86a8c3813be7b4ce1d618ff81577d6370893572ec22e8c2969c830" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/msgpack-1.1.2-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "29ce7557d122e3c00cf95eb41870adb924c0149311a122724c33b85a6bc78c8e" } },
+]
+
+[[packages]]
 name = "multidict"
 version = "6.7.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/multidict-6.7.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "b8cf4ff3b89d9d691b01b4628aa3ca667537307eb4f2bcb61389fc96d90f5b00" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/multidict-6.7.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "a63aebb53daf82ac578ac7c4048387ff9d195e8d2b8049be6fb0c02bd99f51f7" } },
@@ -495,19 +633,19 @@ wheels = [
 [[packages]]
 name = "mypy"
 version = "1.19.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mypy-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "439a9fdf1c3a7f2b9ca2033cb17e4fd8d72afedbce64ac1f3e49ed493a35520b" } }]
 
 [[packages]]
 name = "mypy-extensions"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mypy_extensions-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "e820a60cc25dba2e928511d3e3a96c9ae385d34634dd66b26b010b422fc35368" } }]
 
 [[packages]]
 name = "mysql-connector-python"
 version = "9.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mysql_connector_python-9.5.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1528891e8586345285e45ca9515221d8136d6a5e81ad10efe856952d2908f342" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/mysql_connector_python-9.5.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "ce75875bf77139cd60b2810eff42471e28e8e4caabdbfc20d9d4f664b1fbd448" } },
@@ -518,37 +656,37 @@ wheels = [
 [[packages]]
 name = "narwhals"
 version = "2.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/narwhals-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "ed848c2bb10f995c188211c0b4e1a6bbd97e5be8a9b9176d94a3ef0b258f43dc" } }]
 
 [[packages]]
 name = "nbclient"
 version = "0.10.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/nbclient-0.10.4-2-py3-none-any.whl", hashes = { sha256 = "f53d920af4338d9d3375f8d4f475aa8b539488c9ca99720a397d6226200d13d6" } }]
 
 [[packages]]
 name = "nbconvert"
 version = "7.16.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/nbconvert-7.16.6-2-py3-none-any.whl", hashes = { sha256 = "89493c8b6cc7c96c91c7b1352dd5405c20a3456900e82636747934b411626b24" } }]
 
 [[packages]]
 name = "nbformat"
 version = "5.10.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/nbformat-5.10.4-2-py3-none-any.whl", hashes = { sha256 = "00d1d030ede965804327079cd764771a4ef1e669ee5065223868ac321621b2ae" } }]
 
 [[packages]]
 name = "nest-asyncio"
 version = "1.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/nest_asyncio-1.6.0-2-py3-none-any.whl", hashes = { sha256 = "97f06e3cd2965fc5b14a6993a20c57e62e0a4516deb957410693bbaeae06e4bc" } }]
 
 [[packages]]
 name = "numpy"
 version = "2.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/numpy-2.4.2-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "64657e1e81c855db92360ce12f8ac77f861222f68ddfe37db2263d1a55518954" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/numpy-2.4.2-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "964bfe412fe592d0bc678bce23e027e8c0155e81da6346e57b1e4606931e93f9" } },
@@ -557,9 +695,15 @@ wheels = [
 ]
 
 [[packages]]
+name = "oauthlib"
+version = "3.3.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/oauthlib-3.3.1-2-py3-none-any.whl", hashes = { sha256 = "b9999d1be5c825d926600e3041004714d536cc6f16d2670075829f9c7c99da40" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.20.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/onnx-1.20.0-4-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "9a8a15500f8dece0a78ff98cf08a377bd6e94cf2f40b9018e838a19a55f034c9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/onnx-1.20.0-4-cp312-abi3-linux_ppc64le.whl", hashes = { sha256 = "208991d4aa1a7317309617cb0273ad0e4d0aeaf5260df14329345d79707d7714" } },
@@ -570,19 +714,67 @@ wheels = [
 [[packages]]
 name = "onnxconverter-common"
 version = "1.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/onnxconverter_common-1.16.0-4-py2.py3-none-any.whl", hashes = { sha256 = "2aff3ae28278509da839634c226265f78075654c210d36a3fc5058db375e4156" } }]
+
+[[packages]]
+name = "opencensus"
+version = "0.11.4"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opencensus-0.11.4-2-py2.py3-none-any.whl", hashes = { sha256 = "eedbd569b2a359c36e1b287de65950c4fe78b19f89af2c1c61c74a4a08617ac4" } }]
+
+[[packages]]
+name = "opencensus-context"
+version = "0.1.3"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opencensus_context-0.1.3-2-py2.py3-none-any.whl", hashes = { sha256 = "086e9c1c3c52ac92a6a1f48ae1cf75856683fc5235fadfd1032a1d4f6a082ad5" } }]
+
+[[packages]]
+name = "openshift-client"
+version = "1.0.18"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/openshift_client-1.0.18-2-py2.py3-none-any.whl", hashes = { sha256 = "8935aec9161a05d1c620a7a3d6a22d8f7ef3e057ffe9293ff5eca78031aca892" } }]
+
+[[packages]]
+name = "opentelemetry-api"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_api-1.39.1-2-py3-none-any.whl", hashes = { sha256 = "9e806ddae59651ca5ba8ca35066c80afd8cae466349991a8d1ff710791bff3f1" } }]
+
+[[packages]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_exporter_prometheus-0.60b1-2-py3-none-any.whl", hashes = { sha256 = "b11e5a92dc44d82b648694d72b282177601f90422b90cd98c1608f6f407a022d" } }]
+
+[[packages]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_proto-1.39.1-2-py3-none-any.whl", hashes = { sha256 = "55a0a6703776a71f81eb20ecf129ceeb979f7222c78b96c3a7e65bc6eb40d114" } }]
+
+[[packages]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_sdk-1.39.1-2-py3-none-any.whl", hashes = { sha256 = "2ecc0a8a97572a91e0f42fb2d411e5f8fed192e01ccfaa52eeb912714b16f479" } }]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/opentelemetry_semantic_conventions-0.60b1-2-py3-none-any.whl", hashes = { sha256 = "bfab6bd416479400e40a8363e5dd8a813b33b0e82182d684f35865fde2dbca79" } }]
 
 [[packages]]
 name = "packaging"
 version = "26.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/packaging-26.0-2-py3-none-any.whl", hashes = { sha256 = "0660e283b5ec4d18532f0bfebc853880cdf7743f7a1fde9de230b67525643c5b" } }]
 
 [[packages]]
 name = "pandas"
 version = "2.3.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bcbc34b4f216104edd63086462db75d9b796f53d789b43db3673bbd551be5699" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pandas-2.3.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "e7a45067074b6e5befb818c395023d884676a8dd7e1c77e8d0171526843cec8f" } },
@@ -593,43 +785,49 @@ wheels = [
 [[packages]]
 name = "pandocfilters"
 version = "1.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pandocfilters-1.5.1-2-py2.py3-none-any.whl", hashes = { sha256 = "c42ae3c5f7078b4a009bc3330d1dc3375576056a300810719ab62752806f90e9" } }]
 
 [[packages]]
 name = "papermill"
 version = "2.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/papermill-2.6.0-2-py3-none-any.whl", hashes = { sha256 = "f7e33f1ba5bc85b7b7d2e060386d5f6399c31063deff17f4a46bf8d085f3fb91" } }]
+
+[[packages]]
+name = "paramiko"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/paramiko-4.0.0-2-py3-none-any.whl", hashes = { sha256 = "2ec2a7c40df0a6cb368fd891f5133beeaf623eaa7fe6402d4659185d441e33b0" } }]
 
 [[packages]]
 name = "parso"
 version = "0.8.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/parso-0.8.5-2-py2.py3-none-any.whl", hashes = { sha256 = "08347cc33a697734445b36c0be7aafc5cf981521d8ff7f512d1cbfaa62a97e62" } }]
 
 [[packages]]
 name = "partd"
 version = "1.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/partd-1.4.2-2-py3-none-any.whl", hashes = { sha256 = "3993ed4b1cb89309380c521b4d1328102caa07a3c43836925123ecd21edf8bd7" } }]
 
 [[packages]]
 name = "pathspec"
 version = "1.0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pathspec-1.0.4-2-py3-none-any.whl", hashes = { sha256 = "5035385e957dc1d1781b6f1c49836c0ec2a82a208ca1d49570fe9172687a40e8" } }]
 
 [[packages]]
 name = "pexpect"
 version = "4.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pexpect-4.9.0-2-py2.py3-none-any.whl", hashes = { sha256 = "d46956c267f85748380e9a48e3581ec71a52b3d213f8b621086760abe8949ba2" } }]
 
 [[packages]]
 name = "pillow"
 version = "12.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "331a0ce29141abe2a24e61581cae9355429c9b891b92823bf297acfa42c72df1" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "30b9d7eee6819c1f4988007fbcfd2a7273d63be5cfcefc5e457417838e240088" } },
@@ -640,31 +838,31 @@ wheels = [
 [[packages]]
 name = "platformdirs"
 version = "4.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/platformdirs-4.5.1-2-py3-none-any.whl", hashes = { sha256 = "6978d578ae06df9e7c6d3f1fd69f6fee5fcc7c765d0929f03f853b99d61d520e" } }]
 
 [[packages]]
 name = "plotly"
 version = "6.5.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/plotly-6.5.2-2-py3-none-any.whl", hashes = { sha256 = "1ebfc83e5d4dbd5b8fc5a86bd1f52f73e591a9df925a9bb58d73be8f955f505c" } }]
 
 [[packages]]
 name = "prometheus-client"
 version = "0.24.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/prometheus_client-0.24.1-2-py3-none-any.whl", hashes = { sha256 = "e924547b32d818b4659c4c292a79daf9cd970e60618a106dcc7bc7b21ce565d3" } }]
 
 [[packages]]
 name = "prompt-toolkit"
 version = "3.0.52"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/prompt_toolkit-3.0.52-2-py3-none-any.whl", hashes = { sha256 = "dd6dd43f6411dd0e920933cd971ed160e3e377121c228783b00fb867ca9e10d9" } }]
 
 [[packages]]
 name = "propcache"
 version = "0.4.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/propcache-0.4.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "276cc6da9f30801e39fcf6abc10ed16a72cd2ff9b02e7ab923604cb3173b6131" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/propcache-0.4.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "06e00b4552ec806c932e9577fafd649a51f5b3a5bdfa38d76e6b6dcd51a48cf7" } },
@@ -673,9 +871,15 @@ wheels = [
 ]
 
 [[packages]]
+name = "proto-plus"
+version = "1.27.1"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/proto_plus-1.27.1-2-py3-none-any.whl", hashes = { sha256 = "36c16cc95bca3822d079c23ed5a9062e3ad5f45ef227e8ed195dfb4f3691e00f" } }]
+
+[[packages]]
 name = "protobuf"
 version = "6.33.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "739c7bdbc9374c1279d7f28e3b519f03a478fe4e99fa45f270cfcfb26fd89ead" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "91c3c05053e0c5197eed51add4a8b180fbc7c078df6a2d917d4bdfbaf82fd529" } },
@@ -686,7 +890,7 @@ wheels = [
 [[packages]]
 name = "psutil"
 version = "7.2.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/psutil-7.2.2-2-cp36-abi3-linux_aarch64.whl", hashes = { sha256 = "1d075c398828df89f0136423aae7e63af157c598a1fc523ec63d1c3cb44ba27c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/psutil-7.2.2-2-cp36-abi3-linux_ppc64le.whl", hashes = { sha256 = "d41b4ac8e939bb0213f1e82b005af008afdccef2c9048def70aa58daecd2aa4a" } },
@@ -697,25 +901,34 @@ wheels = [
 [[packages]]
 name = "psycopg"
 version = "3.3.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/psycopg-3.3.2-2-py3-none-any.whl", hashes = { sha256 = "54ee76f9c581b68a618234f1655e7adb378939fca8d41efe237009f20ea14c8e" } }]
 
 [[packages]]
 name = "ptyprocess"
 version = "0.7.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ptyprocess-0.7.0-2-py2.py3-none-any.whl", hashes = { sha256 = "04a9e537c7fd06708ed8fe63d73dd864e0bdcafd39e1bbc00793533d6c2a3e46" } }]
 
 [[packages]]
 name = "pure-eval"
 version = "0.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pure_eval-0.2.3-2-py3-none-any.whl", hashes = { sha256 = "69ca56a05367fa5b08de38f76c9fa60637ebc5ef32726337b3a63732fd53aad9" } }]
+
+[[packages]]
+name = "py-spy"
+version = "0.4.1"
+marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/py_spy-0.4.1-2-py3-none-linux_aarch64.whl", hashes = { sha256 = "632a990ddd5394d1360f4736790daa336a4412ae5d448b71eb1f092e61d46220" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/py_spy-0.4.1-2-py3-none-linux_x86_64.whl", hashes = { sha256 = "ba03163b955927082e19509a9d79a647d3ce782b97f8f343df4f160b562ec9ff" } },
+]
 
 [[packages]]
 name = "pyarrow"
 version = "23.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyarrow-23.0.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "4cf976e2f3c38840bf665772b7d8eaf80ee59b9ab0bd37ef5fe836c6cf088da8" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyarrow-23.0.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "462de3a3463a4d94f8333aa32f0f1f8efce98bbd5add87d1019f8816750866b6" } },
@@ -724,15 +937,27 @@ wheels = [
 ]
 
 [[packages]]
+name = "pyasn1"
+version = "0.6.2"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyasn1-0.6.2-2-py3-none-any.whl", hashes = { sha256 = "cb4b2ddf9ddff27c7a3f46068cef6cecb4f498c13a4b68f5a3fbf325bfc4400a" } }]
+
+[[packages]]
+name = "pyasn1-modules"
+version = "0.4.2"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyasn1_modules-0.4.2-2-py3-none-any.whl", hashes = { sha256 = "5c7bf9849c08413901d2e98c4a3da0861866c4ed1eebaa8f2d4e9540232810f9" } }]
+
+[[packages]]
 name = "pycparser"
 version = "3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pycparser-3.0-2-py3-none-any.whl", hashes = { sha256 = "ec954d7b38d719767f9618d99b29d5b9bcbe8274130883b48e07557274002df6" } }]
 
 [[packages]]
 name = "pycryptodome"
 version = "3.23.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pycryptodome-3.23.0-2-cp37-abi3-linux_aarch64.whl", hashes = { sha256 = "7af3e8fd1e4964ccfabee3df6504780b38253415ab3c5cfd2e4a57f6cdef9bec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pycryptodome-3.23.0-2-cp37-abi3-linux_ppc64le.whl", hashes = { sha256 = "ad09f047593afdd85f21aca5d7890f0ae7edc136eed23fb3f0b2998f8d2f8e4a" } },
@@ -743,13 +968,13 @@ wheels = [
 [[packages]]
 name = "pydantic"
 version = "2.12.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pydantic-2.12.5-2-py3-none-any.whl", hashes = { sha256 = "cc8c4ff220f0e2309ec1781a479c57e40ae9b8ba275da297fbcee62cd31f7b15" } }]
 
 [[packages]]
 name = "pydantic-core"
 version = "2.41.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a966ce92575e67ff1e51d2eff56ea2b90c5e0d5f09aaee9db412e4654f400525" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pydantic_core-2.41.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "ce56d9bafc1406dc926f6b6d770adeeba5e875b5b9d181e20c76384830c8fa6e" } },
@@ -760,19 +985,19 @@ wheels = [
 [[packages]]
 name = "pygments"
 version = "2.19.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pygments-2.19.2-2-py3-none-any.whl", hashes = { sha256 = "d12e1c9329462093f7637532e8167ea0e36ba99b86c5c19bc976c9c146827ec3" } }]
 
 [[packages]]
 name = "pyjwt"
 version = "2.11.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyjwt-2.11.0-2-py3-none-any.whl", hashes = { sha256 = "156bba03d9c86f38be2a7d52ce42f72799f4d1d2264458fa96e9bb4107694095" } }]
 
 [[packages]]
 name = "pymongo"
 version = "4.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pymongo-4.16.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e848adbba4798518c4ebf1d59ee8823568a34fb9d67bcb8f3960dd1b6cd98976" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pymongo-4.16.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "a95bb5a4821cbadb6025f5ced1ddd34054f70bd76451d7ce236bc1426d4aab7e" } },
@@ -781,9 +1006,20 @@ wheels = [
 ]
 
 [[packages]]
+name = "pynacl"
+version = "1.6.2"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pynacl-1.6.2-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1f3b22553675fb2ac2ab7b9c5c5e469553c00e89372b446d213bdda2ba9ef8ed" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pynacl-1.6.2-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "348424d036117a60f9bcec2aa639d8dcebc46ec07f69e892a0b2448b91f075ea" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pynacl-1.6.2-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "66bf1655bda8dc0ead7a88b2859fabfc7441c0dc5c95bc1bc361bb359fd8cc3a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pynacl-1.6.2-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "27848e38e144ecd9e9df6ab61eefe322efc29f52ce25104b79d1e781afe2999b" } },
+]
+
+[[packages]]
 name = "pyodbc"
 version = "5.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyodbc-5.3.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "2eb3d7be108e3488d554b1c407bcb99a5a9f75243f69695f9f62a6699be111ad" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyodbc-5.3.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cd1e489e17647bb1edc754b42a61cc97c42d5b19cb23433c1e9fc10dd2cc496f" } },
@@ -794,31 +1030,31 @@ wheels = [
 [[packages]]
 name = "pyparsing"
 version = "3.3.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyparsing-3.3.2-2-py3-none-any.whl", hashes = { sha256 = "30a9742b4e8861e9a0f86cfba2c73a6df42c2d983dcad43e9806ca1330900be7" } }]
 
 [[packages]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/python_dateutil-2.9.0.post0-2-py2.py3-none-any.whl", hashes = { sha256 = "43bdd9ee7f8852603911a711fdfed201f03448079d0f46732b3211d5f7d56bc3" } }]
 
 [[packages]]
 name = "python-dotenv"
 version = "1.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/python_dotenv-1.2.1-2-py3-none-any.whl", hashes = { sha256 = "7d79a05df3dfae1089746603a46bcfcc52642a3cc6f556d1bbd00e9a59a92855" } }]
 
 [[packages]]
 name = "pytz"
 version = "2025.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pytz-2025.2-2-py3-none-any.whl", hashes = { sha256 = "54ee6be2ecd9daebcd6c1a5024b428e54acd53b047edc6ca8124a727280ac592" } }]
 
 [[packages]]
 name = "pyyaml"
 version = "6.0.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "89f68a62f49c3dcd908f3a10c536a780cf2f95766a8efb87961a548fbd89ac0a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyyaml-6.0.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "71bf5b394a66c99d2c98998e8ed1f728f544805f57f32ebd0f7c7d62fab7f963" } },
@@ -829,7 +1065,7 @@ wheels = [
 [[packages]]
 name = "pyzmq"
 version = "27.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "85bbfe318e2382dcd782e420174f125d94e9984d12fd0b7eb4f110844d60db88" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "61829b36db9e39377f57249ac803cba0913a44f27f4d500acdeda4c2b614ed23" } },
@@ -838,21 +1074,42 @@ wheels = [
 ]
 
 [[packages]]
+name = "ray"
+version = "2.52.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_aarch64.whl", hashes = { sha256 = "08eb8f5fd55292ba6bee363a32491136a5e54af54e007f81e0603986fbea41a4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_x86_64.whl", hashes = { sha256 = "843c0108ad72bb7fc6c23a22e29e6099546a5eaad3ad675c78a146d9080f6ec6" } },
+]
+
+[[packages]]
 name = "referencing"
 version = "0.37.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/referencing-0.37.0-2-py3-none-any.whl", hashes = { sha256 = "f5781948c184906b4b00f2e641b0ddc42104cf87ec38072dc2ad51309fca8bd9" } }]
 
 [[packages]]
 name = "requests"
 version = "2.32.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/requests-2.32.5-2-py3-none-any.whl", hashes = { sha256 = "fb1893f12ec574815e416f8d6326fb673f32b904cce3b8f4ff68442c224874bc" } }]
+
+[[packages]]
+name = "requests-oauthlib"
+version = "2.0.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/requests_oauthlib-2.0.0-2-py2.py3-none-any.whl", hashes = { sha256 = "62dd9f890741b877b59cbdf2a66ec964f353537f7cb9a558230ff92d09b33f6d" } }]
+
+[[packages]]
+name = "rich"
+version = "13.9.4"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/rich-13.9.4-2-py3-none-any.whl", hashes = { sha256 = "ec8ad7c9c333b8a2b249eb68864faecf4e87519e6ae2c8e88de5fada449245e2" } }]
 
 [[packages]]
 name = "rpds-py"
 version = "0.30.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c58fc5ebb49e63a75e163d0e81c617a5150707ec353ea3cd778680bae385e050" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "523f944b006a6f339028b2de2f389918f3a14504f6e01aca6f67e14c5f2868cd" } },
@@ -861,15 +1118,21 @@ wheels = [
 ]
 
 [[packages]]
+name = "rsa"
+version = "4.9.1"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/rsa-4.9.1-2-py3-none-any.whl", hashes = { sha256 = "6e7330d695f8319e865f8b8659959802e072bacb23e745b6c316d2bb7df76997" } }]
+
+[[packages]]
 name = "s3transfer"
 version = "0.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/s3transfer-0.16.0-2-py3-none-any.whl", hashes = { sha256 = "6bd00bc6e00ca3322d00a0f193f5abdb20e4ceb2e8c8f2823dec0b3ad9af540b" } }]
 
 [[packages]]
 name = "scikit-learn"
 version = "1.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "944e305a5a4953234abf2cb09f2d048f5befa71c1d324c01f5cfcca485227d57" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/scikit_learn-1.8.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "169b28daa90cd3d338811af88b611d41f207c375a91303d970cdfc7f44f2e139" } },
@@ -880,7 +1143,7 @@ wheels = [
 [[packages]]
 name = "scipy"
 version = "1.16.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "42287028be0a6e951346e51acff8ff349d670dcb216ceaf00f8b5832ed21af6f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/scipy-1.16.3-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "8ab74686fe33b6c6e1f048039bd4d8d6a0dad195a989925c6b89b985abb10a6b" } },
@@ -891,31 +1154,37 @@ wheels = [
 [[packages]]
 name = "setuptools"
 version = "80.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/setuptools-80.9.0-2-py3-none-any.whl", hashes = { sha256 = "99c28a7b2a30ab65314deda44b45738a4ed1d3070ab7fe38898930274ce652b8" } }]
 
 [[packages]]
 name = "six"
 version = "1.17.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/six-1.17.0-2-py2.py3-none-any.whl", hashes = { sha256 = "b0e8c34e5a82070135af7b1e04fc14595bf4a019087d3370468c13a9d7d921f7" } }]
 
 [[packages]]
 name = "skl2onnx"
 version = "1.19.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/skl2onnx-1.19.1-2-py3-none-any.whl", hashes = { sha256 = "a0512e099edfa89622c5c9f55ac0e17b43584bbfef79984ce131ac9c3852e12d" } }]
+
+[[packages]]
+name = "smart-open"
+version = "7.5.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/smart_open-7.5.0-2-py3-none-any.whl", hashes = { sha256 = "19448cb2f668050aa732246762c4196ec285dd0efedd9b169238f2201b8096d4" } }]
 
 [[packages]]
 name = "soupsieve"
 version = "2.8.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/soupsieve-2.8.3-2-py3-none-any.whl", hashes = { sha256 = "cc56ec0614c1ee1da36a3a18e3e1a6e189868c04e36b0b00f2fa2f867c20d7c3" } }]
 
 [[packages]]
 name = "sqlalchemy"
 version = "2.0.46"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/sqlalchemy-2.0.46-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "198211e3059ffbadc6c315acfa97d16aa75ac7713def5aeb3fa0cde1acfd4fbb" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/sqlalchemy-2.0.46-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "637812b6f4377246731868343c1a70e0f3cf7071200ec838a4c58a860cd769fa" } },
@@ -926,55 +1195,55 @@ wheels = [
 [[packages]]
 name = "stack-data"
 version = "0.6.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/stack_data-0.6.3-2-py3-none-any.whl", hashes = { sha256 = "f5febcc35456f56885af3dcd7e149b04119314a202555248e3404bbd7d947244" } }]
 
 [[packages]]
 name = "starlette"
 version = "0.50.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/starlette-0.50.0-2-py3-none-any.whl", hashes = { sha256 = "cbce1b41efecb38cecbe857405f32666f8b9bfdacafe59f8d79f595a36e4e177" } }]
 
 [[packages]]
 name = "tabulate"
 version = "0.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tabulate-0.9.0-2-py3-none-any.whl", hashes = { sha256 = "97dc4124be7430cab50ab8a9212c69676a7ddf73e3c003be18e0a910cc271d0d" } }]
 
 [[packages]]
 name = "tenacity"
 version = "8.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tenacity-8.5.0-2-py3-none-any.whl", hashes = { sha256 = "8e19468b8a5a25b5a4d1f789b6367d208129f98e85a69bb2dea23fa617d390eb" } }]
 
 [[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/threadpoolctl-3.6.0-2-py3-none-any.whl", hashes = { sha256 = "949a7d2df6ef745211a119ff455e49ec62ec94e017dc54d9b40eb076e17c2aa3" } }]
 
 [[packages]]
 name = "tinycss2"
 version = "1.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tinycss2-1.4.0-2-py3-none-any.whl", hashes = { sha256 = "bf1171276cea213eb267615c9cf29eced1c4739802c8e71cbf63b6f78d96599f" } }]
 
 [[packages]]
 name = "toml"
 version = "0.10.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/toml-0.10.2-2-py2.py3-none-any.whl", hashes = { sha256 = "ddc445e05d6cd4d4f69f3be68b7199a0b0c63c30459a61c90e0cdd887b7a182a" } }]
 
 [[packages]]
 name = "toolz"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/toolz-1.1.0-2-py3-none-any.whl", hashes = { sha256 = "5533a0f5bd76797fbc5db742e56c52bb3db41ccedcdc742ab63e18f1c1b76223" } }]
 
 [[packages]]
 name = "tornado"
 version = "6.5.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "57ac91e431d9a82d0181432616d17b5a118be97da073e02d58e68c55c671061b" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "38dbce8f34adfa440af8057ceee02cd9e70fc780f71b3fc736b3e034b635a30d" } },
@@ -985,61 +1254,61 @@ wheels = [
 [[packages]]
 name = "tqdm"
 version = "4.67.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tqdm-4.67.2-2-py3-none-any.whl", hashes = { sha256 = "2658150d16b0377109f4270397d659ef9118d69834172402963e01d007f1593a" } }]
 
 [[packages]]
 name = "traitlets"
 version = "5.14.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/traitlets-5.14.3-2-py3-none-any.whl", hashes = { sha256 = "ee42d404ebf73fce9f644f2b50496969f4b0456e2c30851be3d8796a6fb0c09c" } }]
 
 [[packages]]
 name = "typeguard"
 version = "4.4.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/typeguard-4.4.4-2-py3-none-any.whl", hashes = { sha256 = "6c742015c1acb5e3141a0a8f8230cfba616f3041651fab949f1433b461144843" } }]
 
 [[packages]]
 name = "typing-extensions"
 version = "4.15.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/typing_extensions-4.15.0-2-py3-none-any.whl", hashes = { sha256 = "28315a85e5b275d75b84624b5a9e43386fb080bc934750089a7741a74895e2ae" } }]
 
 [[packages]]
 name = "typing-inspection"
 version = "0.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/typing_inspection-0.4.2-2-py3-none-any.whl", hashes = { sha256 = "7b7bebd3411949faebda9a12b2b9e3c4b94d18ab29c438152b2b3f5239fa8aab" } }]
 
 [[packages]]
 name = "tzdata"
 version = "2025.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/tzdata-2025.3-2-py2.py3-none-any.whl", hashes = { sha256 = "34decb148c64bdd3d0468d40fe14fde26b16c1c8ddc82d6e96b0df0dd12f5b3b" } }]
 
 [[packages]]
 name = "urllib3"
 version = "2.6.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/urllib3-2.6.3-2-py3-none-any.whl", hashes = { sha256 = "ccb0a302c40bb2e5d9b7f45282847a81e8620fed27b5483a402072563def955e" } }]
 
 [[packages]]
 name = "uvicorn"
 version = "0.34.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uvicorn-0.34.0-2-py3-none-any.whl", hashes = { sha256 = "8888d7f96fafa6b78afa834f9c4564f1dc3a906de18f418f57b051bf6bd7e135" } }]
 
 [[packages]]
 name = "uvicorn-worker"
 version = "0.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uvicorn_worker-0.3.0-3-py3-none-any.whl", hashes = { sha256 = "c0d6f58ba198e2bd40423df9b664ccb1a454e8378e269e693bd5869c2545ee15" } }]
 
 [[packages]]
 name = "uvloop"
 version = "0.22.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "85d62407f6454963a10a56aaade8320fa0a71871e726ffd6b44feb955492c115" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uvloop-0.22.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "25a296298b26028b2f981e69c3c91c318e4f67d9040d98667d6195dddf18a2d7" } },
@@ -1048,9 +1317,15 @@ wheels = [
 ]
 
 [[packages]]
+name = "virtualenv"
+version = "20.36.1"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/virtualenv-20.36.1-2-py3-none-any.whl", hashes = { sha256 = "63c660e83c7cb19846fd4f91d6a92dd557179d7706f3d20c28ebe1f386eae927" } }]
+
+[[packages]]
 name = "watchfiles"
 version = "1.1.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "70bdb90c0b3c8be542f2824e423c5fde49b992c6eaaa4fce04dc88e9d23fc3ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/watchfiles-1.1.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cdb395318ee3cec7996c177134313fc4f8fb9e1a3f3bb48c8a0d2e96df1cc6bc" } },
@@ -1061,19 +1336,25 @@ wheels = [
 [[packages]]
 name = "wcwidth"
 version = "0.5.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wcwidth-0.5.3-2-py3-none-any.whl", hashes = { sha256 = "6e98359959812e4a0832b3e7cf21b8b39ff083e2dcd17b781d9bfa17cff2bfda" } }]
 
 [[packages]]
 name = "webencodings"
 version = "0.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/webencodings-0.5.1-2-py2.py3-none-any.whl", hashes = { sha256 = "4c2a60123079bafd51bfb6235ea0d5c674747deb4036a38eb0a2e34c443260a1" } }]
+
+[[packages]]
+name = "websocket-client"
+version = "1.9.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/websocket_client-1.9.0-2-py3-none-any.whl", hashes = { sha256 = "4d7bfdd6830272263b00f2f41f4ba404a38f5db8ddcd4074ed3eab87a120fbf7" } }]
 
 [[packages]]
 name = "websockets"
 version = "16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "796608a1e806cf083aefe9ce344a3e6b33066202a717a60428e1ec78b6e90124" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/websockets-16.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "3a3312d176fb9759b166ed28306cb75661c61dadcae2414bfc142d1780500b2c" } },
@@ -1084,19 +1365,42 @@ wheels = [
 [[packages]]
 name = "wheel"
 version = "0.46.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wheel-0.46.3-2-py3-none-any.whl", hashes = { sha256 = "581579e7a4b207a7d50a71d2e9ffb18b40920965f06ff852538c64b5845faa83" } }]
+
+[[packages]]
+name = "widgetsnbextension"
+version = "4.0.15"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/widgetsnbextension-4.0.15-2-py3-none-any.whl", hashes = { sha256 = "cfea2d2409a3249b3217c12c2449ffe51417894f6b2f5f7b5401cac21840712e" } }]
+
+[[packages]]
+name = "wrapt"
+version = "2.1.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0e6baa9cfa6d2aab49306b73e139162cf7a25444ff676a25dc80333a1398239" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "7e3fd8324db491cd99350a48a8fbb9c888ee825f94b4eec456916e0689470ade" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "284004f82045f055f77ab79361126742ca11090f0ffe4ea899442dffe1014f97" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/wrapt-2.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "2117b8745946ad08dbf96ed4106bb867e554a869e294f028f2707288aaaacff3" } },
+]
 
 [[packages]]
 name = "yarl"
 version = "1.22.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "(python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine == 's390x' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/yarl-1.22.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "dbe1e46df01df7589b0c580c027927164ec731ab491c3661ce05f7727a349168" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/yarl-1.22.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c5b814b5d54a8b27e8556a16df7e8de3029877436668ff9836bf05e98996f94f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/yarl-1.22.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "945f8a3e92b51cc7782ce89883b952d7a2d7a911b59bb4e1f31ed2a0b7e91a2a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/yarl-1.22.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4818d73c6fddd1e9a30cb5e72d312455b091612e2b9a0ad381422640bf3d9256" } },
 ]
+
+[[packages]]
+name = "zipp"
+version = "3.23.0"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/zipp-3.23.0-2-py3-none-any.whl", hashes = { sha256 = "95c0886648e48bbf0a57a9d942e2251e7a9dc679683fa2e34aca6a59e1bd3832" } }]
 
 # The following packages were excluded from the output:
 # odh-notebooks-meta-runtime-elyra-deps

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -10,8 +10,7 @@ dependencies = [
     "torchvision==0.24.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
-    # "codeflare-sdk~=0.34.0",
+    "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
     "odh-notebooks-meta-runtime-datascience-deps",
 

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -7,64 +7,70 @@ requires-python = ">=3.12"
 [[packages]]
 name = "absl-py"
 version = "2.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/absl_py-2.4.0-8-py3-none-any.whl", hashes = { sha256 = "74a0bef24b3a6c9387b0ca92305761263dfa3481d0ca741ac2ded0aefada4508" } }]
 
 [[packages]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/aiohappyeyeballs-2.6.1-8-py3-none-any.whl", hashes = { sha256 = "dc45f2d839d1d7256ce6c620301f0a940a53ea82dc868722ffdeb2efeed743aa" } }]
 
 [[packages]]
 name = "aiohttp"
 version = "3.13.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/aiohttp-3.13.3-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "48a3dfea5570eb54010ff3fc551c84fe5830d1d785cf1893f68f949badc41799" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/aiohttp-3.13.3-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "967a959401cca3b6367c32f6e3718d5cc42cb3585930cef00cf13bac46d569b4" } },
 ]
 
 [[packages]]
+name = "aiohttp-cors"
+version = "0.8.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/aiohttp_cors-0.8.1-8-py3-none-any.whl", hashes = { sha256 = "8e7369a0d75b345d83f596071807f5621519a96f5d29a90fba3d240dc9490e5a" } }]
+
+[[packages]]
 name = "aiosignal"
 version = "1.4.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/aiosignal-1.4.0-8-py3-none-any.whl", hashes = { sha256 = "eafccd595a0fb90bca1d7cd09bce526fb0a5383e67836fde93f985679736256b" } }]
 
 [[packages]]
 name = "annotated-doc"
 version = "0.0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/annotated_doc-0.0.4-8-py3-none-any.whl", hashes = { sha256 = "faa7d5b50dfb95cf19d9966f4acc85139748e2bcf011e27c3ed9c88b7f23ad2d" } }]
 
 [[packages]]
 name = "annotated-types"
 version = "0.7.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/annotated_types-0.7.0-8-py3-none-any.whl", hashes = { sha256 = "0df853b3946cbff5c914d1851728fe2cb311b9a4b5c7ee721284996f2e4e4be4" } }]
 
 [[packages]]
 name = "ansicolors"
 version = "1.1.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ansicolors-1.1.8-8-py3-none-any.whl", hashes = { sha256 = "2570e4708c611fbe8746fb4771a5f3a734ec6cd7b82dc9236aff2dbf1bd458ab" } }]
 
 [[packages]]
 name = "anyio"
 version = "4.12.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/anyio-4.12.1-8-py3-none-any.whl", hashes = { sha256 = "e3da70dc8754c6587080443b8432847a437b004254e2c93138c2b6edf7b2ac8a" } }]
 
 [[packages]]
 name = "argon2-cffi"
 version = "25.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/argon2_cffi-25.1.0-8-py3-none-any.whl", hashes = { sha256 = "60b23f977354e17c5aa6ef3fc7290423a54dc62c116ec038dc93f996b512e7ce" } }]
 
 [[packages]]
 name = "argon2-cffi-bindings"
 version = "25.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/argon2_cffi_bindings-25.1.0-8-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "6e8c7fce2ba976c9f8b01bb9d56aa3136fd1f0fe089fa3bfd6d9c23f157a28ff" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/argon2_cffi_bindings-25.1.0-8-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "c45698ca1a057282cd4e9156b5d0deece11dc9f248da428fda4caa877883a16a" } },
@@ -73,55 +79,64 @@ wheels = [
 [[packages]]
 name = "asttokens"
 version = "3.0.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/asttokens-3.0.1-8-py3-none-any.whl", hashes = { sha256 = "d2429ef507e44405cfe4ff5daaf328b1534c9555ea98eed8d0d41f9823e31745" } }]
 
 [[packages]]
 name = "attrs"
 version = "25.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "85f1fbf5312813b8f0d40d8390b427722aebccf988fbdfbada47975dd18bfbc0" } }]
+
+[[packages]]
+name = "bcrypt"
+version = "5.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/bcrypt-5.0.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "daa11e64ff8863d9c97864a11f782281083d37b358adfd24a8f93c72d8561be9" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/bcrypt-5.0.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9afdfc5bc2b65bf5660e4848cbd7fd3091bd5f1ba846fba3f3f283e22ec3e2a6" } },
+]
 
 [[packages]]
 name = "beautifulsoup4"
 version = "4.14.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/beautifulsoup4-4.14.3-8-py3-none-any.whl", hashes = { sha256 = "d349acbcb65cf770ddec29c10a8a06b4d77c8557a4159ea6a1e3f7865d65a6d7" } }]
 
 [[packages]]
 name = "bigtree"
 version = "1.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/bigtree-1.3.0-8-py3-none-any.whl", hashes = { sha256 = "93c65aa3d58c75f4d75ff68031f1e589b032e721b9b31e3b5c12d7ae679b0e18" } }]
 
 [[packages]]
 name = "bleach"
 version = "6.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/bleach-6.3.0-8-py3-none-any.whl", hashes = { sha256 = "fea1ccee54da6f2ab5829a1885157726f33564777fcd7cacc177709e6ef946fa" } }]
 
 [[packages]]
 name = "boto3"
 version = "1.42.40"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/boto3-1.42.40-8-py3-none-any.whl", hashes = { sha256 = "5d001b9c1731e738fbe56a66002a0950e12ee7823436474232bdb5c3dfa1c193" } }]
 
 [[packages]]
 name = "botocore"
 version = "1.42.40"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/botocore-1.42.40-8-py3-none-any.whl", hashes = { sha256 = "0b18afece8c5a5ca9b2e6c13087ec26ba0154ccef72df4c53fd0b3fe566d85a8" } }]
 
 [[packages]]
 name = "certifi"
 version = "2026.1.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/certifi-2026.1.4-8-py3-none-any.whl", hashes = { sha256 = "96135d4e477fa6b17419728c91768a4a9103a856d401cfaf737eff8d15229ab0" } }]
 
 [[packages]]
 name = "cffi"
 version = "2.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cffi-2.0.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "0acc81ecbc87de22713bf5c56c0d80f6a4c44b1a44b53d95950f14a5cf164583" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cffi-2.0.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "6c3e98185c5fdb976006970f4083812f512a94cb0e9870825a1a4303d169b4d9" } },
@@ -130,58 +145,79 @@ wheels = [
 [[packages]]
 name = "charset-normalizer"
 version = "3.4.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/charset_normalizer-3.4.4-8-py3-none-any.whl", hashes = { sha256 = "bf8741b5bb0dea60796ebdc2688677e17b6fa47a2661266631d2f0bd87e898f5" } }]
 
 [[packages]]
 name = "click"
-version = "8.3.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/click-8.3.1-8-py3-none-any.whl", hashes = { sha256 = "90707fa25ed8e1ace623139b27975091ae8cf4dd53891f2eef0164a237541358" } }]
+version = "8.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/click-8.2.1-8-py3-none-any.whl", hashes = { sha256 = "24c2f1f87bd02dd14a9ec692816fd069788d3416c53fb8d768e3e9acc8e5b37c" } }]
 
 [[packages]]
 name = "cloudpickle"
 version = "3.1.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cloudpickle-3.1.2-8-py3-none-any.whl", hashes = { sha256 = "a9c9dba766e2288e12bd9f26435a5a3cf3f022d7ee048c6f0c5ba05b796b1cd2" } }]
+
+[[packages]]
+name = "codeflare-sdk"
+version = "0.34.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/codeflare_sdk-0.34.0-8-py3-none-any.whl", hashes = { sha256 = "9ef6b583ee00f04df8199aafb800ea8a6d7eb56dd3f97b1287e6c939d32faf4d" } }]
 
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/colorama-0.4.6-8-py2.py3-none-any.whl", hashes = { sha256 = "08c8b3038b633a70557d54797563b6f1f0fab174e97939ad5459d0479ff628c6" } }]
+
+[[packages]]
+name = "colorful"
+version = "0.5.8"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/colorful-0.5.8-8-py2.py3-none-any.whl", hashes = { sha256 = "9ba8514681b0a1accb47bd0263d94e8fbcad90e58e4fd6feafa3efe0710cd351" } }]
 
 [[packages]]
 name = "comm"
 version = "0.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/comm-0.2.3-8-py3-none-any.whl", hashes = { sha256 = "b6bb31f8cff86599868629a979a4882869533f88244ae9712d25d21b4d41357a" } }]
 
 [[packages]]
 name = "contourpy"
 version = "1.3.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/contourpy-1.3.3-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "8f83592513ce01237d1b3da133e75d666a6a029d3acc807dcfc285fd8188c7ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/contourpy-1.3.3-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "80eb930c1954d2a51944c082f82724494981766a8617f72a8952801a0cb46a1f" } },
 ]
 
 [[packages]]
+name = "cryptography"
+version = "46.0.3"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cryptography-46.0.3-8-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "8c308ee0475994bf9cd3cff12515e78f8a24e4bc15f28b5b7c973d3cbf1505f2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cryptography-46.0.3-8-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "597b2688ec213512f8bd2596e92c72d86600e0ff132f453baf8d45876a97f364" } },
+]
+
+[[packages]]
 name = "cycler"
 version = "0.12.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/cycler-0.12.1-8-py3-none-any.whl", hashes = { sha256 = "2806844466cecf8024b9f67adbed408357cd36c43678cd92db65347fe3bf1a72" } }]
 
 [[packages]]
 name = "dask"
 version = "2026.1.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/dask-2026.1.2-8-py3-none-any.whl", hashes = { sha256 = "8f0d18a08b010676e7b6a6d280d6737f0b637b3863207daf4dcf13fa7cb8ac38" } }]
 
 [[packages]]
 name = "debugpy"
 version = "1.8.20"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/debugpy-1.8.20-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "414cc033dcbe36ba18028ee49b6e1e4ce7fa2205d089b0cb0419c260a3499f1e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/debugpy-1.8.20-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "16817c3fec4c46743ca479afee1cba17e3bfc31b6869e621c7c9e0535c75c94a" } },
@@ -190,73 +226,85 @@ wheels = [
 [[packages]]
 name = "decorator"
 version = "5.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/decorator-5.2.1-8-py3-none-any.whl", hashes = { sha256 = "e9fdc417e2dc2d6cfb0f8a151d3c117f1b1a52e7e7964a04cde969f432d3b5c8" } }]
 
 [[packages]]
 name = "defusedxml"
 version = "0.7.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/defusedxml-0.7.1-8-py2.py3-none-any.whl", hashes = { sha256 = "100f806321484e6cacced152aed79508b498dfffef46725be642f5efa77c189f" } }]
 
 [[packages]]
 name = "dill"
 version = "0.3.9"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/dill-0.3.9-8-py3-none-any.whl", hashes = { sha256 = "10f14f67e7fb824cf1f0c771fc709be3404ee0a3506e385aad9aadd1fca48453" } }]
+
+[[packages]]
+name = "distlib"
+version = "0.4.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/distlib-0.4.0-8-py2.py3-none-any.whl", hashes = { sha256 = "6c00e3348021f675262a7bbece9e56562060dba095acebd59db743b9c482c939" } }]
 
 [[packages]]
 name = "dnspython"
 version = "2.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/dnspython-2.8.0-8-py3-none-any.whl", hashes = { sha256 = "cb0d00a37aa1a0da1b52a58282a87d99f070443fb220abec56907493b0c13bdf" } }]
+
+[[packages]]
+name = "durationpy"
+version = "0.10"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/durationpy-0.10-8-py3-none-any.whl", hashes = { sha256 = "a6a6b9af057afb0d0e60fa900c6ab4b6cc615436c07160dbcc935ba23c18dbc3" } }]
 
 [[packages]]
 name = "entrypoints"
 version = "0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/entrypoints-0.4-8-py3-none-any.whl", hashes = { sha256 = "2595bde80218a7f29b4444d50d323234bb084221818947221be41b0b83a11443" } }]
 
 [[packages]]
 name = "executing"
-version = "2.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/executing-2.2.1-8-py2.py3-none-any.whl", hashes = { sha256 = "2f6db4d258b4375ffcbff9bd4a35c8e7ad883d724fd246221f234116134caf00" } }]
+version = "1.2.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/executing-1.2.0-8-py2.py3-none-any.whl", hashes = { sha256 = "e763ca4ee97f6fe04c08c95f2c1afbcdc1b2197e8bdadb32405e57a3aa47e2b1" } }]
 
 [[packages]]
 name = "fastapi"
 version = "0.128.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/fastapi-0.128.0-8-py3-none-any.whl", hashes = { sha256 = "77137b0aa07820b28a8ca961333a5cac8ade441627a934fd58e338a208301825" } }]
 
 [[packages]]
 name = "fastjsonschema"
 version = "2.21.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/fastjsonschema-2.21.2-8-py3-none-any.whl", hashes = { sha256 = "397a23819799c2adcd3c19b4df8de3eb1d391a91a907957dd39a2a9c30e3ef8a" } }]
 
 [[packages]]
 name = "feast"
 version = "0.59.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/feast-0.59.0-8-py2.py3-none-any.whl", hashes = { sha256 = "0d6d030ce0182b193e3480d4b29caaf60df89545bec77adc00fccb96c35d6685" } }]
 
 [[packages]]
 name = "filelock"
 version = "3.20.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/filelock-3.20.3-8-py3-none-any.whl", hashes = { sha256 = "ac6b78536bd46b95dc6bfcbcb0d298204de00e8a0d5d7949a3b7d8c34b13677f" } }]
 
 [[packages]]
 name = "fonttools"
 version = "4.61.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/fonttools-4.61.1-8-py3-none-any.whl", hashes = { sha256 = "df4a6ffee8687cf753bc89e915f5ddc8b8591ee14229ebd71ddd28ad044c688e" } }]
 
 [[packages]]
 name = "frozenlist"
 version = "1.8.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/frozenlist-1.8.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "881700eeebc28a4f49e8df579f93142d2de6d1bd213d1f07d8c2678712a4c40c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/frozenlist-1.8.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "6f76cab6b903b1ecbd55c5c36a68e8915e921dff43b55222d1d012903a38deee" } },
@@ -265,13 +313,31 @@ wheels = [
 [[packages]]
 name = "fsspec"
 version = "2026.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/fsspec-2026.1.0-8-py3-none-any.whl", hashes = { sha256 = "9e6fcb09b6a0515896b062f8b3de34d6573aeb8e014c4a756f69757cb169af1d" } }]
+
+[[packages]]
+name = "google-api-core"
+version = "2.29.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/google_api_core-2.29.0-8-py3-none-any.whl", hashes = { sha256 = "a9ed5af53e4ed2033dd1115f9f0b35733db4eb275ac1642ea428d983036eb1c7" } }]
+
+[[packages]]
+name = "google-auth"
+version = "2.48.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/google_auth-2.48.0-8-py3-none-any.whl", hashes = { sha256 = "19e14ee583d2618fbcbff44c2561c086d468a5aeb3ee5fe4ffe29b24ce85ad3c" } }]
+
+[[packages]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/googleapis_common_protos-1.72.0-8-py3-none-any.whl", hashes = { sha256 = "47934a3805a715a1eb4238b3a18405d078f11b0e21573ea3512dd5e63f5d659b" } }]
 
 [[packages]]
 name = "greenlet"
 version = "3.3.1"
-marker = "(python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+marker = "(implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/greenlet-3.3.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "348252f8c6f7f0ead62655858103210130b8ae3c74115509b3cc1a2143643412" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/greenlet-3.3.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8b84c817aa3805ab10b99528d4cd48479a44830c2b3eddb2973819f468f1e7bb" } },
@@ -280,7 +346,7 @@ wheels = [
 [[packages]]
 name = "grpcio"
 version = "1.76.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/grpcio-1.76.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "866ba62c9957fd3870bd59c84314b5403b553ce0cd3f8252785b928a684ab2e2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/grpcio-1.76.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b4f0369464abfe082979b87f06f63543a0b7fc7031c8249c8499e390a5a60f58" } },
@@ -289,19 +355,19 @@ wheels = [
 [[packages]]
 name = "gunicorn"
 version = "25.0.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/gunicorn-25.0.1-8-py3-none-any.whl", hashes = { sha256 = "f04cde83710ad24a55922a81ab8eff8f197dc228495e8c9063a9a52107d75f06" } }]
 
 [[packages]]
 name = "h11"
 version = "0.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/h11-0.16.0-8-py3-none-any.whl", hashes = { sha256 = "8d1db287aa7e23e0e4627911e1253e83ed50dccdbe95fb2f54fe7fa1e73abe93" } }]
 
 [[packages]]
 name = "httptools"
 version = "0.7.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/httptools-0.7.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "4d5befe50913843df9657709b97a8b9625ef8461f073fecd87e0ce10df16606e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/httptools-0.7.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "69aafa0bd9ef370e59718dc2a90119ad98b7f73e2ca23dab2b6540dae8d4af02" } },
@@ -310,106 +376,136 @@ wheels = [
 [[packages]]
 name = "idna"
 version = "3.11"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/idna-3.11-8-py3-none-any.whl", hashes = { sha256 = "06e8863466f48a97820617754498038f4ed9483b4b6ad7a83de9b9852824f1b4" } }]
+
+[[packages]]
+name = "importlib-metadata"
+version = "8.7.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/importlib_metadata-8.7.1-8-py3-none-any.whl", hashes = { sha256 = "9438c2c8582fae36d4d851f9c02aa8e327e14a77738d9f1f8a6f7e9bfa3ea908" } }]
+
+[[packages]]
+name = "invoke"
+version = "2.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/invoke-2.2.1-8-py3-none-any.whl", hashes = { sha256 = "05412facff8cf1c8bb9ddc0e0bbc37d64e33318886855bf2876e32e68ad9cf00" } }]
 
 [[packages]]
 name = "ipykernel"
 version = "7.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipykernel-7.1.0-8-py3-none-any.whl", hashes = { sha256 = "615f73c8fa76eff5990684fb6dab28abfcf1f99f42d5b640f0791a158e9f460e" } }]
 
 [[packages]]
 name = "ipython"
 version = "9.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipython-9.9.0-8-py3-none-any.whl", hashes = { sha256 = "f0480ca352c6e87fe1f2bec2731d6e94b03c03c41ad765da38ba65e9cd3e9ec2" } }]
 
 [[packages]]
 name = "ipython-genutils"
 version = "0.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipython_genutils-0.2.0-8-py2.py3-none-any.whl", hashes = { sha256 = "de07bde0665dbf76d7dce8f9f09da299900ee1b8f806d1d1a9c5ee5b2c268760" } }]
 
 [[packages]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipython_pygments_lexers-1.1.1-8-py3-none-any.whl", hashes = { sha256 = "06afa6920250e2b8e2473727f8a0602b09e8ad09e942faa71622103afd0a96fe" } }]
+
+[[packages]]
+name = "ipywidgets"
+version = "8.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ipywidgets-8.1.2-8-py3-none-any.whl", hashes = { sha256 = "4f78c5242b754eba22ae1fa04f5db458e3e562e33ed702c705e9bc5b74af6071" } }]
 
 [[packages]]
 name = "jedi"
 version = "0.19.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jedi-0.19.2-8-py2.py3-none-any.whl", hashes = { sha256 = "8a75d7eb1e0b282575bcdf932826ac7a1064cb179f413f12ee9528b579bfc77c" } }]
 
 [[packages]]
 name = "jinja2"
 version = "3.1.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jinja2-3.1.6-8-py3-none-any.whl", hashes = { sha256 = "a408ce83032742c546ee1adcc7f1e60faa4f8cfcf0d35e99b41c02677efc6433" } }]
 
 [[packages]]
 name = "jmespath"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jmespath-1.1.0-8-py3-none-any.whl", hashes = { sha256 = "c9f774863aa699701141925b609942a7b49f540b1d375a73d95dfa0d8a3734e4" } }]
 
 [[packages]]
 name = "joblib"
 version = "1.5.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/joblib-1.5.3-8-py3-none-any.whl", hashes = { sha256 = "88e859146362855eb5bc51f89a23173c1df8e6ad36ca7d35a595d40073baed18" } }]
 
 [[packages]]
 name = "jsonschema"
 version = "4.26.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jsonschema-4.26.0-8-py3-none-any.whl", hashes = { sha256 = "be0c72f31e2e40f0d71665c09fb7a12e1090ed3d4779cc76e107d738f400f8e5" } }]
 
 [[packages]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jsonschema_specifications-2025.9.1-8-py3-none-any.whl", hashes = { sha256 = "3e3deb5ca590cab381418874db7d4a60151f1dd8a442af91a45c529795de5fe6" } }]
 
 [[packages]]
 name = "jupyter-client"
 version = "8.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jupyter_client-8.8.0-8-py3-none-any.whl", hashes = { sha256 = "9d268884347ec8b61c17c6ccae9cd763d2cc36f6f209f50e91991b62460f1efe" } }]
 
 [[packages]]
 name = "jupyter-core"
 version = "5.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jupyter_core-5.9.1-8-py3-none-any.whl", hashes = { sha256 = "34f67f21dc45b75a2c352e7eba608ce873e02c8652e8a5ebf6d9596476faf483" } }]
 
 [[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jupyterlab_pygments-0.3.0-9-py3-none-any.whl", hashes = { sha256 = "32c26f60e4e3e81a9ad5da3f27b05ad9bda4a334c2f9494d6171c12b856f77bc" } }]
+
+[[packages]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/jupyterlab_widgets-3.0.16-8-py3-none-any.whl", hashes = { sha256 = "537d1eca2317abb024ae22d77995f9a6538146bc866c3dbf4956ea5f016749c3" } }]
 
 [[packages]]
 name = "kafka-python-ng"
 version = "2.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/kafka_python_ng-2.2.3-8-py2.py3-none-any.whl", hashes = { sha256 = "782fe5ddf10b686fbe1c851d38dfe962419978089f605cb15ac1730cb5da829a" } }]
 
 [[packages]]
 name = "kiwisolver"
 version = "1.4.9"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/kiwisolver-1.4.9-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c2cffd6521f8026ad2f61459b16c38ec55a983c91b43dcc59ce96469b6e25bb2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/kiwisolver-1.4.9-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "92bc763320f30cc564b05252da4dd91cf8d6d76c7129be1b0f0e3a8d0e07ac2e" } },
 ]
 
 [[packages]]
+name = "kubernetes"
+version = "35.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/kubernetes-35.0.0-8-py3-none-any.whl", hashes = { sha256 = "86f1ab21bee089befbe1bf8d7339cfd39ee4d22873bc3e2aeb017dd87d47e694" } }]
+
+[[packages]]
 name = "librt"
 version = "0.7.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/librt-0.7.8-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "147eef49063503947d55b8b7b860a7e0cb57180abb8abf43a556886225add77a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/librt-0.7.8-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "cd6a1b0cbdfbf0c1587a964d3eccd5fe6d3d111ac146e69be54a56334307d6dd" } },
@@ -418,19 +514,25 @@ wheels = [
 [[packages]]
 name = "locket"
 version = "1.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/locket-1.0.0-8-py2.py3-none-any.whl", hashes = { sha256 = "0198689cbf84299710d879c95cb2f3ad0afcb83c32ebad0f7b149cc98da2c292" } }]
 
 [[packages]]
 name = "markdown"
 version = "3.10.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/markdown-3.10.1-8-py3-none-any.whl", hashes = { sha256 = "817a697ce457f652cb368a14b9eaf9c62f02b0243468204bd49c618904f6e012" } }]
+
+[[packages]]
+name = "markdown-it-py"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/markdown_it_py-4.0.0-8-py3-none-any.whl", hashes = { sha256 = "2e63f1744bd8d809a002f68dddd01956ffc12964c15397dcdd492aa4bae11bb9" } }]
 
 [[packages]]
 name = "markupsafe"
 version = "3.0.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/markupsafe-3.0.3-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "154348642b745ea3af1ffda4e28f16627ca727969579072c9cfff0169ddbed18" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/markupsafe-3.0.3-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "df3e5bde7aac1f241ccb92a6feb67cc44b1d1776da5bc7a800d276a506062c6f" } },
@@ -439,7 +541,7 @@ wheels = [
 [[packages]]
 name = "matplotlib"
 version = "3.10.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/matplotlib-3.10.8-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "598e9cb437845eab87e2cacbdf0aa3948c1856b489e3ce798269690a32782583" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/matplotlib-3.10.8-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d8ab09fd0b5e73733743333802b6297497954a10697aa0ea9cd24482b01ac606" } },
@@ -448,25 +550,31 @@ wheels = [
 [[packages]]
 name = "matplotlib-inline"
 version = "0.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/matplotlib_inline-0.2.1-8-py3-none-any.whl", hashes = { sha256 = "a439bba0219798e3bb1123bc378f673df65fc1e7ddb59ddbce8155cb9ac45114" } }]
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mdurl-0.1.2-8-py3-none-any.whl", hashes = { sha256 = "45c663f9c94351ece0ba397babc5bc2131de528d527821321c4267c8e8c0b484" } }]
 
 [[packages]]
 name = "minio"
 version = "7.2.20"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/minio-7.2.20-8-py3-none-any.whl", hashes = { sha256 = "c389c3a47d7d72b72c4d09ee5f35e13f31edfc602f54be62a7324789bb526806" } }]
 
 [[packages]]
 name = "mistune"
 version = "3.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mistune-3.2.0-8-py3-none-any.whl", hashes = { sha256 = "fc73c822d78c250b918aa1de37b363014c9075a8417d561954d591784fa3a661" } }]
 
 [[packages]]
 name = "ml-dtypes"
 version = "0.5.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ml_dtypes-0.5.4-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "10b8e17592b58927e78e560ecbec19c8d8bf115707521f421e51eba2c736bead" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ml_dtypes-0.5.4-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e6e9f6e186a3025e88d998ce8301f17cb141cd07a86287bea605696749754c60" } },
@@ -475,7 +583,7 @@ wheels = [
 [[packages]]
 name = "mmh3"
 version = "5.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mmh3-5.2.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "55057f181162b75145170f3bc68505a494debd01978b1b5221a4902e08ce06cd" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mmh3-5.2.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9173452f1e21935d32a6f145866a8d63c2e75d9fce79548fc06aa92daba31452" } },
@@ -484,13 +592,22 @@ wheels = [
 [[packages]]
 name = "mpmath"
 version = "1.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mpmath-1.3.0-8-py3-none-any.whl", hashes = { sha256 = "b321f4f60780963fc0f5a27c61aa0ae7925818535564526855f0874302b9e73b" } }]
+
+[[packages]]
+name = "msgpack"
+version = "1.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/msgpack-1.1.2-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "70a36b2a556ca5261a866ad6fcc6a63bf26be77a66d5e1ed3a9fb1282a8722a3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/msgpack-1.1.2-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "73d2c1e7da99fec6486f18169ec2d4dbb7ea32e41fa06285fc071159436751bb" } },
+]
 
 [[packages]]
 name = "multidict"
 version = "6.7.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/multidict-6.7.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "6acf5e6b59140af5f67f88daca2e44b0bb52dc1a5bf30280e476b64d01c6a979" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/multidict-6.7.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d106f82fc152f2bd3dc000fe1e0206e8edd49a6d735502ef4e3106c1be62268d" } },
@@ -499,19 +616,19 @@ wheels = [
 [[packages]]
 name = "mypy"
 version = "1.19.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mypy-1.19.1-8-py3-none-any.whl", hashes = { sha256 = "c010013c7c2c43c60bdfcf3d67e39fed058ce40e4538c1fbaaa1b71c3bb9b3a9" } }]
 
 [[packages]]
 name = "mypy-extensions"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mypy_extensions-1.1.0-8-py3-none-any.whl", hashes = { sha256 = "854c92eb38dc8b7967177d21c798de0f90d6708ee5f1ff90ab5928e7bc52010b" } }]
 
 [[packages]]
 name = "mysql-connector-python"
 version = "9.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mysql_connector_python-9.5.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "693a89719b6ffd6839710491054ce1fba7241fd25ce8cb4ee321caec5006e1ba" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/mysql_connector_python-9.5.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "fe17786a071175d2d4f02c9520001cc6e70f75e2b5f88f98a0a7098cdfb303eb" } },
@@ -520,52 +637,58 @@ wheels = [
 [[packages]]
 name = "narwhals"
 version = "2.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/narwhals-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "a07c77d0418cd195f37a111752fc5666bc97cfd4154862ea387137cb9fbfef02" } }]
 
 [[packages]]
 name = "nbclient"
 version = "0.10.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/nbclient-0.10.4-8-py3-none-any.whl", hashes = { sha256 = "5d69cb7d7ee53f3bfa26f6557989d2a0e856599104656a6b70f3122dc5fd89d4" } }]
 
 [[packages]]
 name = "nbconvert"
 version = "7.16.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/nbconvert-7.16.6-8-py3-none-any.whl", hashes = { sha256 = "dd4e6998f25e09089b3a566fdbf8bab002ec59b653ef86ee9dc9a1fc46681cae" } }]
 
 [[packages]]
 name = "nbformat"
 version = "5.10.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/nbformat-5.10.4-8-py3-none-any.whl", hashes = { sha256 = "524ff789f8fafbe00aec2a9822c8a1d0f0b73a19058c52e567cd4d49b1059845" } }]
 
 [[packages]]
 name = "nest-asyncio"
 version = "1.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/nest_asyncio-1.6.0-8-py3-none-any.whl", hashes = { sha256 = "a574f5f96d4b52c0f765c2fe72a1d23b07c0d91fe275f1c4b65acab9edca9c35" } }]
 
 [[packages]]
 name = "networkx"
 version = "3.6.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/networkx-3.6.1-8-py3-none-any.whl", hashes = { sha256 = "0d717e7193ff13b3a7bb81e4f9a7157377e4674a507ddd0ef71f41b2f7683c6f" } }]
 
 [[packages]]
 name = "numpy"
 version = "2.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/numpy-2.4.2-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "94403466f4ad374cb65bd803b18c8ab1c34253ac7f98bff37b08f0cb9db6df49" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/numpy-2.4.2-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "80778cf41223a018aad1bca1950c7a356039317db99ca1986ce0dad72ac0d36c" } },
 ]
 
 [[packages]]
+name = "oauthlib"
+version = "3.3.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/oauthlib-3.3.1-8-py3-none-any.whl", hashes = { sha256 = "c74823e84beac7fda735e1961107b61d724843826bd6d08505f0b2b942c7e540" } }]
+
+[[packages]]
 name = "onnx"
 version = "1.20.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/onnx-1.20.0-10-cp312-abi3-linux_aarch64.whl", hashes = { sha256 = "8e483bbec5c7a9d51b292adfec2492b3d4e79aaeae1647d8ffaa0ebeb3769a3a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/onnx-1.20.0-10-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "3e2a9def1b40297f30632a7f0fb616c999ab9096783bdbbe3ef4c33a7fdcc768" } },
@@ -574,19 +697,67 @@ wheels = [
 [[packages]]
 name = "onnxconverter-common"
 version = "1.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/onnxconverter_common-1.16.0-10-py2.py3-none-any.whl", hashes = { sha256 = "e10b80b7d24d4dfae295d1a872bb0046b9a095a58aadf06c2ff03bb7424e34e5" } }]
+
+[[packages]]
+name = "opencensus"
+version = "0.11.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opencensus-0.11.4-8-py2.py3-none-any.whl", hashes = { sha256 = "4be45e7b357769afbeb34d576a05997af19e663c5c210b9d27cbc3c0d0970b80" } }]
+
+[[packages]]
+name = "opencensus-context"
+version = "0.1.3"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opencensus_context-0.1.3-8-py2.py3-none-any.whl", hashes = { sha256 = "6cbc534d5bb803948f575da1b555c0344df7148cd3adebfc71c377b58ce1932a" } }]
+
+[[packages]]
+name = "openshift-client"
+version = "1.0.18"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/openshift_client-1.0.18-8-py2.py3-none-any.whl", hashes = { sha256 = "4a5cb57fb2f2ef3372b504797bed19a9dd75ca93168ec93b7012cbc0b60c7fb0" } }]
+
+[[packages]]
+name = "opentelemetry-api"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_api-1.39.1-8-py3-none-any.whl", hashes = { sha256 = "892530d3de2309f4c7ea86c895fafd5e9d489545db928510efca294bcb7e8610" } }]
+
+[[packages]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_exporter_prometheus-0.60b1-8-py3-none-any.whl", hashes = { sha256 = "94d5b62023f659b091bb5e48818412b2fc9a21e164bece9fbe8a698342410c1e" } }]
+
+[[packages]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_proto-1.39.1-8-py3-none-any.whl", hashes = { sha256 = "bb5b3235b7fb2414378ae1c906e6b4751acc424c37b590336fc4d2850e4a4da5" } }]
+
+[[packages]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_sdk-1.39.1-8-py3-none-any.whl", hashes = { sha256 = "2286f30340a77ade25238fa4c60a3d69a7161a6c4a35fac1c81649792c63fe64" } }]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/opentelemetry_semantic_conventions-0.60b1-8-py3-none-any.whl", hashes = { sha256 = "908640a7c0bf479a1bdbbad21561d895f9a227bd3ea606fdbb686159eb059864" } }]
 
 [[packages]]
 name = "packaging"
 version = "26.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/packaging-26.0-8-py3-none-any.whl", hashes = { sha256 = "092062e21a7b3f6438f35139b1827fd7714a231bf5733cf64375297776341d9a" } }]
 
 [[packages]]
 name = "pandas"
 version = "2.3.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pandas-2.3.3-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "1be1172c219c42243e96e6881579a8e879138055a889bc79942ad11352395c5f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pandas-2.3.3-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e4ecd7983e2c01724ccf099dc7849ee218dcfa8b7790099166bbb05d42821ecc" } },
@@ -595,43 +766,49 @@ wheels = [
 [[packages]]
 name = "pandocfilters"
 version = "1.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pandocfilters-1.5.1-8-py2.py3-none-any.whl", hashes = { sha256 = "07635323ad27159538b3da9dfdb26e4f0efff6261dba7de06219f9bff81253c4" } }]
 
 [[packages]]
 name = "papermill"
 version = "2.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/papermill-2.6.0-8-py3-none-any.whl", hashes = { sha256 = "fbca5b662c14f7127390597bc7a967a1a745fde51efee097c592dcc8b57a193e" } }]
+
+[[packages]]
+name = "paramiko"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/paramiko-4.0.0-8-py3-none-any.whl", hashes = { sha256 = "1d168b4631018edf5bc438dce290503b82fdb7c288935e0513a8f7bbf57b2acc" } }]
 
 [[packages]]
 name = "parso"
 version = "0.8.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/parso-0.8.5-8-py2.py3-none-any.whl", hashes = { sha256 = "00c4b510ffead28141b5de6df44810dbff52df2b98ccfe2d43e4f48887db3965" } }]
 
 [[packages]]
 name = "partd"
 version = "1.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/partd-1.4.2-8-py3-none-any.whl", hashes = { sha256 = "f2d5553a72a83a675110959395135bf8912bed467606ed214ee9e789c8300a3a" } }]
 
 [[packages]]
 name = "pathspec"
 version = "1.0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pathspec-1.0.4-8-py3-none-any.whl", hashes = { sha256 = "e35375066555125ff8f4ac4944dc53860ccfdec819b89ec8e7a5a94466a45ee9" } }]
 
 [[packages]]
 name = "pexpect"
 version = "4.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pexpect-4.9.0-8-py2.py3-none-any.whl", hashes = { sha256 = "6448c0436e779c4343944535a049af0ae8743867b0a2d2c8981b453d614a8069" } }]
 
 [[packages]]
 name = "pillow"
 version = "12.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pillow-12.1.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ef7ebfcfdde88683538a63448fa6a36807022787e28eaa0551a8061d5a937eea" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pillow-12.1.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4e2138d57ea1455b8265d2c6230c98a5323fff06a1d3a24eb8029675bdee0beb" } },
@@ -640,40 +817,46 @@ wheels = [
 [[packages]]
 name = "platformdirs"
 version = "4.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/platformdirs-4.5.1-8-py3-none-any.whl", hashes = { sha256 = "a5c2b5c30d48dd4abaf3d04151dcc76b5e671f578bbab1bb65879fdaa019dcc5" } }]
 
 [[packages]]
 name = "plotly"
 version = "6.5.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/plotly-6.5.2-8-py3-none-any.whl", hashes = { sha256 = "12c1d76726487d3ff20f5e36033c45fb9efe5cd157410492e08a6370615a56bd" } }]
 
 [[packages]]
 name = "prometheus-client"
 version = "0.24.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/prometheus_client-0.24.1-8-py3-none-any.whl", hashes = { sha256 = "76fc4f76250de359da212fd584261d09f27963f30da1242da014443afa026fe5" } }]
 
 [[packages]]
 name = "prompt-toolkit"
 version = "3.0.52"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/prompt_toolkit-3.0.52-8-py3-none-any.whl", hashes = { sha256 = "f750a8ca296bcfc62e8485b31c2a1d4af1d86b3bc917e7aaeba0363e2d279612" } }]
 
 [[packages]]
 name = "propcache"
 version = "0.4.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/propcache-0.4.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "8a63d216fd8ffa6fb857f73f46b89da02aea944e77c251e3e57679deaea10a40" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/propcache-0.4.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "91286c7fbe099359634c2202b305d6de34f337db5ce96a3333beb5de3a0081dd" } },
 ]
 
 [[packages]]
+name = "proto-plus"
+version = "1.27.1"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/proto_plus-1.27.1-8-py3-none-any.whl", hashes = { sha256 = "af807e1dcd3cb48da6199b2062aed99cf9fc9040b662544ae8b85da65078238f" } }]
+
+[[packages]]
 name = "protobuf"
 version = "6.33.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "35935fe06b8398f4edc75a54cf01ee49ebd9a970f9d5ed6b8ee99c18615ef00e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4f2401e8b5bd052f7e01d099ad23459d8968056dcccac1f38988150e90873e69" } },
@@ -682,7 +865,7 @@ wheels = [
 [[packages]]
 name = "psutil"
 version = "7.2.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/psutil-7.2.2-8-cp36-abi3-linux_aarch64.whl", hashes = { sha256 = "9a2f38c959c2e31ff77876f9b1ef46db0cf18686134acc7aaebce8aae26e6495" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/psutil-7.2.2-8-cp36-abi3-linux_x86_64.whl", hashes = { sha256 = "46136fb3c7cdef9a84ea56b187294c01773559badff495c95ccd1dab93e65f73" } },
@@ -691,40 +874,61 @@ wheels = [
 [[packages]]
 name = "psycopg"
 version = "3.3.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/psycopg-3.3.2-8-py3-none-any.whl", hashes = { sha256 = "d9e834c9e76b1c38f902b1e01abba817f161bf14a83528d4841638ca78f8e0ef" } }]
 
 [[packages]]
 name = "ptyprocess"
 version = "0.7.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ptyprocess-0.7.0-8-py2.py3-none-any.whl", hashes = { sha256 = "36cd65ab1dfcc66d40b38152c6dfbb425736a512cfb4cd81c42d4209641a22ef" } }]
 
 [[packages]]
 name = "pure-eval"
 version = "0.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pure_eval-0.2.3-8-py3-none-any.whl", hashes = { sha256 = "2fdc667e87f14de1c0e961c1288dbb4a0f97ce82c41756c47521c9ab86e794b1" } }]
+
+[[packages]]
+name = "py-spy"
+version = "0.4.1"
+marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/py_spy-0.4.1-8-py3-none-linux_aarch64.whl", hashes = { sha256 = "cb40c2741f7ecf0b63812353e81c7f356f00a5aa6fcfe0c4f41f3d755d0f7bc6" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/py_spy-0.4.1-8-py3-none-linux_x86_64.whl", hashes = { sha256 = "5fe3ae248e1cd1c07939b228f9b5f563c1bdbe0ad5c2b908588e9ceac5c42bbb" } },
+]
 
 [[packages]]
 name = "pyarrow"
 version = "23.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyarrow-23.0.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e3b68f46bb314d8576e8c69b76fb8ce94a8eae8b1eafa5e5b3b6db6d365b2e04" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyarrow-23.0.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4ec7d8eb17eac991f8dd2ab1aa5f07d9bb7702cc516bbbe54c6f27aa13ea68a5" } },
 ]
 
 [[packages]]
+name = "pyasn1"
+version = "0.6.2"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyasn1-0.6.2-8-py3-none-any.whl", hashes = { sha256 = "2afa30d461df34eb924b5de8ca863d426cbb0830fd48ba478b4726710f1f80ee" } }]
+
+[[packages]]
+name = "pyasn1-modules"
+version = "0.4.2"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyasn1_modules-0.4.2-8-py3-none-any.whl", hashes = { sha256 = "231a617d02b9b45a58198456cf6a7ee8a1fb1044e884c03b508b4f53a3912f18" } }]
+
+[[packages]]
 name = "pycparser"
 version = "3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pycparser-3.0-8-py3-none-any.whl", hashes = { sha256 = "f4d8b59f46a3cc78ba551978499a162d7a2ed5368c05829835fd88e28b92c4c9" } }]
 
 [[packages]]
 name = "pycryptodome"
 version = "3.23.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pycryptodome-3.23.0-8-cp37-abi3-linux_aarch64.whl", hashes = { sha256 = "9dcbd6516c26dff743bba901130523e04c89080a56b54c44d905d65eb94a3a98" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pycryptodome-3.23.0-8-cp37-abi3-linux_x86_64.whl", hashes = { sha256 = "bfc3ae25ed4a2fede64f1255c249d94c9082445feedb7ea2a07b57d8a41e6fb9" } },
@@ -733,13 +937,13 @@ wheels = [
 [[packages]]
 name = "pydantic"
 version = "2.12.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pydantic-2.12.5-8-py3-none-any.whl", hashes = { sha256 = "8b5301b14a95159f4cc38ecc04bd3d1699b70c45a0077f78ae95d5f6213b0b92" } }]
 
 [[packages]]
 name = "pydantic-core"
 version = "2.41.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pydantic_core-2.41.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e4113db2083c0025dd7050213f5b8314584a39aec4167f2323728d71230165ce" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pydantic_core-2.41.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4a4ab5b754420c459ed39154a5e3e09d4afb3a12be065262d72f35675d2cc7a8" } },
@@ -748,28 +952,37 @@ wheels = [
 [[packages]]
 name = "pygments"
 version = "2.19.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pygments-2.19.2-8-py3-none-any.whl", hashes = { sha256 = "2ae83398f5518a580781b21f89a440d7c6f27de312788e843ee2bb4e50a4fe52" } }]
 
 [[packages]]
 name = "pyjwt"
 version = "2.11.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "fe25b759719c19d3a7b9269ffea226d7cc86db18d0871dd697acea91ae029072" } }]
 
 [[packages]]
 name = "pymongo"
 version = "4.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pymongo-4.16.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "00c96af66a97a84f64e103143b5a73aed9d27f3cd8f78a4ed8a866fd3c71433e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pymongo-4.16.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "89667c5e112a0b7637ed6baabde946bf1fbe494737103aa59e30a368c3abeeed" } },
 ]
 
 [[packages]]
+name = "pynacl"
+version = "1.6.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pynacl-1.6.2-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "2f42695a74ceb286c140cc2a64b289bc44bc364d552279e3305280e08c284b53" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pynacl-1.6.2-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7215deac852f026ca8c85ab24eff7c92f65ff4c3c3fda677a093b6956b81d1f7" } },
+]
+
+[[packages]]
 name = "pyodbc"
 version = "5.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyodbc-5.3.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "2fd65c7042d0a424a78dee64bf5e5cb8231cd632209af5ee0151d863b2a801a2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyodbc-5.3.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4c24962c29072413aea985762ef5ddd981267198b37318dc5e9eaaebe1d2d09f" } },
@@ -778,31 +991,31 @@ wheels = [
 [[packages]]
 name = "pyparsing"
 version = "3.3.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyparsing-3.3.2-8-py3-none-any.whl", hashes = { sha256 = "7fc3009836ec5cda7d1217c9c14aca0a8a99496bf21c5b56fee646211e0f6807" } }]
 
 [[packages]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/python_dateutil-2.9.0.post0-8-py2.py3-none-any.whl", hashes = { sha256 = "040d2df4287501adf79d25126733cdec3d4f4e0e99a5a3e95b7b5e569d31a2ce" } }]
 
 [[packages]]
 name = "python-dotenv"
 version = "1.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/python_dotenv-1.2.1-8-py3-none-any.whl", hashes = { sha256 = "a08f5922b2aec879157e87bf2974d8ca68b9f8729f10b7090c31679bcd5430f0" } }]
 
 [[packages]]
 name = "pytz"
 version = "2025.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pytz-2025.2-8-py3-none-any.whl", hashes = { sha256 = "eba5bbd3586f1b7cc4b8ea150840f34206a71905b492b4eb6dee7a8b3e5612fe" } }]
 
 [[packages]]
 name = "pyyaml"
 version = "6.0.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyyaml-6.0.3-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7677bc0d48b2899571cba6837b2626e235dea769236208bb41c011b51eea2e5f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyyaml-6.0.3-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "f80ad5e481e9f9eaedc6c5ff39711b9b2fce4b70540e337ed804cfa562eed9e4" } },
@@ -811,43 +1024,70 @@ wheels = [
 [[packages]]
 name = "pyzmq"
 version = "27.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyzmq-27.1.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7abfcd2b41bafd090be8a2fa7b3a0ace14299290e48db26802b51d19cdc00cb3" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/pyzmq-27.1.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b83f44f4f770239ab0d4fec22c9cd49176396a8d3e03002529caafc5e9bf9a03" } },
 ]
 
 [[packages]]
+name = "ray"
+version = "2.52.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_aarch64.whl", hashes = { sha256 = "08eb8f5fd55292ba6bee363a32491136a5e54af54e007f81e0603986fbea41a4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_x86_64.whl", hashes = { sha256 = "843c0108ad72bb7fc6c23a22e29e6099546a5eaad3ad675c78a146d9080f6ec6" } },
+]
+
+[[packages]]
 name = "referencing"
 version = "0.37.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/referencing-0.37.0-8-py3-none-any.whl", hashes = { sha256 = "5af0d8a1bfb3aa795cadbdeb9fb284b1125ddc0eb37d5c92240fe835d0b227f0" } }]
 
 [[packages]]
 name = "requests"
 version = "2.32.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/requests-2.32.5-8-py3-none-any.whl", hashes = { sha256 = "744d3e9c8e753ec9cd7795802590b5add22ba34b9daa31f2e7c72da46f8c4ea2" } }]
+
+[[packages]]
+name = "requests-oauthlib"
+version = "2.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/requests_oauthlib-2.0.0-8-py2.py3-none-any.whl", hashes = { sha256 = "3b7270361dcfa6e8814dae66e82d615ae2efb7790c3d357596f97c92a7d8b799" } }]
+
+[[packages]]
+name = "rich"
+version = "13.9.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/rich-13.9.4-8-py3-none-any.whl", hashes = { sha256 = "9f582115c023367d33d9f44df636ad1c037dc540d5fd971e8526b11ea83f33e8" } }]
 
 [[packages]]
 name = "rpds-py"
 version = "0.30.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "08bec73646e2a1a56d16765ed98a60aeffe5d85cc3f0e44a6c3faf35c35a7e37" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1c5b2ca1edc73f64930cb22c3ef990795ca287661f297b81529f647d1ca61a30" } },
 ]
 
 [[packages]]
+name = "rsa"
+version = "4.9.1"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/rsa-4.9.1-8-py3-none-any.whl", hashes = { sha256 = "744e397772c723d62374e4e1fbce0b290dec13871f80e3e9eea6027232fdc472" } }]
+
+[[packages]]
 name = "s3transfer"
 version = "0.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/s3transfer-0.16.0-8-py3-none-any.whl", hashes = { sha256 = "43cd929e0ccc901f04f866bdd2dd42dd9e55f091c9f3c4083fb4e7c15573b013" } }]
 
 [[packages]]
 name = "scikit-learn"
 version = "1.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/scikit_learn-1.8.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "b7d07e893f80180accf08a85ae13f6fcf36dd43749b195d1c1810a2e2057b453" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/scikit_learn-1.8.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1871676b5f2f9d39b3bbe577ff804e4c8be72225ba56692625802c0f416903a4" } },
@@ -856,7 +1096,7 @@ wheels = [
 [[packages]]
 name = "scipy"
 version = "1.16.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/scipy-1.16.3-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3bf5d1e9af75064700274b2955446f7dda60c6652f10c0e3602dbd2b1cae4443" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/scipy-1.16.3-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "05d8cb8aa7a38c8c620ea78874e46a520cddd45e23a4be7a59982aa6f870f9f7" } },
@@ -865,31 +1105,37 @@ wheels = [
 [[packages]]
 name = "setuptools"
 version = "80.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/setuptools-80.9.0-8-py3-none-any.whl", hashes = { sha256 = "6bd60d755d8596e06cbcf7fbabeda42d25203f3c541d8a3d0411ab6043560a49" } }]
 
 [[packages]]
 name = "six"
 version = "1.17.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/six-1.17.0-8-py2.py3-none-any.whl", hashes = { sha256 = "bacf075e56499a81a5869112022caa1d3f3c9669a124d4973e06fb4320f93a80" } }]
 
 [[packages]]
 name = "skl2onnx"
 version = "1.19.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/skl2onnx-1.19.1-8-py3-none-any.whl", hashes = { sha256 = "fd966002d2b0620765e4597b807e03f777e674c852f7739b98fbc12b81f5c264" } }]
+
+[[packages]]
+name = "smart-open"
+version = "7.5.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/smart_open-7.5.0-8-py3-none-any.whl", hashes = { sha256 = "b28e557ee2c0e112c46247620c46bae12472a0dcc2f0ca2c9ae2f2fea0f18a3f" } }]
 
 [[packages]]
 name = "soupsieve"
 version = "2.8.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/soupsieve-2.8.3-8-py3-none-any.whl", hashes = { sha256 = "51b26d67aef862a49b0d10e7adf678de407c2f6495d53a788a1b88ed57ef83e4" } }]
 
 [[packages]]
 name = "sqlalchemy"
 version = "2.0.46"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/sqlalchemy-2.0.46-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "93d6ed427db6f7ca2e690c343a7be14f32f3f7d823e725f7412c0145ca9b9ac4" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/sqlalchemy-2.0.46-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "f3d8fdc5575d32e6b7398b6abdc5cef49c932d92bfb046344eb49d9908a0e12d" } },
@@ -898,73 +1144,73 @@ wheels = [
 [[packages]]
 name = "stack-data"
 version = "0.6.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/stack_data-0.6.3-8-py3-none-any.whl", hashes = { sha256 = "d2732cac3d995934d521100fd86fda953e6440cfe0dabda5bbd6c7682abf238c" } }]
 
 [[packages]]
 name = "starlette"
 version = "0.50.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/starlette-0.50.0-8-py3-none-any.whl", hashes = { sha256 = "30673b3f4ddfbf34d84b31153e6cac0c797930192a7e8ee16c9933f437a3cbdc" } }]
 
 [[packages]]
 name = "sympy"
 version = "1.14.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/sympy-1.14.0-8-py3-none-any.whl", hashes = { sha256 = "3c0b1216cc4af49a4b912d6c9e86d2cdad9bdf315eff8c7f3c0cc3202564da0d" } }]
 
 [[packages]]
 name = "tabulate"
 version = "0.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tabulate-0.9.0-8-py3-none-any.whl", hashes = { sha256 = "199b9a5a1d0e096b4171389dbaa6084cffeba66430c9b3c93f3d67c905e26955" } }]
 
 [[packages]]
 name = "tenacity"
 version = "8.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tenacity-8.5.0-8-py3-none-any.whl", hashes = { sha256 = "964f22c9b82b2442a8dd8dfec29cd77348418d3858facb392cbba167350d5f03" } }]
 
 [[packages]]
 name = "tensorboard"
 version = "2.20.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tensorboard-2.20.0-py3-none-any.whl", hashes = { sha256 = "9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6" } }]
 
 [[packages]]
 name = "tensorboard-data-server"
 version = "0.7.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tensorboard_data_server-0.7.2-py3-none-any.whl", hashes = { sha256 = "7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb" } }]
 
 [[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/threadpoolctl-3.6.0-8-py3-none-any.whl", hashes = { sha256 = "2b33a342d659cde31c4d203066471df28f4a1327705265ce2faa9e4a9c3ddb4f" } }]
 
 [[packages]]
 name = "tinycss2"
 version = "1.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tinycss2-1.4.0-8-py3-none-any.whl", hashes = { sha256 = "bac676c9e4522bfc4f154cf0720daf8212505a44ecdcf71ea75be463028ace48" } }]
 
 [[packages]]
 name = "toml"
 version = "0.10.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/toml-0.10.2-8-py2.py3-none-any.whl", hashes = { sha256 = "45455f8961ae76d8159495fb62a21eed4c659eef17a22d44686c762963e5e2d0" } }]
 
 [[packages]]
 name = "toolz"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/toolz-1.1.0-8-py3-none-any.whl", hashes = { sha256 = "cc9c5a7ba0b6568818d22638f61f0b082ac91779a44360f42e51150b1da8c5d6" } }]
 
 [[packages]]
 name = "torch"
 version = "2.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/torch-2.9.0-13-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e6fce45cd01d82c8053218c922f4344cf25dc540b5ceb3c5eb8e305b204277ba" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/torch-2.9.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "0c8d4a027a93c4e752db2f4f0cce5856812c968e6da5cda0d3f8a611e2ce3a93" } },
@@ -973,7 +1219,7 @@ wheels = [
 [[packages]]
 name = "torchvision"
 version = "0.24.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/torchvision-0.24.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "82dc286d83c02dded23470ba17856f89100cd78d30337232785e99894c445b02" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/torchvision-0.24.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "6c68d11c1d9d740c9c8b25b23799d5206b163128580169457958ea4868067c87" } },
@@ -982,7 +1228,7 @@ wheels = [
 [[packages]]
 name = "tornado"
 version = "6.5.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "f5dd072e394a41ed0cf4eee00bf35955f4795419b62a8efd70061d2a8da6657e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "260a758b4cd58e3a5b3e7e9d657d20da9e5692311733ff93077060cbe32789f5" } },
@@ -991,19 +1237,19 @@ wheels = [
 [[packages]]
 name = "tqdm"
 version = "4.67.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tqdm-4.67.2-8-py3-none-any.whl", hashes = { sha256 = "6875fff58389b1861683b163c53cb0a0bca0ce7a5ea2d843d9a6f347ae5182db" } }]
 
 [[packages]]
 name = "traitlets"
 version = "5.14.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/traitlets-5.14.3-8-py3-none-any.whl", hashes = { sha256 = "c3258b0c94f161c5950fae2e75bc7758ac6fe3e86b25bb17488c331f8c602d0d" } }]
 
 [[packages]]
 name = "triton"
 version = "3.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/triton-3.5.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "55965ef65d99e63026e127e121959b5d9e334fdd40dd776706e94339ec02d0a1" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/triton-3.5.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ffb68096b9d9354b4c9b9c2662e413a18ba80d6322dbbcd620195f7359a10055" } },
@@ -1012,58 +1258,64 @@ wheels = [
 [[packages]]
 name = "typeguard"
 version = "4.4.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/typeguard-4.4.4-8-py3-none-any.whl", hashes = { sha256 = "561cfadd21e86719178be605ce2d733463b82be74a2afe087b79922e47c42d2e" } }]
 
 [[packages]]
 name = "typing-extensions"
 version = "4.15.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/typing_extensions-4.15.0-8-py3-none-any.whl", hashes = { sha256 = "5feadf55498331dbfc73bb1c3bd5352fa307def2eb53d39cf9240b33baabf273" } }]
 
 [[packages]]
 name = "typing-inspection"
 version = "0.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/typing_inspection-0.4.2-8-py3-none-any.whl", hashes = { sha256 = "81411036caaf39bf7a8d2d2970ad6df4585c8f48017cc69562c1f8252b1ccb04" } }]
 
 [[packages]]
 name = "tzdata"
 version = "2025.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/tzdata-2025.3-8-py2.py3-none-any.whl", hashes = { sha256 = "62ad6e28923d20b31af69bfdea8dacdaf6de170929d6a17b829aff7a88507304" } }]
 
 [[packages]]
 name = "urllib3"
 version = "2.6.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/urllib3-2.6.3-8-py3-none-any.whl", hashes = { sha256 = "9cf6bec9f4b46daf2e07170eae9a0798b61070a57ff36919dffadc0da8594d06" } }]
 
 [[packages]]
 name = "uvicorn"
 version = "0.34.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/uvicorn-0.34.0-8-py3-none-any.whl", hashes = { sha256 = "7001560081ed52f9ca0ed9868c69bb82bd212c7418fa940f9f4f2900faf38345" } }]
 
 [[packages]]
 name = "uvicorn-worker"
 version = "0.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/uvicorn_worker-0.3.0-9-py3-none-any.whl", hashes = { sha256 = "c4b538de52be6346031ee244aaf4a153510d239b5b2217dd66a7bac13b86b301" } }]
 
 [[packages]]
 name = "uvloop"
 version = "0.22.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/uvloop-0.22.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "0219061d351e8e0af574bb98c9b3e1495bd0372336bccb9e54ede86f6033ec0d" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/uvloop-0.22.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1fe03605911890509f18ef610ede110ccfe079431488434b4f65467c9be02bd3" } },
 ]
 
 [[packages]]
+name = "virtualenv"
+version = "20.36.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/virtualenv-20.36.1-8-py3-none-any.whl", hashes = { sha256 = "a4ed3477e28d87de9c6e12c4e1d69ee61897ded82f247b108319c2fa565f24cd" } }]
+
+[[packages]]
 name = "watchfiles"
 version = "1.1.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/watchfiles-1.1.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c2b249bda757b23cba6c4a0fb48c0f3537f0f3f049c5555890253166b649df0a" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/watchfiles-1.1.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "6996fea7e823a3772690bea8a84043607eaa669fed87955fd9636b7d70d5a8ca" } },
@@ -1072,19 +1324,25 @@ wheels = [
 [[packages]]
 name = "wcwidth"
 version = "0.5.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/wcwidth-0.5.3-8-py3-none-any.whl", hashes = { sha256 = "93a693b42d09549c0ba4ee7435e761a5727da3a548fc98c0f75231833bc08b37" } }]
 
 [[packages]]
 name = "webencodings"
 version = "0.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/webencodings-0.5.1-8-py2.py3-none-any.whl", hashes = { sha256 = "4e3f083e126c0936eb21d01f8fbc530dc766bac1ef9617b16c55607903954da1" } }]
+
+[[packages]]
+name = "websocket-client"
+version = "1.9.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/websocket_client-1.9.0-8-py3-none-any.whl", hashes = { sha256 = "0e7b602c6b3b0d257775d7bc78abcfd252807826e91f04a4e05991fb0ccd4a7e" } }]
 
 [[packages]]
 name = "websockets"
 version = "16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/websockets-16.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "6624f6e3642ff3e52285a5c7eb353abee705a95f87df4c545399a260a02f8ba2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/websockets-16.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7a0e2067d854293e02e1727a1353f1961aaddbd6b74dee26297847ff2892d1f8" } },
@@ -1093,23 +1351,44 @@ wheels = [
 [[packages]]
 name = "werkzeug"
 version = "3.1.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/werkzeug-3.1.5-8-py3-none-any.whl", hashes = { sha256 = "1105b919127784827722d5e091fe8a4b1a6e0cef991cea7e5e6f27dd09a645b5" } }]
 
 [[packages]]
 name = "wheel"
 version = "0.46.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/wheel-0.46.3-8-py3-none-any.whl", hashes = { sha256 = "658bdf1e3611dfa8a73f9777c1300723ebbb6db4f70a6c6f66a05e757aba1730" } }]
+
+[[packages]]
+name = "widgetsnbextension"
+version = "4.0.15"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/widgetsnbextension-4.0.15-8-py3-none-any.whl", hashes = { sha256 = "397974e955b5e21d84621ec82b001b9fed3bbc3562c8a59a04e737dee630f4a2" } }]
+
+[[packages]]
+name = "wrapt"
+version = "2.1.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/wrapt-2.1.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "612384476b9d11027d318ee601249fa9505397d877d109e724d06a1afd69078e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/wrapt-2.1.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "70cd59427a242e29fbd842b7614d04dcdeac38120bff169caa4902a43691aead" } },
+]
 
 [[packages]]
 name = "yarl"
 version = "1.22.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/yarl-1.22.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "8ce7dd328e59cca7bc2967fbc6363d101f0597f420380d13edfa7b752b109b72" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/yarl-1.22.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c8a2c95689f5288b42b04561b471afd2550916c9b3c3ca2fdd00337e49dc0a7e" } },
 ]
+
+[[packages]]
+name = "zipp"
+version = "3.23.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cuda12.9-ubi9/zipp-3.23.0-8-py3-none-any.whl", hashes = { sha256 = "ed2c789b6794a5a4ff83da99a56d2435f4f7b96bc21360d8d44134082f41ccb7" } }]
 
 # The following packages were excluded from the output:
 # odh-notebooks-meta-runtime-elyra-deps

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -11,8 +11,7 @@ dependencies = [
     "triton~=3.5.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
-    # "codeflare-sdk~=0.34.0",
+    "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
     "odh-notebooks-meta-runtime-datascience-deps",
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -7,980 +7,1238 @@ requires-python = ">=3.12"
 [[packages]]
 name = "absl-py"
 version = "2.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/absl_py-2.4.0-12-py3-none-any.whl", hashes = { sha256 = "87bdbb903f3f51c38114c48a260bdbf4b8e00a24e30a4c2714353791e8957a4b" } }]
 
 [[packages]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/aiohappyeyeballs-2.6.1-12-py3-none-any.whl", hashes = { sha256 = "7098e8746f5dfe0b11b57dbb3427233bab1936771d6847186ebba27f2c62aa33" } }]
 
 [[packages]]
 name = "aiohttp"
 version = "3.13.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/aiohttp-3.13.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1cbefc6957ffe41e6e08aa24b5065c874357f9cc7aa375a1a1af3aa2c5a88c34" } }]
+
+[[packages]]
+name = "aiohttp-cors"
+version = "0.8.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/aiohttp_cors-0.8.1-12-py3-none-any.whl", hashes = { sha256 = "f82e739a4997d7b774043a577395ecc6f410c1f8ad7a9ce82128c36aa4c9cf82" } }]
 
 [[packages]]
 name = "aiosignal"
 version = "1.4.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/aiosignal-1.4.0-12-py3-none-any.whl", hashes = { sha256 = "426fb8a0b7b4c89afed202a2f03c07125f3d153ab19993a367f3df2d8163e4a0" } }]
 
 [[packages]]
 name = "annotated-doc"
 version = "0.0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/annotated_doc-0.0.4-12-py3-none-any.whl", hashes = { sha256 = "cf0d2893e6a43cbf8bd457d13409fbe6cc3f1232316237b4c3a71926de809569" } }]
 
 [[packages]]
 name = "annotated-types"
 version = "0.7.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/annotated_types-0.7.0-12-py3-none-any.whl", hashes = { sha256 = "aff144f6a0596cb63e62ad2341b439b30f5024f6c1fbb7868d9d52138961b5f0" } }]
 
 [[packages]]
 name = "ansicolors"
 version = "1.1.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ansicolors-1.1.8-12-py3-none-any.whl", hashes = { sha256 = "fafbf6dc7a3b7fadeda098de2e2721e36707ff699b7c779843d50a98f6b52527" } }]
 
 [[packages]]
 name = "anyio"
 version = "4.12.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/anyio-4.12.1-12-py3-none-any.whl", hashes = { sha256 = "896f68b97f81bd78c84cacc7f498bf397d16d2f84efc22283d0459225a2c6ab1" } }]
 
 [[packages]]
 name = "argon2-cffi"
 version = "25.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/argon2_cffi-25.1.0-12-py3-none-any.whl", hashes = { sha256 = "f4d86f56507a60bac418b19d7553978917c8b068da5439df6f68e90359e77337" } }]
 
 [[packages]]
 name = "argon2-cffi-bindings"
 version = "25.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/argon2_cffi_bindings-25.1.0-12-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "ae174c7a2376d7db64e4268ee22d09fc6d145b4375271fcdc046309522b42b5f" } }]
 
 [[packages]]
 name = "asttokens"
 version = "3.0.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/asttokens-3.0.1-12-py3-none-any.whl", hashes = { sha256 = "442902ab6d598693fda0e3c5b5a922c64d3c2b86eba431402f7aa1f1dc7b2797" } }]
 
 [[packages]]
 name = "attrs"
 version = "25.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/attrs-25.4.0-12-py3-none-any.whl", hashes = { sha256 = "072d25a509489d22c86e11ec4200909515864d86ecf47f120378f224abb48051" } }]
+
+[[packages]]
+name = "bcrypt"
+version = "5.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/bcrypt-5.0.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "068ff31f8734dd984ee7780ec66c7b63e16a04d97cbb083ec7af9662eefecab8" } }]
 
 [[packages]]
 name = "beautifulsoup4"
 version = "4.14.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/beautifulsoup4-4.14.3-12-py3-none-any.whl", hashes = { sha256 = "d77b90e743eeecc8942c8250a8d93d2747934857ca06bf31df686ede86b3bccf" } }]
 
 [[packages]]
 name = "bigtree"
 version = "1.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/bigtree-1.3.0-12-py3-none-any.whl", hashes = { sha256 = "82b90373d89d0ba0cd54bd047013ca787347c16de101635ac429dc96059c658b" } }]
 
 [[packages]]
 name = "bleach"
 version = "6.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/bleach-6.3.0-12-py3-none-any.whl", hashes = { sha256 = "0678a6725c72002120daa4b7e57624a0c8ff9c8b45ef19ccc6e2db55059eeabf" } }]
 
 [[packages]]
 name = "boto3"
 version = "1.42.40"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/boto3-1.42.40-12-py3-none-any.whl", hashes = { sha256 = "208fd106d5fa232df05d110c0fabbc0896d5091fd1b4f962ccbc45adfcaac06f" } }]
 
 [[packages]]
 name = "botocore"
 version = "1.42.40"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/botocore-1.42.40-12-py3-none-any.whl", hashes = { sha256 = "acb82414c23685eac854feea12c306a3dd196b8794948d9a7c1ac71d3234a70c" } }]
 
 [[packages]]
 name = "certifi"
 version = "2026.1.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/certifi-2026.1.4-12-py3-none-any.whl", hashes = { sha256 = "d59a769e1d4f460b83f06cf8cb21c6214d09de35c8e4a0f7b864daf6734e3881" } }]
 
 [[packages]]
 name = "cffi"
 version = "2.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cffi-2.0.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3356287e9bea4ba17048522adafc40d43bec25321a394b055fc030cd7d559f12" } }]
 
 [[packages]]
 name = "charset-normalizer"
 version = "3.4.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/charset_normalizer-3.4.4-12-py3-none-any.whl", hashes = { sha256 = "b75947f60de7425d3b6e2c2d403837d1c64b608266681b71a0ba75f2788c586e" } }]
 
 [[packages]]
 name = "click"
-version = "8.3.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/click-8.3.1-12-py3-none-any.whl", hashes = { sha256 = "de34f1a288b1d470da10a826e87d03732f6f22b76a77ece0d96c7871194a028d" } }]
+version = "8.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/click-8.2.1-12-py3-none-any.whl", hashes = { sha256 = "3930e2afa8975692a68d9bfc319f6e4cbea69db02b0e0f00036303f9c642d20f" } }]
 
 [[packages]]
 name = "cloudpickle"
 version = "3.1.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cloudpickle-3.1.2-12-py3-none-any.whl", hashes = { sha256 = "d333edb233fa3c1ea649de041c997b55ed2ee51756f62b92ce03d2601ad04976" } }]
+
+[[packages]]
+name = "codeflare-sdk"
+version = "0.34.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/codeflare_sdk-0.34.0-12-py3-none-any.whl", hashes = { sha256 = "5e33e402326260bf4468f5d0477d081de447b806e643cd202f3f25f4323b79d5" } }]
 
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/colorama-0.4.6-12-py2.py3-none-any.whl", hashes = { sha256 = "ce49679c36d7cba422c64ef88bff417a5148fcf5bb008fa612a1c63b4f560e5f" } }]
+
+[[packages]]
+name = "colorful"
+version = "0.5.8"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/colorful-0.5.8-12-py2.py3-none-any.whl", hashes = { sha256 = "bbe0a47c0d11451b0ed8ebe96ed0329d3df2c563ca7e52c45cd03fc401510fd6" } }]
 
 [[packages]]
 name = "comm"
 version = "0.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/comm-0.2.3-12-py3-none-any.whl", hashes = { sha256 = "55e38441286ed4b69db40bcc63104353260c38eef55503cd8ad73b4c46603316" } }]
 
 [[packages]]
 name = "contourpy"
 version = "1.3.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/contourpy-1.3.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b2686838e583cb0ae846689356682f9082ad20e49c3d351f73a477925fd78854" } }]
+
+[[packages]]
+name = "cryptography"
+version = "46.0.3"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cryptography-46.0.3-12-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "49e8e68a2886c9774bcded159876a7fd1571594cda62e0d4b456d38820e55e15" } }]
 
 [[packages]]
 name = "cycler"
 version = "0.12.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/cycler-0.12.1-12-py3-none-any.whl", hashes = { sha256 = "d755e9120ded94296a8bfa57571858762ccaf088a18e26397606e1c68806a185" } }]
 
 [[packages]]
 name = "dask"
 version = "2026.1.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/dask-2026.1.2-12-py3-none-any.whl", hashes = { sha256 = "e8bd895fd0cdd9490fef67fafc48f203e90df90ddf27d28d3b968e9d9828a997" } }]
 
 [[packages]]
 name = "debugpy"
 version = "1.8.20"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/debugpy-1.8.20-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "f9583bed658f803d3447a6fc5f5b55a519ac67e6bbd4272ac0a377eff339281d" } }]
 
 [[packages]]
 name = "decorator"
 version = "5.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/decorator-5.2.1-12-py3-none-any.whl", hashes = { sha256 = "e33c865e8dc8e9e8e2bd344062f32aabf94ef22355d61cf3255200ac0b37f2f4" } }]
 
 [[packages]]
 name = "defusedxml"
 version = "0.7.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/defusedxml-0.7.1-12-py2.py3-none-any.whl", hashes = { sha256 = "a8b061f3e9d228bcf71c75a1020d7e13f100945ff6c36b687669216ba3ae51e9" } }]
 
 [[packages]]
 name = "dill"
 version = "0.3.9"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/dill-0.3.9-12-py3-none-any.whl", hashes = { sha256 = "a3b61f5d01365991bd13ae167992e7cdbe3defdcce4604af16fdc73ef949c69c" } }]
+
+[[packages]]
+name = "distlib"
+version = "0.4.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/distlib-0.4.0-12-py2.py3-none-any.whl", hashes = { sha256 = "9893c8d3ae9adc621ca561f101f46815ed4b928ccf8a7d5eb88f923ee4b8a2b4" } }]
 
 [[packages]]
 name = "dnspython"
 version = "2.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/dnspython-2.8.0-12-py3-none-any.whl", hashes = { sha256 = "dccf35e1501d5cdca48ad92f2679cab11eaf92e6407dff168aef777c2e9bcbb7" } }]
+
+[[packages]]
+name = "durationpy"
+version = "0.10"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/durationpy-0.10-12-py3-none-any.whl", hashes = { sha256 = "b158266e0796dad2476ea9e276ca02cc35fcc58890ba4750f6cecd8ae4a8eab2" } }]
 
 [[packages]]
 name = "entrypoints"
 version = "0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/entrypoints-0.4-12-py3-none-any.whl", hashes = { sha256 = "247bf60a78aff9bb89899240fc5a34f3aa10986469855345ca7197e8ce479832" } }]
 
 [[packages]]
 name = "executing"
-version = "2.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/executing-2.2.1-12-py2.py3-none-any.whl", hashes = { sha256 = "4f6b4754388c66c50d266bf6cc2d36fd30a4282fb8e0cf7cf3536b333bdf233c" } }]
+version = "1.2.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/executing-1.2.0-12-py2.py3-none-any.whl", hashes = { sha256 = "493e100dd9835dbfbe2e552bcf854fd5155be133a0f21aac5c17ce030cf7f76d" } }]
 
 [[packages]]
 name = "fastapi"
 version = "0.128.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/fastapi-0.128.0-12-py3-none-any.whl", hashes = { sha256 = "49817f402a2144593960d82fada4476067852739c4b8b032705a504c78ba5549" } }]
 
 [[packages]]
 name = "fastjsonschema"
 version = "2.21.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/fastjsonschema-2.21.2-12-py3-none-any.whl", hashes = { sha256 = "ffd02805835bcd517eb50982cca4adaf01f45a7a99b68709d14728df37b848ac" } }]
 
 [[packages]]
 name = "feast"
 version = "0.59.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/feast-0.59.0-12-py2.py3-none-any.whl", hashes = { sha256 = "7caf7fae8422c5554634acbdb775ac0cb3465816729c9fa1258b157d54061dd9" } }]
 
 [[packages]]
 name = "filelock"
 version = "3.20.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/filelock-3.20.3-12-py3-none-any.whl", hashes = { sha256 = "fe250756a0ec4ab7f16d51df9fda7919e2d410d1b57348e66f3a1caa0c30cf33" } }]
 
 [[packages]]
 name = "fonttools"
 version = "4.61.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/fonttools-4.61.1-12-py3-none-any.whl", hashes = { sha256 = "9b29c21a9667ba8a4afe73a8ad9729db0d4abb7372c579853ba0295a8e461a82" } }]
 
 [[packages]]
 name = "frozenlist"
 version = "1.8.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/frozenlist-1.8.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "89b3d50cb7ad54c1145bb7fbf458784d698689ed082fc7eb918f4fe560ba1085" } }]
 
 [[packages]]
 name = "fsspec"
 version = "2026.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/fsspec-2026.1.0-12-py3-none-any.whl", hashes = { sha256 = "c763c56fa973f393399f0403bba19e7d6ecf0a89b9acd3c2377a9a89432c5431" } }]
+
+[[packages]]
+name = "google-api-core"
+version = "2.29.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/google_api_core-2.29.0-12-py3-none-any.whl", hashes = { sha256 = "9374566d1bbf319f3dd194ec80bb78660d38d5ad3095b47401363b06826149ad" } }]
+
+[[packages]]
+name = "google-auth"
+version = "2.48.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/google_auth-2.48.0-12-py3-none-any.whl", hashes = { sha256 = "6eff6e3821a68aa15b20e53560256f3e9bf6b6a1cf60db1923e4d7244dc6f7ad" } }]
+
+[[packages]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/googleapis_common_protos-1.72.0-12-py3-none-any.whl", hashes = { sha256 = "f4396b64fbc53961a575a645df0a451d12c04d123522a86bdd8148a5bb5fc0ef" } }]
 
 [[packages]]
 name = "greenlet"
 version = "3.3.1"
-marker = "(python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+marker = "(implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/greenlet-3.3.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8498ff045e9ccb55bbaa7a8bdf6b0fdf9ad80cdd0f7dd59279cd17154a77e8f9" } }]
 
 [[packages]]
 name = "grpcio"
 version = "1.76.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/grpcio-1.76.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4259e0d366d9ee5cf348b8d537e081d1d13c9d926295cb7ae5a6a696a082e14c" } }]
 
 [[packages]]
 name = "gunicorn"
 version = "25.0.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/gunicorn-25.0.1-12-py3-none-any.whl", hashes = { sha256 = "331aca841c0175f070a21c98da0a9c432cd1592317d236e8beaa52e40ed4fbed" } }]
 
 [[packages]]
 name = "h11"
 version = "0.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/h11-0.16.0-12-py3-none-any.whl", hashes = { sha256 = "40b223310f9670ef1e29def08b6740c65c4e1b28f5eab9564ad6009297f86ed6" } }]
 
 [[packages]]
 name = "httptools"
 version = "0.7.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/httptools-0.7.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5e66b192d9dcc93fe7043caad086c21159428d73f734627d06b111fb5108446f" } }]
 
 [[packages]]
 name = "idna"
 version = "3.11"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/idna-3.11-12-py3-none-any.whl", hashes = { sha256 = "6f425e5e5233c4a53940fa17990fd6a68960047888635a72d76dcbf22ffb098d" } }]
+
+[[packages]]
+name = "importlib-metadata"
+version = "8.7.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/importlib_metadata-8.7.1-12-py3-none-any.whl", hashes = { sha256 = "f852453a394808c9913e78d92a3779a1e2483c7793f533d66fc00c55933bb9a1" } }]
+
+[[packages]]
+name = "invoke"
+version = "2.2.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/invoke-2.2.1-12-py3-none-any.whl", hashes = { sha256 = "59bcacd733ad8eba1763240ad52cf0ead14cedd8857acdfec1c8cd2d3ec375c9" } }]
 
 [[packages]]
 name = "ipykernel"
 version = "7.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipykernel-7.1.0-12-py3-none-any.whl", hashes = { sha256 = "08e7fa6cbe41bba05378b380adec9ad4e09a3a73f336e09602e43e623f20c92c" } }]
 
 [[packages]]
 name = "ipython"
 version = "9.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipython-9.9.0-12-py3-none-any.whl", hashes = { sha256 = "af3dd140fa5073a56c952a22935fd56b8858d9845e5e258e1175664ec78ca630" } }]
 
 [[packages]]
 name = "ipython-genutils"
 version = "0.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipython_genutils-0.2.0-12-py2.py3-none-any.whl", hashes = { sha256 = "e8d6329223dad5dbdf754f5186c022f41b29506f5cd76925b022c2c38d7e401c" } }]
 
 [[packages]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipython_pygments_lexers-1.1.1-12-py3-none-any.whl", hashes = { sha256 = "9c3c471d40e848d13984cb21b7daa8c1441394c69d2919fd66034228632f43f3" } }]
+
+[[packages]]
+name = "ipywidgets"
+version = "8.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ipywidgets-8.1.2-12-py3-none-any.whl", hashes = { sha256 = "b6f5cd501b328012abfc07afc02c2a3712e387eb3df4ef562108a33b63c7f0cd" } }]
 
 [[packages]]
 name = "jedi"
 version = "0.19.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jedi-0.19.2-12-py2.py3-none-any.whl", hashes = { sha256 = "b6f4ea13f2daa2ec6d32d26feb3a60ca19ae5052329a8cdd24861ba0b49003fb" } }]
 
 [[packages]]
 name = "jinja2"
 version = "3.1.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jinja2-3.1.6-12-py3-none-any.whl", hashes = { sha256 = "a6bb9f3f819098532595560c6ef31bec3ac0e72e525b68912e8e49229793c855" } }]
 
 [[packages]]
 name = "jmespath"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jmespath-1.1.0-12-py3-none-any.whl", hashes = { sha256 = "e1bc3f133d4a8b3ff9f553bdaf2dbff9cef891a4d1b65f8912cca09fba82fc2b" } }]
 
 [[packages]]
 name = "joblib"
 version = "1.5.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/joblib-1.5.3-12-py3-none-any.whl", hashes = { sha256 = "79cf6cea073d4496e9b2ad082d6f5b6b36dabd214811299aca2e23e794a3045e" } }]
 
 [[packages]]
 name = "jsonschema"
 version = "4.26.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jsonschema-4.26.0-12-py3-none-any.whl", hashes = { sha256 = "13dd4e4d2efeea0e1649b9085adf085c695b6f880ccb7cfd7273198920c62726" } }]
 
 [[packages]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jsonschema_specifications-2025.9.1-12-py3-none-any.whl", hashes = { sha256 = "bf529b2383d50ff6067ffa866e2c9587065d8a39ee2a6a0bd0bfb635cb0deda8" } }]
 
 [[packages]]
 name = "jupyter-client"
 version = "8.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jupyter_client-8.8.0-12-py3-none-any.whl", hashes = { sha256 = "743775cd5df15a83782e3bcd834360fbf54505af95504cdbffc3c5db41790110" } }]
 
 [[packages]]
 name = "jupyter-core"
 version = "5.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jupyter_core-5.9.1-12-py3-none-any.whl", hashes = { sha256 = "07b966674578272439aae7fd8474234e0b6d8818497476e61c6537d2932d2ade" } }]
 
 [[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jupyterlab_pygments-0.3.0-13-py3-none-any.whl", hashes = { sha256 = "e471ec6514339cb9aeaccf5b32a529a1ce20d5e35ee66f3223e9df97c4f31f1d" } }]
+
+[[packages]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/jupyterlab_widgets-3.0.16-12-py3-none-any.whl", hashes = { sha256 = "c876d00a9da7290ca1d48a0b5645bd8e4b724c7cbc5ec23404c2c43b1a64802a" } }]
 
 [[packages]]
 name = "kafka-python-ng"
 version = "2.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/kafka_python_ng-2.2.3-12-py2.py3-none-any.whl", hashes = { sha256 = "17ea4703e77d293f56b57d5e44eabaa3b5950f52a73249b87291ccdba27a3d5b" } }]
 
 [[packages]]
 name = "kiwisolver"
 version = "1.4.9"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/kiwisolver-1.4.9-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1a6498902ec111eaa966aed93607b852cebdd0f98142697eaecb6ee9a3a78f66" } }]
+
+[[packages]]
+name = "kubernetes"
+version = "35.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/kubernetes-35.0.0-12-py3-none-any.whl", hashes = { sha256 = "b6fd3bca38c9c0a33781c2970f4ba209d04e4f9773dff13aad1339d1d16d25a5" } }]
 
 [[packages]]
 name = "librt"
 version = "0.7.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/librt-0.7.8-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "71b8e1c92b67ca1aafea3267ae30a3386f9fefca31189cd05f59c9abadf095e3" } }]
 
 [[packages]]
 name = "locket"
 version = "1.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/locket-1.0.0-12-py2.py3-none-any.whl", hashes = { sha256 = "c11a501218401ad08d0f5bdc71ed8009513839472b8106a021e7041956c76409" } }]
 
 [[packages]]
 name = "markdown"
 version = "3.10.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/markdown-3.10.1-12-py3-none-any.whl", hashes = { sha256 = "ba04ed8d42fe1acfb83d543719efb3ebb6e03363756528468c48c2d01ae0f398" } }]
+
+[[packages]]
+name = "markdown-it-py"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/markdown_it_py-4.0.0-12-py3-none-any.whl", hashes = { sha256 = "afb3064e67dfe1384935f0dd8c854008d2b960c75323274da77e88a0e07dd338" } }]
 
 [[packages]]
 name = "markupsafe"
 version = "3.0.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/markupsafe-3.0.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1a1da02b65d1e3e279dad51f549d451cec1b437d5713ed6578a0efee00ad738f" } }]
 
 [[packages]]
 name = "matplotlib"
 version = "3.10.8"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/matplotlib-3.10.8-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "0ac94c6bf30589e89fb294a5ddbbd85c99db2aacfff5cf1f1c481d4f072ff6aa" } }]
 
 [[packages]]
 name = "matplotlib-inline"
 version = "0.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/matplotlib_inline-0.2.1-12-py3-none-any.whl", hashes = { sha256 = "11ee58c96d1d18f23eb05797db8f9e4e06b29a35439e99058c5f53b7d49fa724" } }]
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mdurl-0.1.2-12-py3-none-any.whl", hashes = { sha256 = "e2894d70e354c982d72ab3dcd21762bef602816c40aa1f7e90e5329d194a8d2f" } }]
 
 [[packages]]
 name = "minio"
 version = "7.2.20"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/minio-7.2.20-12-py3-none-any.whl", hashes = { sha256 = "9d4f1d1009a0465c09e270f92b9bcff5796104d1c188bea455b6e660c3a31b4c" } }]
 
 [[packages]]
 name = "mistune"
 version = "3.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mistune-3.2.0-12-py3-none-any.whl", hashes = { sha256 = "9446170559304f362cfe599941a979ac428be89fbb00f3c4a81ee901c2c2d045" } }]
 
 [[packages]]
 name = "ml-dtypes"
 version = "0.5.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ml_dtypes-0.5.4-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b6643ae63e256dbca63d44167760c438ae8b0472037618f1381a6980d8f67045" } }]
 
 [[packages]]
 name = "mmh3"
 version = "5.2.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mmh3-5.2.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "fb74ebb556869d3c7fd21c787b715185a5f3800adb411c41be199f2eb81bd3a5" } }]
 
 [[packages]]
 name = "mpmath"
 version = "1.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mpmath-1.3.0-12-py3-none-any.whl", hashes = { sha256 = "c508c340bce1fe5ef512f2fc2d07c0ebd2279e4b8140f46e40063f69b544bdd7" } }]
+
+[[packages]]
+name = "msgpack"
+version = "1.1.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/msgpack-1.1.2-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "53c2cbd4ff9f9d2b6546e9953c728bd42037938b4bb583fab999bc15461ed610" } }]
 
 [[packages]]
 name = "multidict"
 version = "6.7.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/multidict-6.7.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a1ef1503b191a4e9b92acbe14d697b8e5f356994a9fe64c1ef3005e49b503494" } }]
 
 [[packages]]
 name = "mypy"
 version = "1.19.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mypy-1.19.1-12-py3-none-any.whl", hashes = { sha256 = "321367bc05080ae7e5d63d25bd60080b95297be60b7425bc5c7d21c09c575aeb" } }]
 
 [[packages]]
 name = "mypy-extensions"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mypy_extensions-1.1.0-12-py3-none-any.whl", hashes = { sha256 = "e2475f631b65f6faf1d6cd5eeb54c02b0acdfd0dbbff422e1b1a8c8a3bf738cc" } }]
 
 [[packages]]
 name = "mysql-connector-python"
 version = "9.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/mysql_connector_python-9.5.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e3b9cf04a64059fac9807c3ab691c6fa57def1a67b2fb1d148095865c3c40541" } }]
 
 [[packages]]
 name = "narwhals"
 version = "2.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/narwhals-2.16.0-12-py3-none-any.whl", hashes = { sha256 = "9ae374797b92f014b21fa1775f8d8eb40162067a50ed7867f056e88bfdd7f85b" } }]
 
 [[packages]]
 name = "nbclient"
 version = "0.10.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/nbclient-0.10.4-12-py3-none-any.whl", hashes = { sha256 = "63ac046e325a5b9bcfaabf54cae34ed623c7cc340ddf8e9be0385140f382a75b" } }]
 
 [[packages]]
 name = "nbconvert"
 version = "7.16.6"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/nbconvert-7.16.6-12-py3-none-any.whl", hashes = { sha256 = "5f3f39819aaa7e052e04dc5d16766de9c7bb753605fd8e9f2182b268dabc6f10" } }]
 
 [[packages]]
 name = "nbformat"
 version = "5.10.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/nbformat-5.10.4-12-py3-none-any.whl", hashes = { sha256 = "f942cc17c1e0c15414c80f57401cab68efcda310cefe6b25cbfcb5e3fc1ffdc7" } }]
 
 [[packages]]
 name = "nest-asyncio"
 version = "1.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/nest_asyncio-1.6.0-12-py3-none-any.whl", hashes = { sha256 = "e212e60467c9091ba5ecfc27bafe799a3242dc0a792fd6db5efb682b38b497f8" } }]
 
 [[packages]]
 name = "networkx"
 version = "3.6.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/networkx-3.6.1-12-py3-none-any.whl", hashes = { sha256 = "4b9c1831e2c3d5d728265bd4594b61804226368d31de8134c14016e1c75afcb9" } }]
 
 [[packages]]
 name = "numpy"
 version = "2.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/numpy-2.4.2-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "cd36af19c4a664024421b00d38fd37f694c6c1e948f169c701bcacf88c76a90d" } }]
+
+[[packages]]
+name = "oauthlib"
+version = "3.3.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/oauthlib-3.3.1-12-py3-none-any.whl", hashes = { sha256 = "e7b3dd6f1775834f640839afc91f5fe6aeb490c1b25c2f7f7fd33ead79ba4c75" } }]
 
 [[packages]]
 name = "onnx"
 version = "1.20.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/onnx-1.20.0-14-cp312-abi3-linux_x86_64.whl", hashes = { sha256 = "f360a63410e8cb18fae1ac5045faf465049f9e059137bd762e7635894e162b9f" } }]
 
 [[packages]]
 name = "onnxconverter-common"
 version = "1.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/onnxconverter_common-1.16.0-14-py2.py3-none-any.whl", hashes = { sha256 = "c631a0fcd6c333ad685c7441e62f1b11a38d1309ccae7386e0b72db2ede4c696" } }]
+
+[[packages]]
+name = "opencensus"
+version = "0.11.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opencensus-0.11.4-12-py2.py3-none-any.whl", hashes = { sha256 = "f0c5f4db0985af9f1fa3ceb701ebd0414f1c38b4076b343fe126c0729ec82a5d" } }]
+
+[[packages]]
+name = "opencensus-context"
+version = "0.1.3"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opencensus_context-0.1.3-12-py2.py3-none-any.whl", hashes = { sha256 = "b22604c803332a64f8bce6c242b82901fc9055c8dd0316dba84965d337593cfe" } }]
+
+[[packages]]
+name = "openshift-client"
+version = "1.0.18"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/openshift_client-1.0.18-12-py2.py3-none-any.whl", hashes = { sha256 = "0410a0dc421bdec9aca784173d888d7d4af814c97013f1e4c066159c7461dbe7" } }]
+
+[[packages]]
+name = "opentelemetry-api"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_api-1.39.1-12-py3-none-any.whl", hashes = { sha256 = "6e88b9a64b2da4c537f875687b7f05bbf4bb7c93bc33fe59abebdd0e41145a82" } }]
+
+[[packages]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_exporter_prometheus-0.60b1-12-py3-none-any.whl", hashes = { sha256 = "edc6a6ee983f0ac4246120b8d5dc8c69f5d77c59b5b905e71077e084224f4a0a" } }]
+
+[[packages]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_proto-1.39.1-12-py3-none-any.whl", hashes = { sha256 = "42a18b22245e3952aa71588991dde856ac5449d7bc9a3e25a70b02aa409da7b7" } }]
+
+[[packages]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_sdk-1.39.1-12-py3-none-any.whl", hashes = { sha256 = "ca6c04a79a5b986fc0ca5b1a3f76a027c19e1d6d0bc2e0457e5b4ad905e7a83d" } }]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/opentelemetry_semantic_conventions-0.60b1-12-py3-none-any.whl", hashes = { sha256 = "cf7ad2af9a289cbbc2655cf09d9f1228a0f6d7ee717b5cc2354765ec8b512bc4" } }]
 
 [[packages]]
 name = "packaging"
 version = "26.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/packaging-26.0-12-py3-none-any.whl", hashes = { sha256 = "27bd7ee27d0595c1c676f194e4d3f1d4153b5373f9e5a4dc3dfde0847e8e7d53" } }]
 
 [[packages]]
 name = "pandas"
 version = "2.3.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pandas-2.3.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a14b8bd8c61b99a8cc72604fb16831e5738a5784ac03bf9f9e8c0ba020b0cc5c" } }]
 
 [[packages]]
 name = "pandocfilters"
 version = "1.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pandocfilters-1.5.1-12-py2.py3-none-any.whl", hashes = { sha256 = "91b8ba1aaf10eb36459893a22f818324a18f7aec4af8b8449ec5c5eea666357f" } }]
 
 [[packages]]
 name = "papermill"
 version = "2.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/papermill-2.6.0-12-py3-none-any.whl", hashes = { sha256 = "92aaf5d27574a22c70ca765f38264cffffbf840ef90fe2da847c664a37e2087b" } }]
+
+[[packages]]
+name = "paramiko"
+version = "4.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/paramiko-4.0.0-12-py3-none-any.whl", hashes = { sha256 = "a92d81be86d0da61f621da8c22e2b5b607531fe0e2382c67ea0491e83b357ef9" } }]
 
 [[packages]]
 name = "parso"
 version = "0.8.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/parso-0.8.5-12-py2.py3-none-any.whl", hashes = { sha256 = "9d43dac9f1cbad156ef336e50a25926cf1944e3c543a4efa6bd3896524edbe4d" } }]
 
 [[packages]]
 name = "partd"
 version = "1.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/partd-1.4.2-12-py3-none-any.whl", hashes = { sha256 = "116cf96516a437b080ce96791d8b1734643e52171e959a3e8171ca88be46cf92" } }]
 
 [[packages]]
 name = "pathspec"
 version = "1.0.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pathspec-1.0.4-12-py3-none-any.whl", hashes = { sha256 = "caabdb865a96c744c89a6c4c88b8b3559bb9cd66e7c35b5d0f2a161cef268130" } }]
 
 [[packages]]
 name = "pexpect"
 version = "4.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pexpect-4.9.0-12-py2.py3-none-any.whl", hashes = { sha256 = "9a74af89150373e2eed4d708b491e06db6a8ccb276a422a647c4616e1726b619" } }]
 
 [[packages]]
 name = "pillow"
 version = "12.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pillow-12.1.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "84b7ebd797e5ee63f3e94f3c175dfcd7c2f0adf3eea19b6d081ff27ce996498d" } }]
 
 [[packages]]
 name = "platformdirs"
 version = "4.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/platformdirs-4.5.1-12-py3-none-any.whl", hashes = { sha256 = "e967df3385d89b0cab88f5b96c69d4b8f41aeefad86e28571b6e2d67053820f3" } }]
 
 [[packages]]
 name = "plotly"
 version = "6.5.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/plotly-6.5.2-12-py3-none-any.whl", hashes = { sha256 = "cdbbc084db618485e2fc6b3d02d7444b94de4b338c88f581d5a1ee6dd4f330ee" } }]
 
 [[packages]]
 name = "prometheus-client"
 version = "0.24.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/prometheus_client-0.24.1-12-py3-none-any.whl", hashes = { sha256 = "459e14fe26620155a5cac1f94a347204c7ac1bd72ce75b1544a22aacf0431992" } }]
 
 [[packages]]
 name = "prompt-toolkit"
 version = "3.0.52"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/prompt_toolkit-3.0.52-12-py3-none-any.whl", hashes = { sha256 = "1b5720a6241c2013b8ca01279cf4b80625f8a2cb73038638b2ca25e3e95d1b04" } }]
 
 [[packages]]
 name = "propcache"
 version = "0.4.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/propcache-0.4.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c74e4e3ce7061abe3afe37875d44cd6cfb140f50fce141586e3ecf045b21af51" } }]
+
+[[packages]]
+name = "proto-plus"
+version = "1.27.1"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/proto_plus-1.27.1-12-py3-none-any.whl", hashes = { sha256 = "815dc8eee988b8e357207627775aafb5d8e4e9edecaf936659c0196106ea8945" } }]
 
 [[packages]]
 name = "protobuf"
 version = "6.33.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/protobuf-6.33.5-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9e90baa440fa0e19d30489e6a69919adc27f43539e6bf9deb7a87d994a77d6f" } }]
 
 [[packages]]
 name = "psutil"
 version = "7.2.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/psutil-7.2.2-12-cp36-abi3-linux_x86_64.whl", hashes = { sha256 = "89e67524d18caf744653ae2d613790b6ff4d2ccf63f9caee5c30d73c1519b9c8" } }]
 
 [[packages]]
 name = "psycopg"
 version = "3.3.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/psycopg-3.3.2-12-py3-none-any.whl", hashes = { sha256 = "847ca131792a180763c9e37a01cc312af40def5215058bb9fb6b164837f162c7" } }]
 
 [[packages]]
 name = "ptyprocess"
 version = "0.7.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ptyprocess-0.7.0-12-py2.py3-none-any.whl", hashes = { sha256 = "4f1a65ea6132c1961bf615e67c2a9660e2810364016922e7b6f3b1519d3ae63e" } }]
 
 [[packages]]
 name = "pure-eval"
 version = "0.2.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pure_eval-0.2.3-12-py3-none-any.whl", hashes = { sha256 = "7ba9e6e92265ed12ed058e7ed509f326161f9b67ee8b5fea1414309bc661809b" } }]
+
+[[packages]]
+name = "py-spy"
+version = "0.4.1"
+marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/py_spy-0.4.1-12-py3-none-linux_x86_64.whl", hashes = { sha256 = "63a33198cc171606d75f0046d206bef939393e07418a98a7dcbf6180ca9fe762" } }]
 
 [[packages]]
 name = "pyarrow"
 version = "23.0.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyarrow-23.0.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1c43aabd24a14163e5b0b1564096fc521d3d64747d837f455ca853129c16430a" } }]
+
+[[packages]]
+name = "pyasn1"
+version = "0.6.2"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyasn1-0.6.2-12-py3-none-any.whl", hashes = { sha256 = "ce8a5a0ad628595d25ea3b39d6cc5434c15a659aee784a9981f2f74e36c97f85" } }]
+
+[[packages]]
+name = "pyasn1-modules"
+version = "0.4.2"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyasn1_modules-0.4.2-12-py3-none-any.whl", hashes = { sha256 = "2d8c79fc0e55351758791c5004e9a53f45af032c8cd0c746cf91841bc65df67a" } }]
 
 [[packages]]
 name = "pycparser"
 version = "3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pycparser-3.0-12-py3-none-any.whl", hashes = { sha256 = "af62504a3e3d773f45d93b2006efd0c5f2f7c64876eb811af0111568f8fd59f2" } }]
 
 [[packages]]
 name = "pycryptodome"
 version = "3.23.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pycryptodome-3.23.0-12-cp37-abi3-linux_x86_64.whl", hashes = { sha256 = "a791b01796e981db5492530be8222109c2eb96bb41eaf6d29fc0e0fd682b4da0" } }]
 
 [[packages]]
 name = "pydantic"
 version = "2.12.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pydantic-2.12.5-12-py3-none-any.whl", hashes = { sha256 = "9aaf6700e4f5ea2b7160e03bf1de1faa02de41e9899ad4cc3c114107f9b620a9" } }]
 
 [[packages]]
 name = "pydantic-core"
 version = "2.41.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pydantic_core-2.41.5-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d56db4ab5cefb824472a3bdf5ca787f11337fc8c42493eed54169deb7aaa43a6" } }]
 
 [[packages]]
 name = "pygments"
 version = "2.19.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pygments-2.19.2-12-py3-none-any.whl", hashes = { sha256 = "72d73014486063f02ff928b149e37d6508a4af0ca946918b13f3277a55b1459a" } }]
 
 [[packages]]
 name = "pyjwt"
 version = "2.11.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyjwt-2.11.0-12-py3-none-any.whl", hashes = { sha256 = "a5cfd460c28823f86a02bc70e41665faf9344efdaf28aaf553b98a4f856f5a28" } }]
 
 [[packages]]
 name = "pymongo"
 version = "4.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pymongo-4.16.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b04a36b4d95c57ce1b53e911c679899db49f7ae9174adefcc6ee0f980c3bd546" } }]
+
+[[packages]]
+name = "pynacl"
+version = "1.6.2"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pynacl-1.6.2-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "88e21cd347b7a1670a64941f6bf6ef3c0d91b9828a24d32a1c1e362cd1b378cf" } }]
 
 [[packages]]
 name = "pyodbc"
 version = "5.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyodbc-5.3.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ba8ce902623206a70b31e7348df71e1c5be1b2330652882db301d254cddcba9b" } }]
 
 [[packages]]
 name = "pyparsing"
 version = "3.3.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyparsing-3.3.2-12-py3-none-any.whl", hashes = { sha256 = "f3eb96c6b5c8b0f6a4a8837363fe7bc4dcd6ad929c8e18a0555951bd308ce5ab" } }]
 
 [[packages]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/python_dateutil-2.9.0.post0-12-py2.py3-none-any.whl", hashes = { sha256 = "284313f6271cad0b7249e7ee967e1e43f5f45f6a55dac06db602b96b0c4b1ec6" } }]
 
 [[packages]]
 name = "python-dotenv"
 version = "1.2.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/python_dotenv-1.2.1-12-py3-none-any.whl", hashes = { sha256 = "a5f341caea1bea0818ec2826f47fad7fe66ef30d638e980de8cc353351aaf338" } }]
 
 [[packages]]
 name = "pytz"
 version = "2025.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pytz-2025.2-12-py3-none-any.whl", hashes = { sha256 = "85c582512e33b1d245b3d8ba42f8d3b3882367ae8239e2b440f8da09f4a05c23" } }]
 
 [[packages]]
 name = "pyyaml"
 version = "6.0.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyyaml-6.0.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "58bf16ae36f4380e4aecf2182bcc1979751f5339af92267561c0cef6a91cc7a6" } }]
 
 [[packages]]
 name = "pyzmq"
 version = "27.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/pyzmq-27.1.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "44942ecaed93c35cc75eade17abe3c6c666d45c1a396ede980145151f37ac03c" } }]
+
+[[packages]]
+name = "ray"
+version = "2.52.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/ray-2.52.1-cp312-cp312-manylinux2014_x86_64.whl", hashes = { sha256 = "843c0108ad72bb7fc6c23a22e29e6099546a5eaad3ad675c78a146d9080f6ec6" } }]
 
 [[packages]]
 name = "referencing"
 version = "0.37.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/referencing-0.37.0-12-py3-none-any.whl", hashes = { sha256 = "cf65c08ede0fbf891d25e3ff3bb2e3c0ae7b6a99df8451211f03a2c0f31bfe91" } }]
 
 [[packages]]
 name = "requests"
 version = "2.32.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/requests-2.32.5-12-py3-none-any.whl", hashes = { sha256 = "4e125d46b89ddcf03c2c9bf32e1524b2f296639981ce56d2e4f7b523e2bbdb9e" } }]
+
+[[packages]]
+name = "requests-oauthlib"
+version = "2.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/requests_oauthlib-2.0.0-12-py2.py3-none-any.whl", hashes = { sha256 = "834269d2d1ffea09a5c9e594d7a3b3de7183ffdc6715db063faf99d9fd165e08" } }]
+
+[[packages]]
+name = "rich"
+version = "13.9.4"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/rich-13.9.4-12-py3-none-any.whl", hashes = { sha256 = "7db784f6a28ce6c156c6ecd19131c71b5dca11a02ebc81e13ef48b934217c812" } }]
 
 [[packages]]
 name = "rpds-py"
 version = "0.30.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/rpds_py-0.30.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c9263e806793ecc6a0b1dc17d0c6dc48ea0d2487240ca1886665d9e20086dbef" } }]
+
+[[packages]]
+name = "rsa"
+version = "4.9.1"
+marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/rsa-4.9.1-12-py3-none-any.whl", hashes = { sha256 = "7d59b532c39fc89522df28fda7c55c1018022c3271cd22fb4f2d5402db2c5729" } }]
 
 [[packages]]
 name = "s3transfer"
 version = "0.16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/s3transfer-0.16.0-12-py3-none-any.whl", hashes = { sha256 = "cbfabf189b49aee3fc77915678ebf9ace4b0d6ea0a43041b4c1a175f87e9aa01" } }]
 
 [[packages]]
 name = "scikit-learn"
 version = "1.8.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/scikit_learn-1.8.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1bbfaf3b55cd0f3ec24dbc4cfc5bfdb7498bf365a9952ee64944abb4577c4d84" } }]
 
 [[packages]]
 name = "scipy"
 version = "1.16.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/scipy-1.16.3-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "388d7f96db8405801d03fb5e803df079f1985e63d2464e0d3cea75a7d69d2dce" } }]
 
 [[packages]]
 name = "setuptools"
 version = "80.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/setuptools-80.9.0-12-py3-none-any.whl", hashes = { sha256 = "4e4c981e3fe034b0931da927e5093da1ee6bdd4b9b67b5314e5143f4edbae556" } }]
 
 [[packages]]
 name = "six"
 version = "1.17.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/six-1.17.0-12-py2.py3-none-any.whl", hashes = { sha256 = "17ae9f11fa05d9d24ae6b03f70bed13bf5b37d2cd72a148158534d7fede352b6" } }]
 
 [[packages]]
 name = "skl2onnx"
 version = "1.19.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/skl2onnx-1.19.1-12-py3-none-any.whl", hashes = { sha256 = "a96c4aa294741d40d05bd0fd3229668c16541ff5977d5b0da2bebc424c483e99" } }]
+
+[[packages]]
+name = "smart-open"
+version = "7.5.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/smart_open-7.5.0-12-py3-none-any.whl", hashes = { sha256 = "67e757cc65fa8d6c84a3747c6a0464c1f580d2f90a6ce2990ef3d8edee5a8aed" } }]
 
 [[packages]]
 name = "soupsieve"
 version = "2.8.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/soupsieve-2.8.3-12-py3-none-any.whl", hashes = { sha256 = "454b21722ae0195e9ba22ef69dd283ee74097ba6e6c17297a7c0956f236ebd92" } }]
 
 [[packages]]
 name = "sqlalchemy"
 version = "2.0.46"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/sqlalchemy-2.0.46-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b797454d05cc0d067175cf743311e2a81358d2403bc20e0a5a0e458bee75c8ed" } }]
 
 [[packages]]
 name = "stack-data"
 version = "0.6.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/stack_data-0.6.3-12-py3-none-any.whl", hashes = { sha256 = "47bdc8db8566d0591a926aa8c0e323d0f33060e92593fcbdea03b73f2af43e26" } }]
 
 [[packages]]
 name = "starlette"
 version = "0.50.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/starlette-0.50.0-12-py3-none-any.whl", hashes = { sha256 = "8cfb447b06b4674fad44d5ce7efef578ee89f1ef445402b34d8563f14486f8f5" } }]
 
 [[packages]]
 name = "sympy"
 version = "1.14.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/sympy-1.14.0-12-py3-none-any.whl", hashes = { sha256 = "cda9c318ab11cf4c9564e0171f84fce04c8c8d2a4dc1c727d487502522568dfd" } }]
 
 [[packages]]
 name = "tabulate"
 version = "0.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tabulate-0.9.0-12-py3-none-any.whl", hashes = { sha256 = "cfee7dcb2bea49c06d348610438d0a710ef650fe7d30c66187873b4e4d8599d1" } }]
 
 [[packages]]
 name = "tenacity"
 version = "8.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tenacity-8.5.0-12-py3-none-any.whl", hashes = { sha256 = "278cf7a9b5c03608765266a8d6aae4ff9e38ae5cdc48dc369f926f85eae57e15" } }]
 
 [[packages]]
 name = "tensorboard"
 version = "2.20.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tensorboard-2.20.0-py3-none-any.whl", hashes = { sha256 = "9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6" } }]
 
 [[packages]]
 name = "tensorboard-data-server"
 version = "0.7.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tensorboard_data_server-0.7.2-py3-none-any.whl", hashes = { sha256 = "7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb" } }]
 
 [[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/threadpoolctl-3.6.0-12-py3-none-any.whl", hashes = { sha256 = "accc49ba424f009eb72d6a6485006ee0cced2de7d34175b152f04ee61d02f76c" } }]
 
 [[packages]]
 name = "tinycss2"
 version = "1.4.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tinycss2-1.4.0-12-py3-none-any.whl", hashes = { sha256 = "70393d130f6304c3250d252977fe2d5f071f9a61080745b560920848eadd63fd" } }]
 
 [[packages]]
 name = "toml"
 version = "0.10.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/toml-0.10.2-12-py2.py3-none-any.whl", hashes = { sha256 = "30496325c5d30fb7d57fd711447b066b6ed3523dba43ca6c28358280ecf98b6d" } }]
 
 [[packages]]
 name = "toolz"
 version = "1.1.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/toolz-1.1.0-12-py3-none-any.whl", hashes = { sha256 = "712f025f9e0f127d0ba763cfb521e81d342a53d4049136937606ae4bd8e9fdbf" } }]
 
 [[packages]]
 name = "torch"
 version = "2.9.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/torch-2.9.0-17-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1a2e0760e06708a70993460cc9b3869e5c1c18e849214533eaca45b30326e693" } }]
 
 [[packages]]
 name = "torchvision"
 version = "0.24.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/torchvision-0.24.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7617c646bbea06eb847c28ee138822e889db500257d42038eb7a2b9a7a856f59" } }]
 
 [[packages]]
 name = "tornado"
 version = "6.5.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tornado-6.5.4-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "f379ef79107cbcf9daa9373d4db16d29fa22da1c25a4e3c8d059e6eedd62f95b" } }]
 
 [[packages]]
 name = "tqdm"
 version = "4.67.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tqdm-4.67.2-12-py3-none-any.whl", hashes = { sha256 = "6d0c7d199d7f78e73ca2cdf44bba992789cae0cc36c3f0a115fa5ea0439c4120" } }]
 
 [[packages]]
 name = "traitlets"
 version = "5.14.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/traitlets-5.14.3-12-py3-none-any.whl", hashes = { sha256 = "3dea046d9e73d7b34713e879b783fbd171075cce3ce22065b3a7291d1ff60c1a" } }]
 
 [[packages]]
 name = "triton"
 version = "3.5.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/triton-3.5.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "075e6b6ce4cb39f9c20981947eb83b14c4af64e874d65ebf5f9577ff31850db3" } }]
 
 [[packages]]
 name = "typeguard"
 version = "4.4.4"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/typeguard-4.4.4-12-py3-none-any.whl", hashes = { sha256 = "173e1f1ccad163bf2ba05340c62ce723de4bf890b765928b4bc362d86a9bcb8a" } }]
 
 [[packages]]
 name = "typing-extensions"
 version = "4.15.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/typing_extensions-4.15.0-12-py3-none-any.whl", hashes = { sha256 = "1d25cd4fd5dd3d405c988b94d645d8dd8f04d6df8218d4a224de8c75edc1f8dd" } }]
 
 [[packages]]
 name = "typing-inspection"
 version = "0.4.2"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/typing_inspection-0.4.2-12-py3-none-any.whl", hashes = { sha256 = "64406cf67f754b675649b5199b3c57291b567b268c7b348e6356b23b1dde08da" } }]
 
 [[packages]]
 name = "tzdata"
 version = "2025.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/tzdata-2025.3-12-py2.py3-none-any.whl", hashes = { sha256 = "638c2b9cd2a8160ac705a88bae5e649753323d46946c75cfb1c52faa7623da33" } }]
 
 [[packages]]
 name = "urllib3"
 version = "2.6.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/urllib3-2.6.3-12-py3-none-any.whl", hashes = { sha256 = "6cf66bfb41200935a49921bd99d9d0763e23a89b8883f58377d08d6fd2b3df1f" } }]
 
 [[packages]]
 name = "uvicorn"
 version = "0.34.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/uvicorn-0.34.0-12-py3-none-any.whl", hashes = { sha256 = "34c8f4daa43f894f8245a7de2362559a7adf1915ecf39535cea2e47610ed43e8" } }]
 
 [[packages]]
 name = "uvicorn-worker"
 version = "0.3.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/uvicorn_worker-0.3.0-13-py3-none-any.whl", hashes = { sha256 = "bb2e79b95dcc296d8423d5c4cc116705dc497b871ebddde0a4884a1a51a48585" } }]
 
 [[packages]]
 name = "uvloop"
 version = "0.22.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/uvloop-0.22.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c230e833b138292b354138a1b8b5198aaf612d003f0169b692a09c698c658e96" } }]
+
+[[packages]]
+name = "virtualenv"
+version = "20.36.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/virtualenv-20.36.1-12-py3-none-any.whl", hashes = { sha256 = "b6ec6193977ec45105dc89bed001497d7902d444954d603f586d0ae8cb625e1a" } }]
 
 [[packages]]
 name = "watchfiles"
 version = "1.1.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/watchfiles-1.1.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "fb582c68c0ffd64e9232326a10e8375ac27ff09648030bc90a572a944c7fc631" } }]
 
 [[packages]]
 name = "wcwidth"
 version = "0.5.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/wcwidth-0.5.3-12-py3-none-any.whl", hashes = { sha256 = "aad03aa8bd3b0ae43c729691220d8b2d0c5361940bc0fdb8f51060cd94abc55e" } }]
 
 [[packages]]
 name = "webencodings"
 version = "0.5.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/webencodings-0.5.1-12-py2.py3-none-any.whl", hashes = { sha256 = "e7f39fe5e861487a1bfb268591aecb0e6b3a0181de7e77d4506f9215a748706a" } }]
+
+[[packages]]
+name = "websocket-client"
+version = "1.9.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/websocket_client-1.9.0-12-py3-none-any.whl", hashes = { sha256 = "0d27170c96d2d68f3eed4c3b47486ac2aa6b0f9463603109a0848e0e563147ba" } }]
 
 [[packages]]
 name = "websockets"
 version = "16.0"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/websockets-16.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e4398565ba1044af0812832b67de45402e5560ff79edb4c6599859582cc89959" } }]
 
 [[packages]]
 name = "werkzeug"
 version = "3.1.5"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/werkzeug-3.1.5-12-py3-none-any.whl", hashes = { sha256 = "ba35d44fe1b3b63263e93c8a9c00ca61a957d2b1b96ff6ae9882d745b33b65fb" } }]
 
 [[packages]]
 name = "wheel"
 version = "0.46.3"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/wheel-0.46.3-12-py3-none-any.whl", hashes = { sha256 = "b06dc8c2a5f9e81dc36db6e386789c06202ecbf3e111c365ce5550693b4b132e" } }]
+
+[[packages]]
+name = "widgetsnbextension"
+version = "4.0.15"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/widgetsnbextension-4.0.15-12-py3-none-any.whl", hashes = { sha256 = "91f19d95e76c52a6fd3ecf262b4bb7241f2d5f88938f51969d595c4a1e356aa7" } }]
+
+[[packages]]
+name = "wrapt"
+version = "2.1.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/wrapt-2.1.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5f9f90c9580b0b68eb65c4a167de1f2c7696ba7fb583b27d3c7422fd4ac110ca" } }]
 
 [[packages]]
 name = "yarl"
 version = "1.22.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/yarl-1.22.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a0b227a86ac28684a000eb566c876665a8eaa551f2432736167e1dcae4025d73" } }]
+
+[[packages]]
+name = "zipp"
+version = "3.23.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/rocm6.4-ubi9/zipp-3.23.0-12-py3-none-any.whl", hashes = { sha256 = "7ad214f3a5ee9fbe1dc039e2f4dd18e6a17ded1c1e98e6b0cf969ffad1128e77" } }]
 
 # The following packages were excluded from the output:
 # odh-notebooks-meta-runtime-elyra-deps

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "tensorboard~=2.18.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
     "codeflare-sdk~=0.34.0",
     "odh-notebooks-meta-runtime-datascience-deps",
 

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "tensorboard~=2.20.0",
 
     # Datascience and useful extensions
-    # TODO(RHAIENG-3039): Re-enable codeflare-sdk before RHOAI 3.4 GA
     "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
     "odh-notebooks-meta-runtime-datascience-deps",


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/RHAIENG-3039

- Uncomment codeflare-sdk in jupyter/datascience and runtimes/datascience
- Add Codeflare-SDK to jupyter-datascience-notebook imagestream manifest

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Codeflare-SDK (v0.34) across multiple Jupyter notebook variants
  * Added Ray distributed computing framework support
  * Added OpenTelemetry observability stack and OpenShift client support

* **Chores**
  * Updated dependency versions and resolved dependency graphs across runtime environments
  * Added packages for system utilities, SSH, security, and advanced analytics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->