### PR TITLE
RHAIENG-2860: codeserver - ripgrep from RHOAI wheel, uv bump, docs and prefetch fixes

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -31,7 +31,7 @@ ARG LOCAL_BUILD=false
 #   - Node.js/npm: installed from prefetched RPMs
 #   - npm dependencies: package-lock.json resolved URLs rewritten to file:///cachi2/...
 #   - node-gyp: system headers via nodejs-devel RPM (NPM_CONFIG_NODEDIR=/usr),
-#     VS Code remote headers (22.20.0) from prefetched tarballs, ripgrep prefetched
+#     VS Code remote headers (22.20.0) from prefetched tarballs, ripgrep from RHOAI Python wheel (deps/pip)
 #   - Build scripts patched to avoid any network fetches (patches/*.patch)
 ############################################################################################
 # e.g., registry.access.redhat.com/ubi9/python-312:latest
@@ -105,7 +105,7 @@ RUN cd ${CODESERVER_SOURCE_CODE} && GHA_BUILD="${GHA_BUILD}" ./apply-patch.sh
 # setup-offline-binaries.sh does all offline preparation in one shot:
 #   - sources codeserver-offline-env.sh (ELECTRON_SKIP_BINARY_DOWNLOAD, NPM_CONFIG_NODEDIR, etc.)
 #   - node-gyp uses system headers (NPM_CONFIG_NODEDIR=/usr from nodejs-devel RPM)
-#   - ripgrep from cachi2 generic; .vsix from utils/; .build/node/ = system /usr/bin/node (per-arch)
+#   - ripgrep from pip (RHOAI wheel in deps/pip), .vsix from cachi2 generic; .build/node/ = system /usr/bin/node (per-arch)
 #   - pre-populates .build/builtInExtensions/ so gulp skips network downloads
 #   - rewrites package-lock.json "resolved" URLs to file:///cachi2/...
 # CI=1 makes ci/dev/postinstall.sh run "npm ci" (not "npm install") in subdirs,

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -31,7 +31,7 @@ ARG LOCAL_BUILD=false
 #   - Node.js/npm: installed from prefetched RPMs
 #   - npm dependencies: package-lock.json resolved URLs rewritten to file:///cachi2/...
 #   - node-gyp: system headers via nodejs-devel RPM (NPM_CONFIG_NODEDIR=/usr),
-#     VS Code remote headers (22.20.0) from prefetched tarballs, ripgrep prefetched
+#     VS Code remote headers (22.20.0) from prefetched tarballs, ripgrep from RHOAI Python wheel (deps/pip)
 #   - Build scripts patched to avoid any network fetches (patches/*.patch)
 ############################################################################################
 # e.g., registry.access.redhat.com/ubi9/python-312:latest
@@ -105,7 +105,7 @@ RUN cd ${CODESERVER_SOURCE_CODE} && GHA_BUILD="${GHA_BUILD}" ./apply-patch.sh
 # setup-offline-binaries.sh does all offline preparation in one shot:
 #   - sources codeserver-offline-env.sh (ELECTRON_SKIP_BINARY_DOWNLOAD, NPM_CONFIG_NODEDIR, etc.)
 #   - node-gyp uses system headers (NPM_CONFIG_NODEDIR=/usr from nodejs-devel RPM)
-#   - ripgrep from cachi2 generic; .vsix from utils/; .build/node/ = system /usr/bin/node (per-arch)
+#   - ripgrep from pip (RHOAI wheel in deps/pip), .vsix from cachi2 generic; .build/node/ = system /usr/bin/node (per-arch)
 #   - pre-populates .build/builtInExtensions/ so gulp skips network downloads
 #   - rewrites package-lock.json "resolved" URLs to file:///cachi2/...
 # CI=1 makes ci/dev/postinstall.sh run "npm ci" (not "npm install") in subdirs,

--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -55,10 +55,10 @@ scripts/lockfile-generators/prefetch-all.sh \
 ```
 
 This single command orchestrates all four lockfile generators:
-1. Generic artifacts (GPG keys, node headers, oc client, VS Code extensions)
-2. Pip wheels (numpy, scipy, pandas, scikit-learn, etc. via RHOAI index)
+1. Generic artifacts (GPG keys, VS Code .vsix extensions; ripgrep and oc client come from pip wheel and RPM respectively)
+2. Pip wheels (numpy, scipy, pandas, scikit-learn, ripgrep, uv, etc. via RHOAI index)
 3. NPM packages (code-server + VS Code extensions)
-4. RPMs (gcc, nodejs, nginx, openblas, etc. via Hermeto)
+4. RPMs (gcc, nodejs, nginx, openblas, openshift-clients, etc. via Hermeto)
 
 Lockfiles are organized into variant subdirectories under `prefetch-input/`:
 
@@ -81,10 +81,10 @@ After running, dependencies are in:
 
 ```
 cachi2/output/deps/
-├── generic/    # GPG keys, tarballs, oc client, VS Code extensions
-├── rpm/        # RPM packages + repodata/
+├── generic/    # GPG keys, VS Code .vsix extensions (ripgrep from pip, oc from RPM)
+├── rpm/        # RPM packages + repodata/ (includes openshift-clients)
 ├── npm/        # npm tarballs
-└── pip/        # Python wheels
+└── pip/        # Python wheels (RHOAI index: ripgrep, uv, micropipenv, etc.)
 ```
 
 > **Tip:** You only need to re-run this when inputs change (e.g. after editing
@@ -255,7 +255,7 @@ the container at `/cachi2`. This gives the Dockerfile the same
 | `/cachi2/output/deps/rpm/` | All RPM packages plus `repodata/` metadata. The Dockerfile points dnf at this directory as a local repo |
 | `/cachi2/output/deps/pip/` | Python wheels prefetched from the RHOAI index. Installed with `uv pip install --no-index --find-links /cachi2/output/deps/pip` |
 | `/cachi2/output/deps/npm/` | npm tarballs. `package-lock.json` resolved URLs are rewritten to `file:///cachi2/output/deps/npm/` so `npm ci --offline` finds them |
-| `/cachi2/output/deps/generic/` | GPG keys, ripgrep binaries, oc client tarball, VS Code .vsix extensions. (Node headers from nodejs-devel RPM; Electron download skipped.) |
+| `/cachi2/output/deps/generic/` | GPG keys, VS Code .vsix extensions. Ripgrep comes from the RHOAI Python wheel in deps/pip; the oc client is installed via the openshift-clients RPM (deps/rpm). Node headers from nodejs-devel RPM; Electron download skipped. |
 
 The `:z` suffix is a SELinux relabel flag for podman — it allows the container
 process to read the bind-mounted directory on SELinux-enabled hosts (Fedora,

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
@@ -9,14 +9,3 @@ input:
     # CentOS Stream 9 GPG key (needed in whl-cache stage for ppc64le/s390x dnf install
     # from CentOS baseos/appstream/crb repos; UBI9 images only ship the Red Hat key)
     - url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
-
-    # ripgrep: one version (v13.0.0-13) for all 4 arches; @vscode/ripgrep postinstall patched to use it (see apply-patch.sh).
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-      filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-    # aarch64: no musl build upstream; GNU build aliased to musl filename (postinstall expects aarch64-unknown-linux-musl).
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-gnu.tar.gz
-      filename: ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-      filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-      filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
@@ -5,15 +5,3 @@ artifacts:
   - download_url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
     checksum: sha256:146059788b214d7ba0dd70c1cf21111e594c6cfde201da8a9a88fe7101be8a78
     filename: RPM-GPG-KEY-CentOS-Official
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-    checksum: sha256:324cd645481db1ceda8621409c9151fc58d182b90cc5c428db80edb21fb26df3
-    filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-gnu.tar.gz
-    checksum: sha256:1b0ca509f8707f2128f1b3ef245c3ea666d49a737431288536d49bd74652d143
-    filename: ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-    checksum: sha256:a3fdb2c6ef9d4ff927ca1cb1e56f7aed7913d1be4dd4546aec400118c26452ab
-    filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-    checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
-    filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/apply-patch.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/apply-patch.sh
@@ -74,7 +74,9 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" || "$ARCH" == "ppc64le" || "$ARCH
     #   adds defence in depth.
     #
     # [RIPGREP] Overwrite @vscode/ripgrep postinstall in the cached npm tarball with our
-    # patched version (ripgrep/postinstall.js) so a single v13.0.0-13 is used for all arches.
+    # patched version (ripgrep/postinstall.js). When RIPGREP_BINARY_PATH is set (by
+    # setup-offline-binaries.sh from the RHOAI Python wheel), the binary is copied from
+    # there; otherwise the script falls back to downloading the prebuilt v13.0.0-13.
     RIPGREP_PATCHED="${CODESERVER_SOURCE_PREFETCH}/ripgrep/postinstall.js"
     RIPGREP_TGZ=$(find /cachi2/output/deps/npm -name "*ripgrep*.tgz" -type f 2>/dev/null | head -1)
     if [[ -n "${RIPGREP_TGZ}" && -f "${RIPGREP_PATCHED}" ]]; then

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/README.md
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/README.md
@@ -1,6 +1,6 @@
 # Patches for code-server (v4.106.3) — overlay onto prefetch-input/code-server
 
-This directory is **copied over** the read-only `prefetch-input/code-server` submodule during the build (Dockerfile `COPY`). Files here overwrite the corresponding paths under the code-server source. **Do not modify `prefetch-input/code-server`**; all editable changes belong in this patches tree. The script `apply-patch.sh` (run after the COPY) then patches the ripgrep/vsce-sign npm tarballs and applies `patches/series`.
+This directory is **copied over** the read-only `prefetch-input/code-server` submodule during the build (Dockerfile `COPY`). Files here overwrite the corresponding paths under the code-server source. **Do not modify `prefetch-input/code-server`**; all editable changes belong in this patches tree. The script `apply-patch.sh` (run after the COPY) then patches the @vscode/ripgrep and vsce-sign npm tarballs (ripgrep binary is supplied from the RHOAI Python wheel via `RIPGREP_BINARY_PATH`) and applies `patches/series`.
 
 ---
 

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/ripgrep/postinstall.js
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/ripgrep/postinstall.js
@@ -11,6 +11,8 @@ const download = require('./download');
 
 const fsExists = util.promisify(fs.exists);
 const mkdir = util.promisify(fs.mkdir);
+const copyFile = util.promisify(fs.copyFile);
+const chmod = util.promisify(fs.chmod);
 const exec = util.promisify(child_process.exec);
 
 const forceInstall = process.argv.includes('--force');
@@ -21,6 +23,7 @@ if (forceInstall) {
 const VERSION = 'v13.0.0-13';
 const MULTI_ARCH_LINUX_VERSION = 'v13.0.0-4';// use this for arm-unknown-linux-gnueabihf and powerpc64le-unknown-linux-gnu until we can fix https://github.com/microsoft/ripgrep-prebuilt/issues/24 and https://github.com/microsoft/ripgrep-prebuilt/issues/32 respectively.
 const BIN_PATH = path.join(__dirname, '../bin');
+const RG_BINARY = path.join(BIN_PATH, 'rg');
 
 process.on('unhandledRejection', (reason, promise) => {
  console.log('Unhandled rejection: ', promise, 'reason:', reason);
@@ -91,6 +94,23 @@ async function retry(fn, maxRetries = 5) {
 }
 
 async function main() {
+ // Use ripgrep from RHOAI Python wheel when set (hermetic code-server build).
+ const ripgrepBinaryPath = process.env.RIPGREP_BINARY_PATH;
+ if (ripgrepBinaryPath) {
+  const srcExists = await fsExists(ripgrepBinaryPath);
+  if (srcExists) {
+   if (!(await fsExists(BIN_PATH))) {
+    await mkdir(BIN_PATH);
+   }
+   await copyFile(ripgrepBinaryPath, RG_BINARY);
+   await chmod(RG_BINARY, 0o755);
+   console.log(`Using ripgrep from RIPGREP_BINARY_PATH: ${ripgrepBinaryPath}`);
+   process.exit(0);
+  }
+  console.error(`RIPGREP_BINARY_PATH set but file not found: ${ripgrepBinaryPath}`);
+  process.exit(1);
+ }
+
  const binExists = await fsExists(BIN_PATH);
  if (!forceInstall && binExists) {
  console.log('bin/ folder already exists, exiting');

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 #
 #   1. npm config: offline, prefer-offline, fetch-retries=0 (and legacy-peer-deps).
 #   2. node-gyp: NPM_CONFIG_NODEDIR=/usr (from codeserver-offline-env.sh) → system headers.
-#   3. Ripgrep: copy prefetched tarballs to /tmp/vscode-ripgrep-cache-<version>/.
-#   4. VSCode .vsix: copy from utils/ (git-tracked) to VSCODE_OFFLINE_CACHE for patched fetch.js.
+#   3. Ripgrep: install from RHOAI Python wheel (prefetched in deps/pip), export RIPGREP_BINARY_PATH for postinstall.
+#   4. VSCode .vsix: copy to VSCODE_OFFLINE_CACHE for patched fetch.js.
 #   5. Node: pre-populate .build/node/ with system /usr/bin/node so gulp skips download.
 #   6. Pre-populate .build/builtInExtensions/<name>/ from extracted .vsix in utils/.
 #   7. Rewrite package-lock.json "resolved" URLs to file:///cachi2/output/deps/npm/...
@@ -45,15 +45,16 @@ npm config set --global legacy-peer-deps true
 # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 (set in codeserver-offline-env.sh) prevents
 # the @playwright/browser-chromium postinstall from attempting any download.
 
-# Setup VSCode ripgrep - use the cache directory that @vscode/ripgrep expects
-# Prefetched in prefetch-input/artifacts.in.yaml; Cachi2 puts them in HERMETO_OUTPUT/deps/generic/.
-# Cache dir: <os.tmpdir()>/vscode-ripgrep-cache-<packageVersion>/ (see @vscode/ripgrep lib/download.js).
-# We use a single version (v13.0.0-13) for all 4 arches; apply-patch.sh patches @vscode/ripgrep
-# so its postinstall uses VERSION for every target (no MULTI_ARCH_LINUX_VERSION).
-VSCODE_RIPGREP_VERSION="1.15.14"
-RIPGREP_CACHE_DIR="/tmp/vscode-ripgrep-cache-${VSCODE_RIPGREP_VERSION}"
-mkdir -p "${RIPGREP_CACHE_DIR}"
-cp "${HERMETO_OUTPUT}/deps/generic/ripgrep-v13."*.tar.gz "${RIPGREP_CACHE_DIR}/"
+# Setup VSCode ripgrep from RHOAI Python wheel (ripgrep==15.0.0 in pyproject.toml; prefetched by cachi2 into deps/pip).
+# The patched @vscode/ripgrep postinstall.js copies the binary from RIPGREP_BINARY_PATH into its bin/.
+pip install --no-cache-dir --no-index --find-links "${HERMETO_OUTPUT}/deps/pip" ripgrep
+RIPGREP_BINARY_PATH=$(which rg)
+if [[ -z "${RIPGREP_BINARY_PATH}" || ! -x "${RIPGREP_BINARY_PATH}" ]]; then
+  echo "ERROR: ripgrep binary not found after pip install (which rg: $(which rg))"
+  exit 1
+fi
+export RIPGREP_BINARY_PATH
+echo "Using ripgrep from Python wheel: ${RIPGREP_BINARY_PATH}"
 
 # Setup VSCode marketplace extensions and Node.js binaries from prefetched files.
 # VSCODE_OFFLINE_CACHE is already exported by codeserver-offline-env.sh.

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
@@ -6,13 +6,6 @@
 # is auto-generated and contains integrity hashes for each URL.
 
 input:
-    # ripgrep: one version (v13.0.0-13) for all 4 arches; @vscode/ripgrep postinstall patched to use it (see apply-patch.sh).
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-      filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-    # aarch64: no musl build upstream; GNU build aliased to musl filename (postinstall expects aarch64-unknown-linux-musl).
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-gnu.tar.gz
-      filename: ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-      filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-    - url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-      filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
+    # Temporary add it here, so it won't break the RHDS build, until we have enough time
+    # to update all .tekton files for all versions.
+    - url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
@@ -2,15 +2,6 @@
 metadata:
   version: '1.0'
 artifacts:
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-    checksum: sha256:324cd645481db1ceda8621409c9151fc58d182b90cc5c428db80edb21fb26df3
-    filename: ripgrep-v13.0.0-13-x86_64-unknown-linux-musl.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-aarch64-unknown-linux-gnu.tar.gz
-    checksum: sha256:1b0ca509f8707f2128f1b3ef245c3ea666d49a737431288536d49bd74652d143
-    filename: ripgrep-v13.0.0-13-aarch64-unknown-linux-musl.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-    checksum: sha256:a3fdb2c6ef9d4ff927ca1cb1e56f7aed7913d1be4dd4546aec400118c26452ab
-    filename: ripgrep-v13.0.0-13-powerpc64le-unknown-linux-gnu.tar.gz
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-    checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
-    filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
+  - download_url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+    checksum: sha256:146059788b214d7ba0dd70c1cf21111e594c6cfde201da8a9a88fe7101be8a78
+    filename: RPM-GPG-KEY-CentOS-Official

--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     # https://issues.redhat.com/browse/AIPCC-9544 py-spy excluded on ppc64le for codeserver
     "py-spy~=0.4.1; platform_machine != 's390x' and platform_machine != 'ppc64le'",
     "prometheus-client~=0.24.1",
+    "ripgrep==15.0.0",
 ]
 
 [tool.uv]

--- a/codeserver/ubi9-python-3.12/requirements.cpu.txt
+++ b/codeserver/ubi9-python-3.12/requirements.cpu.txt
@@ -11,10 +11,10 @@ attrs==25.4.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597
 bigtree==1.3.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:99d8d851604d798f73fc4cacad4ad2cc91043a9f6d3a50f43bdf5493f51f30d4
-boto3==1.42.62 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:96226bc9fd9487d43aa1f8ebc1f3c71bad7461bd48e993975f6dbe0d0ff1a701
-botocore==1.42.62 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:76c49e8a70d265680edf3a9529a5234f4654c9ec993f917f4c92464e329f71af
+boto3==1.42.64 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2136abdf2b233e1a89b9563874cf7203d2b88439bcc99486cf8881be3c9b599a
+botocore==1.42.64 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f01171e5c1f437649384c7c4fa761562bf4d154a1af9545c09d4553186f40ae6
 certifi==2026.2.25 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:89b205c5656277a076916d355623beb9922d01b1faa8a71292ddbb2772267334
 cffi==2.0.0 ; python_full_version >= '3.9' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
@@ -69,16 +69,16 @@ fastapi==0.135.1 ; implementation_name == 'cpython' and sys_platform == 'linux' 
     --hash=sha256:376029076bc714d64c931f8e3cb90822ef75217a011e248f72d369c5bc5b8d2d
 feast==0.60.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5b5ce554984cc9cab77979369a0d69a02e5468890fad14ae848c7ce3d0eb806b
-filelock==3.25.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:9d7158fb10cc65a9c95fb26704cc9a43ecb87e5b557f80afb7624581a33732cb
-fonttools==4.61.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:c45d987b139ef820cb9861c34a54cf2af8969ef509727ed0b86e53621086b0d4
+filelock==3.25.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d3e0cda4591270f41b9643a2f23776bf464f89be02a8cac4c6da5f57c93e710b
+fonttools==4.62.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d434544d2031d3ff74e457a6f52b5e0271375ba9f2aab003a1bd7daa6967814a
 fsspec==2026.2.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:be7a3c935aa1e8af807cfd79299c2e8dfd6cd8b5ef1f44f8f2ea1437150cf3e3
 google-api-core==2.30.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e6937da0490ab68afeb371edffa186c05e8de8950bb560a4a3eea5df3a8c1b3
-google-auth==2.48.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:d89a9eb7f8b6e285448aa7360db8e18c2368f707590dacf54ba9755cff47130b
+google-auth==2.49.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d219a78bdadf92759107909dd63dec7d9c17da7f76f7829d055eec45889e794a
 google-cloud-core==2.5.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9c9ee916f16dddfe48519418de0924fb6aeacceaaace9f3587e5ed713213b3c1
 google-cloud-storage==3.9.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -87,8 +87,8 @@ google-crc32c==1.8.0 ; implementation_name == 'cpython' and sys_platform == 'lin
     --hash=sha256:edfdfaaf68a74fdd3cb96b6c32d0252d75d1a600f91cdc209de1f83e9efb2326
 google-resumable-media==2.8.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3b7950f804158036ba5a343210072e1b1f4047fadb36fd8646de7022f02b091c
-googleapis-common-protos==1.72.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:9f349ac2065f598cd33e25c4542353311f1bdf77527e63807d6a76423df22a77
+googleapis-common-protos==1.73.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a2abe1c34d079d8fefb05ba82f82b5850e918a207685568caac8ff7bc297a6db
 greenlet==3.3.2 ; (implementation_name == 'cpython' and platform_machine == 'AMD64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'WIN32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'win32' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:e0fd18b6ddf87d452645fd636cb2fd211e4e348252dc20bd3dfd6d8f379b2768 \
     --hash=sha256:c79c679536b7024db466eb611b7cdc5d3cf780d2d8e7faddc969b8f12c657b0b \
@@ -134,11 +134,11 @@ kfp-pipeline-spec==2.15.2 ; implementation_name == 'cpython' and sys_platform ==
     --hash=sha256:dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f
 kfp-server-api==2.15.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e
-kiwisolver==1.4.9 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:6b8d47ed9e7058c657e3d768b30f68ba2c6da43c18fe52f77c6da5a016bf2b3a \
-    --hash=sha256:220b778cd567dcb1429618e19be1be4cdadb81f39f4cb6ea8602c32d8de01169 \
-    --hash=sha256:93eeac87f3a28da46bc0856704f04308d2ee0d7b2eef065df670780a4d3c6f2b \
-    --hash=sha256:8bdea8292fb12ea12596bd6cd83dfe6858841e183d87fc937589bca6fa2ecd57
+kiwisolver==1.5.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8e7aad50d1f232928bcd8da178cd2fc51b097da865ef618eb9bfb6d62606c09e \
+    --hash=sha256:08879841b49fb8485101b8ba7941f265952d23dd6c41336ab8cef2b9ad277668 \
+    --hash=sha256:9c2a60d7b10a02997d29b94aaad133d52bb959d8267a008b7d6c6747e49c50e9 \
+    --hash=sha256:118f0fe64543c8266beb42a9232570377687dcf00feb16f6319f54885517154a
 kubeflow-training==1.9.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3eca0e2fefe9dc0d7bc5b3f5a91695cd52bba07140184425669665b7d77dcdc5
 kubernetes==35.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -182,11 +182,11 @@ narwhals==2.17.0 ; implementation_name == 'cpython' and sys_platform == 'linux' 
     --hash=sha256:7ae0196ed17cda5672a6cb38d18a76ec8de1177c782efcda9a092b80da4b3afd
 nest-asyncio==1.6.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9b34967049bea63b974f905031be1a40be280873f7f128102008b85738daa2c7
-numpy==2.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:5603e2b0bce09fd4a7e1e3a95a591de39b1c9015a780988886788c4c7033af00 \
-    --hash=sha256:7273ea0644dd9ca14f0ad15d597f0a1c0d387aea96754c2628e847ab0551cfd0 \
-    --hash=sha256:4d5c6e081756c80baf124a62af4ef089c6e03c2cfb187ffbb8565fd992ab7e4a \
-    --hash=sha256:16dc3c9dbda81e94e3341d918464fe0f0b83e3207372feb1ad2e79a62add6baa
+numpy==2.4.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:98581bec09046df5dab1e44cb8635d037de5d28effa9bae6dfc6940496d90454 \
+    --hash=sha256:27d4caf8354d4781fdee729a3a8b96b37c31e49d7f7efaaa358d8d37f6e980db \
+    --hash=sha256:db1aaae84b7f165c244bcbb4e4ec11d673554dc7fdd274992cde7f0a597aefd3 \
+    --hash=sha256:65bd66a25eee23d6b4f37fec6d0b5e370ce1632c436d2d0033b4b874df9e9da7
 oauthlib==3.3.1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1bf73c8e0aead3761794f6e5b15228bee706cda020facd0df347c145843adf40
 onnx==1.20.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -277,8 +277,8 @@ pyparsing==3.3.2 ; implementation_name == 'cpython' and sys_platform == 'linux' 
     --hash=sha256:4fb4ea2103bc5ee9bc3949f973fde987a9d3a8d2d88865cee7293bdb00d00bf3
 python-dateutil==2.9.0.post0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:89e5d6f444e51ac0a18370406b265fa1f51c88824476fd08c56db669dd317775
-python-discovery==1.1.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:06d50da2b0e478a7035060a42f1ebb0955ebd9077bd3ee0270cc4ec3aea90682
+python-discovery==1.1.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:36e0131ecbc1f5a41eb39b3892f52eac743ee7d0732382f22d4e4d99809eb5a4
 python-dotenv==1.2.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:58bee80c6e48ce9d2b6bcb805bf670d3b45438911bb32e82f9145369b9deaf63
 pytz==2026.1.post1 ; implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -303,6 +303,11 @@ requests-toolbelt==1.0.0 ; implementation_name == 'cpython' and sys_platform == 
     --hash=sha256:3b8db9e1e64c559059b34851b461cd9d1d7c5914025389003343dffb9f65961d
 retrying==1.4.2 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f9407f09c56a12614cd1cbe7105f457320608afde261e6d9fc74021fee339d6b
+ripgrep==15.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:93ed0069ccab915caa2febf6891c2c6cbcb380a02c091f31cb69d114b0006e35 \
+    --hash=sha256:6fa60d858a5d3f336e60e8a7564b812970e3d429d3093cd6f9cec99e420a3697 \
+    --hash=sha256:1c87d0ab0385598981275fa5dc8d27b67727cf9a43a9b6825baecd7592ec616a \
+    --hash=sha256:80e5dded9a3543d6be49816a4c0c526ae74f948832291687b8c213945037e87e
 rpds-py==0.30.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:11729e4f36a649a22271d688f0edf12b4d5a3ea0c6f6d5c2a0adaa659be540a8 \
     --hash=sha256:5218e8a6c45c31def0d833f4c6a713943cc8e13122c5c04d8e0506c49502ebf0 \

--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -827,6 +827,17 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/retrying-1.4.2-2-py3-none-any.whl", hashes = { sha256 = "f9407f09c56a12614cd1cbe7105f457320608afde261e6d9fc74021fee339d6b" } }]
 
 [[packages]]
+name = "ripgrep"
+version = "15.0.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ripgrep-15.0.0-2-py3-none-linux_aarch64.whl", hashes = { sha256 = "93ed0069ccab915caa2febf6891c2c6cbcb380a02c091f31cb69d114b0006e35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ripgrep-15.0.0-2-py3-none-linux_ppc64le.whl", hashes = { sha256 = "6fa60d858a5d3f336e60e8a7564b812970e3d429d3093cd6f9cec99e420a3697" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ripgrep-15.0.0-2-py3-none-linux_s390x.whl", hashes = { sha256 = "1c87d0ab0385598981275fa5dc8d27b67727cf9a43a9b6825baecd7592ec616a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ripgrep-15.0.0-2-py3-none-linux_x86_64.whl", hashes = { sha256 = "80e5dded9a3543d6be49816a4c0c526ae74f948832291687b8c213945037e87e" } },
+]
+
+[[packages]]
 name = "rpds-py"
 version = "0.30.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"

--- a/docs/hermetic-guide.md
+++ b/docs/hermetic-guide.md
@@ -149,8 +149,9 @@ one. Key changes in each stage:
   the local cachi2 repo) instead of downloading via nvm.
 - `npm ci --offline` replaces `npm install`: all `resolved` URLs in
   `package-lock.json` are rewritten to `file:///cachi2/output/deps/npm/`.
-- Electron, node-gyp headers, Playwright, ripgrep, and VS Code extensions
-  are copied from prefetched generic artifacts instead of being downloaded.
+- Electron, node-gyp headers, Playwright, and VS Code extensions are copied
+  from prefetched generic artifacts; ripgrep is installed from the RHOAI Python
+  wheel (deps/pip) and the patched @vscode/ripgrep postinstall copies it.
 - `nfpm` (RPM packager) is installed from a prefetched RPM instead of
   downloading from GitHub.
 
@@ -162,8 +163,8 @@ one. Key changes in each stage:
 **`cpu-base` stage**  OS packages and tools:
 - All `dnf install` commands use the local cachi2 RPM repo when
   `LOCAL_BUILD=true`.
-- The `oc` client is installed from a prefetched tarball instead of
-  downloading from mirror.openshift.com.
+- The `oc` client is installed from the openshift-clients RPM (prefetched in
+  deps/rpm) instead of downloading a tarball from mirror.openshift.com.
 
 **`codeserver` stage**  final image:
 - Python packages are installed with `uv pip install --no-index --find-links

--- a/scripts/lockfile-generators/README.md
+++ b/scripts/lockfile-generators/README.md
@@ -173,7 +173,7 @@ gmake codeserver-ubi9-python-3.12 BUILD_ARCH=linux/arm64 PUSH_IMAGES=no
 If you need to regenerate only one dependency type, or for debugging:
 
 ```bash
-# 1. Generic artifacts (GPG keys, node headers, nfpm, oc client, VS Code extensions, etc.)
+# 1. Generic artifacts (GPG keys, VS Code .vsix, etc.; codeserver uses pip for ripgrep, RPM for oc)
 python3 scripts/lockfile-generators/create-artifact-lockfile.py \
     --artifact-input codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
 
@@ -217,10 +217,10 @@ codeserver/ubi9-python-3.12/
     └── patches/                              # patch files (shared)
 
 cachi2/output/deps/
-├── generic/    # downloaded artifacts (GPG keys, tarballs, etc.)
-├── rpm/        # downloaded RPMs + repodata/
+├── generic/    # GPG keys, .vsix, etc. (codeserver: ripgrep in pip, oc in rpm)
+├── rpm/        # downloaded RPMs + repodata/ (includes openshift-clients for codeserver)
 ├── npm/        # downloaded npm tarballs
-└── pip/        # downloaded Python wheels/sdists
+└── pip/        # downloaded Python wheels (RHOAI index: ripgrep, uv, etc.)
 ```
 
 ---
@@ -246,9 +246,9 @@ input:
     # GPG keys for verifying prefetched RPM packages
     - url: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
 
-    # OpenShift oc client (one per arch, filename distinguishes them)
-    - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-x86_64.tar.gz
+    # OpenShift oc client (one per arch) — optional; codeserver uses openshift-clients RPM in rpms.in.yaml instead
+    # - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
+    #   filename: openshift-client-linux-x86_64.tar.gz
 
     # VSCode marketplace extensions
     - url: https://github.com/microsoft/vscode-js-debug/releases/download/v1.105.0/ms-vscode.js-debug.1.105.0.vsix
@@ -374,8 +374,10 @@ The downloaded files are used for **local testing with podman**; in Konflux CI,
 cachi2 prefetches them automatically from `artifacts.lock.yaml`.
 
 **Typical artifacts:** GPG keys, X.org source tarballs (libxkbfile, util-macros),
-Node.js/Electron headers, nfpm RPMs, OpenShift `oc` client binaries, Playwright
-Chromium, ripgrep binaries, VS Code marketplace extensions (.vsix).
+Node.js/Electron headers, nfpm RPMs, Playwright Chromium, VS Code marketplace
+extensions (.vsix). For codeserver, ripgrep is supplied via the RHOAI Python
+wheel (deps/pip) and the `oc` client via the openshift-clients RPM (deps/rpm);
+they are not in generic artifacts.
 
 ### Requirements
 

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 # This script orchestrates downloading all four dependency types:
 #
 #   1. Generic artifacts — GPG keys, nfpm-built RPMs, Node.js headers,
-#      Electron binaries (into cachi2/output/deps/generic/).
+#      Electron binaries, VS Code .vsix (into cachi2/output/deps/generic/).
+#      Component-specific: codeserver gets ripgrep from pip, oc from RPM.
 #   2. Pip wheels — Python packages resolved from pyproject.toml
 #      (into cachi2/output/deps/pip/).
 #   3. NPM packages — tarballs resolved from package-lock.json files

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -36,10 +36,16 @@ class TestBaseImage:
         image_metadata = conftest.get_image_metadata(image)
         source_location = image_metadata.labels.get("io.openshift.build.source-location", "")
 
-        # Dockerfile.konflux does not have source-location label
+        # Dockerfile.konflux does not have source-location label. Use skopeo or local image env.
         if not source_location:
             image_info = skopeo_utils.get_image_info(image)
-            return "PIP_INDEX_URL" not in image_info.env
+            # When skopeo fails (e.g. "manifest unknown" for ephemeral tags), use env from
+            # local image inspect (image is already pulled earlier in the test run).
+            env = image_info.env if image_info is not None else image_metadata.env
+            if not env:
+                # No env from skopeo or local inspect; assume non-AIPCC so PyPI checks run.
+                return False
+            return "PIP_INDEX_URL" not in env
 
         # Extract relative path from URL (after /tree/main/)
         source_dir = None

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -45,6 +45,8 @@ class Image:
     id: str | None
     name: str
     labels: dict[str, str]
+    # Env from image config when available (local inspect or skopeo); used when source_location is missing
+    env: dict[str, str] | None = None
 
     @classmethod
     def from_docker(cls, image: docker.models.images.Image, name: str):
@@ -52,7 +54,8 @@ class Image:
         # returns labels in ContainerConfig only (see containers/podman#2017 and compat API).
         # So we read from both so labels are present when running against Podman (e.g. GHA).
         labels = _labels_from_docker_attrs(image.attrs)
-        return Image(id=image.id, name=name, labels=labels)
+        env = _env_from_docker_attrs(image.attrs)
+        return Image(id=image.id, name=name, labels=labels, env=env)
 
 
 def _labels_from_docker_attrs(attrs: dict[str, Any]) -> dict[str, str]:
@@ -62,6 +65,21 @@ def _labels_from_docker_attrs(attrs: dict[str, Any]) -> dict[str, str]:
         labels = config.get("Labels")
         if isinstance(labels, dict) and labels:
             return dict(labels)
+    return {}
+
+
+def _env_from_docker_attrs(attrs: dict[str, Any]) -> dict[str, str]:
+    """Extract env (KEY=VALUE list) from Docker/Podman inspect attrs."""
+    for key in ("Config", "ContainerConfig"):
+        config = attrs.get(key) or {}
+        env_list = config.get("Env")
+        if isinstance(env_list, list) and env_list:
+            parsed = {}
+            for item in env_list:
+                if isinstance(item, str) and "=" in item:
+                    k, v = item.split("=", 1)
+                    parsed[k] = v
+            return parsed
     return {}
 
 
@@ -85,7 +103,7 @@ def get_image_metadata(image: str) -> Image:
         # skopeo inspect (may be None if skopeo not installed or inspect failed)
         image_info = skopeo_utils.get_image_info(image)
         if image_info is not None and image_info.labels is not None:
-            return Image(id=None, name=image, labels=image_info.labels)
+            return Image(id=None, name=image, labels=image_info.labels, env=image_info.env or {})
         # pull & docker inspect
         image_metadata = client.client.images.pull(image)
         assert isinstance(image_metadata, docker.models.images.Image)


### PR DESCRIPTION
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): codeserver - ripgrep from RHOAI wheel, uv bump, docs and prefetch fixes

## Description

- Ripgrep from RHOAI Python wheel (deps/pip). Add to pyproject.toml; patched
  postinstall.js uses RIPGREP_BINARY_PATH from setup-offline-binaries.sh.
  Remove ripgrep tarballs from odh/rhds artifacts.
- Bump uv in both Dockerfiles to match lockfile and pip cache.
- create-requirements-lockfile.sh: report wget failures (filename + URL) instead of silent exit.
- Update READMEs, hermetic-guide, and script comments for ripgrep-from-pip.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched ripgrep from prefetched prebuilt artifacts to the RHOAI Python wheel; added ripgrep to Python dependencies and updated many pinned packages and lockfiles.
  * Removed legacy prefetched ripgrep entries across lockfiles and inputs; added multi-architecture wheel entries.

* **Documentation**
  * Updated build/packaging docs and lockfile guidance to reflect ripgrep via pip and oc coming from RPMs.

* **Tests**
  * Improved container image tests to handle missing image environment data safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->