### PR TITLE
NO-JIRA: chore(.tekton): update multiarch pipeline with new params and task updates

### DIFF
--- a/.tekton/multiarch-combined-pipeline.yaml
+++ b/.tekton/multiarch-combined-pipeline.yaml
@@ -62,10 +62,6 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
-  - default: docker
-    description: The format for the resulting image's mediaType. Valid values are oci or docker.
-    name: buildah-format
-    type: string
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
@@ -326,8 +322,6 @@ spec:
     - name: IMAGES
       value:
       - $(tasks.build-images.results.IMAGE_REF[*])
-    - name: BUILDAH_FORMAT
-      value: $(params.buildah-format)
     runAfter:
     - build-images
     taskRef:


### PR DESCRIPTION
Based on
* https://github.com/rhoai-ide-konflux/notebooks/pull/35

## Source of truth

The inline `pipelineSpec` in [.tekton/notebooks-b951c-push.yaml](.tekton/notebooks-b951c-push.yaml) (lines 35-606) represents the latest pipeline template. Both the push and pull-request b951c files have identical `pipelineSpec` sections.

## Custom additions to preserve

These are NOT in b951c but must be kept in the combined pipeline:

- `event-type` param (line 19-22)
- `rhoai-init` task with `when` condition (lines 152-193)
- `init` task's `runAfter: [rhoai-init]` (lines 214-216)
- `send-slack-notification` finally task (lines 122-149)
- `show-sbom` finally task (lines 108-120) -- present in combined, absent in b951c; keep it

## Changes to apply

### 1. Upgrade `init` task from 0.2 to 0.3

In [.tekton/multiarch-combined-pipeline.yaml](.tekton/multiarch-combined-pipeline.yaml):

- Update bundle SHA from `task-init:0.2@sha256:ebf06778...` to `task-init:0.3@sha256:aa6f8632cc23d605c5942505ff1d00280db16a6fda5c4c56c4ed9ae936b5fbc6`
- Remove params `image-url`, `rebuild`, `skip-checks` from the `init` task (keep only `enable-cache-proxy`)

### 2. Remove `when` conditions that reference `$(tasks.init.results.build)`

The new init:0.3 no longer produces a `build` result. Remove the `when` blocks from:

- `clone-repository` task (lines 238-242)
- `build-images` task (lines 327-331)
- `build-image-index` task (lines 359-363)
- `build-source-image` task (lines 386-390) -- remove only the `init.results.build` condition, keep the `build-source-image` param condition

### 3. Update task bundle SHAs

| Task | Old | New |
|------|-----|-----|
| `buildah-remote-oci-ta` | `sha256:4ba241...` | `sha256:417f776b6be35d6e51d9133ef8f0540f20ff80d761c76de37fb0e51786918950` |
| `build-image-index` | `sha256:8c422a...` | `sha256:30989fa1f475bb8f6bda811b26bd4ddf7187288ed5815ce634ba399341852c75` |
| `push-dockerfile-oci-ta` | `sha256:6fb61b...` | `sha256:2623be4a9bad87ade614b4b24a8f98a4e100042a845e8f162b8237168697294c` |
| `rpms-signature-scan` | `sha256:a99d8f...` | `sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a` |

### 4. Remove `BUILDAH_FORMAT` param from `build-images` task

The b951c template does not pass `BUILDAH_FORMAT` to the `build-images` task. Remove this param (currently around line 305):

```yaml
    - name: BUILDAH_FORMAT
      value: $(params.buildah-format)
```

### 5. Update description

Replace the description to match b951c's wording, appending the custom combined pipeline note:

```yaml
  description: |
    This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

    _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_

    Combined pipeline for PRs and Pushes.
    Logic is controlled by the 'event-type' parameter.
```

### 6. Restored `additional-tags` param

The AI wanted to remove it with the following justificatrion

> The b951c template does not define an `additional-tags` param at the pipeline level (only the `apply-tags` task still references it from PipelineRun params). However, looking more carefully, the combined pipeline does not have an `additional-tags` param either -- it was already removed. The `apply-tags` task still references `$(params.additional-tags[*])` though. In b951c, the `apply-tags` task does NOT pass `ADDITIONAL_TAGS`. Remove this param from the `apply-tags` task.

### Summary of changes

All changes are to the single file [.tekton/multiarch-combined-pipeline.yaml](.tekton/multiarch-combined-pipeline.yaml). No other files are modified.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to support multi-architecture and multi-platform builds with matrix-driven per-arch decisions.
  * Added configuration parameters: enable-cache-proxy, additional-tags, SOURCE_URL, HTTP_PROXY, and NO_PROXY.
  * Removed per-task rebuild flags in favor of matrix-driven behavior.
  * Modernized pipeline task references to newer public bundles and improved orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->