### PR TITLE
ISSUE #3058: validate and enforce directory existence and `pyproject.toml` in `find_target_dirs`

### DIFF
--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -160,7 +160,11 @@ def check_uv() -> None:
 def find_target_dirs(target_dir: Path | None) -> list[Path]:
     """Find directories containing pyproject.toml."""
     if target_dir is not None:
-        return [target_dir]
+        candidate = target_dir if target_dir.is_absolute() else ROOT_DIR / target_dir
+        if not candidate.is_dir() or not (candidate / "pyproject.toml").is_file():
+            error(f"Target directory must exist and contain pyproject.toml: {candidate}")
+            raise SystemExit(1)
+        return [candidate]
 
     info("Scanning main directories for Python projects...")
     dirs: set[Path] = set()


### PR DESCRIPTION
## Description

The `find_target_dirs` function in `scripts/pylocks_generator.py` returns a user-supplied `target_dir` without validating that it exists or contains a `pyproject.toml`. A typo can cause the command to exit successfully while generating nothing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation when specifying a target directory, ensuring it exists as a valid directory and contains required configuration files before proceeding with processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->