### PR TITLE
chore: handle wget download when there is an error

### DIFF
--- a/scripts/lockfile-generators/create-requirements-lockfile.sh
+++ b/scripts/lockfile-generators/create-requirements-lockfile.sh
@@ -153,38 +153,65 @@ if [[ "$DO_DOWNLOAD" == true ]]; then
   echo ""
   echo "=== Step 3: Downloading wheels ==="
 
+  # Output directory must match Cachi2 layout so prefetched wheels are found
+  # during hermetic/offline builds (e.g. Docker COPY from cachi2/output/deps/pip).
   OUT_DIR="cachi2/output/deps/pip"
   mkdir -p "$OUT_DIR"
 
+  # Use sha256sum on Linux, shasum -a 256 on macOS (portable).
   if command -v sha256sum &>/dev/null; then
     sha256_of() { sha256sum "$1" | cut -d' ' -f1; }
   else
     sha256_of() { shasum -a 256 "$1" | cut -d' ' -f1; }
   fi
 
+  # Count lines in pylock that look like "url = \"...\" ... sha256 = \"...\""
+  # (one per wheel; multi-line wheel blocks have one such line per wheel).
   total=$(grep -c 'url = ".*sha256 = "' "$PYLOCK_FILE" || true)
   echo "  ${total} wheel(s) to download into ${OUT_DIR}/"
   echo ""
 
   idx=0
+  # Read one line per wheel from the lockfile (same pattern as above).
   while IFS= read -r line; do
     idx=$((idx + 1))
 
+    # Extract URL and expected sha256 from lockfile line (TOML-style).
     url=$(echo "$line" | sed 's/.*url = "\([^"]*\)".*/\1/')
     sha=$(echo "$line" | sed 's/.*sha256 = "\([^"]*\)".*/\1/')
 
+    if [[ -z "$url" || -z "$sha" ]]; then
+      echo "  ERROR: failed to parse url or sha256 from lockfile line (wheel ${idx})" >&2
+      echo "  line: ${line:0:120}..." >&2
+      exit 1
+    fi
+
+    # Filename is the last path segment of the URL, without query/fragment.
     filename="${url##*/}"; filename="${filename%%[?#]*}"
+    if [[ -z "$filename" ]]; then
+      echo "  ERROR: could not derive filename from URL (wheel ${idx})" >&2
+      echo "  URL: ${url}" >&2
+      exit 1
+    fi
     dest="${OUT_DIR}/${filename}"
 
     echo "[${idx}/${total}] ${filename}"
 
+    # Download only if not already present (allows resuming after partial run).
     if [[ ! -f "$dest" ]]; then
       echo "  Downloading: ${url}"
-      wget -q -O "$dest" "$url"
+      if ! wget -q -O "$dest" "$url"; then
+        echo "  ERROR: download failed for ${filename}" >&2
+        echo "  URL: ${url}" >&2
+        echo "  Run 'wget -O /dev/null \"${url}\"' to see the full error." >&2
+        rm -f "$dest"
+        exit 1
+      fi
     else
       echo "  Already exists, skipping download."
     fi
 
+    # Verify digest so corrupted or wrong-version files are detected.
     actual=$(sha256_of "$dest")
     if [[ "$actual" != "$sha" ]]; then
       echo "  ERROR: checksum mismatch (got ${actual}, expected ${sha})" >&2


### PR DESCRIPTION
chore: handle wget download when there is an error

## Description
chore: handle wget download when there is an error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management workflow with improved wheel download verification and validation.
  * Added robust error handling and integrity checks to ensure reliable dependency resolution across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->