### PR TITLE
ISSUE#1237: fix: duplicate variable assignment in `test_notebook.ipynb`

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/test/test_notebook.ipynb
+++ b/jupyter/datascience/ubi9-python-3.12/test/test_notebook.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "class TestPythonVersion(unittest.TestCase):\n",
     "    def test_version(self):\n",
-    "        expected_major_minor = expected_major_minor = get_expected_version('Python')\n",
+    "        expected_major_minor = get_expected_version('Python')\n",
     "        actual_major_minor = get_major_minor(python_version())\n",
     "        self.assertEqual(actual_major_minor, expected_major_minor, \"incorrect version\")\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ pythonPlatform = "Linux"
 
 # https://docs.astral.sh/ruff/configuration
 [tool.ruff]
-include = ["pyproject.toml", "ci/**/*.py", "ntb/**/*.py", "tests/**/*.py"]
+include = ["pyproject.toml", "ci/**/*.py", "ntb/**/*.py", "tests/**/*.py", "jupyter/**/*.ipynb"]
 exclude = [ ]
 target-version = "py314"
 line-length = 120
@@ -168,6 +168,8 @@ pep8-naming.classmethod-decorators = ["pydantic.validator"]
 [tool.ruff.lint.per-file-ignores]
 # Inner functions are serialized and executed inside containers, so imports must be local.
 "tests/containers/workbenches/gpu_library_loading_test.py" = ["PLC0415"]
+# Ignore many stylistic and formatting rules for notebooks, but keep Pylint rules like PLW0128
+"jupyter/**/*.ipynb" = ["E", "F", "W", "Q", "I", "PLR0402", "PLC0414", "RUF100", "PLW0108"]
 
 # https://docs.astral.sh/ruff/formatter
 [tool.ruff.format]


### PR DESCRIPTION
* Fixes #1237

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixed a duplicate assignment in the test suite to improve test reliability.

* **Chores**
  * Updated linting configuration to expand code quality checks across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->