### PR TITLE
RHAIENG-3388: fix(codeserver): build failure in auditwheel install, it's not in aipcc index and has to come from PyPI

### DIFF
--- a/codeserver/ubi9-python-3.12/devel_env_setup.sh
+++ b/codeserver/ubi9-python-3.12/devel_env_setup.sh
@@ -24,7 +24,7 @@ build_pillow() {
 
     : ================= Fix Pillow Wheel ====================
     cd /pillowwheel
-    uv pip install auditwheel
+    uv pip install --extra-index-url https://pypi.org/simple auditwheel
     auditwheel repair pillow*.whl
     mv wheelhouse/pillow*.whl ${WHEEL_DIR}
 
@@ -78,7 +78,7 @@ if [[ $(uname -m) == "s390x" ]]; then \
     source "$HOME/.cargo/env"
 
     export MAX_JOBS=${MAX_JOBS:-$(nproc)}
-     
+
     if [[ $(uname -m) == "s390x" ]]; then
         echo "Checking OpenBLAS pkg-config..."
         pkg-config --exists openblas || echo "Warning: openblas.pc not found"
@@ -122,7 +122,7 @@ if [[ $(uname -m) == "ppc64le" ]]; then
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/OpenBLAS/lib/
     export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
     export CMAKE_ARGS="-DPython3_EXECUTABLE=python"
-    
+
     PYARROW_VERSION=$(grep -A1 '"pyarrow"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
     build_pyarrow ${PYARROW_VERSION}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-3388

## Description

build failure in auditwheel install, it's not in aipcc index and has to come from PyPI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python 3.12 development environment setup configuration for UBI9
  * Enhanced auditwheel installation with explicit PyPI extra index specification
  * Refined ppc64le architecture-specific build configuration for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->