### PR TITLE
RHAIENG-3668: chore(tests): remove version specifier check in test_main.py since we won't be pinning versions in pyproject.toml in the future

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -106,10 +106,6 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                     assert "version" in pylock_packages[requirement.name], (
                         f"Version missing for {requirement.name} in pylock.toml"
                     )
-                    version = pylock_packages[requirement.name]["version"]
-                    assert requirement.specifier.contains(version), (
-                        f"Version of {d} in pyproject.toml does not match {version=} in pylock.toml"
-                    )
 
             with subtests.test(msg="checking imagestream manifest consistency with pylock.toml", pyproject=file):
                 _skip_unimplemented_manifests(directory)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-3668

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error reporting for version alignment validation to provide clearer feedback when single specifiers have stale exceptions.

* **Refactor**
  * Removed version validation logic that compared dependency versions across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->