### PR TITLE
fix(trustyai): build failure in pytorch compilation on ppc64le

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -134,8 +134,12 @@ if [[ $(uname -m) == "ppc64le" ]] || [[ $(uname -m) == "s390x" ]]; then
 	git clone --depth 1 --branch "v${TORCH_VERSION}" --recurse-submodules --shallow-submodules https://github.com/pytorch/pytorch.git
         cd pytorch
         # Filter out lintrunner - it's a dev tool for linting, not needed for building PyTorch
-        # uv cannot parse lintrunner's pyproject.toml (missing project.version)
-        grep -v lintrunner requirements.txt | uv pip install -r /dev/stdin
+        #  uv cannot parse lintrunner's pyproject.toml (missing project.version)
+        # Update: the previous solution stopped working: grep -v lintrunner requirements.txt | uv pip install -r /dev/stdin
+        #  fails with error: Error parsing included file in `/dev/stdin` at position 76
+        #   Caused by: failed to read from file `/dev/requirements-build.txt`: No such file or directory (os error 2)
+        #  it seems that pytorch has added some -r included files and now we need to resolve it relative to the input file
+        pip install --no-cache-dir -r requirements.txt
         python setup.py develop
         rm -f dist/torch*+git*whl
         MAX_JOBS=${MAX_JOBS:-$(nproc)} \


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C07ANR2U56C/p1771520858856879

## Description

The -r requirements inclusion was added in
* https://github.com/pytorch/pytorch/pull/158111
 
and it looks to be a new Torch 2.9 addition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the development environment configuration by improving how Python packages are installed from requirement files. Updated the installation process to better handle complex requirements with included dependencies and relative path resolution. This change provides developers with a more stable and reliable local development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->