### PR TITLE
RHAIENG-2860: Add VSCode built-in .vsix to utils/ (js-debug, companion, profile-table)

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -55,8 +55,8 @@ ARG NODE_VERSION=22.21.1
 ARG CODESERVER_VERSION=v4.106.3
 
 # [HERMETIC] Import GPG keys for prefetched RPM verification.
-# CentOS key needed because libX11-devel comes from CentOS Stream repos.
-RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official
+# CentOS key imported only if prefetched (present in Dockerfile.cpu; may be absent in Konflux).
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
@@ -94,6 +94,8 @@ COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/setup-offline-binaries.sh ${CO
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/codeserver-offline-env.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/tweak-gha.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/apply-patch.sh ${CODESERVER_SOURCE_CODE}/
+# [HERMETIC] utils/ contains git-tracked .vsix (built-in extensions + Python/Jupyter); used by setup-offline-binaries.sh and final stage.
+COPY ${CODESERVER_CONTEXT}/utils/ ${CODESERVER_SOURCE_CODE}/utils/
 
 # [HERMETIC] apply-patch.sh enables gcc-toolset-14 and applies patches (ripgrep, vsce-sign,
 # patches/series). npm ci, build, and release run in separate RUN steps below for caching.
@@ -103,7 +105,7 @@ RUN cd ${CODESERVER_SOURCE_CODE} && GHA_BUILD="${GHA_BUILD}" ./apply-patch.sh
 # setup-offline-binaries.sh does all offline preparation in one shot:
 #   - sources codeserver-offline-env.sh (ELECTRON_SKIP_BINARY_DOWNLOAD, NPM_CONFIG_NODEDIR, etc.)
 #   - node-gyp uses system headers (NPM_CONFIG_NODEDIR=/usr from nodejs-devel RPM)
-#   - ripgrep, .vsix extensions from cachi2 generic; .build/node/ = system /usr/bin/node (per-arch)
+#   - ripgrep from cachi2 generic; .vsix from utils/; .build/node/ = system /usr/bin/node (per-arch)
 #   - pre-populates .build/builtInExtensions/ so gulp skips network downloads
 #   - rewrites package-lock.json "resolved" URLs to file:///cachi2/...
 # CI=1 makes ci/dev/postinstall.sh run "npm ci" (not "npm install") in subdirs,
@@ -158,9 +160,8 @@ ARG PYLOCK_FLAVOR
 
 # [HERMETIC] Import GPG keys for Red Hat and CentOS repos (needed for dnf to verify prefetched RPMs).
 # CentOS key is prefetched as a generic artifact (see artifacts.in.yaml).
-# UBI9 images only ship the Red Hat key; CentOS key is needed for ppc64le/s390x packages
-# from CentOS Stream repos (mesa-libGL, etc.).
-RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official
+# UBI9 images only ship the Red Hat key; CentOS key imported only if prefetched (Dockerfile.cpu; may be absent in Konflux).
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing.
@@ -238,8 +239,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 # [HERMETIC] Import GPG keys for prefetched RPM verification.
-# CentOS key needed because mesa-libGL comes from CentOS Stream repos.
-RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official
+# CentOS key imported only if prefetched (present in Dockerfile.cpu; may be absent in Konflux).
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -55,8 +55,8 @@ ARG NODE_VERSION=22.21.1
 ARG CODESERVER_VERSION=v4.106.3
 
 # [HERMETIC] Import GPG keys for prefetched RPM verification.
-# CentOS key needed because libX11-devel comes from CentOS Stream repos.
-RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official
+# CentOS key imported only if prefetched (present in Dockerfile.cpu; may be absent in Konflux).
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
@@ -94,6 +94,8 @@ COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/setup-offline-binaries.sh ${CO
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/codeserver-offline-env.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/tweak-gha.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/apply-patch.sh ${CODESERVER_SOURCE_CODE}/
+# [HERMETIC] utils/ contains git-tracked .vsix (built-in extensions + Python/Jupyter); used by setup-offline-binaries.sh and final stage.
+COPY ${CODESERVER_CONTEXT}/utils/ ${CODESERVER_SOURCE_CODE}/utils/
 
 # [HERMETIC] apply-patch.sh enables gcc-toolset-14 and applies patches (ripgrep, vsce-sign,
 # patches/series). npm ci, build, and release run in separate RUN steps below for caching.
@@ -103,7 +105,7 @@ RUN cd ${CODESERVER_SOURCE_CODE} && GHA_BUILD="${GHA_BUILD}" ./apply-patch.sh
 # setup-offline-binaries.sh does all offline preparation in one shot:
 #   - sources codeserver-offline-env.sh (ELECTRON_SKIP_BINARY_DOWNLOAD, NPM_CONFIG_NODEDIR, etc.)
 #   - node-gyp uses system headers (NPM_CONFIG_NODEDIR=/usr from nodejs-devel RPM)
-#   - ripgrep, .vsix extensions from cachi2 generic; .build/node/ = system /usr/bin/node (per-arch)
+#   - ripgrep from cachi2 generic; .vsix from utils/; .build/node/ = system /usr/bin/node (per-arch)
 #   - pre-populates .build/builtInExtensions/ so gulp skips network downloads
 #   - rewrites package-lock.json "resolved" URLs to file:///cachi2/...
 # CI=1 makes ci/dev/postinstall.sh run "npm ci" (not "npm install") in subdirs,
@@ -158,9 +160,8 @@ ARG PYLOCK_FLAVOR
 
 # [HERMETIC] Import GPG keys for Red Hat and CentOS repos (needed for dnf to verify prefetched RPMs).
 # CentOS key is prefetched as a generic artifact (see artifacts.in.yaml).
-# UBI9 images only ship the Red Hat key; CentOS key is needed for ppc64le/s390x packages
-# from CentOS Stream repos (mesa-libGL, etc.).
-RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official
+# UBI9 images only ship the Red Hat key; CentOS key imported only if prefetched (Dockerfile.cpu; may be absent in Konflux).
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing.
@@ -238,8 +239,8 @@ WORKDIR /opt/app-root/bin
 USER 0
 
 # [HERMETIC] Import GPG keys for prefetched RPM verification.
-# CentOS key needed because mesa-libGL comes from CentOS Stream repos.
-RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official
+# CentOS key imported only if prefetched (present in Dockerfile.cpu; may be absent in Konflux).
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
@@ -10,8 +10,6 @@ input:
     # from CentOS baseos/appstream/crb repos; UBI9 images only ship the Red Hat key)
     - url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
-    # Node: system Node from nodejs RPM (like che-code). ppc64le/s390x use native gulp
-    # task; BUILD_TARGETS added in gulpfile.reh.js overlay. No Node tarball prefetched.
     # ripgrep: one version (v13.0.0-13) for all 4 arches; @vscode/ripgrep postinstall patched to use it (see apply-patch.sh).
     - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
       filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
@@ -22,14 +20,3 @@ input:
       filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
     - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
       filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-    # argon2: not prefetched; builds from source via node-gyp (gcc-toolset-14 in rpm-base).
-    # The npm package is in the lockfile; when the mirror has no prebuild, it falls back to compile.
-    # OpenShift oc client: installed via dnf (openshift-clients RPM in rpms.in.yaml), not prefetched here.
-
-    # VSCode marketplace extensions (built-in extensions bundled with code-server)
-    - url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
-      filename: ms-vscode.js-debug-companion.1.1.3.vsix
-    - url: https://github.com/microsoft/vscode-js-debug/releases/download/v1.105.0/ms-vscode.js-debug.1.105.0.vsix
-      filename: ms-vscode.js-debug.1.105.0.vsix
-    - url: https://github.com/microsoft/vscode-js-profile-visualizer/releases/download/v1.0.10/ms-vscode.vscode-js-profile-table.1.0.10.vsix
-      filename: ms-vscode.vscode-js-profile-table.1.0.10.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
@@ -17,12 +17,3 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
     filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-  - download_url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
-    checksum: sha256:7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93
-    filename: ms-vscode.js-debug-companion.1.1.3.vsix
-  - download_url: https://github.com/microsoft/vscode-js-debug/releases/download/v1.105.0/ms-vscode.js-debug.1.105.0.vsix
-    checksum: sha256:0c45b90342e8aafd4ff2963b4006de64208ca58c2fd01fea7a710fe61dcfd12a
-    filename: ms-vscode.js-debug.1.105.0.vsix
-  - download_url: https://github.com/microsoft/vscode-js-profile-visualizer/releases/download/v1.0.10/ms-vscode.vscode-js-profile-table.1.0.10.vsix
-    checksum: sha256:7361748ddf9fd09d8a2ed1f2a2d7376a2cf9aae708692820b799708385c38e08
-    filename: ms-vscode.vscode-js-profile-table.1.0.10.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
@@ -10,16 +10,16 @@ set -euo pipefail
 #   1. npm config: offline, prefer-offline, fetch-retries=0 (and legacy-peer-deps).
 #   2. node-gyp: NPM_CONFIG_NODEDIR=/usr (from codeserver-offline-env.sh) → system headers.
 #   3. Ripgrep: copy prefetched tarballs to /tmp/vscode-ripgrep-cache-<version>/.
-#   4. VSCode .vsix: copy to VSCODE_OFFLINE_CACHE for patched fetch.js.
+#   4. VSCode .vsix: copy from utils/ (git-tracked) to VSCODE_OFFLINE_CACHE for patched fetch.js.
 #   5. Node: pre-populate .build/node/ with system /usr/bin/node so gulp skips download.
-#   6. Pre-populate .build/builtInExtensions/<name>/ from extracted .vsix.
+#   6. Pre-populate .build/builtInExtensions/<name>/ from extracted .vsix in utils/.
 #   7. Rewrite package-lock.json "resolved" URLs to file:///cachi2/output/deps/npm/...
 #
 # Root postinstall (ci/dev/postinstall.sh) runs install-deps custom-packages first, then
 # test, lib/vscode; custom-packages populates the npm cache for lockfile resolution.
 #
-# All artifacts are prefetched by cachi2 via artifacts.in.yaml and stored at
-# /cachi2/output/deps/generic/.
+# Ripgrep/oc/GPG key are prefetched by cachi2 (artifacts.in.yaml) at /cachi2/output/deps/generic/.
+# Built-in .vsix (js-debug, js-debug-companion, vscode-js-profile-table) are in utils/.
 ############################################################################################
 
 # codeserver-offline-env.sh is the single source of truth for all env vars
@@ -57,12 +57,14 @@ cp "${HERMETO_OUTPUT}/deps/generic/ripgrep-v13."*.tar.gz "${RIPGREP_CACHE_DIR}/"
 
 # Setup VSCode marketplace extensions and Node.js binaries from prefetched files.
 # VSCODE_OFFLINE_CACHE is already exported by codeserver-offline-env.sh.
+# Built-in .vsix (js-debug, etc.) are in repo at utils/ (COPY'd into image); not from cachi2.
 mkdir -p "${VSCODE_OFFLINE_CACHE}"
+VSIX_UTILS="${CODESERVER_SOURCE_CODE}/utils"
 
-# Copy .vsix extension files
-cp "${HERMETO_OUTPUT}/deps/generic/ms-vscode.js-debug-companion.1.1.3.vsix" "${VSCODE_OFFLINE_CACHE}/"
-cp "${HERMETO_OUTPUT}/deps/generic/ms-vscode.js-debug.1.105.0.vsix" "${VSCODE_OFFLINE_CACHE}/"
-cp "${HERMETO_OUTPUT}/deps/generic/ms-vscode.vscode-js-profile-table.1.0.10.vsix" "${VSCODE_OFFLINE_CACHE}/"
+# Copy .vsix extension files from utils/ (git-tracked large files)
+cp "${VSIX_UTILS}/ms-vscode.js-debug-companion.1.1.3.vsix" "${VSCODE_OFFLINE_CACHE}/"
+cp "${VSIX_UTILS}/ms-vscode.js-debug.1.105.0.vsix" "${VSCODE_OFFLINE_CACHE}/"
+cp "${VSIX_UTILS}/ms-vscode.vscode-js-profile-table.1.0.10.vsix" "${VSCODE_OFFLINE_CACHE}/"
 
 # [HERMETIC] Pre-populate .build/node/ with system Node (like che-code) so gulp skips download.
 # build-vscode.sh is patched to build for current arch (vscode-reh-web-linux-${NODE_ARCH}).
@@ -105,9 +107,9 @@ populate_vsix() {
     echo "  -> ${ext_dir}"
 }
 
-populate_vsix "${HERMETO_OUTPUT}/deps/generic/ms-vscode.js-debug-companion.1.1.3.vsix" "ms-vscode.js-debug-companion"
-populate_vsix "${HERMETO_OUTPUT}/deps/generic/ms-vscode.js-debug.1.105.0.vsix" "ms-vscode.js-debug"
-populate_vsix "${HERMETO_OUTPUT}/deps/generic/ms-vscode.vscode-js-profile-table.1.0.10.vsix" "ms-vscode.vscode-js-profile-table"
+populate_vsix "${VSIX_UTILS}/ms-vscode.js-debug-companion.1.1.3.vsix" "ms-vscode.js-debug-companion"
+populate_vsix "${VSIX_UTILS}/ms-vscode.js-debug.1.105.0.vsix" "ms-vscode.js-debug"
+populate_vsix "${VSIX_UTILS}/ms-vscode.vscode-js-profile-table.1.0.10.vsix" "ms-vscode.vscode-js-profile-table"
 
 # Rewrite all package-lock.json "resolved" URLs to point to the cachi2 file cache.
 # https://registry.npmjs.org/foo/-/foo-1.0.0.tgz → file:///cachi2/output/deps/npm/...

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
@@ -6,12 +6,6 @@
 # is auto-generated and contains integrity hashes for each URL.
 
 input:
-    # CentOS Stream 9 GPG key (needed in whl-cache stage for ppc64le/s390x dnf install
-    # from CentOS baseos/appstream/crb repos; UBI9 images only ship the Red Hat key)
-    - url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
-
-    # Node: system Node from nodejs RPM (like che-code). ppc64le/s390x use native gulp
-    # task; BUILD_TARGETS added in gulpfile.reh.js overlay. No Node tarball prefetched.
     # ripgrep: one version (v13.0.0-13) for all 4 arches; @vscode/ripgrep postinstall patched to use it (see apply-patch.sh).
     - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
       filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
@@ -22,13 +16,3 @@ input:
       filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
     - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
       filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-    # argon2: not prefetched; builds from source via node-gyp (gcc-toolset-14 in rpm-base).
-    # The npm package is in the lockfile; when the mirror has no prebuild, it falls back to compile.
-
-    # VSCode marketplace extensions (built-in extensions bundled with code-server)
-    - url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
-      filename: ms-vscode.js-debug-companion.1.1.3.vsix
-    - url: https://github.com/microsoft/vscode-js-debug/releases/download/v1.105.0/ms-vscode.js-debug.1.105.0.vsix
-      filename: ms-vscode.js-debug.1.105.0.vsix
-    - url: https://github.com/microsoft/vscode-js-profile-visualizer/releases/download/v1.0.10/ms-vscode.vscode-js-profile-table.1.0.10.vsix
-      filename: ms-vscode.vscode-js-profile-table.1.0.10.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
@@ -2,9 +2,6 @@
 metadata:
   version: '1.0'
 artifacts:
-  - download_url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
-    checksum: sha256:146059788b214d7ba0dd70c1cf21111e594c6cfde201da8a9a88fe7101be8a78
-    filename: RPM-GPG-KEY-CentOS-Official
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
     checksum: sha256:324cd645481db1ceda8621409c9151fc58d182b90cc5c428db80edb21fb26df3
     filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
@@ -17,12 +14,3 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
     filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-  - download_url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
-    checksum: sha256:7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93
-    filename: ms-vscode.js-debug-companion.1.1.3.vsix
-  - download_url: https://github.com/microsoft/vscode-js-debug/releases/download/v1.105.0/ms-vscode.js-debug.1.105.0.vsix
-    checksum: sha256:0c45b90342e8aafd4ff2963b4006de64208ca58c2fd01fea7a710fe61dcfd12a
-    filename: ms-vscode.js-debug.1.105.0.vsix
-  - download_url: https://github.com/microsoft/vscode-js-profile-visualizer/releases/download/v1.0.10/ms-vscode.vscode-js-profile-table.1.0.10.vsix
-    checksum: sha256:7361748ddf9fd09d8a2ed1f2a2d7376a2cf9aae708692820b799708385c38e08
-    filename: ms-vscode.vscode-js-profile-table.1.0.10.vsix

--- a/codeserver/ubi9-python-3.12/utils/ms-vscode.js-debug-companion.1.1.3.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-vscode.js-debug-companion.1.1.3.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93
+size 52784

--- a/codeserver/ubi9-python-3.12/utils/ms-vscode.js-debug.1.105.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-vscode.js-debug.1.105.0.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c45b90342e8aafd4ff2963b4006de64208ca58c2fd01fea7a710fe61dcfd12a
+size 1314222

--- a/codeserver/ubi9-python-3.12/utils/ms-vscode.vscode-js-profile-table.1.0.10.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-vscode.vscode-js-profile-table.1.0.10.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7361748ddf9fd09d8a2ed1f2a2d7376a2cf9aae708692820b799708385c38e08
+size 350996


### PR DESCRIPTION
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): Add VSCode built-in .vsix to utils/ (js-debug, companion, profile-table)

## Description
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): Add VSCode built-in .vsix to utils/ (js-debug, companion, profile-table)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled three VS Code extensions for offline development (JS debugger, debugger companion, profiler table).

* **Chores**
  * Switched extension sourcing to the repository's local utilities and added Git LFS pointers for those binaries.
  * Removed related external prefetch entries for those artifacts.
  * Made certain GPG key imports tolerant when a key is absent to avoid import failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->