### PR TITLE
RHAIENG-2860: Enable hermetic build for codeserver/ubi9-python-3.12

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -343,6 +343,7 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
 # [HERMETIC] Install useful OS packages from prefetched RPMs.
 # nodejs: provides libnode.so needed at runtime by code-server's bundled node binary
 #         (installed via rpm2cpio which skips dependency resolution).
+# cpio: required for rpm2cpio | cpio -idmv below (install here to avoid a second dnf call).
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 PACKAGES=(
@@ -352,6 +353,7 @@ PACKAGES=(
     gettext
     # nss_wrapper: required by generate_container_user (LD_PRELOAD=libnss_wrapper.so)
     nss_wrapper
+    cpio
 )
 dnf install -y "${PACKAGES[@]}"
 dnf clean all
@@ -368,8 +370,6 @@ COPY --from=rpm-base /tmp/code-server-*.rpm /tmp/
 # Install code-server via rpm2cpio (dnf rejects unsigned RPMs built from source on Konflux/Conforma)
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y cpio
-dnf -y clean all
 cd /
 rpm2cpio /tmp/code-server-${CODESERVER_VERSION/v/}-*.rpm | cpio -idmv
 EOF

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -341,6 +341,7 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
 # [HERMETIC] Install useful OS packages from prefetched RPMs.
 # nodejs: provides libnode.so needed at runtime by code-server's bundled node binary
 #         (installed via rpm2cpio which skips dependency resolution).
+# cpio: required for rpm2cpio | cpio -idmv below (install here to avoid a second dnf call).
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 PACKAGES=(
@@ -350,6 +351,7 @@ PACKAGES=(
     gettext
     # nss_wrapper: required by generate_container_user (LD_PRELOAD=libnss_wrapper.so)
     nss_wrapper
+    cpio
 )
 dnf install -y "${PACKAGES[@]}"
 dnf clean all
@@ -366,8 +368,6 @@ COPY --from=rpm-base /tmp/code-server-*.rpm /tmp/
 # Install code-server via rpm2cpio (dnf rejects unsigned RPMs built from source on Konflux/Conforma)
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y cpio
-dnf -y clean all
 cd /
 rpm2cpio /tmp/code-server-${CODESERVER_VERSION/v/}-*.rpm | cpio -idmv
 EOF
@@ -470,7 +470,8 @@ COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/run-code-server.sh ${CODESERVER_SO
 
 ENV SHELL=/bin/bash
 
-ENV PYTHONPATH=/opt/app-root/bin/python3
+# Directory where uv pip install puts packages; PYTHONPATH must be a directory, not the python binary.
+ENV PYTHONPATH=/opt/app-root/lib/python3.12/site-packages
 
 # Copy requirements files (pylock.toml for metadata; requirements.txt used for installation)
 COPY ${CODESERVER_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
@@ -50,15 +50,15 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
     checksum: sha256:324cd645481db1ceda8621409c9151fc58d182b90cc5c428db80edb21fb26df3
     filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
-    checksum: sha256:0f308620a428f56fe871fcc5d7c668c461dfed3244f717b698f3e9e92aca037a
+  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-gnu.tar.gz
+    checksum: sha256:1b0ca509f8707f2128f1b3ef245c3ea666d49a737431288536d49bd74652d143
     filename: ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
     checksum: sha256:a3fdb2c6ef9d4ff927ca1cb1e56f7aed7913d1be4dd4546aec400118c26452ab
-    filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
+    filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-musl.tar.gz
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
-    filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
+    filename: ripgrep-v13.0.0-13-s390x-unknown-linux-musl.tar.gz
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-4/ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu.tar.gz
     checksum: sha256:3ddd7c0797c14cefd3ee61f13f15ac219bfecee8e6f6e27fd15c102ef229653a
     filename: ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu.tar.gz

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -1460,13 +1460,6 @@ arches:
     name: openblas-openmp
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/o/openblas-openmp64-0.3.26-2.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3544936
-    checksum: sha256:58375d20a4bf7aac5fbf45b73dd5bb1a8bc641e0b97b2b5d4ba3c16d80311c07
-    name: openblas-openmp64
-    evr: 0.3.26-2.el9
-    sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/o/openblas-serial-0.3.26-2.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 3498840
@@ -4792,6 +4785,13 @@ arches:
     name: openblas-devel
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/codeready-builder/os/Packages/o/openblas-openmp64-0.3.26-2.el9.aarch64.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-rpms
+    size: 3544936
+    checksum: sha256:58375d20a4bf7aac5fbf45b73dd5bb1a8bc641e0b97b2b5d4ba3c16d80311c07
+    name: openblas-openmp64
+    evr: 0.3.26-2.el9
+    sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/codeready-builder/os/Packages/o/openblas-openmp64_-0.3.26-2.el9.aarch64.rpm
     repoid: codeready-builder-for-rhel-9-x86_64-rpms
     size: 3543050
@@ -4864,10 +4864,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/repodata/ff6afbb5590cec985a8abc828c802890617a96ef8078a1572a52a0be7ad59c8a-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/repodata/8c529c0af1d53c7ae34edc350309cc9b9c25bac4bdfe08df09b32d216367a775-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34364
-    checksum: sha256:ff6afbb5590cec985a8abc828c802890617a96ef8078a1572a52a0be7ad59c8a
+    checksum: sha256:8c529c0af1d53c7ae34edc350309cc9b9c25bac4bdfe08df09b32d216367a775
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.ppc64le.rpm
@@ -6345,13 +6345,6 @@ arches:
     size: 4543241
     checksum: sha256:0776ca7cae38482ded3cd044c39bea92349bb1fdff5fc0977aef9b57fff36c0a
     name: openblas-openmp
-    evr: 0.3.26-2.el9
-    sourcerpm: openblas-0.3.26-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/o/openblas-openmp64-0.3.26-2.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4482450
-    checksum: sha256:6a1c60419440fe3e2694b407086b7389ac044d81ec030bf8196d5828dde4c5fa
-    name: openblas-openmp64
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/o/openblas-serial-0.3.26-2.el9.ppc64le.rpm
@@ -9693,6 +9686,13 @@ arches:
     name: openblas-devel
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/codeready-builder/os/Packages/o/openblas-openmp64-0.3.26-2.el9.ppc64le.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-rpms
+    size: 4482450
+    checksum: sha256:6a1c60419440fe3e2694b407086b7389ac044d81ec030bf8196d5828dde4c5fa
+    name: openblas-openmp64
+    evr: 0.3.26-2.el9
+    sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/codeready-builder/os/Packages/o/openblas-openmp64_-0.3.26-2.el9.ppc64le.rpm
     repoid: codeready-builder-for-rhel-9-x86_64-rpms
     size: 4476910
@@ -9765,10 +9765,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/repodata/3d48fbd5859c9b12022268e74dee409a770e366f0f65757b5c28a3df3fb1d5ed-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/repodata/5b6f42676fc1e04a945f8a63a111e72aaca8bd26d4f69f34abeee1ba6446cb77-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32808
-    checksum: sha256:3d48fbd5859c9b12022268e74dee409a770e366f0f65757b5c28a3df3fb1d5ed
+    checksum: sha256:5b6f42676fc1e04a945f8a63a111e72aaca8bd26d4f69f34abeee1ba6446cb77
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.s390x.rpm
@@ -11274,13 +11274,6 @@ arches:
     size: 3649910
     checksum: sha256:4029d63e2406d0c444790303c12284ce59674e0175a915f681f07587e8e33732
     name: openblas-openmp
-    evr: 0.3.26-2.el9
-    sourcerpm: openblas-0.3.26-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/o/openblas-openmp64-0.3.26-2.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3588930
-    checksum: sha256:db66489d56d110d855c60a0fbdb36cc4c072137654ec3c13e73340eb90909fd4
-    name: openblas-openmp64
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/o/openblas-serial-0.3.26-2.el9.s390x.rpm
@@ -14566,6 +14559,13 @@ arches:
     name: openblas-devel
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/codeready-builder/os/Packages/o/openblas-openmp64-0.3.26-2.el9.s390x.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-rpms
+    size: 3588930
+    checksum: sha256:db66489d56d110d855c60a0fbdb36cc4c072137654ec3c13e73340eb90909fd4
+    name: openblas-openmp64
+    evr: 0.3.26-2.el9
+    sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/codeready-builder/os/Packages/o/openblas-openmp64_-0.3.26-2.el9.s390x.rpm
     repoid: codeready-builder-for-rhel-9-x86_64-rpms
     size: 3578513
@@ -14638,10 +14638,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/repodata/3ed776b733945710ce6d2e1c51adb03dd8eef9278642ae85cf3e248606d4f11c-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/repodata/618e82350683be2d774e2cbe542232caaff48f4fce79c01ff56b40112bf0b571-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 33005
-    checksum: sha256:3ed776b733945710ce6d2e1c51adb03dd8eef9278642ae85cf3e248606d4f11c
+    checksum: sha256:618e82350683be2d774e2cbe542232caaff48f4fce79c01ff56b40112bf0b571
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.x86_64.rpm
@@ -16119,13 +16119,6 @@ arches:
     size: 5180333
     checksum: sha256:357c33b876bc5d0c14342592fbf23e2cc34a43b27d158d13ac0ab658608b5399
     name: openblas-openmp
-    evr: 0.3.26-2.el9
-    sourcerpm: openblas-0.3.26-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/o/openblas-openmp64-0.3.26-2.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 5062343
-    checksum: sha256:6bf2f5658c077d2012c488c891f41a98545b701246a23a98f66b1337190fe3a4
-    name: openblas-openmp64
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/o/openblas-serial-0.3.26-2.el9.x86_64.rpm
@@ -19474,6 +19467,13 @@ arches:
     name: openblas-devel
     evr: 0.3.26-2.el9
     sourcerpm: openblas-0.3.26-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/codeready-builder/os/Packages/o/openblas-openmp64-0.3.26-2.el9.x86_64.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-rpms
+    size: 5062343
+    checksum: sha256:6bf2f5658c077d2012c488c891f41a98545b701246a23a98f66b1337190fe3a4
+    name: openblas-openmp64
+    evr: 0.3.26-2.el9
+    sourcerpm: openblas-0.3.26-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/codeready-builder/os/Packages/o/openblas-openmp64_-0.3.26-2.el9.x86_64.rpm
     repoid: codeready-builder-for-rhel-9-x86_64-rpms
     size: 5043253
@@ -19546,7 +19546,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/repodata/fd61f3d858b750437c5274ecbcd5557e0ec92552116b5f04b7aa744ce0edb78c-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/repodata/618da00859523e2a4bb67ee62e36cf10b141af12f83bd8e2773dd66f668e1e14-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34742
-    checksum: sha256:fd61f3d858b750437c5274ecbcd5557e0ec92552116b5f04b7aa744ce0edb78c
+    checksum: sha256:618da00859523e2a4bb67ee62e36cf10b141af12f83bd8e2773dd66f668e1e14

--- a/codeserver/ubi9-python-3.12/requirements.cpu.txt
+++ b/codeserver/ubi9-python-3.12/requirements.cpu.txt
@@ -90,7 +90,6 @@ googleapis-common-protos==1.72.0 ; implementation_name == 'cpython' and sys_plat
 greenlet==3.3.2 ; (implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:23d109a14d7c5fe854806c2aaf1c93b5c293e27a5ce2ae7db1cb8ae882cac75c \
     --hash=sha256:68ef1ff6bcea69be356e5a805d745d3ab1aecc60aad3db3aaffd8c1ab617c02f \
-    --hash=sha256:c188631f301fd80d918990ea39561dfb4080c5e23c67b8be3992be2d14b9b1cf \
     --hash=sha256:b12423d1bad2cf4a22a1d91d0aa2690503bc10d00b5e12909ae24030872e7858
 gunicorn==25.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:04f73b7587728045d41c6938e60a60bfb70bff43b9f53d22e691b485de8a7931


### PR DESCRIPTION
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): Enable hermetic build for codeserver ubi9-python-3.12 CPU image
Update prefetch-input, lock files for RHDS.

## Description
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): Enable hermetic build for codeserver ubi9-python-3.12 CPU image
Update prefetch-input, lock files for RHDS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated dependency installation to streamline image builds and reduce extra package install steps.
  * Aligned Python runtime path to reference installed packages for more reliable package loading.
  * Updated architecture-specific artifact URLs and checksums.
  * Removed a redundant package verification hash.
  * Added duplicate package entries in metadata (data-only change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->