### PR TITLE
RHAIENG-3347: chore(dockerfile_fragments.py): shift a comment around to unify Dockerfile and Dockerfile.konflux files

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -70,8 +70,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -48,8 +48,8 @@ USER root
 ARG TARGETARCH
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -17,8 +17,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -16,8 +16,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -14,8 +14,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -35,8 +35,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -35,8 +35,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -33,8 +33,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -33,8 +33,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -35,8 +35,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -60,8 +60,8 @@ WORKDIR /opt/app-root/bin
 USER root
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -28,8 +28,8 @@ RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "mic
 USER root
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -24,8 +24,8 @@ ENV UV_DEFAULT_INDEX=https://pypi.org/simple
 USER root
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -18,8 +18,8 @@ USER 0
 ARG TARGETARCH
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -14,8 +14,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -16,8 +16,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -16,8 +16,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -14,8 +14,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -14,8 +14,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -18,8 +18,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 ### BEGIN upgrade first to avoid fixable vulnerabilities
-# If we have a Red Hat subscription prepared, refresh it
 RUN /bin/bash <<'EOF'
+# If we have a Red Hat subscription prepared, refresh it
 set -Eeuxo pipefail
 if command -v subscription-manager &> /dev/null; then
   subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -52,8 +52,8 @@ def sanity_check(dockerfile: pathlib.Path, replacements: dict[str, str]):
 
 def main():
     subscription_manager_register_refresh = textwrap.dedent(r"""
-        # If we have a Red Hat subscription prepared, refresh it
         RUN /bin/bash <<'EOF'
+        # If we have a Red Hat subscription prepared, refresh it
         set -Eeuxo pipefail
         if command -v subscription-manager &> /dev/null; then
           subscription-manager identity &>/dev/null && subscription-manager refresh || echo "No identity, skipping refresh."


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed shell script syntax errors in container build configurations.
  * Improved error handling during subscription refresh steps in Dockerfiles.

* **Chores**
  * Enhanced robustness of build scripts with stricter error checking across container images.
  * Reorganized conditional logic and comments for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->