### PR TITLE
[RHAIENG-2819]: chore(actions) Mitigate ARM64 disk space failures and fix .linuxbrew cache permissions

### DIFF
--- a/.github/actions/free-up-disk-space/action.yml
+++ b/.github/actions/free-up-disk-space/action.yml
@@ -4,11 +4,14 @@ description: 'Removes unnecessary packages and files to free up disk space on Gi
 runs:
   using: "composite"
   steps:
-    - name: Free up additional disk space
+    - name: Free up disk space
       shell: bash
       run: |
         set -x
         df -h
+        sudo docker system prune -af  || true
+        sudo apt-get clean
+        sudo rm -rf /tmp/*
         sudo apt-get update
         sudo apt-get purge -y '^dotnet-.*' '^llvm-.*' 'php.*' '^mongodb-.*'
         sudo apt-get autoremove -y --purge
@@ -20,6 +23,5 @@ runs:
         sudo rm -rf /usr/share/dotnet &
         sudo rm -rf /opt/ghc &
         sudo rm -rf /opt/hostedtoolcache/CodeQL &
-        sudo docker image prune --all --force &
         wait
         df -h

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -13,6 +13,13 @@ runs:
       shell: bash
       run: sudo apt-get -qq remove podman crun
 
+    # Ensure parent dir exists and is runner-owned so cache restore can set file modes (avoids "Cannot change mode: Operation not permitted").
+    - name: Prepare .linuxbrew parent for cache
+      shell: bash
+      run: |
+        sudo mkdir -p /home/linuxbrew
+        sudo chown -R "$(whoami):$(whoami)" /home/linuxbrew
+
     - uses: actions/cache@v5
       # https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
       # https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
@@ -20,6 +27,17 @@ runs:
       with:
         path: /home/linuxbrew/.linuxbrew
         key: linuxbrew-${{ runner.os }}-${{ runner.arch }}
+
+    # Restored cache can have wrong ownership or immutable flags; fix so brew/podman and mode changes work.
+    - name: Fix .linuxbrew ownership and permissions after cache restore
+      if: steps.cached-linuxbrew.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        if [[ -d /home/linuxbrew/.linuxbrew ]]; then
+          sudo chattr -R -i /home/linuxbrew/.linuxbrew 2>/dev/null || true
+          sudo chown -R "$(whoami):$(whoami)" /home/linuxbrew/.linuxbrew
+          sudo chmod -R u+rwX,go=rX /home/linuxbrew/.linuxbrew
+        fi
 
     - name: Install podman (linux/amd64, or qemu-user emulation)
       if: contains(fromJSON('["linux/amd64", "linux/s390x", "linux/ppc64le"]'), inputs.platform) && steps.cached-linuxbrew.outputs.cache-hit != 'true'

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -68,6 +68,8 @@ jobs:
       # Makefile variables
       BUILD_ARCH: ${{ inputs.platform }}
       RELEASE_PYTHON_VERSION: ${{ inputs.python }}
+      # Faster/smaller cache restore on resource-constrained runners (e.g. arm64). RHAIENG-2819
+      GHA_CACHE_ZSTD_LEVEL: "3"
 
     steps:
 
@@ -160,7 +162,7 @@ jobs:
 
       # region Free up disk space
 
-      - name: Free up additional disk space
+      - name: Free up disk space
         uses: ./.github/actions/free-up-disk-space
         # https://docs.github.com/en/actions/learn-github-actions/expressions
         # NOTE: the arm64 GitHub hosted runner does not have the /mnt-mounted scratch disk
@@ -324,7 +326,7 @@ jobs:
           # leave a breadcrumb trail in the logs.
           (while true; do
             echo "=== $(date -u '+%H:%M:%S') ==="
-            df -h | grep "${HOME}/.local/share/containers"
+            df -h / /mnt "${HOME}/.local/share/containers" 2>/dev/null || df -h
             free -h
             sleep 30
           done) &
@@ -567,7 +569,12 @@ jobs:
       - run: df -h
         if: "${{ !cancelled() }}"
 
-      - run: sudo compsize -x "${HOME}/.local/share/containers"
+      - run: |
+          if mountpoint -q "${HOME}/.local/share/containers"; then
+            sudo compsize -x "${HOME}/.local/share/containers"
+          else
+            echo "Skipping compsize: ${HOME}/.local/share/containers is not a btrfs mountpoint."
+          fi
         if: "${{ !cancelled() && steps.install-compsize.outcome == 'success' }}"
 
       # print system logs, useful when hunting for OOM kills

--- a/ci/cached-builds/gha_lvm_overlay.sh
+++ b/ci/cached-builds/gha_lvm_overlay.sh
@@ -21,6 +21,23 @@ tmp_pv_loop_path=/mnt/tmp-pv.img
 
 VG_NAME=buildvg
 
+
+# Detect if /mnt is a separate block device from /
+ROOT_DEV=$(df --output=source / | tail -1)
+MNT_DEV=$(df --output=source /mnt | tail -1)
+if [[ "$ROOT_DEV" == "$MNT_DEV" ]]; then
+  echo "Single-disk runner (/mnt on same fs as root) — skipping LVM, using root fs directly."
+  # Keep disk-reclaim behavior consistent with the dual-disk path.
+  sudo swapoff -a || true
+  sudo rm -f /mnt/swapfile || true
+  mkdir -p "${build_mount_path}"
+  sudo chown -R "${build_mount_path_ownership}" "${build_mount_path}"
+  if [[ ! -d "${GITHUB_WORKSPACE}" ]]; then
+    sudo mkdir -p "${GITHUB_WORKSPACE}"
+    sudo chown -R "${WORKSPACE_OWNER}" "${GITHUB_WORKSPACE}"
+  fi
+  exit 0
+fi
 # github runners have an active swap file in /mnt/swapfile
 # we want to reuse the temp disk, so first unmount swap and clean the temp disk
 echo "Unmounting and removing swap file."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- **ARM64 / resource-constrained runners ([RHAIENG-2819](https://issues.redhat.com/browse/RHAIENG-2819)):**
  - **Pre-flight cleanup:** New step at the start of the “Free up disk space” path that runs `docker system prune -af --volumes`, `apt-get clean`, and `rm -rf /tmp/*` to remove orphaned assets from crashed runs and free space before heavy builds (same `if` condition as the existing free-up-disk-space step).
  - **Cache compression:** Set job-level env `GHA_CACHE_ZSTD_LEVEL: "3"` to reduce cache size and speed up restore on constrained runners (e.g. arm64).

- **Install Podman action – .linuxbrew cache permissions:**
  - **Prepare parent for cache:** New step before `actions/cache`: create `/home/linuxbrew` and `chown -R` to the runner so cache restore can set file modes without “Operation not permitted”.
  - **Fix after cache restore:** When cache hit, run `chattr -R -i` (clear immutable), `chown -R` to runner, and `chmod -R u+rwX,go=rX` on `/home/linuxbrew/.linuxbrew` so brew/podman work and “Cannot change mode to rwxr-xr-x: Operation not permitted” is resolved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- **Pre-flight cleanup / ARM64 loopback / cache env:** Trigger the “Build Notebooks” workflow (e.g. push or `workflow_dispatch`) and confirm jobs that use the disk-pressure path (cuda, tensorflow, pytorch, rocm, or `linux/arm64`) run the new steps and complete without “No space left on device” or LVM failures on arm64 where applicable.
- **.linuxbrew permissions:** On a matrix that uses the Linuxbrew cache (e.g. `install-podman-action` with cache hit), confirm the “Prepare .linuxbrew parent for cache” and “Fix .linuxbrew ownership and permissions after cache restore” steps run and that subsequent `brew`/`podman` steps do not report “Cannot change mode: Operation not permitted”.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened pre-build disk cleanup: added docker system prune, apt-get clean, /tmp cleanup and other cache removals; removed background docker image prune.
  * Faster, smaller cache restores via adjusted cache compression level.
  * Prepare and fix ownership/permissions for .linuxbrew before/after cache restore.
  * Safer disk checks with guarded filesystem-size commands to avoid failures.
  * Detect and skip complex volume setup on single-disk runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->