### PR TITLE
chore: add ayush17 to OWNERS reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
 
 reviewers:
   - atheo89
+  - ayush17
   - daniellutz
   - dibryant
   - jiridanek


### PR DESCRIPTION
## Description

Adding `ayush17` to the OWNERS reviewers list to enable:
- Triggering GitHub Actions workflows (e.g., Update Tekton Tags, Create Release)
- Reviewing and approving PRs
- Supporting release management tasks for ODH/RHOAI

## Context

Currently unable to trigger workflows like `update-tags.yaml` for post-release tag updates, requiring assistance from other team members.

Related ticket: [RHAIENG-3167](https://issues.redhat.com/browse/RHAIENG-3167) (Release notebooks for ODH 3.4-EA2)

## Changes

- Added `ayush17` to the `reviewers` list in alphabetical order

## Checklist

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] N/A - No testing required for OWNERS file change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review team assignments.

---

**Note:** This release contains only internal administrative updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->