### PR TITLE
NO-JIRA: chore(Tekton pipelines): rename `build-container` to `build-images` across configs to fix

### DIFF
--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -39,7 +39,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -39,7 +39,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -40,7 +40,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -37,7 +37,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -40,7 +40,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -37,7 +37,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -37,7 +37,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -37,7 +37,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - 3.4-v1.43
   taskRunSpecs:
-  - pipelineTaskName: build-container
+  - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:


### PR DESCRIPTION
## Description

```
[User error] PipelineRun open-data-hub-tenant/odh-workbench-jupyter-minimal-rocm-py312-ubi9-on-push-dzdjw doesn't define taskRunSpecs correctly: pipelineRun's taskrunSpecs defined wrong taskName: "build-container", does not exist in Pipeline
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configurations across multiple runtime and workbench container definitions to reorganize task execution in the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->