### PR TITLE
fix(codeserver): fix 502 bad gateway for culling probe

### DIFF
--- a/codeserver/ubi9-python-3.12/httpd/httpd.conf
+++ b/codeserver/ubi9-python-3.12/httpd/httpd.conf
@@ -4,8 +4,8 @@ Listen 8080
 
 # Load modules
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule unixd_module modules/mod_unixd.so
 LoadModule authz_core_module modules/mod_authz_core.so
-LoadModule mime_module modules/mod_mime.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule cgi_module modules/mod_cgi.so
 LoadModule rewrite_module modules/mod_rewrite.so
@@ -32,6 +32,7 @@ DocumentRoot "/opt/app-root"
     Options +ExecCGI
     Require all granted
     AddHandler cgi-script .cgi
+    DirectoryIndex access.cgi
 </Directory>
 
 # Error and access logs


### PR DESCRIPTION
Fixes #3091

## Summary

Fix 502 Bad Gateway error that occurs during Activity Culling probe in Code Server workbench.

### Changes

- Add `mod_unixd` module to httpd.conf (required for CGI execution on Unix systems)
- Remove `mod_mime` module (not needed for this use case)
- Add `DirectoryIndex access.cgi` to ensure proper routing to the CGI script

### Problem

The culling probe was returning 502 errors because the Apache httpd server wasn't properly configured to execute CGI scripts. The missing `mod_unixd` module prevented the CGI server from starting correctly.

### Solution

This fix ensures the `/api/kernels` endpoint correctly routes to `access.cgi` for Activity Culling functionality.