### PR TITLE
RHAIENG-3056: remove UV and PIP_INDEX environment variables AIPCC-migrated dockerfiles

### DIFF
--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -8,14 +8,6 @@ ARG BASE_IMAGE
 ####################
 FROM ${BASE_IMAGE} AS cpu-base
 
-### BEGIN RHAIENG-2189: this is AIPCC migration phase 1.5
-ENV PIP_INDEX_URL=https://pypi.org/simple
-# UV_INDEX_URL is deprecated in favor of UV_DEFAULT_INDEX
-ENV UV_INDEX_URL=https://pypi.org/simple
-# https://docs.astral.sh/uv/reference/environment/#uv_default_index
-ENV UV_DEFAULT_INDEX=https://pypi.org/simple
-### END RHAIENG-2189: this is AIPCC migration phase 1.5
-
 WORKDIR /opt/app-root/bin
 
 # OS Packages needs to be installed as root


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-3056

## Description

Remove the AIPCC migration phase 1.5 workaround from all Dockerfiles that still contain it. This workaround was added during the transition to AIPCC and forces pip/uv to use PyPI instead of the AIPCC index.

## How Has This Been Tested?

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker image build configuration by removing obsolete migration-phase environment variable settings from the Python 3.12 CPU base image layer. These maintenance changes simplify the build setup, improve overall configuration clarity, and eliminate legacy code remnants while ensuring complete backward compatibility and uninterrupted deployment stability across all runtime environments and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->