### PR TITLE
chore(tests/containers): fix cowsay test with enhanced skopeo utilities with expanded Pydantic models for ENVs

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -16,7 +16,7 @@ import allure
 import pytest
 import testcontainers.core.container
 
-from tests.containers import conftest, docker_utils, utils
+from tests.containers import conftest, docker_utils, skopeo_utils, utils
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
@@ -41,6 +41,11 @@ class TestBaseImage:
         """Check if the image is AIPCC-enabled by looking for uv.lock.d in source directory."""
         image_metadata = conftest.get_image_metadata(image)
         source_location = image_metadata.labels.get("io.openshift.build.source-location", "")
+
+        # Dockerfile.konflux does not have source-location label
+        if not source_location:
+            image_info = skopeo_utils.get_image_info(image)
+            return "PIP_CONFIG_FILE" in image_info.env
 
         # Extract relative path from URL (after /tree/main/)
         source_dir = None

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -69,9 +69,9 @@ def get_image_metadata(image: str) -> Image:
         image_metadata = client.client.images.get(image)
     except docker.errors.ImageNotFound:
         # skopeo inspect
-        labels = skopeo_utils.get_image_labels(image)
-        if labels is not None:
-            return Image(id=None, name=image, labels=labels)
+        image_info = skopeo_utils.get_image_info(image)
+        if image_info.labels is not None:
+            return Image(id=None, name=image, labels=image_info.labels)
         # pull & docker inspect
         image_metadata = client.client.images.pull(image)
         assert isinstance(image_metadata, docker.models.images.Image)


### PR DESCRIPTION
## Description

Improves the code quality in the tests a bit.

* refactor(tests/containers): extract get_image_config() helper from get_image_labels()
* refactor(tests/containers): replace JSON parsing with Pydantic models for skopeo output

Detects an AIPCC-enabled RHDS image using ENV vars, because for some reason it does not have the odh-io labels set.

* chore(tests/containers): fix cowsay test with enhanced skopeo utilities with expanded Pydantic models for ENVs and 

## How Has This Been Tested?

* https://github.com/jiridanek/notebooks/actions/runs/21987817410

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UV-lock detection for container images by checking image environment when source metadata is missing, reducing incorrect unlock decisions.

* **Tests**
  * Enhanced image inspection and metadata retrieval with structured parsing and stronger error handling to make tests more reliable and reduce false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->