### PR TITLE
RHAIENG-3101: disable embedded co-pilot from code-server

### DIFF
--- a/codeserver/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver/ubi9-python-3.12/run-code-server.sh
@@ -52,6 +52,10 @@ universal_json_settings='// vscode settings are written in json-with-comments
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
 
+  // Disable GitHub Copilot in code-server
+  // official doc https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code
+  "chat.disableAIFeatures": true,
+
   // RHOAIENG-14518: Disable the "Do you trust the authors [...]" startup prompt
   "security.workspace.trust.enabled": false,
   "security.workspace.trust.startupPrompt": "never"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-3101

## Description
<!--- Describe your changes in detail -->
This PR  disables GitHub Copilot in code-server by using `"chat.disableAIFeatures": true` option on the user settings.json file official documentation here ->  https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build image:
AMD: `quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:on-pr-b29f7cf86cfd5a2ffff86cc755db2947a1920066-linux-d160-m4xlarge-amd64@sha256:54494b69e8542fa4c70d1b857a51e6610e7173b5038485f672a66b374a151694`
konflux build: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-release/pipelineruns/odh-workbench-codeserver-datascience-cpu-py312-ubi9-on-pul7lbtg

Before:
<img width="2565" height="1300" alt="Screenshot 2026-02-10 at 12 37 07" src="https://github.com/user-attachments/assets/c862f0bb-968b-4497-ab43-e7d6f0d28b4a" />

After fresh startup:
<img width="2565" height="1300" alt="Screenshot 2026-02-10 at 13 20 58" src="https://github.com/user-attachments/assets/6546cc78-9097-4fca-903c-8fd46ee7429e" />



Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled GitHub Copilot and other AI features in the default user settings
  * Added a global setting to disable Copilot (chat.disableAIFeatures)
  * Included the new option in the universal/default settings block with explanatory comments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->