### PR TITLE
ISSUE #967: fix(sandbox): improve error reporting for missing Dockerfile dependencies

### DIFF
--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -100,6 +100,11 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
     for dep in prereqs:
         if dep.is_absolute():
             dep = dep.relative_to(ROOT_DIR)
+
+        if not dep.exists():
+            logging.error(f"File or directory '{dep}' referenced in the Dockerfile was not found on disk. Please ensure the file exists.")
+            sys.exit(1)
+
         if dep.is_dir():
             shutil.copytree(dep, tmpdir / dep, symlinks=False, dirs_exist_ok=True)
         else:


### PR DESCRIPTION
## Description

    Resolves #967. This avoids a confusing FileNotFoundError and stack trace from
    shutil when a file copied in a Dockerfile does not exist on disk, pointing
    the user directly to the problem instead.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sandbox initialization validation to detect missing prerequisites early and prevent downstream errors during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->