### PR TITLE
fix: update update-tags.yaml regex to support EA naming pattern

### DIFF
--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       new_tag:
-        description: "Set a new image tag (e.g. YYYYx-vn.n)"
+        description: "Set a new image tag (e.g. 3.4_ea1-v1.41 or 2025a-v1.41)"
         required: true
 jobs:
   update-tags:
@@ -23,7 +23,8 @@ jobs:
         id: replace
         run: |
           set -e
-          regex="[0-9]{4}[a-z]-v[0-9]+\.[0-9]+"
+          # Updated regex to match both old (2025a-v1.41) and new (3.4_ea1-v1.41) tag patterns
+          regex="([0-9]{4}[a-z]|[0-9]+\.[0-9]+(_ea[0-9]+)?)-v[0-9]+\.[0-9]+"
           new_tag="${{ github.event.inputs.new_tag }}"
 
           echo "Searching for tags in .tekton/*.yaml..."


### PR DESCRIPTION
## Problem

The `update-tags.yaml` workflow regex `[0-9]{4}[a-z]-v[0-9]+\\.[0-9]+` only matches the old tag pattern like `2025a-v1.41`.

It **fails** to match the new EA (Early Access) naming pattern like `3.4_ea2-v1.42`.

## Solution

Updated the regex to:
```regex
([0-9]{4}[a-z]|[0-9]+\.[0-9]+(_ea[0-9]+)?)-v[0-9]+\.[0-9]+
```

This now matches **both** patterns:
- ✅ Old pattern: `2025a-v1.41`, `2024b-v1.40`
- ✅ New EA pattern: `3.4_ea1-v1.41`, `3.4_ea2-v1.42`, `3.4-v1.40`

## Testing

Regex validation:
```bash
# Test cases
echo "2025a-v1.41" | grep -oP '([0-9]{4}[a-z]|[0-9]+\.[0-9]+(_ea[0-9]+)?)-v[0-9]+\.[0-9]+'
# Output: 2025a-v1.41 ✅

echo "3.4_ea2-v1.42" | grep -oP '([0-9]{4}[a-z]|[0-9]+\.[0-9]+(_ea[0-9]+)?)-v[0-9]+\.[0-9]+'
# Output: 3.4_ea2-v1.42 ✅

echo "3.4-v1.40" | grep -oP '([0-9]{4}[a-z]|[0-9]+\.[0-9]+(_ea[0-9]+)?)-v[0-9]+\.[0-9]+'
# Output: 3.4-v1.40 ✅
```

Fixes the workflow failure reported by @atheo89 in [RHAIENG-2640](https://issues.redhat.com/browse/RHAIENG-2640).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow tag matching logic to support new tag formats with optional `_eaN` suffix while maintaining backward compatibility with existing tag formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->