### PR TITLE
ISSUE #2972: chore(.coderabbit.yaml): add pre-merge title and branch prefix checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,18 +37,18 @@ reviews:
           If missing, suggest adding one but do not treat as a hard failure.
 
         GENTLE NUDGE - Preferred format:
-          The ideal format is: "<TICKET>: <scope>, <description>"
+          The ideal format is: "<TICKET>: <scope>: <description>"
           where <scope> is one of: chore, feat, fix, docs, refactor, test, build,
           ci, style, perf, revert (optionally scoped like chore(.tekton/)).
           If the title doesn't follow this format but satisfies the strict rules
           above, just mention the preferred format as a suggestion.
 
         Valid examples:
-          - "RHAIENG-3019: chore, remove tf2onnx from pyproject.toml(s)"
-          - "NO-JIRA: chore(.tekton), update multiarch pipeline"
-          - "ISSUE #2944: chore(base-images/aipcc.sh), enable COPR repo"
-          - "[release-2.11] RHAIENG-3019: chore, remove tf2onnx"
-          - "[rhoai-2.25][RHAIENG-3209] chore(workbenches/runtimes), update llmcompressor"
+          - "RHAIENG-3019: chore: remove tf2onnx from pyproject.toml(s)"
+          - "NO-JIRA: chore(.tekton): update multiarch pipeline"
+          - "ISSUE #2944: chore(base-images/aipcc.sh): enable COPR repo"
+          - "[release-2.11] RHAIENG-3019: chore: remove tf2onnx"
+          - "[rhoai-2.25][RHAIENG-3209] chore(workbenches/runtimes): update llmcompressor"
     custom_checks:
       - name: "Branch prefix policy"
         mode: warning   # change to "error" once confirmed with the team


### PR DESCRIPTION
## Description

* https://github.com/opendatahub-io/notebooks/issues/2972

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added pre-merge validation: PR title rules (warning level) with exemptions and prioritized human-authored formatting guidance, plus optional ticket reference handling.
  * Added a branch-prefix policy (warning level) that validates PR title branch prefixes against the base branch and provides a one-line fix hint on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->