### PR TITLE
RHAIENG-2846 Prefetch: COMPONENT_DIR from Makefile, local build default, Tekton discovery

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -280,7 +280,13 @@ jobs:
         id: prefetch
         run: |
           set -Eeuxo pipefail
-          COMPONENT_DIR=$(echo "${{ inputs.target }}" | sed 's|-|/|')
+          # Derive component dir from Makefile (single source of truth). Works for all
+          # image targets (codeserver, jupyter-*, runtime-*, rstudio-*, base-images-*).
+          COMPONENT_DIR=$(make -n "${{ inputs.target }}" 2>&1 | sed -n 's/.*#\*# Image build directory: <\([^>]*\)>.*/\1/p' | head -n1)
+          if [ -z "$COMPONENT_DIR" ]; then
+            echo "Could not derive COMPONENT_DIR from Makefile for target ${{ inputs.target }}" >&2
+            exit 1
+          fi
           if [ -d "$COMPONENT_DIR/prefetch-input" ]; then
             echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR"
             pip3 install --quiet --break-system-packages pyyaml

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SHELL := bash
 .DELETE_ON_ERROR:
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
+# Used where we need an empty expansion (avoids undefined variable warning).
+empty :=
 
 # todo: leave the default recipe prefix for now
 ifeq ($(origin .RECIPEPREFIX), undefined)
@@ -85,14 +87,20 @@ define build_image
 			awk -F= '!/^#/ && NF {gsub(/^[ \t]+|[ \t]+$$/, "", $$1); gsub(/^[ \t]+|[ \t]+$$/, "", $$2); printf "--build-arg %s=%s ", $$1, $$2}' $(CONF_FILE); \
 		fi))
 
-	# Hermetic local build: when cachi2/output/ exists AND this target has a
-	# prefetch-input/ directory, mount pre-downloaded deps and set LOCAL_BUILD=true.
-	$(eval CACHI2_VOLUME := $(if $(and $(wildcard cachi2/output),$(wildcard $(BUILD_DIR)prefetch-input)),--volume $(ROOT_DIR)cachi2/output:/cachi2/output:Z --build-arg LOCAL_BUILD=true,))
+	# Make is only used for local and GHA builds (Konflux does not run make).
+	# Default to local build for hermetic-capable targets: always set LOCAL_BUILD=true
+	# when prefetch-input/ exists; mount cachi2/output only when it exists (after prefetch).
+	$(eval LOCAL_BUILD_ARG := $(if $(wildcard $(BUILD_DIR)prefetch-input),--build-arg LOCAL_BUILD=true,))
+	$(eval CACHI2_VOLUME := $(if $(and $(wildcard cachi2/output),$(wildcard $(BUILD_DIR)prefetch-input)),--volume $(ROOT_DIR)cachi2/output:/cachi2/output:Z,))
 
 	$(info # Building $(IMAGE_NAME) using $(DOCKERFILE_NAME) with $(CONF_FILE) and $(BUILD_ARGS)...)
 
+	@if [ -d '$(BUILD_DIR)prefetch-input' ] && [ ! -d cachi2/output ]; then \
+	  echo "Prefetch required for hermetic build. Run: scripts/lockfile-generators/prefetch-all.sh --component-dir $(patsubst %/,%,$(BUILD_DIR)) — see scripts/lockfile-generators/README.md"; \
+	  exit 1; \
+	fi
 	$(ROOT_DIR)/scripts/sandbox.py --dockerfile '$(2)' --platform '$(BUILD_ARCH)' -- \
-		$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) $(CACHI2_VOLUME) --platform=$(BUILD_ARCH) --label release=$(RELEASE) --tag $(IMAGE_NAME) --file '$(2)' $(BUILD_ARGS) {}\;
+		$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_CACHE_ARGS) $(LOCAL_BUILD_ARG) $(CACHI2_VOLUME) --platform=$(BUILD_ARCH) --label release=$(RELEASE) --tag $(IMAGE_NAME) --file '$(2)' $(BUILD_ARGS) {}\;
 endef
 
 # Push function for the notebook image:
@@ -111,8 +119,8 @@ endef
 define image
 	$(eval BUILD_DIRECTORY := $(shell echo $(2) | sed 's/\/Dockerfile.*//'))
 	$(eval VARIANT := $(shell echo $(notdir $(2)) | cut -d. -f2))
-	$(eval DOCKERFILE := $(BUILD_DIRECTORY)/Dockerfile$(if $(KONFLUX:no=),.konflux,$()).$(VARIANT))
-	$(eval CONF_FILE := $(BUILD_DIRECTORY)/build-args/$(if $(KONFLUX:no=),konflux.,$())$(shell echo $(VARIANT)).conf)
+	$(eval DOCKERFILE := $(BUILD_DIRECTORY)/Dockerfile$(if $(KONFLUX:no=),.konflux,$(empty)).$(VARIANT))
+	$(eval CONF_FILE := $(BUILD_DIRECTORY)/build-args/$(if $(KONFLUX:no=),konflux.,$(empty))$(shell echo $(VARIANT)).conf)
 	$(info #*# Image build Dockerfile: <$(DOCKERFILE)> #(MACHINE-PARSED LINE)#*#...)
 	$(info #*# Image build directory: <$(BUILD_DIRECTORY)> #(MACHINE-PARSED LINE)#*#...)
 

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
@@ -35,15 +35,15 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
     checksum: sha256:324cd645481db1ceda8621409c9151fc58d182b90cc5c428db80edb21fb26df3
     filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
-    checksum: sha256:0f308620a428f56fe871fcc5d7c668c461dfed3244f717b698f3e9e92aca037a
+  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-gnu.tar.gz
+    checksum: sha256:1b0ca509f8707f2128f1b3ef245c3ea666d49a737431288536d49bd74652d143
     filename: ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
     checksum: sha256:a3fdb2c6ef9d4ff927ca1cb1e56f7aed7913d1be4dd4546aec400118c26452ab
-    filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
+    filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-musl.tar.gz
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
-    filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
+    filename: ripgrep-v13.0.0-13-s390x-unknown-linux-musl.tar.gz
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-4/ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu.tar.gz
     checksum: sha256:3ddd7c0797c14cefd3ee61f13f15ac219bfecee8e6f6e27fd15c102ef229653a
     filename: ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu.tar.gz

--- a/scripts/lockfile-generators/README.md
+++ b/scripts/lockfile-generators/README.md
@@ -37,9 +37,9 @@ All scripts must be run from the **repository root**.
 
 ---
 
-## Orchestrator — `prefetch-all.sh`
+## Orchestrator `prefetch-all.sh`
 
-**For most local and CI use, this is the only script you need to run.**
+**For most local and CI use, this is the main script you need to run.**
 
 `prefetch-all.sh` orchestrates all four lockfile generators in the correct
 order, downloading dependencies into `cachi2/output/deps/`. After running it,
@@ -66,6 +66,7 @@ Then build with make:
 ```bash
 # On macOS use gmake
 gmake codeserver-ubi9-python-3.12 BUILD_ARCH=linux/arm64 PUSH_IMAGES=no
+# OR using Local podman build (Please scroll down to Local podman build section for more detail.)
 ```
 
 ### Options
@@ -75,7 +76,6 @@ gmake codeserver-ubi9-python-3.12 BUILD_ARCH=linux/arm64 PUSH_IMAGES=no
 | `--component-dir DIR` | Component directory (required), e.g. `codeserver/ubi9-python-3.12` |
 | `--rhds` | Use downstream (RHDS) lockfiles instead of upstream (ODH, the default) |
 | `--flavor NAME` | Lock file flavor (default: `cpu`) |
-| `--tekton-file FILE` | Tekton PipelineRun YAML for npm path discovery (auto-detected from `.tekton/` if omitted) |
 | `--activation-key KEY` | Red Hat activation key for RHEL RPMs (optional) |
 | `--org ORG` | Red Hat organization ID for RHEL RPMs (optional) |
 
@@ -83,10 +83,23 @@ gmake codeserver-ubi9-python-3.12 BUILD_ARCH=linux/arm64 PUSH_IMAGES=no
 
 | Step | Condition | Script called |
 |------|-----------|---------------|
-| 1. Generic artifacts | `artifacts.in.yaml` exists | `create-artifact-lockfile.py` |
-| 2. Pip wheels | `pyproject.toml` exists | `create-requirements-lockfile.sh --download` |
-| 3. NPM packages | `package-lock.json` files found | `download-npm.sh` |
-| 4. RPMs | `rpms.in.yaml` exists | `hermeto-fetch-rpm.sh` (if lockfile committed) or `create-rpm-lockfile.sh --download` |
+| 1. Generic artifacts | `prefetch-input/<variant>/artifacts.in.yaml` exists | `create-artifact-lockfile.py` |
+| 2. Pip wheels | `pyproject.toml` exists in component dir | `create-requirements-lockfile.sh --download` |
+| 3. NPM packages | Tekton PipelineRun found for component (see below) | `download-npm.sh --tekton-file` |
+| 4. RPMs | `prefetch-input/<variant>/rpms.in.yaml` exists | `hermeto-fetch-rpm.sh` (if lockfile committed) or `create-rpm-lockfile.sh --download` |
+
+**Variant directory:** Lockfiles live under `prefetch-input/odh/` (upstream) or
+`prefetch-input/rhds/` (downstream). If that directory is missing, steps 1 and 4
+are skipped; steps 2 (pip) and 3 (npm) still run when their inputs exist
+(`pyproject.toml`, or a Tekton file for the component).
+
+**Step 3 (NPM):** The script finds the Tekton file automatically via
+`find_tekton_yaml`: it looks for a `.tekton/*pull-request*.yaml` whose
+`dockerfile` param matches this component, RHDS first
+(`COMPONENT_DIR/Dockerfile.konflux.*`), then ODH (`COMPONENT_DIR/Dockerfile.*`).
+If no Tekton file is found, npm is skipped. If the Tekton file has no
+`npm`-type `prefetch-input` entries, `download-npm.sh` exits successfully
+(nothing to download).
 
 Steps are skipped if their input files don't exist. For RPMs, if
 `rpms.lock.yaml` is already committed, it downloads directly (skipping
@@ -95,11 +108,13 @@ lockfile regeneration) — this avoids cross-platform issues on arm64 CI runners
 ### GitHub Actions integration
 
 The GHA workflow template (`.github/workflows/build-notebooks-TEMPLATE.yaml`)
-calls `prefetch-all.sh` automatically for codeserver targets before running
-`make`. Non-codeserver targets skip the prefetch step entirely. After the
-build, container tests run (e.g. `tests/containers` with pytest); image
-metadata is read from both Docker `Config` and `ContainerConfig` so labels
-work when the daemon is Podman (see
+derives the component directory from the **Makefile** (dry-run of the build
+target, parsing `#*# Image build directory: <...>`), so it works for all image
+targets (codeserver, jupyter-*, runtime-*, rstudio-*, base-images-*). Prefetch
+runs when `COMPONENT_DIR/prefetch-input` exists; otherwise the step is skipped.
+After the build, container tests run (e.g. `tests/containers` with pytest);
+image metadata is read from both Docker `Config` and `ContainerConfig` so
+labels work when the daemon is Podman (see
 [tests/containers/docs/github-vs-local-image-metadata.md](../../tests/containers/docs/github-vs-local-image-metadata.md)).
 
 **uv version:** The repo root `uv.toml` specifies the `uv` version (e.g.
@@ -110,8 +125,9 @@ work when the daemon is Podman (see
 
 ## Individual tools
 
-The four scripts below can also be run individually for debugging or partial
-updates. `prefetch-all.sh` calls them internally.
+The five options below can be used for hermetic builds. Scripts 1–4 can also be
+run individually for debugging or partial updates; `prefetch-all.sh` calls them
+internally. Option 5 (Git submodule) is a manual setup.
 
 | # | Type | Main script | What it generates |
 |---|------|-------------|-------------------|
@@ -119,6 +135,7 @@ updates. `prefetch-all.sh` calls them internally.
 | 2 | RPM | [create-rpm-lockfile.sh](#2-rpm-packages--create-rpm-lockfilesh) | `rpms.lock.yaml` |
 | 3 | npm | [download-npm.sh](#3-npm-packages--download-npmsh) | Downloaded tarballs in `cachi2/output/deps/npm/` |
 | 4 | pip (RHOAI) | [create-requirements-lockfile.sh](#4-pip-packages-rhoai--create-requirements-lockfilesh) | `pylock.<flavor>.toml` + `requirements.<flavor>.txt` |
+| 5 | Git submodule | (manual setup) | [Pinned repo under prefetch-input/](#5-git-submodule) |
 
 ### Helper scripts (used internally by the main tools)
 
@@ -516,7 +533,8 @@ collisions.  Files that already exist are skipped.
 - `--lock-file <path>` — process a single `package-lock.json`.
 - `--tekton-file <path>` — parse a Tekton PipelineRun YAML to discover all
   `npm`-type `prefetch-input` paths, then process every `package-lock.json`
-  found under them.
+  found under them. If the file has **no** `npm`-type entries, the script
+  exits 0 (nothing to download) instead of erroring.
 
 Both flags can be combined.  URLs that are already local (`file:///cachi2/...`)
 are automatically skipped.
@@ -707,39 +725,89 @@ python3 scripts/lockfile-generators/helpers/download-pip-packages.py \
 
 ---
 
+## 5. Git submodule
+
+The notebooks repository uses external code (e.g. code-server) that is normally
+cloned during the Docker build. For hermetic builds, Konflux can prefetch these
+dependencies via **git submodules**: the external repo is added as a submodule
+under `prefetch-input/` and pinned to a specific commit or tag. The build then
+uses the checked-out tree instead of running `git clone` at build time.
+
+### Setup
+
+Run from the **repository root**. Replace the submodule URL and
+`<component>/prefetch-input/<name>` with your target path (e.g.
+`codeserver/ubi9-python-3.12/prefetch-input/code-server`).
+
+```bash
+# Add the external repo as a submodule under prefetch-input
+git submodule add https://github.com/coder/code-server.git \
+    codeserver/ubi9-python-3.12/prefetch-input/code-server
+
+# Pin to a specific tag (or commit)
+cd codeserver/ubi9-python-3.12/prefetch-input/code-server
+git fetch --tags
+git checkout tags/v4.104.0
+git submodule update --init --recursive   # pull nested submodules if any
+
+# Commit the submodule and .gitmodules
+cd ../..
+git add -A .
+git commit -m "Added submodule code-server"
+```
+
+Use the same tag or commit that your Dockerfile or build scripts expect, so the
+hermetic build uses an identical source tree.
+
+---
+
 ## Appendix: Local podman build
 
 After running `prefetch-all.sh`, the **recommended** way to build is via make:
 
 ```bash
-# Makefile auto-detects cachi2/output/ and injects --volume + LOCAL_BUILD=true
+# Make sets LOCAL_BUILD=true for hermetic targets; mounts cachi2/output when it exists
 gmake codeserver-ubi9-python-3.12 BUILD_ARCH=linux/arm64 PUSH_IMAGES=no
 ```
 
-The Makefile evaluates each target independently: `CACHI2_VOLUME` is only set
-when both `cachi2/output/` exists AND the target directory has a
-`prefetch-input/` subdirectory. Non-hermetic targets are completely unaffected.
+The Makefile sets `LOCAL_BUILD=true` for any target that has `prefetch-input/`;
+it adds the cachi2 volume only when `cachi2/output/` exists (after prefetch).
+Non-hermetic targets are unaffected.
 
 ### Alternative: manual podman build
 
-For developers who want to run `podman build` directly, the key flags are:
+Running `podman build` directly differs from `gmake` in these ways:
 
-- `-v $(realpath ./cachi2):/cachi2:z` bind-mount the prefetched dependencies
-  so the Dockerfile can install from them offline.
-- `--build-arg LOCAL_BUILD=true` signals the Dockerfile that this is a local
-  build (configures dnf to use the local cachi2 RPM repo).
+| Aspect | `gmake codeserver-ubi9-python-3.12 BUILD_ARCH=... PUSH_IMAGES=no` | Manual `podman build ...` |
+|--------|-------------------------------------------------------------------|---------------------------|
+| **Build context** | Minimal (via `scripts/sandbox.py`: only files needed by the Dockerfile) | Full repo (`.`). |
+| **Volume** | `--volume $(ROOT_DIR)cachi2/output:/cachi2/output:Z` (mounts only `cachi2/output`) | Often `-v ./cachi2:/cachi2` (mounts whole dir); equivalent is `-v ./cachi2/output:/cachi2/output:z`. |
+| **Build args** | From `build-args/cpu.conf`: `INDEX_URL`, `BASE_IMAGE`, `PYLOCK_FLAVOR` | You must pass these (and `LOCAL_BUILD=true`) explicitly. |
+| **Tag** | `$(IMAGE_REGISTRY):codeserver-ubi9-python-3.12-$(RELEASE)_$(DATE)` | Whatever you pass with `-t`. |
+| **Label** | `--label release=$(RELEASE)` | Omitted unless you add it. |
+| **Cache** | Default `CONTAINER_BUILD_CACHE_ARGS ?= --no-cache` | Podman uses its default cache unless you pass `--no-cache`. |
+
+To approximate the make build when running podman manually, use the same volume
+path as make and pass all build-args from `build-args/cpu.conf`:
+
+- Bind-mount **only** `cachi2/output` at `/cachi2/output` (same as make).
+- Pass `LOCAL_BUILD=true` and the same `BASE_IMAGE`, `PYLOCK_FLAVOR`, and
+  `INDEX_URL` as in `codeserver/ubi9-python-3.12/build-args/cpu.conf`.
 
 ```bash
+# Same volume path as Makefile; build-args from build-args/cpu.conf
 podman build \
     -f codeserver/ubi9-python-3.12/Dockerfile.cpu \
-    --platform linux/amd64 \
+    --platform linux/arm64 \
     -t code-server-test \
     --build-arg LOCAL_BUILD=true \
     --build-arg BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest \
     --build-arg PYLOCK_FLAVOR=cpu \
-    -v "$(realpath ./cachi2):/cachi2:z" \
+    --build-arg INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4-EA1/cpu-ubi9/simple/ \
+    -v "$(realpath ./cachi2/output):/cachi2/output:z" \
     .
 ```
 
-To build for a different architecture, change `--platform` and `ARCH`
-accordingly (e.g. `linux/arm64` / `aarch64`, `linux/ppc64le` / `ppc64le`).
+To build for a different architecture, change `--platform` (e.g. `linux/amd64`,
+`linux/arm64`, `linux/ppc64le`). The manual command uses the **full repo** as
+context; make uses a **sandboxed** context for reproducibility.

--- a/scripts/lockfile-generators/download-npm.sh
+++ b/scripts/lockfile-generators/download-npm.sh
@@ -197,7 +197,8 @@ if [[ -n "$TEKTON_FILE" ]]; then
     npm_paths=$(extract_npm_paths_from_tekton "$TEKTON_FILE")
 
     if [[ -z "$npm_paths" ]]; then
-        error_exit "No npm-type prefetch-input entries found in $TEKTON_FILE"
+        echo "No npm-type prefetch-input entries in $TEKTON_FILE — nothing to download"
+        exit 0
     fi
 
     while IFS= read -r npm_path; do

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -17,7 +17,8 @@ set -euo pipefail
 #      (into cachi2/output/deps/rpm/).
 #
 # Each step is skipped if its input file is not present in the component's
-# prefetch-input/<variant>/ directory.
+# prefetch-input/<variant>/ directory. Step 3 (NPM) discovers the Tekton
+# file via find_tekton_yaml (RHDS = Dockerfile.konflux.*, ODH = Dockerfile.*). No Tekton file → skip npm.
 #
 # After running this script, `make <target>` auto-detects cachi2/output/
 # and passes --volume + --build-arg LOCAL_BUILD=true to podman build.
@@ -43,7 +44,6 @@ SCRIPTS_PATH="scripts/lockfile-generators"
 COMPONENT_DIR=""
 VARIANT="odh"       # "odh" = upstream (CentOS Stream), "rhds" = downstream (RHEL)
 FLAVOR="cpu"        # selects which pylock/requirements files to use (cpu, cuda, rocm)
-TEKTON_FILE=""
 ACTIVATION_KEY=""
 ORG=""
 
@@ -58,8 +58,6 @@ Options:
                           e.g. codeserver/ubi9-python-3.12
   --rhds                  Use downstream (RHDS) lockfiles instead of upstream (ODH)
   --flavor NAME           Lock file flavor (default: cpu)
-  --tekton-file FILE      Tekton PipelineRun YAML for npm path discovery
-                          (auto-detected from .tekton/ if omitted)
   --activation-key KEY    Red Hat activation key for RHEL RPMs (optional)
   --org ORG               Red Hat organization ID for RHEL RPMs (optional)
   -h, --help              Show this help
@@ -73,6 +71,41 @@ HELPEOF
 error_exit() {
   echo "Error: $1" >&2
   exit 1
+}
+
+# find_tekton_yaml COMPONENT_DIR VARIANT
+# Finds .tekton/*pull-request*.yaml files that build this component for the
+# given variant by matching the pipeline's dockerfile param. Requires yq;
+# must be run from repo root.
+#
+#   ODH (upstream):  dockerfile is COMPONENT_DIR/Dockerfile.* (excludes Dockerfile.konflux.*).
+#   RHDS (downstream): dockerfile is COMPONENT_DIR/Dockerfile.konflux.*
+# Outputs matching file paths one per line. Returns 0 if at least one match.
+find_tekton_yaml() {
+  local comp_dir="$1"
+  local variant="$2"
+  local found=0
+  local f dockerfile_path
+  if [[ ! -d ".tekton" ]] || ! command -v yq &>/dev/null; then
+    return 1
+  fi
+  for f in .tekton/*pull-request*.yaml; do
+    [[ -f "$f" ]] || continue
+    dockerfile_path=$(yq -r '.spec.params[] | select(.name == "dockerfile") | .value' "$f" 2>/dev/null)
+    [[ -n "$dockerfile_path" ]] || continue
+    if [[ "$variant" == "odh" ]]; then
+      if [[ "$dockerfile_path" == "$comp_dir/Dockerfile."* ]] && [[ "$dockerfile_path" != "$comp_dir/Dockerfile.konflux."* ]]; then
+        echo "$f"
+        found=1
+      fi
+    elif [[ "$variant" == "rhds" ]]; then
+      if [[ "$dockerfile_path" == "$comp_dir/Dockerfile.konflux."* ]]; then
+        echo "$f"
+        found=1
+      fi
+    fi
+  done
+  [[ $found -eq 1 ]]
 }
 
 # Must run from the repo root because all paths (lockfiles, Tekton YAMLs,
@@ -89,8 +122,6 @@ while [[ $# -gt 0 ]]; do
     --rhds)              VARIANT="rhds"; shift ;;
     --flavor)            [[ $# -ge 2 ]] || error_exit "--flavor requires a value"
                          FLAVOR="$2"; shift 2 ;;
-    --tekton-file)       [[ $# -ge 2 ]] || error_exit "--tekton-file requires a value"
-                         TEKTON_FILE="$2"; shift 2 ;;
     --activation-key)    [[ $# -ge 2 ]] || error_exit "--activation-key requires a value"
                          ACTIVATION_KEY="$2"; shift 2 ;;
     --org)               [[ $# -ge 2 ]] || error_exit "--org requires a value"
@@ -139,7 +170,9 @@ if [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_D
 fi
 
 VARIANT_DIR="$PREFETCH_DIR/$VARIANT"
-[[ -d "$VARIANT_DIR" ]] || error_exit "Variant directory not found: $VARIANT_DIR"
+if [[ ! -d "$VARIANT_DIR" ]]; then
+  echo "Note: Variant directory not found ($VARIANT_DIR). Steps 1 and 4 (generic, RPM) will be skipped if their inputs are missing."
+fi
 
 echo "=============================================="
 echo " prefetch-all.sh"
@@ -198,66 +231,37 @@ fi
 # =========================================================================
 # Step 3: NPM packages (download-npm.sh)
 #
-# Downloads npm tarballs by extracting resolved URLs from package-lock.json
-# files.  Two strategies:
-#
-#   Preferred: use --tekton-file (or auto-detect from .tekton/) to find all
-#   npm directories referenced in the Tekton PipelineRun.  This processes
-#   all lockfiles in a single invocation and requires yq.
-#
-#   Fallback: recursively find package-lock.json files under prefetch-input/
-#   and process each one individually.
+# Auto-detect Tekton file via find_tekton_yaml (RHDS first, then ODH). If found,
+# download npm tarballs from the prefetch-input paths listed there. If no
+# Tekton file is found for this component, skip npm. Requires yq.
 #
 # Output: cachi2/output/deps/npm/
 # =========================================================================
 echo "=== [3/4] NPM packages ==="
 
 npm_done=false
+tekton_file=""
 
-# Try to auto-detect the Tekton PipelineRun YAML that references this
-# component's prefetch-input directory.  The Tekton file lists all npm
-# lockfile paths as task parameters, so download-npm.sh can process them
-# all at once instead of discovering them one by one.
-if [[ -z "$TEKTON_FILE" ]] && [[ -d ".tekton" ]] && command -v yq &>/dev/null; then
-  auto_tekton=$(grep -rl "$COMPONENT_DIR/prefetch-input" .tekton/*pull-request*.yaml 2>/dev/null | head -1) || true
-  if [[ -n "$auto_tekton" ]]; then
-    TEKTON_FILE="$auto_tekton"
-    echo "  Auto-detected tekton file: $TEKTON_FILE"
+# Find the Tekton PipelineRun YAML: RHDS first (dockerfile COMPONENT_DIR/Dockerfile.konflux.*),
+# then ODH (dockerfile COMPONENT_DIR/Dockerfile.*). The file lists npm prefetch-input
+# paths for download-npm.sh to process in one go.
+if [[ -d ".tekton" ]] && command -v yq &>/dev/null; then
+  tekton_file=$(find_tekton_yaml "$COMPONENT_DIR" "rhds" 2>/dev/null | head -1) || true
+  if [[ -z "$tekton_file" ]]; then
+    tekton_file=$(find_tekton_yaml "$COMPONENT_DIR" "odh" 2>/dev/null | head -1) || true
   fi
-fi
-
-if [[ -n "$TEKTON_FILE" ]]; then
-  if [[ ! -f "$TEKTON_FILE" ]]; then
-    echo "  Warning: Tekton file not found: $TEKTON_FILE — falling back to auto-discovery"
-  elif ! command -v yq &>/dev/null; then
-    echo "  Warning: yq not found — falling back to auto-discovery"
-  else
-    "$SCRIPTS_PATH/download-npm.sh" --tekton-file "$TEKTON_FILE"
+  if [[ -n "$tekton_file" ]]; then
+    echo "  Auto-detected tekton file: $tekton_file"
+    "$SCRIPTS_PATH/download-npm.sh" --tekton-file "$tekton_file"
     npm_done=true
   fi
 fi
 
-# Fallback: find and process package-lock.json files individually.
-# Excludes node_modules/ to avoid processing installed (non-lockfile) copies.
-if [[ "$npm_done" != true ]]; then
-  echo "  Discovering package-lock.json files under $PREFETCH_DIR..."
-  npm_count=0
-  while IFS= read -r -d '' lock; do
-    echo "  Processing: $lock"
-    "$SCRIPTS_PATH/download-npm.sh" --lock-file "$lock"
-    npm_count=$((npm_count + 1))
-  done < <(find "$PREFETCH_DIR" -not -path "*/node_modules/*" -name "package-lock.json" -print0 2>/dev/null)
-
-  if [[ $npm_count -eq 0 ]]; then
-    echo "  No package-lock.json files found — skipping npm download"
-    STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
-  else
-    echo "  Processed $npm_count package-lock.json file(s)"
-  fi
-fi
-
-if [[ "$npm_done" == true ]] || [[ ${npm_count:-0} -gt 0 ]]; then
+if [[ "$npm_done" == true ]]; then
   STEPS_RUN=$((STEPS_RUN + 1))
+else
+  echo "  No Tekton file found for this component — skipping npm download"
+  STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
 fi
 echo ""
 
@@ -307,8 +311,14 @@ fi
 # =========================================================================
 echo "=============================================="
 echo " prefetch-all.sh complete"
-echo "  Steps run    : $STEPS_RUN"
-echo "  Steps skipped: $STEPS_SKIPPED"
+echo "  component : $COMPONENT_DIR"
+echo "  variant   : $VARIANT"
+echo "  flavor    : $FLAVOR"
+echo "  prefetch  : $PREFETCH_DIR"
+echo "  lockfiles : $VARIANT_DIR"
+echo "  tekton file: $tekton_file"
+echo "  steps run    : $STEPS_RUN"
+echo "  steps skipped: $STEPS_SKIPPED"
 echo ""
 echo " Dependencies are in: cachi2/output/deps/"
 if [[ -d "cachi2/output/deps" ]]; then


### PR DESCRIPTION
[RHAIENG-2846](https://issues.redhat.com/browse/RHAIENG-2846) Post-hermetic cleanup

- **GHA:** Derive COMPONENT_DIR from Makefile; fail clearly if missing.
- **Makefile:** Always pass LOCAL_BUILD=true for hermetic targets; require cachi2/output when prefetch-input exists; skip prefetch check when goal is all-images (matrix generation); fix empty-variable warning.
- **prefetch-all.sh:** Add find_tekton_yaml (ODH/RHDS by dockerfile param); remove --tekton-file and package-lock fallback; allow running without variant dir.
- **download-npm.sh:** Exit 0 when Tekton file has no npm entries.
- Regenerate artifacts.lock.yaml and pylock.cpu.toml; update README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variant-aware prefetch inputs with auto-detection of build configuration files.
  * Automatic Tekton file detection for NPM processing, eliminating manual specification.

* **Bug Fixes**
  * Graceful handling when NPM dependencies are not found.
  * Added preflight validation for local builds to catch missing dependencies early.

* **Documentation**
  * Comprehensive updates to build and prefetch guidance reflecting variant-aware workflows and improved local build procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->