### PR TITLE
NO-JIRA: fix(tests): stop extract_image_targets() from parsing make database comments as targets

### DIFF
--- a/ci/cached-builds/gen_gha_matrix_jobs.py
+++ b/ci/cached-builds/gen_gha_matrix_jobs.py
@@ -55,7 +55,16 @@ def extract_image_targets(
 
     # Extract the 'all-images' entry and its values
     all_images = []
-    match = re.search(rf"^{makefile_all_target}:\s+(.*)$", output, re.MULTILINE)
+    match = re.search(
+        rf"""
+        ^{makefile_all_target}:  # target name
+        \s+                      # colon and whitespace separator
+        ( [^#]* )                # prerequisites (stop before any inline comment)
+        $                        # end of line
+        """,
+        output,
+        re.MULTILINE | re.VERBOSE,
+    )
     if match:
         all_images = match.group(1).split()
 

--- a/tests/manifests.py
+++ b/tests/manifests.py
@@ -296,9 +296,8 @@ class TestManifests:
         sys.path.insert(0, str(ROOT_DIR / "ci/cached-builds"))
         from ci.cached_builds import gen_gha_matrix_jobs  # noqa: PLC0415
 
-        python_311 = gen_gha_matrix_jobs.extract_image_targets(ROOT_DIR, env={"RELEASE_PYTHON_VERSION": "3.11"})
         python_312 = gen_gha_matrix_jobs.extract_image_targets(ROOT_DIR, env={"RELEASE_PYTHON_VERSION": "3.12"})
-        targets = python_311 + python_312
+        targets = python_312
         # TODO(jdanek): this is again duplicating knowledge, but, what can I do?
         expected_manifest_paths = {
             "jupyter-minimal-ubi9-python-3.12": ROOT_DIR / "manifests/base/jupyter-minimal-notebook-imagestream.yaml",


### PR DESCRIPTION
## Summary

- `make --print-data-base` appends inline comments like `# Explicit rule.` to target dependency lines. The previous `(.*)` regex captured them, so `'#'` appeared in the targets list and caused a `KeyError` at test collection time in `tests/manifests.py::TestManifests`.
- Fixed by switching to a verbose regex with `[^#]*` to stop before any inline comment.
- Also removed the dead `python_311` call in `get_targets()` — the Makefile only defines `all-images` for Python 3.12, so the 3.11 call always returned an empty/comment-only result.

## Test plan

- [x] `./uv run pytest tests/manifests.py -x -v` — all 25 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Removed Python 3.11 from test matrix; testing now focuses exclusively on Python 3.12.

* **Chores**
  * Enhanced CI job generation pattern for improved robustness in parsing configuration prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->