### PR TITLE
build-template: add codeserver build optimizations and monitoring

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -166,7 +166,7 @@ jobs:
         # NOTE: the arm64 GitHub hosted runner does not have the /mnt-mounted scratch disk
         if: "${{ contains(inputs.target, 'rocm') || contains(inputs.target, 'cuda') ||
          contains(inputs.target, 'pytorch') || contains(inputs.target, 'tensorflow') ||
-         inputs.platform == 'linux/arm64' }}"
+         contains(inputs.target, 'codeserver') || inputs.platform == 'linux/arm64' }}"
 
       - id: install-compsize
         run: sudo apt-get install -y btrfs-compsize
@@ -238,6 +238,16 @@ jobs:
              # Compiling pyzmq through UV needs this in CFLAGS
              extra_podman_build_args += '--env=CFLAGS=-Dundefined=64 --env=CXXFLAGS=-Dundefined=64 --unsetenv=CFLAGS --unsetenv=CXXFLAGS'
 
+          if "codeserver" in "${{ inputs.target }}":
+             # Hermetic codeserver builds compile from source on every run — there
+             # is no effective layer cache to reuse.  --layers=false stops podman
+             # from persisting intermediate layers within each stage, cutting peak
+             # disk use roughly in half.
+             extra_podman_build_args += ' --layers=false'
+             # GHA runners (16GB RAM) need reduced VS Code build parallelism.
+             # apply-patch.sh checks GHA_BUILD and runs patches/tweak-gha.sh.
+             extra_podman_build_args += ' --build-arg GHA_BUILD=true'
+
           event_name: Literal['push', 'pull_request', 'pull_request_target', 'schedule', 'workflow_dispatch'] = "${{ fromJson(inputs.github).event_name }}"
           cache = "${{ env.CACHE }}"
 
@@ -300,8 +310,14 @@ jobs:
       - name: "Build: make ${{ inputs.target }}"
         id: make-target
         run: |
-          # print running stats on disk occupancy
-          (while true; do df -h | grep "${HOME}/.local/share/containers"; sleep 30; done) &
+          # Print disk and memory stats every 30s so OOM/disk-full failures
+          # leave a breadcrumb trail in the logs.
+          (while true; do
+            echo "=== $(date -u '+%H:%M:%S') ==="
+            df -h | grep "${HOME}/.local/share/containers"
+            free -h
+            sleep 30
+          done) &
 
           make ${{ inputs.target }}
         env:


### PR DESCRIPTION
## Summary

Codeserver hermetic builds on GHA runners are failing silently (runner loses communication) due to OOM / disk exhaustion. This PR adds:

- **Free disk space** for `codeserver` targets — same treatment as `rocm`, `cuda`, `pytorch`, `tensorflow`
- **`--layers=false`** to reduce peak disk usage — codeserver compiles from source every run so there's no layer cache to benefit from
- **`--build-arg GHA_BUILD=true`** to reduce VS Code build parallelism — GHA runners only have 16GB RAM
- **Build monitoring with timestamps + `free -h`** — so future OOM/disk-full failures leave a clear breadcrumb trail in CI logs instead of the uninformative "runner lost communication" message

These changes are needed on `main` so that `pull_request_target` workflows pick them up.

## Context

- Prerequisite for https://github.com/opendatahub-io/notebooks/pull/2985 (hermetic codeserver build)
- Failed run: https://github.com/opendatahub-io/notebooks/actions/runs/22500172157/job/65185013844?pr=2985

## Test plan

- [ ] Verify CI passes on this PR (template-only change, no functional builds affected)
- [ ] After merge, re-run codeserver build in PR #2985 to confirm runner no longer OOMs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized codeserver target builds with adjusted caching configuration
  * Enhanced build process monitoring with timestamped progress tracking and memory usage reporting for improved visibility into build operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->