### PR TITLE
chore(align-dockerfile-script): Make check_dockerfile_alignment.sh backward compatable with older bash version

### DIFF
--- a/scripts/check_dockerfile_alignment.sh
+++ b/scripts/check_dockerfile_alignment.sh
@@ -18,11 +18,12 @@ main() {
     echo "Scanning ${start_dirs[*]} for directories containing Dockerfile.konflux.*"
     echo "Comparing Dockerfiles, ignoring comments and LABEL blocks..."
 
-    # Populate array of directories
+    # Populate array of directories (while-read is portable; mapfile requires Bash 4+)
     local docker_dirs=()
     for dir in "${start_dirs[@]}"; do
-        mapfile -t dirs < <(find_docker_dirs "$dir")
-        docker_dirs+=("${dirs[@]}")
+        while IFS= read -r line; do
+            docker_dirs+=("$line")
+        done < <(find_docker_dirs "$dir")
     done
 
     # Process all directories and check for differences
@@ -111,9 +112,9 @@ find_diff() {
 
     echo "---- diff $file_orig $file_konflux ----"
 
-    # Use process substitution to feed stripped files to diff
+    # Use process substitution to feed stripped files to diff (plain diff for Mac/BSD and Linux/GNU portability)
     local diff_output
-    diff_output=$(diff --color=always <(strip <"$dir/$file_orig") <(strip <"$dir/$file_konflux") || true)
+    diff_output=$(diff <(strip <"$dir/$file_orig") <(strip <"$dir/$file_konflux") || true)
 
     if [ -n "$diff_output" ]; then
         echo "❌ Differences found between $file_orig and $file_konflux"


### PR DESCRIPTION
chore(align-dockerfile-script): Make check_dockerfile_alignment.sh backward compatable with older bash version

## Description
chore(align-dockerfile-script): Make check_dockerfile_alignment.sh backward compatable with older bash version

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced portability of the Dockerfile alignment verification script for improved cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->