### PR TITLE
RHAIENG-2846 [1/3]: Python dependency updates + runtime fixes for codeserver

### DIFF
--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -1,17 +1,32 @@
+# [HERMETIC] pyproject.toml changes for hermetic build:
+#   - Added uv + micropipenv as explicit deps (cachi2 prefetches everything in dependencies[])
+#   - Added ipykernel + debugpy explicitly (previously pulled transitively)
+#   - Added odh-notebooks-meta-workbench-datascience-deps (shared meta-package replacing
+#     individual deps like boto3, kafka-python-ng, numpy, pandas, plotly, scipy, scikit-learn)
+#   - Upgraded feast ~=0.59.0 (pinned for RHOAI 3.4 compatibility)
+#   - Excluded py-spy on ppc64le (maturin can't fetch crates.io in --network=none)
+#   - Added urllib3>=2.6.0 override (CVE-2025-66418)
+#   - Added local path source for the meta-package
 [project]
 name = "notebooks"
 version = "0.1.0"
 requires-python = "==3.12.*"
 
 dependencies = [
+    # Installer/tooling used in Docker/CI (prefetched with main deps for cachi2 offline)
+    "uv==0.9.28",
+    "micropipenv[toml]==1.10.0",
+
     # Base packages
     "wheel~=0.46.3",
     "setuptools~=80.9.0",
 
     "ipykernel~=7.1.0",
+    "debugpy==1.8.20",
 
     # Datascience packages
     "feast~=0.59.0",
+
     # RHAIENG-1475: skl2onnx excluded on s390x for codeserver
     "skl2onnx~=1.19.1; platform_machine != 's390x'",
     "odh-notebooks-meta-workbench-datascience-deps",
@@ -29,6 +44,7 @@ dependencies = [
 environments = [
     "sys_platform == 'linux' and implementation_name == 'cpython'",
 ]
+
 override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/kubernetes-client/python/issues/2458

--- a/codeserver/ubi9-python-3.12/requirements.cpu.txt
+++ b/codeserver/ubi9-python-3.12/requirements.cpu.txt
@@ -1,0 +1,401 @@
+--index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4-EA1/cpu-ubi9/simple/
+annotated-doc==0.0.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e313f1ebf34a5d9c95c172ddc561af3453158e7c9cb3a7c7224c80d96edd5454
+annotated-types==0.7.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0b4f2636b9768e864eceeb8e8ea986b4363b280559f0de3a07c5703da7cda06b
+anyio==4.12.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:778891010e52a0ea96916cdfd962ae4698486ef5f7a324e9c35f73f1ac69f56c
+asttokens==3.0.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b73d3ab8d1af0fc803933f0b4f86def33b1a3b44111cbeda1d41b68a17cf7d06
+attrs==25.4.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:278ad9ce90064af2b877c7217db6d1c4331d6b43308a174aa3725c0a75548922
+bigtree==1.3.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f17475ea80e7ebd3aa1ef7c0cf63860124a9d94af3df0cfa8a67f2d2f6a8c595
+boto3==1.42.40 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dec411effc25c73baa2e4fa7a30e5e260220d9c4ca05b580035ce29989758d0f
+botocore==1.42.40 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4a6f198923cb925471fa1abfc9b06411abdd97fe5f2ab13899f806b411bdfae7
+certifi==2026.1.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3a21348b3c8e2722ddc07887f13f9b957bce49a5c508fa432d1e64afd0633189
+cffi==2.0.0 ; python_full_version >= '3.9' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
+    --hash=sha256:6422df588b9ebd82b7730192a75cd52c15ee475da8940cdb42a2c3999dd0b19a \
+    --hash=sha256:00c3435e836d3cc68b477ca65e0a71f66eba70ee1c573b3c8da2e80d10c1be7d \
+    --hash=sha256:e83c8632abe74f94b1323767152890e2eba8c0793b5dcf44e01fdf294e8dbaff \
+    --hash=sha256:e000853e9d4ff1cf4884bd277e293ffd410ec6876d86a9b32abb5f2a46ea31c5
+charset-normalizer==3.4.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8e2d00f3a069ba1d4308ca758da519b41ba69bf5c2230a4d114ddc9c6b8d0d37
+click==8.3.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8a04874d43b415abb3eeaf003ea3f2ae1b6e502f34c6c17100bee9770e0d0855
+cloudpickle==3.1.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7d49d126993f7e9f5e5ad945bc232fab0274339cadc6c2a5b453ee21fa2228e2
+colorama==0.4.6 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6b4a8e5d766a573b0ff926b3f946f064d6ff1fbf81c5942d176f3c34e683d511
+comm==0.2.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d11d5eb9a6bc83c49b622e5382985e78da0e1c801c68102e016e2bafe873a4c6
+contourpy==1.3.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8469ae6cc3fe7df1cdb4a045c5f6de4d51b13f92693ec25f163b4b2c4c784019 \
+    --hash=sha256:8c347f7b9ce74908500fd815d1c2573d90f81fc4302d1508984cfd0a2cd6a4fb \
+    --hash=sha256:4ecc8ad763aa42c4e743b0ea2d8dab0d401a246b7dc0e193222cf2eeab2e91a3 \
+    --hash=sha256:af5488cce75628e9ca1cbaa56cf0fed72711b7815628a6ab46f92384496d2ca8
+cryptography==46.0.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0cecc7cb9880de1c61c9ac614e30d656bc7663b00999d29ff9cbc56e873ddac1 \
+    --hash=sha256:541de6f6db7fe5539b5857cbfec902744c2993ebae33b2441e6ec32edf738391 \
+    --hash=sha256:ececca50e3e724e0778cf9880f2b8461b4465dc72cda3af4120c5c24004da5a9 \
+    --hash=sha256:641e9f655b62e29f53ff2233c3e33f33fc969adc3341aa3913656ae9be82d706
+cycler==0.12.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:578089e91a06aa4be4eb6c1d2199f869d74301b272b8847bdb7fbadf8667a061
+dask==2026.1.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:47bf96d4cb3b3c31e71cedd18739ac4c07ed191960d64b76cfec74f3bcbe00f9
+debugpy==1.8.20 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fd0257b951293cdfbd069b6caf8630af172ab9b7fb41c37445b7152025084703 \
+    --hash=sha256:02f1afad493434b5655dd8913c3dd40fa7272fa08d68753628d5d0fc83581c44 \
+    --hash=sha256:3b68f27f2de2b13ea3dd7b2c2fff2126158ff2654d3b7bf182a55ef2616ca389 \
+    --hash=sha256:062086090429afef9b94916d1c9caf1bf9419cdccbff42f93060809abe53180f
+decorator==5.2.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:483506902081a5b9f3a2a13b93f1e11b4e9a773d650525c37794dfc28311aa45
+dill==0.3.9 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1ac03aa46a9699d4bc68f52c2986eb7d8ea8696e0ade30a6b1f645df1e203e46
+distlib==0.4.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a587b9426e6cf59e6116e6d329150e4e45b08211f1892e1cf100c16a41f8e9b8
+docstring-parser==0.17.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:36586f85ca0b2dbc64cdcc4667e32489f0d7bd7f89e6a7b2c8561fe97cbe1aa2
+durationpy==0.10 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dc904bb9882e53d3b2c02e0d61a4475c2ef4717d7d593636996c1ce2862ce4c2
+executing==2.2.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d72048a79b547d5f3c2fe6fb84d2982568dc0fbe168b35f8b04eb9545167bce1
+fastapi==0.128.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:aa44c45b7a9297b81b15ed283d15efe6c479d7c433f3291943309ac842b974be
+feast==0.59.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a8df1c93bb5b479c3096b521ca9a7de7e5f6051e7b6fed1dea4610e83a175591
+filelock==3.20.3 ; python_full_version >= '3.10' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ea920484a56693a87027eb8d173059eda17fe42a4fbad454e2052b20394d0648
+fonttools==4.61.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5020171c7aab8256034ca74ec45682707faae7f0d5193d3026225be5c123cdd9
+fsspec==2026.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:54a6fa32a68e743176fd422dc0ce8e8818f289f74246c54be76836e767f8d964
+google-api-core==2.29.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b53ae99a823e1c7e02925a156367db84f23637a5fc66bdec6c0d00161cd30b5e
+google-auth==2.48.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ac62d2a52b59f3ff27deb36036a25d31cc5d6f91f35b192556505500c953fad1
+google-cloud-core==2.5.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6677dc86b165215623a63ed12b9a9cae4ee685357c215e8c8d95362e6dbb41d5
+google-cloud-storage==3.8.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bc6b5fb1ebf956cc1d757995afabc0fea8fd818ef0cc87462e4f6b861df683d3
+google-crc32c==1.8.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:22ed97284ee0471743e762fa0c060fd648ae4d4d4e0519089cf44d6078ddbb23
+google-resumable-media==2.8.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0dd2b94e087dca67aca2f0f6440beca94d49952fc5a922a7c00de8055771f1f5
+googleapis-common-protos==1.72.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:45a4a645393bb9b9c4658017a19a483b11bffbbced740ecc2123652f9121f581
+greenlet==3.3.1 ; (implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:24edd58f59cfafffc0e87738beb981b5f4723df347b0743a9143d06bd46e8882 \
+    --hash=sha256:eeab02f043e10f97b3b4f444e6e6ec4ea892fae8dd37613664ad795e5f15e1e8 \
+    --hash=sha256:2e4b002ac1300e2765cf2bb1a6c780093d436d9f847b1ba07da375b0776b7286
+gunicorn==25.0.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:301e2f2ed18c1d3595cb1c1e8de6a7c6c43aa554ea206a8827c3666dd3520ac0
+h11==0.16.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a6ea88ccc48bdf70fc193707ac0761eced8e30f45132a07a181ff8170a15901b
+httptools==0.7.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:763f5a67f822dd8dacd0ca09a85caa46d595e91b792774ce8758ccb4a4f8f109 \
+    --hash=sha256:194fad05c00c061242d910da6cbeae7d85a73c8afde93303cc8f42e4102da9ea \
+    --hash=sha256:902e8a7528cadcdeb3eb0a74c0708f33ee964afa93707ee8bde2a162e6a68f79 \
+    --hash=sha256:478b8c70f32938d8c79ab9802911a573a742f408e22b246293bf6a931d430afd
+idna==3.11 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c649c08ebd979268bffb0e7ac1cf9169bac80a95767505b69dd5197af4f0f5e0
+ipykernel==7.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d0dd6cc41024482cce8fefdc7d63bd115eace79d0e363c9a6ecd41da1a162091
+ipython==9.10.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:08bc8f1d9c12a72a1f206fd75e64c598cba50bdc780e1654a4e11c7c3c7eeb70
+ipython-pygments-lexers==1.1.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a5a812d0c0c28edef983e7931a257908f5383d5746a567f52e10fafc7924c4d2
+jedi==0.19.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4815e61b5edd92ff5e30ee0faa3c08acb54aaffce40372b6045723b043946a6b
+jinja2==3.1.6 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8538159cdbb2c2d4c14777f4a64426d25c947033b7e556ab3ee24cda29e63ec2
+jmespath==1.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b935c0e0488a86998683927afb3273d62048c0a4ab2903bafe3455c36c275d56
+joblib==1.5.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ac0416208abbaa6ce8362539091d1341a5b794a6f6a4ae03cc3fb7ed65126172
+jsonschema==4.26.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3250059c36324159412eea15b11ecee94fe6be09f38d8c7e02767bcdd712bc53
+jsonschema-specifications==2025.9.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:48ee20e787525846e5091d539a8b4f108306f28af05aae7ee0f7310fbabe5c43
+jupyter-client==8.8.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:df922f8cd3c9ae7726dfbc9f38da6b53bd77d305d79aba8a667387da5be5ee55
+jupyter-core==5.9.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:14eadf9c6454e91add55d3104b3a6eac53490c3401fa5be81df98f885ac901dc
+kafka-python-ng==2.2.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c84c3248b88c194ce55e8fd6d7447b690d7be806a511c6a42be0e28b99313b70
+kfp==2.15.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2859271caef7a7073879f931316c3122e97e1b9f661b61914a972cc348d77936
+kfp-pipeline-spec==2.15.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0642dbf1a08d05ad69e290dd4a5a4d361472d841bd336c094c72eeb4a717fde4
+kfp-server-api==2.15.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0fb8cf028b98d2d8340ac40df61520937d3cea4c5029eb28dab7d15c8bdce7f6
+kiwisolver==1.4.9 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9a5f9313b897290fa5cab2de1d42eb24d43e89d599f56aed07c9b13df04d90e6 \
+    --hash=sha256:dbe3b766e873691141b25e4a403988be08a351c8017853460a174d2d925c2e1b \
+    --hash=sha256:58573fd3dffa10db22c29709fcd7b420bcfe549320df8f07c21b09ef525359e7 \
+    --hash=sha256:1214beb3903b78c4ee063472c91281ee72cd48e2482603cc4c49702eb00c0ad0
+kubeflow-training==1.9.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f0668471ebc3f8927c86aa8e66d1cb95f177092c57ca403c5034fddfb8039d5a
+kubernetes==35.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:46baed613ea13516eb95834fd146f18680ce5adb391e499decd67128ab0330b4
+librt==0.7.8 ; implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
+    --hash=sha256:5705f57d5d5fcb3b4faa8a171bb999d7473e8ec88e78c4e1b7e49ea3ecd500dd \
+    --hash=sha256:ec99c7fb2d4fe6e816afef02ab4905a3ecdb509249781d4d605286833fb44524 \
+    --hash=sha256:562d661c1e6f0d887bfbba258f5bc512989cae52ab6f21935f845245c229c3cb \
+    --hash=sha256:ba32112f5c7d8f3d46713a059f8da36ed29fd92541880bb64c968be2370dab2b
+locket==1.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:94bd944f1ebb1ed06f9d1f51abc4b9170b297d34e2a3675057bb94222e42173e
+markupsafe==3.0.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:be9085c1d5d30211587cea5c20975258e7b6c494e4e17400e1b13b163f171d5d \
+    --hash=sha256:f7f5244c8cc33750d2d763872c0ca0e9e281a6224eb49b0acd4f084ff09e16aa \
+    --hash=sha256:85c46b6956d9d22caa30b3667568e5be98a845355adf8b7ac2d85514cc1c82a7 \
+    --hash=sha256:54ac81cd20fbc5b9c02b5141996b23c6e43864fa6094ca944d822229a596d5db
+matplotlib==3.10.8 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:77b447234996332569eb0b88ce49d8bb9c44b232343c919309fe7a1f0ca4274a \
+    --hash=sha256:be6c38957d7eeaf1e2fdfd02a58278ef03f820f80d86cadbe1955fa008826a82 \
+    --hash=sha256:a301b6bc930497826d346a71c8f88da6cf0e4b80a85f9f357df5843b99e1cc58 \
+    --hash=sha256:a27691ddee0d31a5837a7b7c38afb1927044f1b4db8b6027712ef91ebfd76c17
+matplotlib-inline==0.2.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6a1b97fed26c7c7452c3357db29aa75e0298b1c8e0a4cb8e42220e68cb28b4cf
+micropipenv==1.10.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b78ed8e7223a1da2fdf7241da021bf9d2da6385763cda4ca9bf7da929eaea8f2
+ml-dtypes==0.5.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c017e0ea0689b170958967d96754946c07d396280c51d9ae201d83a9a599469e \
+    --hash=sha256:2fce8e1e21bd26d18d4254336e17f7f2f132dbca77b4b3fe89da25ab5a3d87eb \
+    --hash=sha256:465326e6f9d0808e629db8de657ffc83368203e2500381ba5c742b624fb16b49 \
+    --hash=sha256:99ab1ca510c19ebe5a90fdb5f0e46f700be1f3e411b788e8c6443f7c0c454c7a
+mmh3==5.2.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a0f623387e12ac34c60cc90c8ed9664c7bd61927441e7c6b010e352a61a66a40 \
+    --hash=sha256:14f33a4ce72edcd47eea68a67602587ceab99073292cf779bbfae53fcd4db01a \
+    --hash=sha256:7f6547ccc2b902b25bab862c62d9a6386b3d1a518781ef7ddbb4bc546b6af3c3 \
+    --hash=sha256:dcd2bde82c615df769140b503f34ea2c635b17fc3e8433f05c7c1072a24330f4
+mypy==1.19.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:439a9fdf1c3a7f2b9ca2033cb17e4fd8d72afedbce64ac1f3e49ed493a35520b
+mypy-extensions==1.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e820a60cc25dba2e928511d3e3a96c9ae385d34634dd66b26b010b422fc35368
+narwhals==2.16.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ed848c2bb10f995c188211c0b4e1a6bbd97e5be8a9b9176d94a3ef0b258f43dc
+nest-asyncio==1.6.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:97f06e3cd2965fc5b14a6993a20c57e62e0a4516deb957410693bbaeae06e4bc
+numpy==2.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:64657e1e81c855db92360ce12f8ac77f861222f68ddfe37db2263d1a55518954 \
+    --hash=sha256:964bfe412fe592d0bc678bce23e027e8c0155e81da6346e57b1e4606931e93f9 \
+    --hash=sha256:1dfd1d87f42afb5284a56ed41d912a7bad2f92b975d988888fd47a1366fc4c53 \
+    --hash=sha256:e7efba02506ae2de8205189536c5ff2e20901271c2eb5694f69cf33fdc9a9507
+oauthlib==3.3.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b9999d1be5c825d926600e3041004714d536cc6f16d2670075829f9c7c99da40
+onnx==1.20.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9a8a15500f8dece0a78ff98cf08a377bd6e94cf2f40b9018e838a19a55f034c9 \
+    --hash=sha256:208991d4aa1a7317309617cb0273ad0e4d0aeaf5260df14329345d79707d7714 \
+    --hash=sha256:1374bb1d9aab7ae9c2fdabdb0d6e4332050dea72dc4d236b646fa3238b93a4d0 \
+    --hash=sha256:58e4c1ed03afd78cde7ff52ffc1eef0312f981f67b3eaf89bdeafa717f88d032
+onnxconverter-common==1.16.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2aff3ae28278509da839634c226265f78075654c210d36a3fc5058db375e4156
+opencensus==0.11.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:eedbd569b2a359c36e1b287de65950c4fe78b19f89af2c1c61c74a4a08617ac4
+opencensus-context==0.1.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:086e9c1c3c52ac92a6a1f48ae1cf75856683fc5235fadfd1032a1d4f6a082ad5
+packaging==26.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0660e283b5ec4d18532f0bfebc853880cdf7743f7a1fde9de230b67525643c5b
+pandas==2.3.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bcbc34b4f216104edd63086462db75d9b796f53d789b43db3673bbd551be5699 \
+    --hash=sha256:e7a45067074b6e5befb818c395023d884676a8dd7e1c77e8d0171526843cec8f \
+    --hash=sha256:7b497503ce5c15eeb8fa56e6a1b77bff8b403532c7f681b9ebd3172aac811a50 \
+    --hash=sha256:f2bf8a40b6a6a7a82ec67ad11ea4a65642bb75207d59e32b0001b46d2547c332
+parso==0.8.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:08347cc33a697734445b36c0be7aafc5cf981521d8ff7f512d1cbfaa62a97e62
+partd==1.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3993ed4b1cb89309380c521b4d1328102caa07a3c43836925123ecd21edf8bd7
+pathspec==1.0.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5035385e957dc1d1781b6f1c49836c0ec2a82a208ca1d49570fe9172687a40e8
+pexpect==4.9.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d46956c267f85748380e9a48e3581ec71a52b3d213f8b621086760abe8949ba2
+pillow==12.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:331a0ce29141abe2a24e61581cae9355429c9b891b92823bf297acfa42c72df1 \
+    --hash=sha256:30b9d7eee6819c1f4988007fbcfd2a7273d63be5cfcefc5e457417838e240088 \
+    --hash=sha256:30a3a5d62d45e9eaa12a526f150ab371891b540b313e5b770e535d008ba39f20 \
+    --hash=sha256:9f40684adac64414d5f8e5aab195f9faf2f4867ca472faf82e5a19edf3fb7cc1
+pip==26.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8f0bff463cbb3f5ec7a0bd339bdcc3e8fe44845d47df80eb03a0247aca1b06b2
+platformdirs==4.5.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6978d578ae06df9e7c6d3f1fd69f6fee5fcc7c765d0929f03f853b99d61d520e
+plotly==6.5.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1ebfc83e5d4dbd5b8fc5a86bd1f52f73e591a9df925a9bb58d73be8f955f505c
+prometheus-client==0.24.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e924547b32d818b4659c4c292a79daf9cd970e60618a106dcc7bc7b21ce565d3
+prompt-toolkit==3.0.52 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dd6dd43f6411dd0e920933cd971ed160e3e377121c228783b00fb867ca9e10d9
+proto-plus==1.27.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:36c16cc95bca3822d079c23ed5a9062e3ad5f45ef227e8ed195dfb4f3691e00f
+protobuf==6.33.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:739c7bdbc9374c1279d7f28e3b519f03a478fe4e99fa45f270cfcfb26fd89ead \
+    --hash=sha256:91c3c05053e0c5197eed51add4a8b180fbc7c078df6a2d917d4bdfbaf82fd529 \
+    --hash=sha256:a362cf9de2fd5148ac661ef2cee438f2234ca953866dae0ce9e92b57dc47a608 \
+    --hash=sha256:e166b849df656d8a50295b3f80e5dd443157d2136d1bbd0d5ee0b7519b152266
+psutil==7.2.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1d075c398828df89f0136423aae7e63af157c598a1fc523ec63d1c3cb44ba27c \
+    --hash=sha256:d41b4ac8e939bb0213f1e82b005af008afdccef2c9048def70aa58daecd2aa4a \
+    --hash=sha256:cc5dc187b73af687b122e07191e335d24f89454677291a9556adbf177f7b22c3 \
+    --hash=sha256:39832a207d7d8b2834b44148f303a3cb0bb39eb932bb2a170bb05281cc900bdc
+ptyprocess==0.7.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:04a9e537c7fd06708ed8fe63d73dd864e0bdcafd39e1bbc00793533d6c2a3e46
+pure-eval==0.2.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:69ca56a05367fa5b08de38f76c9fa60637ebc5ef32726337b3a63732fd53aad9
+py-spy==0.4.1 ; implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+    --hash=sha256:632a990ddd5394d1360f4736790daa336a4412ae5d448b71eb1f092e61d46220 \
+    --hash=sha256:ba03163b955927082e19509a9d79a647d3ce782b97f8f343df4f160b562ec9ff
+pyarrow==23.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4cf976e2f3c38840bf665772b7d8eaf80ee59b9ab0bd37ef5fe836c6cf088da8 \
+    --hash=sha256:462de3a3463a4d94f8333aa32f0f1f8efce98bbd5add87d1019f8816750866b6 \
+    --hash=sha256:835b252ebe30b1c72973b6053719213256cf8a8f38978029ac80475ec774386e \
+    --hash=sha256:e30245e5da3e008c5492361833f042280a3d21a53e37a4758b0e5e45b7f59935
+pyasn1==0.6.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cb4b2ddf9ddff27c7a3f46068cef6cecb4f498c13a4b68f5a3fbf325bfc4400a
+pyasn1-modules==0.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5c7bf9849c08413901d2e98c4a3da0861866c4ed1eebaa8f2d4e9540232810f9
+pycparser==3.0 ; python_full_version >= '3.9' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
+    --hash=sha256:ec954d7b38d719767f9618d99b29d5b9bcbe8274130883b48e07557274002df6
+pydantic==2.12.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cc8c4ff220f0e2309ec1781a479c57e40ae9b8ba275da297fbcee62cd31f7b15
+pydantic-core==2.41.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a966ce92575e67ff1e51d2eff56ea2b90c5e0d5f09aaee9db412e4654f400525 \
+    --hash=sha256:ce56d9bafc1406dc926f6b6d770adeeba5e875b5b9d181e20c76384830c8fa6e \
+    --hash=sha256:eee5cf9017dca982cd43074555a6a72e07d62afca3964ee01d02f4528d8334e4 \
+    --hash=sha256:a0fe192417ab47aa326d002d8d2b901671361a4adfd36c704e7367422383fb5f
+pygments==2.19.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d12e1c9329462093f7637532e8167ea0e36ba99b86c5c19bc976c9c146827ec3
+pyjwt==2.11.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:156bba03d9c86f38be2a7d52ce42f72799f4d1d2264458fa96e9bb4107694095
+pyparsing==3.3.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:30a9742b4e8861e9a0f86cfba2c73a6df42c2d983dcad43e9806ca1330900be7
+python-dateutil==2.9.0.post0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:43bdd9ee7f8852603911a711fdfed201f03448079d0f46732b3211d5f7d56bc3
+python-dotenv==1.2.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7d79a05df3dfae1089746603a46bcfcc52642a3cc6f556d1bbd00e9a59a92855
+pytz==2025.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:54ee6be2ecd9daebcd6c1a5024b428e54acd53b047edc6ca8124a727280ac592
+pyyaml==6.0.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:89f68a62f49c3dcd908f3a10c536a780cf2f95766a8efb87961a548fbd89ac0a \
+    --hash=sha256:71bf5b394a66c99d2c98998e8ed1f728f544805f57f32ebd0f7c7d62fab7f963 \
+    --hash=sha256:ee388a7853f97b6df3f3e19c47d578b34c9722eaf2a511a573848c31467121b5 \
+    --hash=sha256:3e2d8f89b54d2971dadfba75228c84ca7285194f3104be2aa1baec14f6048d17
+pyzmq==27.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:85bbfe318e2382dcd782e420174f125d94e9984d12fd0b7eb4f110844d60db88 \
+    --hash=sha256:61829b36db9e39377f57249ac803cba0913a44f27f4d500acdeda4c2b614ed23 \
+    --hash=sha256:199061ccd388d426179cdeb4b05d4d29adaae7fc418f40b0aa6ce45be93140c4 \
+    --hash=sha256:9131bf5482cc4bd46ce62080020aeeab7e329e6f8034b7c564e534e17b105dd2
+referencing==0.37.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f5781948c184906b4b00f2e641b0ddc42104cf87ec38072dc2ad51309fca8bd9
+requests==2.32.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fb1893f12ec574815e416f8d6326fb673f32b904cce3b8f4ff68442c224874bc
+requests-oauthlib==2.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:62dd9f890741b877b59cbdf2a66ec964f353537f7cb9a558230ff92d09b33f6d
+requests-toolbelt==1.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d5cec317a78584d1a442e900ecf35e58369aa05963cdaf214fccc98e6a41676a
+retrying==1.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4799680a9e8a98e9c7512e7fa37a84c79b0a0215c08be03c378262cabb714cf0
+rpds-py==0.30.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c58fc5ebb49e63a75e163d0e81c617a5150707ec353ea3cd778680bae385e050 \
+    --hash=sha256:523f944b006a6f339028b2de2f389918f3a14504f6e01aca6f67e14c5f2868cd \
+    --hash=sha256:6202004cb98bafb1872b7353595ff9f38169a1d2872088284f5cd0e38a03d797 \
+    --hash=sha256:cfe393754ccfa4daf019d81b41408ef8d5561cc94608dc1d512053d1f8b7fb03
+rsa==4.9.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6e7330d695f8319e865f8b8659959802e072bacb23e745b6c316d2bb7df76997
+s3transfer==0.16.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6bd00bc6e00ca3322d00a0f193f5abdb20e4ceb2e8c8f2823dec0b3ad9af540b
+scikit-learn==1.8.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:944e305a5a4953234abf2cb09f2d048f5befa71c1d324c01f5cfcca485227d57 \
+    --hash=sha256:169b28daa90cd3d338811af88b611d41f207c375a91303d970cdfc7f44f2e139 \
+    --hash=sha256:872a59c85f4c13c65310e23caf187ecebeac542b0c6b92b6f10fc61e5148adee \
+    --hash=sha256:67ae9fa81bc635a66f10d35699d03bb6aa243d4789720fada0742d0e5c816334
+scipy==1.16.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:42287028be0a6e951346e51acff8ff349d670dcb216ceaf00f8b5832ed21af6f \
+    --hash=sha256:8ab74686fe33b6c6e1f048039bd4d8d6a0dad195a989925c6b89b985abb10a6b \
+    --hash=sha256:66448443cff584cd5ae6c238efa859e9048027954c891efeef600beefb61ec3c \
+    --hash=sha256:90d60a78a9963fc5339d8d9d33ebaa8d71ccba6608641a7ef2ee2235d39e9192
+setuptools==80.9.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:99c28a7b2a30ab65314deda44b45738a4ed1d3070ab7fe38898930274ce652b8
+six==1.17.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b0e8c34e5a82070135af7b1e04fc14595bf4a019087d3370468c13a9d7d921f7
+skl2onnx==1.19.1 ; implementation_name == 'cpython' and platform_machine != 's390x' and sys_platform == 'linux' \
+    --hash=sha256:a0512e099edfa89622c5c9f55ac0e17b43584bbfef79984ce131ac9c3852e12d
+smart-open==7.5.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:19448cb2f668050aa732246762c4196ec285dd0efedd9b169238f2201b8096d4
+sqlalchemy==2.0.46 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:198211e3059ffbadc6c315acfa97d16aa75ac7713def5aeb3fa0cde1acfd4fbb \
+    --hash=sha256:637812b6f4377246731868343c1a70e0f3cf7071200ec838a4c58a860cd769fa \
+    --hash=sha256:d1980e6bbd5c41bf9b0db331dc4121ccc93b6b03ce9aa878462ca717bb3b6ae2 \
+    --hash=sha256:ab4cb30abd8bbec3e5873ee7407a3e855d1cd3fa276ba1b3daa72edfebcdcb17
+stack-data==0.6.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f5febcc35456f56885af3dcd7e149b04119314a202555248e3404bbd7d947244
+starlette==0.50.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cbce1b41efecb38cecbe857405f32666f8b9bfdacafe59f8d79f595a36e4e177
+tabulate==0.9.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:97dc4124be7430cab50ab8a9212c69676a7ddf73e3c003be18e0a910cc271d0d
+tenacity==8.5.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8e19468b8a5a25b5a4d1f789b6367d208129f98e85a69bb2dea23fa617d390eb
+threadpoolctl==3.6.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:949a7d2df6ef745211a119ff455e49ec62ec94e017dc54d9b40eb076e17c2aa3
+toml==0.10.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ddc445e05d6cd4d4f69f3be68b7199a0b0c63c30459a61c90e0cdd887b7a182a
+toolz==1.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5533a0f5bd76797fbc5db742e56c52bb3db41ccedcdc742ab63e18f1c1b76223
+tornado==6.5.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:57ac91e431d9a82d0181432616d17b5a118be97da073e02d58e68c55c671061b \
+    --hash=sha256:38dbce8f34adfa440af8057ceee02cd9e70fc780f71b3fc736b3e034b635a30d \
+    --hash=sha256:9aada83aff5e31704141379a1ab44292d53a193917cc584230daac6b00567814 \
+    --hash=sha256:54b1f7edf70c241cd8bd3bd38f8963b7b39e161a526fcad8a7a27297a0efff15
+tqdm==4.67.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2658150d16b0377109f4270397d659ef9118d69834172402963e01d007f1593a
+traitlets==5.14.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ee42d404ebf73fce9f644f2b50496969f4b0456e2c30851be3d8796a6fb0c09c
+typeguard==4.4.4 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6c742015c1acb5e3141a0a8f8230cfba616f3041651fab949f1433b461144843
+typing-extensions==4.15.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:28315a85e5b275d75b84624b5a9e43386fb080bc934750089a7741a74895e2ae
+typing-inspection==0.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7b7bebd3411949faebda9a12b2b9e3c4b94d18ab29c438152b2b3f5239fa8aab
+tzdata==2025.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:34decb148c64bdd3d0468d40fe14fde26b16c1c8ddc82d6e96b0df0dd12f5b3b
+urllib3==2.6.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ccb0a302c40bb2e5d9b7f45282847a81e8620fed27b5483a402072563def955e
+uv==0.9.28 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f036e972362c121476072dc3bb1222ee575a72ba80e86c7958f328788ad09d6d \
+    --hash=sha256:e304040280c3a73ca8f85f8215f0280db4a1f7f58a7ba57ff7d55a9f3e310a52 \
+    --hash=sha256:8ad689c0036d9ae58fe0d753d91124687e0a03e84f5eef81ffa32ef6bda396b2 \
+    --hash=sha256:98dadbc8bce085a06e5c49ccd7cfe4752c67f454c84babdb4f1522aa9ec0b5ea
+uvicorn==0.34.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8888d7f96fafa6b78afa834f9c4564f1dc3a906de18f418f57b051bf6bd7e135
+uvicorn-worker==0.3.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c0d6f58ba198e2bd40423df9b664ccb1a454e8378e269e693bd5869c2545ee15
+uvloop==0.22.1 ; implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
+    --hash=sha256:85d62407f6454963a10a56aaade8320fa0a71871e726ffd6b44feb955492c115 \
+    --hash=sha256:25a296298b26028b2f981e69c3c91c318e4f67d9040d98667d6195dddf18a2d7 \
+    --hash=sha256:eacf86249a9cd8a8de0c2abf2ce1c741cc0ad24cb131b0140df37378bb7b8467 \
+    --hash=sha256:9d60caeeebe2b984e8e32732488df21455c4b08c5ec4c74f8ae47ff9cad28c1f
+virtualenv==20.36.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:63c660e83c7cb19846fd4f91d6a92dd557179d7706f3d20c28ebe1f386eae927
+watchfiles==1.1.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:70bdb90c0b3c8be542f2824e423c5fde49b992c6eaaa4fce04dc88e9d23fc3ec \
+    --hash=sha256:cdb395318ee3cec7996c177134313fc4f8fb9e1a3f3bb48c8a0d2e96df1cc6bc \
+    --hash=sha256:e2234ead6be4c19ec3eadeee83bbc4975079558746edc4f054fe2e643d23aa71 \
+    --hash=sha256:55795d8fce8353b1831003580ca558c191760cbebea2c2697748dc286104c2ed
+wcwidth==0.5.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6e98359959812e4a0832b3e7cf21b8b39ff083e2dcd17b781d9bfa17cff2bfda
+websocket-client==1.9.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4d7bfdd6830272263b00f2f41f4ba404a38f5db8ddcd4074ed3eab87a120fbf7
+websockets==16.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:796608a1e806cf083aefe9ce344a3e6b33066202a717a60428e1ec78b6e90124 \
+    --hash=sha256:3a3312d176fb9759b166ed28306cb75661c61dadcae2414bfc142d1780500b2c \
+    --hash=sha256:233628b31109bf0d3c295210b729c93d4a3779edb4699e6ba15c079fc44281a1 \
+    --hash=sha256:d594b324a87c3050e5d87c463df27e5b3b6db7020014c0b106f0f2c375cd1218
+wheel==0.46.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:581579e7a4b207a7d50a71d2e9ffb18b40920965f06ff852538c64b5845faa83
+wrapt==2.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e0e6baa9cfa6d2aab49306b73e139162cf7a25444ff676a25dc80333a1398239 \
+    --hash=sha256:7e3fd8324db491cd99350a48a8fbb9c888ee825f94b4eec456916e0689470ade \
+    --hash=sha256:284004f82045f055f77ab79361126742ca11090f0ffe4ea899442dffe1014f97 \
+    --hash=sha256:2117b8745946ad08dbf96ed4106bb867e554a869e294f028f2707288aaaacff3

--- a/codeserver/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver/ubi9-python-3.12/run-code-server.sh
@@ -2,7 +2,10 @@
 
 # Load bash libraries
 SCRIPT_DIR=$(dirname -- "$0")
-source ${SCRIPT_DIR}/utils/*.sh
+for f in "${SCRIPT_DIR}"/utils/*.sh; do
+  # shellcheck source=/dev/null
+  [[ -f "$f" ]] && source "$f"
+done
 
 # Start nginx and httpd
 run-nginx.sh &
@@ -39,8 +42,10 @@ create_dir_and_file() {
   fi
 }
 
+CODE_SERVER_DATA_DIR="/opt/app-root/src/.local/share/code-server"
+
 # Define universal settings
-universal_dir="/opt/app-root/src/.local/share/code-server/User/"
+universal_dir="${CODE_SERVER_DATA_DIR}/User/"
 user_settings_filepath="${universal_dir}settings.json"
 universal_json_settings='// vscode settings are written in json-with-comments
 /* https://code.visualstudio.com/docs/languages/json#_json-with-comments */
@@ -88,7 +93,7 @@ create_dir_and_file "$vscode_dir" "$settings_filepath" "$json_settings"
 create_dir_and_file "$vscode_dir" "$launch_filepath" "$json_launch_settings"
 
 # Ensure the extensions directory exists
-extensions_dir="/opt/app-root/src/.local/share/code-server/extensions"
+extensions_dir="${CODE_SERVER_DATA_DIR}/extensions"
 mkdir -p "$extensions_dir"
 
 # Copy installed extensions to the runtime extensions directory if they do not already exist
@@ -108,7 +113,7 @@ else
 fi
 
 # Ensure log directory exists
-logs_dir="/opt/app-root/src/.local/share/code-server/coder-logs"
+logs_dir="${CODE_SERVER_DATA_DIR}/coder-logs"
 if [ ! -d "$logs_dir" ]; then
   echo "Debug: Log directory not found, creating '$logs_dir'..."
   mkdir -p "$logs_dir"
@@ -124,9 +129,9 @@ else
     echo "IPv6 not detected: falling back to IPv4 only"
 fi
 
-# Start server
 start_process /usr/bin/code-server \
     --bind-addr "${BIND_ADDR}" \
+    --user-data-dir "${CODE_SERVER_DATA_DIR}" \
     --disable-telemetry \
     --auth none \
     --disable-update-check \

--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -450,6 +450,12 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/matplotlib_inline-0.2.1-2-py3-none-any.whl", hashes = { sha256 = "6a1b97fed26c7c7452c3357db29aa75e0298b1c8e0a4cb8e42220e68cb28b4cf" } }]
 
 [[packages]]
+name = "micropipenv"
+version = "1.10.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/micropipenv-1.10.0-2-py3-none-any.whl", hashes = { sha256 = "b78ed8e7223a1da2fdf7241da021bf9d2da6385763cda4ca9bf7da929eaea8f2" } }]
+
+[[packages]]
 name = "ml-dtypes"
 version = "0.5.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -592,6 +598,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "30a3a5d62d45e9eaa12a526f150ab371891b540b313e5b770e535d008ba39f20" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pillow-12.1.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9f40684adac64414d5f8e5aab195f9faf2f4867ca472faf82e5a19edf3fb7cc1" } },
 ]
+
+[[packages]]
+name = "pip"
+version = "26.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/pip-26.0-2-py3-none-any.whl", hashes = { sha256 = "8f0bff463cbb3f5ec7a0bd339bdcc3e8fe44845d47df80eb03a0247aca1b06b2" } }]
 
 [[packages]]
 name = "platformdirs"
@@ -974,6 +986,17 @@ name = "urllib3"
 version = "2.6.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/urllib3-2.6.3-2-py3-none-any.whl", hashes = { sha256 = "ccb0a302c40bb2e5d9b7f45282847a81e8620fed27b5483a402072563def955e" } }]
+
+[[packages]]
+name = "uv"
+version = "0.9.28"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uv-0.9.28-2-py3-none-linux_aarch64.whl", hashes = { sha256 = "f036e972362c121476072dc3bb1222ee575a72ba80e86c7958f328788ad09d6d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uv-0.9.28-2-py3-none-linux_ppc64le.whl", hashes = { sha256 = "e304040280c3a73ca8f85f8215f0280db4a1f7f58a7ba57ff7d55a9f3e310a52" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uv-0.9.28-2-py3-none-linux_s390x.whl", hashes = { sha256 = "8ad689c0036d9ae58fe0d753d91124687e0a03e84f5eef81ffa32ef6bda396b2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA1/cpu-ubi9/uv-0.9.28-2-py3-none-linux_x86_64.whl", hashes = { sha256 = "98dadbc8bce085a06e5c49ccd7cfe4752c67f454c84babdb4f1522aa9ec0b5ea" } },
+]
 
 [[packages]]
 name = "uvicorn"


### PR DESCRIPTION
## Summary

Part **1 of 3** for the hermetic codeserver build ([RHAIENG-2846](https://issues.redhat.com/browse/RHAIENG-2846)). This PR contains **backward-compatible changes** that work with the existing (non-hermetic) Dockerfile.

### Changes

- **`run-code-server.sh`**: Three independent improvements:
  - Robust `source` loop (for-loop instead of glob, handles missing files and spaces in paths)
  - HOME/XDG fallback (fixes EACCES errors when HOME=/root in test stage)
  - `--user-data-dir` flag (explicit writable path for code-server data)
  - Disable GitHub Copilot chat features (`chat.disableAIFeatures: true`)

- **`pyproject.toml`**: Add `uv`, `micropipenv`, `debugpy` as explicit dependencies (needed for cachi2 hermetic prefetch); exclude `py-spy` on ppc64le

- **`uv.lock.d/pylock.cpu.toml`**: Regenerated with new dependencies (adds micropipenv, pip, uv entries)

- **`pylock.toml`** *(new)*: New lockfile format (not referenced by current Dockerfile -- prepared for hermetic build)

- **`requirements.txt`** *(new)*: Requirements file for cachi2 prefetch (not referenced by current Dockerfile)

### Buildability

The existing Dockerfile is **not modified**. It continues to build exactly as before. The new files (`pylock.toml`, `requirements.txt`) are not referenced by the current Dockerfile and are harmless additions.

### Review focus

~63 lines of human-authored changes in `run-code-server.sh` and `pyproject.toml`. The lockfiles are machine-generated.

### PR Stack

- **[1/3] This PR** - Python deps + runtime fixes
- [2/3] Prefetch input data (repos, RPM/artifact manifests, submodule) -- depends on this PR
- [3/3] Hermetic Dockerfile + build patches + Tekton pipelines -- depends on [2/3]

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IPython kernel and debugger support for improved notebook debugging and interactive sessions.
  * Ensured runtime uses a configurable data directory so user settings, extensions, and logs persist in one place.

* **Chores**
  * Updated and expanded dependency manifests and lockfiles for reproducible, architecture-aware installs.
  * Added/pinned scientific and runtime packages and applied platform-specific constraints and overrides for stability and security.
  * Revised lockfile-generation workflow and documentation to produce flavor-specific outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->