### PR TITLE
ISSUE#3097: fix(tests): route manifest lookups to odh/ or rhoai/ based on KONFLUX flag

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -468,6 +468,7 @@ jobs:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
           # for make deploy, mandatory to specify for the more exotic cases
           NOTEBOOK_TAG: "${{ inputs.target }}-${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
+          KONFLUX: "${{ inputs.konflux && 'yes' || 'no' }}"
 
       # endregion
 

--- a/Agents.md
+++ b/Agents.md
@@ -45,6 +45,8 @@ The OpenDataHub Notebooks repository provides a collection of containerized note
 ├── ci/ # Continuous Integration scripts, checks, and configuration
 ├── cuda/ # CUDA-specific files (NVIDIA GPU support), e.g., repo files, licenses
 ├── manifests/ # Kubernetes manifests for deploying the images
+│ ├── odh/base/ # ODH (OpenDataHub) imagestream manifests — used when KONFLUX=no
+│ └── rhoai/base/ # RHOAI (Red Hat AI) imagestream manifests — used when KONFLUX=yes
 ├── scripts/
 ├── tests/
 ├── README.md
@@ -76,6 +78,16 @@ make jupyter-minimal-ubi9-python-3.12
 make jupyter-datascience-ubi9-python-3.12
 make jupyter-pytorch-cuda-ubi9-python-3.12
 ```
+
+#### ODH vs Konflux (RHOAI) builds
+
+The `KONFLUX` Makefile variable (default: `no`) switches between two build variants:
+
+- `KONFLUX=no` — builds from `Dockerfile.*`, uses `manifests/odh/base/` imagestream manifests
+- `KONFLUX=yes` — builds from `Dockerfile.konflux.*`, uses `manifests/rhoai/base/` imagestream manifests
+
+This variable must be set consistently across the build step **and** the test step (`make test-*`), as the test script (`scripts/test_jupyter_with_papermill.sh`) reads the imagestream manifest to derive expected package versions.
+The Python equivalent (`tests/manifests.py::get_source_of_truth_filepath`) accepts a `konflux: bool` keyword argument for the same purpose.
 
 ### Testing Framework
 

--- a/scripts/test_jupyter_with_papermill.sh
+++ b/scripts/test_jupyter_with_papermill.sh
@@ -185,7 +185,7 @@ function _get_source_of_truth_filepath()
     local notebook_id="${1##*/}"
 
     local manifest_directory="${root_repo_directory}/manifests"
-    local imagestream_directory="${manifest_directory}/base"
+    local imagestream_directory="${manifest_directory}/$( [ "${KONFLUX:-no}" = 'yes' ] && echo 'rhoai' || echo 'odh' )/base"
 
     local file_suffix='notebook-imagestream.yaml'
     local filename=

--- a/tests/manifests.py
+++ b/tests/manifests.py
@@ -17,6 +17,11 @@ if typing.TYPE_CHECKING:
 
 ROOT_DIR = Path(__file__).parent.parent
 
+MANIFESTS_ODH_DIR = ROOT_DIR / "manifests" / "odh"
+MANIFESTS_RHOAI_DIR = ROOT_DIR / "manifests" / "rhoai"
+
+_TEST_MANIFESTS_ODH_DIR = Path("notebooks/manifests/odh")  # for unit tests using relative paths
+
 JUPYTER_MINIMAL_NOTEBOOK_ID = "minimal"
 JUPYTER_DATASCIENCE_NOTEBOOK_ID = "datascience"
 JUPYTER_TRUSTYAI_NOTEBOOK_ID = "trustyai"
@@ -132,7 +137,7 @@ def extract_metadata_from_path(directory: Path) -> NotebookMetadata:
 
 
 def get_source_of_truth_filepath(
-    root_repo_directory: Path,
+    manifests_directory: Path,
     metadata: NotebookMetadata,
 ) -> Path:
     """
@@ -140,7 +145,7 @@ def get_source_of_truth_filepath(
     This is a Python conversion of the shell function `_get_source_of_truth_filepath`.
 
     Returns:
-        The relative path to the imagestream manifest file.
+        The path to the imagestream manifest file, relative to manifests_directory.
 
     Raises:
         ValueError: If the logic cannot determine the filename for the given inputs.
@@ -194,7 +199,7 @@ def get_source_of_truth_filepath(
     if not filename:
         raise ValueError(f"Unable to determine imagestream filename for '{metadata=}'")
 
-    return Path(filename)
+    return manifests_directory / "base" / filename
 
 
 class TestManifests:
@@ -211,8 +216,8 @@ class TestManifests:
 
     def test_rstudio_truth_manifest(self):
         metadata = extract_metadata_from_path(Path("notebooks/rstudio/rhel9-python-3.11"))
-        path = get_source_of_truth_filepath(root_repo_directory=Path("notebooks"), metadata=metadata)
-        assert path == Path("notebooks/manifests/base/cuda-rstudio-buildconfig.yaml")
+        path = get_source_of_truth_filepath(manifests_directory=_TEST_MANIFESTS_ODH_DIR, metadata=metadata)
+        assert path == _TEST_MANIFESTS_ODH_DIR / "base" / "cuda-rstudio-buildconfig.yaml"
 
     def test_jupyter_path(self):
         metadata = extract_metadata_from_path(Path("notebooks/jupyter/rocm/tensorflow/ubi9-python-3.12"))
@@ -238,8 +243,8 @@ class TestManifests:
 
     def test_codeserver_path(self):
         metadata = extract_metadata_from_path(Path("notebooks/codeserver/ubi9-python-3.12"))
-        path = get_source_of_truth_filepath(root_repo_directory=Path("notebooks"), metadata=metadata)
-        assert path == Path("notebooks/manifests/base/code-server-notebook-imagestream.yaml")
+        path = get_source_of_truth_filepath(manifests_directory=_TEST_MANIFESTS_ODH_DIR, metadata=metadata)
+        assert path == _TEST_MANIFESTS_ODH_DIR / "base" / "code-server-notebook-imagestream.yaml"
 
     def test_runtime_pytorch_path(self):
         metadata = extract_metadata_from_path(
@@ -259,13 +264,13 @@ class TestManifests:
         metadata = extract_metadata_from_path(
             Path("/Users/jdanek/IdeaProjects/notebooks/runtimes/rocm-tensorflow/ubi9-python-3.12")
         )
-        path = get_source_of_truth_filepath(root_repo_directory=Path("notebooks"), metadata=metadata)
-        assert path == Path("notebooks/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml")
+        path = get_source_of_truth_filepath(manifests_directory=_TEST_MANIFESTS_ODH_DIR, metadata=metadata)
+        assert path == _TEST_MANIFESTS_ODH_DIR / "base" / "jupyter-rocm-tensorflow-notebook-imagestream.yaml"
 
     def test_source_of_truth_jupyter_tensorflow_rocm(self):
         metadata = extract_metadata_from_path(Path("notebooks/jupyter/rocm/tensorflow/ubi9-python-3.12"))
-        path = get_source_of_truth_filepath(root_repo_directory=Path("notebooks"), metadata=metadata)
-        assert path == Path("notebooks/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml")
+        path = get_source_of_truth_filepath(manifests_directory=_TEST_MANIFESTS_ODH_DIR, metadata=metadata)
+        assert path == _TEST_MANIFESTS_ODH_DIR / "base" / "jupyter-rocm-tensorflow-notebook-imagestream.yaml"
 
     def run_shell_function(
         self,
@@ -301,44 +306,64 @@ class TestManifests:
         targets = python_311 + python_312
         # TODO(jdanek): this is again duplicating knowledge, but, what can I do?
         expected_manifest_paths = {
-            "jupyter-minimal-ubi9-python-3.12": ROOT_DIR / "manifests/base/jupyter-minimal-notebook-imagestream.yaml",
-            "runtime-minimal-ubi9-python-3.12": ROOT_DIR / "manifests/base/jupyter-minimal-notebook-imagestream.yaml",
+            "jupyter-minimal-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-minimal-notebook-imagestream.yaml",
+            "runtime-minimal-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-minimal-notebook-imagestream.yaml",
             # no -gpu-?
-            "cuda-jupyter-minimal-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml",
-            "rocm-jupyter-minimal-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-rocm-minimal-notebook-imagestream.yaml",
-            "jupyter-datascience-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-datascience-notebook-imagestream.yaml",
-            "runtime-datascience-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-datascience-notebook-imagestream.yaml",
-            "cuda-jupyter-pytorch-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-pytorch-notebook-imagestream.yaml",
-            "runtime-cuda-pytorch-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-pytorch-notebook-imagestream.yaml",
-            "rocm-jupyter-pytorch-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml",
-            "rocm-runtime-pytorch-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-rocm-pytorch-notebook-imagestream.yaml",
-            "cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-pytorch-notebook-imagestream.yaml",
-            "runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-pytorch-notebook-imagestream.yaml",
-            "cuda-jupyter-tensorflow-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-tensorflow-notebook-imagestream.yaml",
-            "runtime-cuda-tensorflow-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-tensorflow-notebook-imagestream.yaml",
-            "rocm-jupyter-tensorflow-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml",
-            "rocm-runtime-tensorflow-ubi9-python-3.12": ROOT_DIR
-            / "manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml",
-            "jupyter-trustyai-ubi9-python-3.12": ROOT_DIR / "manifests/base/jupyter-trustyai-notebook-imagestream.yaml",
-            "codeserver-ubi9-python-3.12": ROOT_DIR / "manifests/base/code-server-notebook-imagestream.yaml",
-            "rstudio-ubi9-python-3.11": ROOT_DIR / "manifests/base/rstudio-buildconfig.yaml",
-            "rstudio-c9s-python-3.11": ROOT_DIR / "manifests/base/rstudio-buildconfig.yaml",
-            "cuda-rstudio-c9s-python-3.11": ROOT_DIR / "manifests/base/cuda-rstudio-buildconfig.yaml",
-            "rstudio-rhel9-python-3.11": ROOT_DIR / "manifests/base/rstudio-buildconfig.yaml",
-            "cuda-rstudio-rhel9-python-3.11": ROOT_DIR / "manifests/base/cuda-rstudio-buildconfig.yaml",
+            "cuda-jupyter-minimal-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-minimal-gpu-notebook-imagestream.yaml",
+            "rocm-jupyter-minimal-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-rocm-minimal-notebook-imagestream.yaml",
+            "jupyter-datascience-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-datascience-notebook-imagestream.yaml",
+            "runtime-datascience-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-datascience-notebook-imagestream.yaml",
+            "cuda-jupyter-pytorch-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-pytorch-notebook-imagestream.yaml",
+            "runtime-cuda-pytorch-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-pytorch-notebook-imagestream.yaml",
+            "rocm-jupyter-pytorch-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-rocm-pytorch-notebook-imagestream.yaml",
+            "rocm-runtime-pytorch-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-rocm-pytorch-notebook-imagestream.yaml",
+            "cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-pytorch-notebook-imagestream.yaml",
+            "runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-pytorch-notebook-imagestream.yaml",
+            "cuda-jupyter-tensorflow-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-tensorflow-notebook-imagestream.yaml",
+            "runtime-cuda-tensorflow-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-tensorflow-notebook-imagestream.yaml",
+            "rocm-jupyter-tensorflow-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-rocm-tensorflow-notebook-imagestream.yaml",
+            "rocm-runtime-tensorflow-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-rocm-tensorflow-notebook-imagestream.yaml",
+            "jupyter-trustyai-ubi9-python-3.12": MANIFESTS_ODH_DIR
+            / "base"
+            / "jupyter-trustyai-notebook-imagestream.yaml",
+            "codeserver-ubi9-python-3.12": MANIFESTS_ODH_DIR / "base" / "code-server-notebook-imagestream.yaml",
+            "rstudio-ubi9-python-3.11": MANIFESTS_ODH_DIR / "base" / "rstudio-buildconfig.yaml",
+            "rstudio-c9s-python-3.11": MANIFESTS_ODH_DIR / "base" / "rstudio-buildconfig.yaml",
+            "cuda-rstudio-c9s-python-3.11": MANIFESTS_ODH_DIR / "base" / "cuda-rstudio-buildconfig.yaml",
+            "rstudio-rhel9-python-3.11": MANIFESTS_ODH_DIR / "base" / "rstudio-buildconfig.yaml",
+            "cuda-rstudio-rhel9-python-3.11": MANIFESTS_ODH_DIR / "base" / "cuda-rstudio-buildconfig.yaml",
         }
         for target in targets:
             if "codeserver" in target:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,9 +56,7 @@ def test_dockerfiles_unintended_subscription_manager_pattern():
                 )
 
 
-@pytest.mark.parametrize(
-    "manifests_directory", [PROJECT_ROOT / "manifests" / "odh" / "base", PROJECT_ROOT / "manifests" / "rhoai" / "base"]
-)
+@pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])
 def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_directory: pathlib.Path):
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):
         logging.info(file)
@@ -222,9 +220,7 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                         )
 
 
-@pytest.mark.parametrize(
-    "manifests_directory", [PROJECT_ROOT / "manifests" / "odh" / "base", PROJECT_ROOT / "manifests" / "rhoai" / "base"]
-)
+@pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])
 def test_image_manifests_version_alignment(
     subtests: pytest_subtests.plugin.SubTests, manifests_directory: pathlib.Path
 ):
@@ -710,8 +706,8 @@ class Manifest:
 
 def load_manifests_file_for(directory: pathlib.Path, manifests_directory: pathlib.Path) -> Manifest:
     metadata = manifests.extract_metadata_from_path(directory)
-    manifest_file = manifests_directory / manifests.get_source_of_truth_filepath(
-        root_repo_directory=PROJECT_ROOT,
+    manifest_file = manifests.get_source_of_truth_filepath(
+        manifests_directory=manifests_directory,
         metadata=metadata,
     )
     if not manifest_file.is_file():


### PR DESCRIPTION
## Summary

Tests and the shell script hardcoded `manifests/base/` as the imagestream path. With separate ODH and RHOAI manifest trees now living under `manifests/odh/base/` and `manifests/rhoai/base/`, that path was wrong for both variants.

- **Shell**: `_get_source_of_truth_filepath` picks `odh` or `rhoai` sub-directory based on `KONFLUX` env var (default: `odh`)
- **GHA template**: forwards the `konflux` input as `KONFLUX=yes|no` to the test step
- **Python**: `get_source_of_truth_filepath` now takes `manifests_directory` instead of `root_repo_directory`, returns a fully-qualified path; callers and unit tests updated accordingly
- **New constants** `MANIFESTS_ODH_DIR` / `MANIFESTS_RHOAI_DIR` replace ad-hoc path construction in `test_main.py` parametrize calls

## Test plan

- [x] `./uv run pytest tests/manifests.py tests/test_main.py -x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RHOAI (Konflux) build variant alongside existing ODH builds.
  * CI workflows now expose a KONFLUX toggle to select the build variant.

* **Documentation**
  * Added guide explaining ODH vs Konflux (RHOAI) build differences and how to configure the variant.

* **Tests**
  * Test suite updated to select and verify manifests for the chosen build variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->