### PR TITLE
chore(.tekton): build-platforms parameter to Tekton ROCm base image pipelines (UBI9 and C9S) to use bigger builder

### DIFF
--- a/.tekton/odh-base-image-rocm-6-4-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-c9s-push.yaml
@@ -25,6 +25,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-base-image-rocm-py312-c9s:{{revision}}
+  - name: build-platforms
+    value:
+      - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.4/c9s-python-3.12/Dockerfile.rocm
   - name: build-args-file

--- a/.tekton/odh-base-image-rocm-6-4-py312-ubi9-push.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-ubi9-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-base-image-rocm-py312-ubi9:{{revision}}
+  - name: build-platforms
+    value:
+      - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.4/ubi9-python-3.12/Dockerfile.rocm
   - name: build-args-file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
