### PR TITLE
RHAIENG-3347: tests(cuda): allow `ldd` to find torch libs for torchvision

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -106,8 +106,15 @@ class TestBaseImage:
                             continue
 
                         count_scanned += 1
-                        ld_library_path = (
-                            os.environ.get("LD_LIBRARY_PATH", "") + os.path.pathsep + os.path.dirname(dlib)
+
+                        ld_library_path = os.path.pathsep.join(
+                            (
+                                os.environ.get("LD_LIBRARY_PATH", ""),
+                                # $ORIGIN
+                                os.path.dirname(dlib),
+                                # torchvision needs libtorch_cpu.so, libc10_cuda.so from torch
+                                "/opt/app-root/lib/python3.12/site-packages/torch/lib/",
+                            )
                         )
                         output = subprocess.check_output(
                             ["ldd", dlib],


### PR DESCRIPTION
this pr got a 👍 on slack https://redhat-internal.slack.com/archives/C096ZR053RQ/p1772128810488379?thread_ts=1762874870.367099&cid=C096ZR053RQ

## Description

* https://github.com/opendatahub-io/notebooks/pull/3012#issuecomment-3966457854

```
SUBFAILED[dlib='/opt/app-root/lib64/python3.12/site-packages/torchvision/image.so'] tests/containers/base_image_test.py::TestBaseImage::test_elf_files_can_link_runtime_libs[ghcr.io/opendatahub-io/notebooks/workbench-images:runtime-cuda-pytorch-ubi9-python-3.12-_03532fe891d8b8c146b039e7465c68a5594d9145] - Failed: dlib='/opt/app-root/lib64/python3.12/site-packages/torchvision/image.so' has unsatisfied dependencies deps='libc10_cuda.so => not found'
FAILED tests/containers/base_image_test.py::TestBaseImage::test_elf_files_can_link_runtime_libs[ghcr.io/opendatahub-io/notebooks/workbench-images:runtime-cuda-pytorch-ubi9-python-3.12-_03532fe891d8b8c146b039e7465c68a5594d9145] - contains 14 failed subtests
= 15 failed, 8 passed, 13 skipped, 3 deselected, 4 warnings, 10 subtests passed in 80.69s (0:01:20) =
```

## How Has This Been Tested?

* https://github.com/opendatahub-io/notebooks/actions/runs/22451578306

see for example passing test in

* https://github.com/opendatahub-io/notebooks/actions/runs/22451578306/job/65021280145

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved ELF linking test library path resolution to properly locate runtime library dependencies by expanding the search paths used during dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->