### PR TITLE
chore(prefetch-gomod): Add Go module prefetch for hermetic builds (create-go-lockfile, hermeto-fetch-gomod)

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -1,6 +1,6 @@
 ############################################################################################
 # Hermetic Dockerfile for codeserver/ubi9-python-3.12
-#
+# Test #1
 # RHAIENG-2846: All build steps run without network access. Every dependency
 # (RPMs, npm packages, Python wheels, generic tarballs) is prefetched by cachi2
 # and mounted at /cachi2/output/deps/{rpm,pip,generic}/ during the build.

--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -54,11 +54,12 @@ scripts/lockfile-generators/prefetch-all.sh \
     --activation-key my-key --org my-org
 ```
 
-This single command orchestrates all four lockfile generators:
-1. Generic artifacts (GPG keys, VS Code .vsix extensions; ripgrep and oc client come from pip wheel and RPM respectively)
-2. Pip wheels (numpy, scipy, pandas, scikit-learn, ripgrep, uv, etc. via RHOAI index)
+This single command orchestrates all five lockfile generators:
+1. Generic artifacts (GPG keys, node headers, oc client, VS Code extensions)
+2. Pip wheels (numpy, scipy, pandas, scikit-learn, etc. via RHOAI index)
 3. NPM packages (code-server + VS Code extensions)
-4. RPMs (gcc, nodejs, nginx, openblas, openshift-clients, etc. via Hermeto)
+4. RPMs (gcc, nodejs, nginx, openblas, etc. via Hermeto)
+5. Go modules (go.mod/go.sum via Hermeto; used by images that build Go binaries)
 
 Lockfiles are organized into variant subdirectories under `prefetch-input/`:
 

--- a/docs/hermetic-guide.md
+++ b/docs/hermetic-guide.md
@@ -200,11 +200,12 @@ detailed usage.
 
 | Script | Purpose |
 |--------|---------|
-| `prefetch-all.sh` | Orchestrator  runs all four generators in order |
+| `prefetch-all.sh` | Orchestrator — runs all five generators in order |
 | `create-artifact-lockfile.py` | Generic artifacts → `artifacts.lock.yaml` |
 | `create-rpm-lockfile.sh` | RPMs → `rpms.lock.yaml` (via `rpm-lockfile-prototype`) |
 | `download-npm.sh` | npm tarballs → `cachi2/output/deps/npm/` |
 | `create-requirements-lockfile.sh` | pip → `pylock.toml` + `requirements.txt` |
+| `create-go-lockfile.sh` | Go modules → `cachi2/output/deps/gomod/` (via Hermeto) |
 
 ### Makefile
 

--- a/scripts/lockfile-generators/README.md
+++ b/scripts/lockfile-generators/README.md
@@ -1,8 +1,8 @@
 # Lockfile Generators
 
 Scripts to generate lockfiles for **generic artifacts**, **RPMs**, **npm packages**,
-and **pip packages**, download the referenced packages and support **offline**
-hermetic image builds via Cachi2/Hermeto.
+**pip packages**, and **Go modules (gomod)**, download the referenced packages and
+support **offline** hermetic image builds via Cachi2/Hermeto.
 
 ## Why lockfiles?
 
@@ -30,6 +30,8 @@ to process and where to find them:
     requirements_files: ["requirements.cpu.txt"]
   - path: codeserver/ubi9-python-3.12/prefetch-input/code-server/lib/vscode/extensions
     type: npm                                              # package-lock.json (many)
+  - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+    type: gomod                                            # go.mod + go.sum (Go modules)
   # ... more npm entries for code-server root, build/, test/, patched lockfiles, etc.
 ```
 
@@ -41,7 +43,7 @@ All scripts must be run from the **repository root**.
 
 **For most local and CI use, this is the main script you need to run.**
 
-`prefetch-all.sh` orchestrates all four lockfile generators in the correct
+`prefetch-all.sh` orchestrates all five lockfile generators in the correct
 order, downloading dependencies into `cachi2/output/deps/`. After running it,
 the Makefile auto-detects `cachi2/output/` and passes `--volume` +
 `--build-arg LOCAL_BUILD=true` to `podman build`.
@@ -87,11 +89,12 @@ gmake codeserver-ubi9-python-3.12 BUILD_ARCH=linux/arm64 PUSH_IMAGES=no
 | 2. Pip wheels | `pyproject.toml` exists in component dir | `create-requirements-lockfile.sh --download` |
 | 3. NPM packages | Tekton PipelineRun found for component (see below) | `download-npm.sh --tekton-file` |
 | 4. RPMs | `prefetch-input/<variant>/rpms.in.yaml` exists | `hermeto-fetch-rpm.sh` (if lockfile committed) or `create-rpm-lockfile.sh --download` |
+| 5. Go modules | Tekton file has `prefetch-input` entries with `type: gomod` | `create-go-lockfile.sh --tekton-file` |
 
 **Variant directory:** Lockfiles live under `prefetch-input/odh/` (upstream) or
 `prefetch-input/rhds/` (downstream). If that directory is missing, steps 1 and 4
-are skipped; steps 2 (pip) and 3 (npm) still run when their inputs exist
-(`pyproject.toml`, or a Tekton file for the component).
+are skipped; steps 2 (pip), 3 (npm), and 5 (gomod) still run when their inputs exist
+(`pyproject.toml`, a Tekton file for the component, or gomod-type prefetch-input).
 
 **Step 3 (NPM):** The script finds the Tekton file automatically via
 `find_tekton_yaml`: it looks for a `.tekton/*pull-request*.yaml` whose
@@ -100,6 +103,12 @@ are skipped; steps 2 (pip) and 3 (npm) still run when their inputs exist
 If no Tekton file is found, npm is skipped. If the Tekton file has no
 `npm`-type `prefetch-input` entries, `download-npm.sh` exits successfully
 (nothing to download).
+
+**Step 5 (Go modules):** Uses the same Tekton file as step 3. If the file has
+one or more `prefetch-input` entries with `type: gomod` and a `path` to a
+directory containing `go.mod` and `go.sum`, `create-go-lockfile.sh` runs Hermeto
+to fetch Go modules into `cachi2/output/deps/gomod/`. If there are no gomod
+entries, the step is skipped.
 
 Steps are skipped if their input files don't exist. For RPMs, if
 `rpms.lock.yaml` is already committed, it downloads directly (skipping
@@ -125,9 +134,9 @@ labels work when the daemon is Podman (see
 
 ## Individual tools
 
-The five options below can be used for hermetic builds. Scripts 1–4 can also be
+The six options below can be used for hermetic builds. Scripts 1–5 can also be
 run individually for debugging or partial updates; `prefetch-all.sh` calls them
-internally. Option 5 (Git submodule) is a manual setup.
+internally. Option 6 (Git submodule) is a manual setup.
 
 | # | Type | Main script | What it generates |
 |---|------|-------------|-------------------|
@@ -135,7 +144,8 @@ internally. Option 5 (Git submodule) is a manual setup.
 | 2 | RPM | [create-rpm-lockfile.sh](#2-rpm-packages--create-rpm-lockfilesh) | `rpms.lock.yaml` |
 | 3 | npm | [download-npm.sh](#3-npm-packages--download-npmsh) | Downloaded tarballs in `cachi2/output/deps/npm/` |
 | 4 | pip (RHOAI) | [create-requirements-lockfile.sh](#4-pip-packages-rhoai--create-requirements-lockfilesh) | `pylock.<flavor>.toml` + `requirements.<flavor>.txt` |
-| 5 | Git submodule | (manual setup) | [Pinned repo under prefetch-input/](#5-git-submodule) |
+| 5 | Go modules (gomod) | [create-go-lockfile.sh](#5-go-modules--create-go-lockfilesh) | Go module cache in `cachi2/output/deps/gomod/` |
+| 6 | Git submodule | (manual setup) | [Pinned repo under prefetch-input/](#6-git-submodule) |
 
 ### Helper scripts (used internally by the main tools)
 
@@ -146,6 +156,7 @@ internally. Option 5 (Git submodule) is a manual setup.
 | `helpers/download-rpms.sh` | RPM | Download RPMs from `rpms.lock.yaml` via `wget` into `cachi2/output/deps/rpm/` and create DNF repo metadata. Standalone alternative to `hermeto-fetch-rpm.sh`. |
 | `helpers/hermeto-fetch-rpm.sh` | RPM | Download RPMs from `rpms.lock.yaml` using [Hermeto](https://github.com/hermetoproject/hermeto) in a container. Handles RHEL entitlement cert extraction for `cdn.redhat.com` auth. Called by `create-rpm-lockfile.sh --download`. |
 | `helpers/hermeto-fetch-npm.sh` | npm | Alternative npm fetcher using [Hermeto](https://github.com/hermetoproject/hermeto) in a container. |
+| `helpers/hermeto-fetch-gomod.sh` | Go modules | Fetches Go dependencies from a directory with `go.mod`/`go.sum` using [Hermeto](https://github.com/hermetoproject/hermeto) in a container. Output: `cachi2/output/deps/gomod/`. Called by `create-go-lockfile.sh`. |
 | `rewrite-npm-urls.sh` | npm (Dockerfile) | Rewrites `resolved` URLs in `package-lock.json` / `package.json` to `file:///cachi2/output/deps/npm/`. |
 | `helpers/rpm-lockfile-generate.sh` | RPM | Runs `rpm-lockfile-prototype` inside the lockfile container. Not for direct host use. |
 | `Dockerfile.rpm-lockfile` | RPM | Builds the container image for `create-rpm-lockfile.sh` (includes `rpm-lockfile-prototype` v0.20.0, `createrepo_c`, `modulemd-tools`). Applies patches from `patches/` at build time. |
@@ -188,6 +199,13 @@ python3 scripts/lockfile-generators/create-artifact-lockfile.py \
 # 4. pip packages (numpy, scipy, pandas, pyarrow, etc.) — via RHOAI index + download for local testing
 ./scripts/lockfile-generators/create-requirements-lockfile.sh \
     --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml --download
+
+# 5. Go modules (e.g. mongocli) — from Tekton file or single directory
+./scripts/lockfile-generators/create-go-lockfile.sh \
+    --tekton-file .tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-pull-request.yaml
+# Or a single directory with go.mod + go.sum:
+./scripts/lockfile-generators/create-go-lockfile.sh \
+    --prefetch-dir jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
 ```
 
 > **Note:** The `--download` flag (and `download-npm.sh`) fetches packages into
@@ -220,7 +238,8 @@ cachi2/output/deps/
 ├── generic/    # GPG keys, .vsix, etc. (codeserver: ripgrep in pip, oc in rpm)
 ├── rpm/        # downloaded RPMs + repodata/ (includes openshift-clients for codeserver)
 ├── npm/        # downloaded npm tarballs
-└── pip/        # downloaded Python wheels (RHOAI index: ripgrep, uv, etc.)
+├── pip/        # downloaded Python wheels/sdists
+└── gomod/      # Go module cache (from go.mod/go.sum via Hermeto)
 ```
 
 ---
@@ -727,7 +746,71 @@ python3 scripts/lockfile-generators/helpers/download-pip-packages.py \
 
 ---
 
-## 5. Git submodule
+## 5. Go modules — `create-go-lockfile.sh`
+
+Prefetches Go dependencies for hermetic builds. Go modules are pinned in
+`go.sum` (no separate lockfile). The script discovers `gomod`-type
+`prefetch-input` paths from a Tekton PipelineRun YAML or a single
+`--prefetch-dir`, then runs [Hermeto](https://github.com/hermetoproject/hermeto)
+`fetch-deps` for each directory that contains `go.mod` and `go.sum`. Output is
+written to `cachi2/output/deps/gomod/` so Dockerfiles can build Go code offline
+(e.g. `GOPROXY=file:///cachi2/output/deps/gomod`).
+
+**Typical use:** Images that build Go binaries (e.g. mongocli) during the
+Docker build. The Tekton file lists the path to the Go module under
+`prefetch-input` with `type: gomod`; the source is usually a git submodule under
+`prefetch-input/` (e.g. `jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli`).
+
+### Requirements
+
+`podman`, `jq`. `yq` required when using `--tekton-file`.
+
+### Usage
+
+```bash
+# From Tekton: discover all gomod prefetch-input paths and fetch each
+./scripts/lockfile-generators/create-go-lockfile.sh --tekton-file .tekton/<pipeline>-pull-request.yaml
+
+# Single directory (must contain go.mod and go.sum)
+./scripts/lockfile-generators/create-go-lockfile.sh --prefetch-dir path/to/gomod/source
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--tekton-file PATH` | Tekton PipelineRun YAML; extract `prefetch-input` entries with `type: gomod`. |
+| `--prefetch-dir PATH` | Single directory containing `go.mod` and `go.sum` (required if not using `--tekton-file`). |
+
+### Example (jupyter pytorch+llmcompressor with mongocli)
+
+```bash
+# From Tekton file (recommended when the pipeline already defines prefetch-input)
+./scripts/lockfile-generators/create-go-lockfile.sh \
+    --tekton-file .tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-pull-request.yaml
+
+# Single directory
+./scripts/lockfile-generators/create-go-lockfile.sh \
+    --prefetch-dir jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+```
+
+### Helper: `helpers/hermeto-fetch-gomod.sh`
+
+Fetches Go modules for one directory using Hermeto in a container. Called by
+`create-go-lockfile.sh` for each gomod path. Can be run standalone for a single
+module:
+
+```bash
+./scripts/lockfile-generators/helpers/hermeto-fetch-gomod.sh \
+    --prefetch-dir jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+```
+
+**Requirements:** `podman`, `jq`. Must be run from the repository root (Hermeto
+expects a git repo for SBOM).
+
+---
+
+## 6. Git submodule
 
 The notebooks repository uses external code (e.g. code-server) that is normally
 cloned during the Docker build. For hermetic builds, Konflux can prefetch these
@@ -739,7 +822,8 @@ uses the checked-out tree instead of running `git clone` at build time.
 
 Run from the **repository root**. Replace the submodule URL and
 `<component>/prefetch-input/<name>` with your target path (e.g.
-`codeserver/ubi9-python-3.12/prefetch-input/code-server`).
+`codeserver/ubi9-python-3.12/prefetch-input/code-server`). For Go modules, the
+same submodule path is listed in the Tekton `prefetch-input` with `type: gomod`.
 
 ```bash
 # Add the external repo as a submodule under prefetch-input

--- a/scripts/lockfile-generators/create-go-lockfile.sh
+++ b/scripts/lockfile-generators/create-go-lockfile.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# create-go-lockfile.sh — Prefetch Go modules for hermetic builds using Hermeto.
+#
+# Go dependencies are pinned in go.sum (no separate lockfile). This script
+# discovers gomod-type prefetch-input paths (from a Tekton file or a single
+# --prefetch-dir) and runs hermeto fetch-deps for each, writing modules
+# into cachi2/output/deps/gomod/ so Dockerfiles can build offline.
+#
+# Usage:
+#   # From Tekton: discover all gomod paths and fetch each
+#   ./scripts/lockfile-generators/create-go-lockfile.sh --tekton-file .tekton/foo-pull-request.yaml
+#
+#   # Single directory (must contain go.mod and go.sum)
+#   ./scripts/lockfile-generators/create-go-lockfile.sh --prefetch-dir jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/mongocli
+#
+# Must be run from the repository root.
+
+SCRIPTS_PATH="scripts/lockfile-generators"
+TEKTON_FILE=""
+PREFETCH_DIR=""
+
+show_help() {
+  cat << EOF
+Usage: $SCRIPTS_PATH/create-go-lockfile.sh [OPTIONS]
+
+Prefetch Go modules for hermetic builds. At least one of --tekton-file or
+--prefetch-dir is required. Run from the repository root.
+
+Options:
+  --tekton-file PATH   Tekton PipelineRun YAML; extract gomod-type prefetch-input paths
+  --prefetch-dir PATH   Single directory containing go.mod and go.sum
+  -h, --help            Show this help
+EOF
+}
+
+error_exit() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+# Print gomod prefetch-input paths from a Tekton file (one per line).
+extract_gomod_paths_from_tekton() {
+  local tekton_file="$1"
+  yq eval '
+    .spec.params[]
+    | select(.name == "prefetch-input")
+    | .value[]
+    | select(.type == "gomod")
+    | .path
+  ' "$tekton_file"
+}
+
+# --- Validation: run from repo root ---
+if [[ ! -d "$SCRIPTS_PATH" ]]; then
+  error_exit "This script must be run from the repository root."
+fi
+
+# --- Argument parsing ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tekton-file)   [[ $# -ge 2 ]] || error_exit "--tekton-file requires a value"
+                     TEKTON_FILE="$2"; shift 2 ;;
+    --prefetch-dir)  [[ $# -ge 2 ]] || error_exit "--prefetch-dir requires a value"
+                     PREFETCH_DIR="$2"; shift 2 ;;
+    -h|--help)       show_help; exit 0 ;;
+    --help)          show_help; exit 0 ;;
+    *)               error_exit "Unknown argument: '$1'" ;;
+  esac
+done
+
+[[ -z "$TEKTON_FILE" && -z "$PREFETCH_DIR" ]] && error_exit "At least one of --tekton-file or --prefetch-dir is required."
+
+if [[ -n "$TEKTON_FILE" && ! -f "$TEKTON_FILE" ]]; then
+  error_exit "Tekton file not found: $TEKTON_FILE"
+fi
+if [[ -n "$PREFETCH_DIR" ]]; then
+  [[ -d "$PREFETCH_DIR" ]] || error_exit "Prefetch directory not found: $PREFETCH_DIR"
+  [[ -f "$PREFETCH_DIR/go.mod" ]] || error_exit "go.mod not found in $PREFETCH_DIR"
+fi
+
+if [[ -n "$TEKTON_FILE" ]]; then
+  command -v yq &>/dev/null || error_exit "yq is required for --tekton-file (https://github.com/mikefarah/yq)."
+fi
+
+# --- Collect gomod directories to process ---
+gomod_paths=()
+if [[ -n "$PREFETCH_DIR" ]]; then
+  gomod_paths+=("$PREFETCH_DIR")
+fi
+if [[ -n "$TEKTON_FILE" ]]; then
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    gomod_paths+=("$p")
+  done <<< "$(extract_gomod_paths_from_tekton "$TEKTON_FILE")"
+fi
+
+# Deduplicate (in case both --prefetch-dir and Tekton list the same path)
+gomod_paths=($(printf '%s\n' "${gomod_paths[@]}" | sort -u))
+
+if [[ ${#gomod_paths[@]} -eq 0 ]]; then
+  echo "No gomod prefetch paths to process."
+  exit 0
+fi
+
+echo "Go module prefetch: ${#gomod_paths[@]} path(s)"
+for dir in "${gomod_paths[@]}"; do
+  [[ -f "$dir/go.mod" ]] && [[ -f "$dir/go.sum" ]] || {
+    echo "Skipping $dir (missing go.mod or go.sum)" >&2
+    continue
+  }
+  echo "--- Fetching Go modules for $dir ---"
+  "$SCRIPTS_PATH/helpers/hermeto-fetch-gomod.sh" --prefetch-dir "$dir"
+done
+
+echo "create-go-lockfile.sh finished. Go modules are in cachi2/output/deps/gomod/"

--- a/scripts/lockfile-generators/helpers/hermeto-fetch-gomod.sh
+++ b/scripts/lockfile-generators/helpers/hermeto-fetch-gomod.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# hermeto-fetch-gomod.sh — Download Go modules using Hermeto.
+#
+# Fetches all Go dependencies for a module (go.mod + go.sum) into
+# cachi2/output/deps/gomod/ so Dockerfiles can build Go code offline
+# (e.g. GOPROXY=file:///cachi2/output/deps/gomod).
+#
+# Hermeto (hermetoproject/hermeto) runs in a container, reads go.mod/go.sum
+# from the given source directory, and downloads modules into the output
+# directory. No separate lockfile is needed — go.sum pins dependencies.
+
+HERMETO_IMAGE="ghcr.io/hermetoproject/hermeto:0.46.2"
+HERMETO_OUTPUT="./cachi2/output"
+
+PREFETCH_DIR=""
+
+show_help() {
+  cat << 'EOF'
+Usage: helpers/hermeto-fetch-gomod.sh [OPTIONS]
+
+Download Go modules for a directory containing go.mod using Hermeto.
+
+Options:
+  --prefetch-dir DIR     Directory containing go.mod and go.sum (required)
+  --help                 Show this help
+EOF
+}
+
+error_exit() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+# --- Argument parsing ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefetch-dir)    [[ $# -ge 2 ]] || error_exit "--prefetch-dir requires a value"
+                       PREFETCH_DIR="$2"; shift 2 ;;
+    -h|--help)         show_help; exit 0 ;;
+    *)                 error_exit "Unknown argument: '$1'" ;;
+  esac
+done
+
+[[ -z "$PREFETCH_DIR" ]] && error_exit "--prefetch-dir is required."
+[[ -f "$PREFETCH_DIR/go.mod" ]] || error_exit "go.mod not found in $PREFETCH_DIR"
+[[ -f "$PREFETCH_DIR/go.sum" ]] || error_exit "go.sum not found in $PREFETCH_DIR"
+
+# Hermeto requires the source to be a git repo with an 'origin' remote (it
+# uses it for SBOM). Mount the repo root and pass the gomod path as JSON.
+[[ -d .git ]] || error_exit "This script must be run from the repository root (no .git found)."
+HERMETO_JSON=$(jq -n --arg path "$PREFETCH_DIR" '{type: "gomod", path: $path}')
+
+# Hermeto fetch-deps wipes its --output directory on every run. Use a staging
+# dir so we can merge into the shared cachi2/output/ without destroying other
+# dep types (pip, npm, rpm, generic).
+HERMETO_STAGING=$(mktemp -d)
+trap 'rm -rf "$HERMETO_STAGING"' EXIT
+
+echo "--- Downloading Go modules via hermeto ---"
+podman run --rm \
+  -v "$(pwd):/source:z" \
+  -v "$HERMETO_STAGING:/output:z" \
+  "$HERMETO_IMAGE" \
+  fetch-deps --source /source --output /output "$HERMETO_JSON"
+
+# Hermeto may run as root; fix ownership so the host user can use the files.
+if ! test -w "$HERMETO_STAGING/deps/gomod" 2>/dev/null; then
+  sudo chown -R "$(id -u):$(id -g)" "$HERMETO_STAGING" 2>/dev/null || true
+fi
+
+# Merge into shared cachi2/output. If multiple gomod prefetch paths are used,
+# later runs merge into the same deps/gomod tree (Go module cache layout).
+mkdir -p "$HERMETO_OUTPUT/deps/gomod"
+if [[ -d "$HERMETO_STAGING/deps/gomod" ]]; then
+  cp -a "$HERMETO_STAGING/deps/gomod"/* "$HERMETO_OUTPUT/deps/gomod/" 2>/dev/null || true
+elif [[ -d "$HERMETO_STAGING/deps" ]]; then
+  # Some hermeto versions may use a different subdir; merge whatever is under deps/
+  for sub in "$HERMETO_STAGING/deps"/*/; do
+    [[ -d "$sub" ]] && cp -a "$sub"* "$HERMETO_OUTPUT/deps/gomod/" 2>/dev/null || true
+  done
+fi
+# Preserve bom and build-config if present (last run wins)
+[[ -f "$HERMETO_STAGING/bom.json" ]] && cp -f "$HERMETO_STAGING/bom.json" "$HERMETO_OUTPUT/bom.json"
+[[ -f "$HERMETO_STAGING/.build-config.json" ]] && cp -f "$HERMETO_STAGING/.build-config.json" "$HERMETO_OUTPUT/.build-config.json"
+
+echo "Finished! Go modules are in $HERMETO_OUTPUT/deps/gomod"

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Hermetic builds (Konflux/Tekton and local) require every dependency to be
 # prefetched so the Dockerfile can build fully offline (no network access).
-# This script orchestrates downloading all four dependency types:
+# This script orchestrates downloading all five dependency types:
 #
 #   1. Generic artifacts — GPG keys, nfpm-built RPMs, Node.js headers,
 #      Electron binaries, VS Code .vsix (into cachi2/output/deps/generic/).
@@ -16,6 +16,8 @@ set -euo pipefail
 #      (into cachi2/output/deps/npm/).
 #   4. RPMs — system packages resolved from rpms.lock.yaml via Hermeto
 #      (into cachi2/output/deps/rpm/).
+#   5. Go modules — Go deps from go.mod/go.sum via Hermeto (gomod)
+#      (into cachi2/output/deps/gomod/).
 #
 # Each step is skipped if its input file is not present in the component's
 # prefetch-input/<variant>/ directory. Step 3 (NPM) discovers the Tekton
@@ -198,13 +200,13 @@ STEPS_SKIPPED=0
 # =========================================================================
 ARTIFACTS_INPUT="$VARIANT_DIR/artifacts.in.yaml"
 if [[ -f "$ARTIFACTS_INPUT" ]]; then
-  echo "=== [1/4] Generic artifacts ==="
+  echo "=== [1/5] Generic artifacts ==="
   python3 "$SCRIPTS_PATH/create-artifact-lockfile.py" \
       --artifact-input "$ARTIFACTS_INPUT"
   STEPS_RUN=$((STEPS_RUN + 1))
   echo ""
 else
-  echo "=== [1/4] Generic artifacts — SKIPPED (no $ARTIFACTS_INPUT) ==="
+  echo "=== [1/5] Generic artifacts — SKIPPED (no $ARTIFACTS_INPUT) ==="
   STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
 fi
 
@@ -219,13 +221,13 @@ fi
 # =========================================================================
 PYPROJECT="$COMPONENT_DIR/pyproject.toml"
 if [[ -f "$PYPROJECT" ]]; then
-  echo "=== [2/4] Pip wheels ==="
+  echo "=== [2/5] Pip wheels ==="
   "$SCRIPTS_PATH/create-requirements-lockfile.sh" \
       --pyproject-toml "$PYPROJECT" --flavor "$FLAVOR" --download
   STEPS_RUN=$((STEPS_RUN + 1))
   echo ""
 else
-  echo "=== [2/4] Pip wheels — SKIPPED (no $PYPROJECT) ==="
+  echo "=== [2/5] Pip wheels — SKIPPED (no $PYPROJECT) ==="
   STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
 fi
 
@@ -238,7 +240,7 @@ fi
 #
 # Output: cachi2/output/deps/npm/
 # =========================================================================
-echo "=== [3/4] NPM packages ==="
+echo "=== [3/5] NPM packages ==="
 
 npm_done=false
 tekton_file=""
@@ -292,7 +294,7 @@ echo ""
 RPM_INPUT="$VARIANT_DIR/rpms.in.yaml"
 RPM_LOCKFILE="$VARIANT_DIR/rpms.lock.yaml"
 if [[ -f "$RPM_INPUT" ]]; then
-  echo "=== [4/4] RPMs ==="
+  echo "=== [4/5] RPMs ==="
   if [[ -f "$RPM_LOCKFILE" ]]; then
     echo "  rpms.lock.yaml exists — downloading RPMs only (skipping lockfile regeneration)"
     "$SCRIPTS_PATH/helpers/hermeto-fetch-rpm.sh" --prefetch-dir "$VARIANT_DIR"
@@ -303,9 +305,38 @@ if [[ -f "$RPM_INPUT" ]]; then
   STEPS_RUN=$((STEPS_RUN + 1))
   echo ""
 else
-  echo "=== [4/4] RPMs — SKIPPED (no $RPM_INPUT) ==="
+  echo "=== [4/5] RPMs — SKIPPED (no $RPM_INPUT) ==="
   STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
 fi
+
+# =========================================================================
+# Step 5: Go modules (create-go-lockfile.sh)
+#
+# Prefetches Go dependencies from go.mod/go.sum via Hermeto (gomod). Uses
+# the same Tekton file as NPM to discover gomod-type prefetch-input paths.
+# Output: cachi2/output/deps/gomod/
+# =========================================================================
+echo "=== [5/5] Go modules ==="
+if [[ -n "$tekton_file" ]] && command -v yq &>/dev/null; then
+  gomod_paths=$(yq eval '
+    .spec.params[]
+    | select(.name == "prefetch-input")
+    | .value[]
+    | select(.type == "gomod")
+    | .path
+  ' "$tekton_file" 2>/dev/null) || true
+  if [[ -n "$gomod_paths" ]] && [[ "$(echo "$gomod_paths" | grep -c .)" -gt 0 ]]; then
+    "$SCRIPTS_PATH/create-go-lockfile.sh" --tekton-file "$tekton_file"
+    STEPS_RUN=$((STEPS_RUN + 1))
+  else
+    echo "  No gomod-type prefetch-input in Tekton file — skipping"
+    STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
+  fi
+else
+  echo "  No Tekton file or yq — skipping Go modules"
+  STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
+fi
+echo ""
 
 # =========================================================================
 # Summary — show what ran, what was skipped, and disk usage per dep type.


### PR DESCRIPTION
chore(prefetch-gomod): Add Go module prefetch for hermetic builds (create-go-lockfile, hermeto-fetch-gomod)

## Description

- create-go-lockfile.sh: discover gomod prefetch-input paths from Tekton or   --prefetch-dir and run hermeto fetch-deps for each; output to cachi2/output/deps/gomod/
- helpers/hermeto-fetch-gomod.sh: run Hermeto container to fetch Go modules for a directory with go.mod/go.sum
- prefetch-all.sh and Konflux hermetic builds

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Go modules in the dependency prefetch workflow: a new Go modules prefetch step (now Step 5) that hermetically fetches go.mod/go.sum-based dependencies and writes results to the Go modules cache.

* **Documentation**
  * Updated guides, READMEs, examples, and quick-starts to describe the new Go modules generator, discovery methods, and output location.

* **Chores**
  * Updated step progress counters and summary messaging to reflect the new five-step flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->