### PR TITLE
build-template: add codeserver build support and RHDS subscription env vars

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -166,7 +166,7 @@ jobs:
         # NOTE: the arm64 GitHub hosted runner does not have the /mnt-mounted scratch disk
         if: "${{ contains(inputs.target, 'rocm') || contains(inputs.target, 'cuda') ||
          contains(inputs.target, 'pytorch') || contains(inputs.target, 'tensorflow') ||
-         inputs.platform == 'linux/arm64' }}"
+         contains(inputs.target, 'codeserver') || inputs.platform == 'linux/arm64' }}"
 
       - id: install-compsize
         run: sudo apt-get install -y btrfs-compsize
@@ -238,6 +238,16 @@ jobs:
              # Compiling pyzmq through UV needs this in CFLAGS
              extra_podman_build_args += '--env=CFLAGS=-Dundefined=64 --env=CXXFLAGS=-Dundefined=64 --unsetenv=CFLAGS --unsetenv=CXXFLAGS'
 
+          if "codeserver" in "${{ inputs.target }}":
+             # Hermetic codeserver builds compile from source on every run — there
+             # is no effective layer cache to reuse.  --layers=false stops podman
+             # from persisting intermediate layers within each stage, cutting peak
+             # disk use roughly in half.
+             extra_podman_build_args += ' --layers=false'
+             # GHA runners (16GB RAM) need reduced VS Code build parallelism.
+             # apply-patch.sh checks GHA_BUILD and runs patches/tweak-gha.sh.
+             extra_podman_build_args += ' --build-arg GHA_BUILD=true'
+
           event_name: Literal['push', 'pull_request', 'pull_request_target', 'schedule', 'workflow_dispatch'] = "${{ fromJson(inputs.github).event_name }}"
           cache = "${{ env.CACHE }}"
 
@@ -262,6 +272,10 @@ jobs:
       # Hermetic builds: when the target ships a prefetch-input/ directory,
       # download all dependencies into cachi2/output/ so the Dockerfile can
       # build fully offline.  Targets without prefetch-input/ are unaffected.
+      # For RHDS/AIPCC builds (subscription: true), the --rhds flag selects the
+      # downstream lockfiles and the SUBSCRIPTION_* env vars supply the RHEL
+      # credentials for RPM downloads from cdn.redhat.com — secrets never
+      # appear on the command line.
       - name: "Prefetch hermetic build dependencies"
         id: prefetch
         run: |
@@ -271,7 +285,13 @@ jobs:
             echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR"
             pip3 install --quiet --break-system-packages pyyaml
             command -v uv &>/dev/null || pip3 install --quiet --break-system-packages uv
-            scripts/lockfile-generators/prefetch-all.sh --component-dir "$COMPONENT_DIR"
+
+            PREFETCH_ARGS=(--component-dir "$COMPONENT_DIR")
+            if [[ "${{ inputs.subscription }}" == "true" ]]; then
+              PREFETCH_ARGS+=(--rhds)
+            fi
+
+            scripts/lockfile-generators/prefetch-all.sh "${PREFETCH_ARGS[@]}"
             if [ -x scripts/lockfile-generators/post-prefetch.sh ]; then
               scripts/lockfile-generators/post-prefetch.sh --component-dir "$COMPONENT_DIR"
             fi
@@ -279,12 +299,20 @@ jobs:
           else
             echo "No prefetch-input/ found for $COMPONENT_DIR — skipping"
           fi
+        env:
+          SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
+          SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 
       - name: "Build: make ${{ inputs.target }}"
         id: make-target
         run: |
-          # print running stats on disk occupancy
-          (while true; do df -h | grep "${HOME}/.local/share/containers"; sleep 30; done) &
+          # print running stats on disk and memory occupancy
+          (while true; do
+            echo "=== $(date -u '+%H:%M:%S') ==="
+            df -h | grep "${HOME}/.local/share/containers"
+            free -h
+            sleep 30
+          done) &
 
           make ${{ inputs.target }}
         env:


### PR DESCRIPTION
## Summary

Since `pull_request_target` loads the workflow template from the **base branch** (main), all template changes must land on main before they take effect for PRs like #2985.

This PR includes all template changes needed for hermetic codeserver + AIPCC builds:

- **Free up disk space for codeserver**: adds `contains(inputs.target, 'codeserver')` to the free-up-disk-space condition
- **Codeserver build optimizations**: `--layers=false` to reduce peak disk usage, `--build-arg GHA_BUILD=true` to limit VS Code compile parallelism on 16GB GHA runners
- **RHDS/AIPCC prefetch support**: passes `--rhds` flag to `prefetch-all.sh` when `inputs.subscription` is true, and exposes `SUBSCRIPTION_ORG` / `SUBSCRIPTION_ACTIVATION_KEY` secrets as env vars so the prefetch scripts can download RPMs from `cdn.redhat.com`
- **Build monitoring**: adds timestamps and `free -h` to the resource monitoring loop

## Test plan

- [ ] Verify existing ODH builds are unaffected (no `inputs.subscription` = no `--rhds` flag, no subscription env vars used)
- [ ] Verify AIPCC builds pick up `--rhds` and use `rhds/rpms.lock.yaml` for prefetching
- [ ] Verify codeserver builds get disk space freed and `--layers=false` / `GHA_BUILD=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow to securely manage subscription credentials during dependency preparation.
  * Enhanced build diagnostics with additional disk and memory usage checks for long-running builds.
  * Broadened cleanup/space-freeing checks to cover additional build targets.
  * Adjusted container build behavior for codeserver targets to improve compatibility with the CI runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->