### PR TITLE
Add submodule checkout and optional prefetch step to build template

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -81,6 +81,7 @@ jobs:
         if: ${{ fromJson(inputs.github).event_name != 'pull_request_target' }}
         with:
           lfs: ${{ contains(inputs.target, 'codeserver') }}
+          submodules: recursive
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
       # we need to checkout the pr branch, not pr target (the default for pull_request_target)
       # user access check is done in calling workflow
@@ -89,6 +90,7 @@ jobs:
         with:
           ref: "refs/pull/${{ fromJson(inputs.github).event.number }}/merge"
           lfs: ${{ contains(inputs.target, 'codeserver') }}
+          submodules: recursive
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       # https://github.com/docker/setup-qemu-action?tab=readme-ov-file#about
@@ -257,6 +259,27 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
              f.write(f"CONTAINER_BUILD_CACHE_ARGS={extra_podman_build_args} {cache_args}\n")
 
+      # Hermetic builds: when the target ships a prefetch-input/ directory,
+      # download all dependencies into cachi2/output/ so the Dockerfile can
+      # build fully offline.  Targets without prefetch-input/ are unaffected.
+      - name: "Prefetch hermetic build dependencies"
+        id: prefetch
+        run: |
+          set -Eeuxo pipefail
+          COMPONENT_DIR=$(echo "${{ inputs.target }}" | sed 's|-|/|')
+          if [ -d "$COMPONENT_DIR/prefetch-input" ]; then
+            echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR"
+            pip3 install --quiet --break-system-packages pyyaml
+            command -v uv &>/dev/null || pip3 install --quiet --break-system-packages uv
+            scripts/lockfile-generators/prefetch-all.sh --component-dir "$COMPONENT_DIR"
+            if [ -x scripts/lockfile-generators/post-prefetch.sh ]; then
+              scripts/lockfile-generators/post-prefetch.sh --component-dir "$COMPONENT_DIR"
+            fi
+            echo "EXTRA_BUILD_ARGS=--volume $(pwd)/cachi2/output:/cachi2/output:Z --build-arg LOCAL_BUILD=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No prefetch-input/ found for $COMPONENT_DIR — skipping"
+          fi
+
       - name: "Build: make ${{ inputs.target }}"
         id: make-target
         run: |
@@ -266,7 +289,7 @@ jobs:
           make ${{ inputs.target }}
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
-          CONTAINER_BUILD_CACHE_ARGS: "${{ steps.extra-container-build-args.outputs.CONTAINER_BUILD_CACHE_ARGS }}"
+          CONTAINER_BUILD_CACHE_ARGS: "${{ steps.extra-container-build-args.outputs.CONTAINER_BUILD_CACHE_ARGS }} ${{ steps.prefetch.outputs.EXTRA_BUILD_ARGS }}"
           # We don't have access to image registry for PRs, so disable pushing
           PUSH_IMAGES: "${{ (fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'pull_request_target') && 'no' || 'yes' }}"
           KONFLUX: "${{ inputs.konflux && 'yes' || 'no' }}"


### PR DESCRIPTION
## Summary

Adds generic hermetic build support to the reusable workflow template. Any image target can opt into hermetic (offline) builds simply by shipping a `prefetch-input/` directory — no further workflow changes needed.

Targets **without** `prefetch-input/` are completely unaffected (the step prints "skipping").

## Changes

- **`.github/workflows/build-notebooks-TEMPLATE.yaml`** (1 file, +24/-1):
  - Checkout submodules recursively for all targets
  - Add "Prefetch hermetic build dependencies" step that detects `prefetch-input/` and calls `prefetch-all.sh`
  - Call optional `post-prefetch.sh` for component-specific post-prefetch actions (e.g. moving deps to LVM)
  - Append cachi2 volume mount + `LOCAL_BUILD=true` to `CONTAINER_BUILD_CACHE_ARGS`

## Test plan

- [ ] Verify CI passes — the prefetch step is a no-op for all current targets (none have `prefetch-input/`)
- [ ] After syncing to downstream, re-run hermetic codeserver PR's CI to confirm prefetch activates

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow to support offline dependency prefetching for improved build reliability.
  * Enhanced repository checkout to recursively fetch submodules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->