### PR TITLE
RHOAIENG-24788: fix(jupyterlab-git): increase git commands timeout to 120s

### DIFF
--- a/jupyter/utils/jupyter_server_config.py
+++ b/jupyter/utils/jupyter_server_config.py
@@ -4,3 +4,5 @@ c = get_config()
 c.WebPDFExporter.enabled = False
 c.QtPDFExporter.enabled = False
 c.QtPNGExporter.enabled = False
+# JupyterLab Git extension: increase timeout for clone/pull/push (default 20s)
+c.JupyterLabGit.git_command_timeout = 120


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-24788

## Description
Increased the timout for jupyterlab-git commands to 120s

## Testing
Clone a git repo. Wait to finish successfully.

https://github.com/adrielparedes/notebooks/actions/runs/22460378054

## Documentation

https://github.com/jupyterlab/jupyterlab-git/blob/main/README.md#server-settings 

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the JupyterLab Git operation timeout to 120 seconds, allowing longer-running Git actions (clone, pull, push) to complete before timing out. This improves reliability for large repositories or slow networks and reduces interrupted operations caused by short default timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->