### PR TITLE
AIPCC-12576: refactor(pylocks_generator): centralize logging, and run lock generation in parallel

### DIFF
--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -351,12 +351,12 @@ def process_directory(
     if python_version is None:
         log.warning(f"Could not extract valid Python version from directory name: {tdir}")
         log.warning("Expected directory format: .../ubi9-python-X.Y")
-        return tdir, True, log
+        return tdir, False, log
 
     flavors = detect_flavors(tdir)
     if not flavors:
         log.warning(f"No Dockerfiles found in {tdir} (cpu/cuda/rocm). Skipping.")
-        return tdir, True, log
+        return tdir, False, log
 
     log.print(f"📦 Python version: {python_version}")
     log.print("🧩 Detected flavors:")


### PR DESCRIPTION
Workaround for

https://redhat.atlassian.net/browse/AIPCC-12576

## Description

Rewrites `scripts/pylocks_generator.py` to generate pylock files in parallel using `ThreadPoolExecutor`, replacing the previous serial loop. Also introduces a `LogBuffer` class for consistent, non-interleaved output from worker threads.

### What changed

- **Parallel execution** via `ThreadPoolExecutor(max_workers=6)` — worker threads run `uv pip compile` concurrently; output is buffered per directory and flushed atomically when each future completes
- **`LogBuffer` class** — single source of ANSI formatting (`info`, `warn`, `error`, `ok`, `print`); `buffered=False` for the main thread (immediate print), `buffered=True` for workers (grouped flush)
- **`IndexMode` uses `StrEnum`** (UP042) instead of `str, Enum`
- **Code organisation** — section banners replaced with `# region` / `# endregion` markers for IDE folding; module-level `info()`/`warn()` functions removed
- **`MAX_WORKERS = 6`** chosen based on empirical benchmarks (see below)

### Parallelism benchmarks

Measured on macOS 12-core with RH PyPI index (no HTTP cache headers). 5–6 repeated runs per worker count:

| MAX_WORKERS | mean | std | note |
|---|---|---|---|
| 5 | 107 s | 6 s | indistinguishable from n=6 |
| **6** | **107 s** | **7 s** | **current default** |
| 7 | 119 s | 17 s | worse mean, variance doubles |
| 8 | 113 s | 11 s | worse than n=6 |

The variance spike at n=7 is the key signal: higher worker counts introduce scheduling jitter without reducing wall time. n=5 and n=6 are statistically indistinguishable; n=6 is kept as the default.

<img width="1950" height="750" alt="image" src="https://github.com/user-attachments/assets/47e51131-a907-4742-8b4c-80335cba3bbc" />

For context: each `uv` subprocess already uses `UV_CONCURRENT_DOWNLOADS=50` connections internally. The outer parallelism gains come from overlapping one solver's CPU time with another's network wait (pipeline effect). The RH PyPI index returns `x-rh-edge-cache-status: NotCacheable` on all responses, so uv re-fetches package metadata on every run — this is the main source of run-to-run variance.

## How Has This Been Tested?

Ran `gmake refresh-lock-files` on the full repository (18 project directories, CPU/CUDA/ROCm flavors) and verified all lock files were regenerated correctly.

Ran benchmarks with 28 total timed invocations across worker counts 3–12.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Script now processes directories in parallel for faster completion.
  * Logging rewritten to buffer per-task output and flush results in a clearer, ordered way.
* **Bug Fixes / Reliability**
  * Improved handling of long-running operations with timeouts and clearer failure reporting.
  * Unexpected errors in tasks are captured and reported; overall run exits non-zero when any task fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->