### PR TITLE
fix(scripts): fix disordered output in pylocks_generator.py on CI

### DIFF
--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -101,7 +101,7 @@ def info(msg: str) -> None:
 
 
 def warn(msg: str) -> None:
-    print(f"⚠️ {YELLOW}{msg}{RESET}", file=sys.stderr)
+    print(f"⚠️ {YELLOW}{msg}{RESET}")
 
 
 def error(msg: str) -> None:
@@ -109,7 +109,7 @@ def error(msg: str) -> None:
 
 
 def ok(msg: str) -> None:
-    print(f"✅ {GREEN}{msg}{RESET}", file=sys.stderr)
+    print(f"✅ {GREEN}{msg}{RESET}")
 
 
 def read_conf_value(conf_file: Path, key: str) -> str | None:
@@ -299,6 +299,7 @@ def run_lock(
 
     cmd.extend(index_flags)
 
+    sys.stdout.flush()
     result = subprocess.run(cmd, cwd=project_dir, check=False)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary

The output of `pylocks_generator.py` was completely disordered in GitHub Actions: ✅/⚠️ success and warning messages appeared as a block *before* the directory processing headers they belonged to, making the log hard to read and debug.

## Root Cause

GitHub Actions captures stdout and stderr as two independent byte streams and merges them by timestamp into the displayed log. The script had a split between streams:

- `info()` and `print()` → **stdout** (buffered in Python)
- `ok()` and `warn()` → **stderr** (`file=sys.stderr`, unbuffered)
- `error()` → **stderr** (fatal, appropriate)

Because Python's stdout is block-buffered while stderr is unbuffered, the stderr lines (✅/⚠️) were flushed and timestamped *immediately*, while the buffered stdout lines (===, 🔹 headers) were flushed later as a block. When CI merged the two streams by timestamp, stderr content appeared earlier in the log than the stdout content that logically preceded it.

Note: `PYTHONUNBUFFERED=1` or manual `flush()` calls alone would *not* fix this — they only improve within-stream ordering. The inter-stream ordering issue requires putting all non-fatal output on the same stream.

The previous `pylocks_generator.sh` had the identical stdout/stderr split (`ok`/`warn` used `>&2`), but bash has no buffering layer between `echo` and the OS, so the race was less likely to manifest.

## Fix

1. **Move `ok()` and `warn()` from stderr to stdout** — all non-fatal log output now goes through a single stream, so GitHub Actions can merge it in correct order.

2. **Add `sys.stdout.flush()` before `subprocess.run()`** in `run_lock()` — ensures Python's buffered stdout is fully written before the subprocess starts writing to its inherited stdout, preventing subprocess output from appearing before the Python lines that preceded it.

`error()` is intentionally kept on stderr: it signals a fatal condition and is immediately followed by `raise SystemExit`.

## Test plan

- [x] Run `make refresh-lock-files INDEX_MODE=auto` locally and verify headers appear before their corresponding ✅/⚠️ lines
- [x] Observe CI log from a triggered run to confirm ordered output

* before: https://github.com/opendatahub-io/notebooks/actions/runs/23140385176/job/67214836577
* after: https://github.com/opendatahub-io/notebooks/actions/runs/23140400301/job/67214891000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted runtime message routing so warnings and success messages are emitted to the primary output stream.
  * Ensured output is flushed before launching external dependency compilation to reduce race conditions and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->