### PR TITLE
[RHAIENG-3668] Decouple pyproject from tests and rely only on pylocks

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import allure
 import packaging.requirements
+import packaging.specifiers
 import packaging.version
 import pytest
 import yaml
@@ -75,8 +76,17 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                 assert "requires-python" in pyproject["project"], (
                     "pyproject.toml is missing a [project.requires-python] section"
                 )
-                assert pyproject["project"]["requires-python"] == f"=={python}.*", (
-                    "pyproject.toml does not declare the expected Python version"
+                major, minor = (int(v) for v in python.split("."))
+                requires_python_specifier = packaging.specifiers.SpecifierSet(pyproject["project"]["requires-python"])
+                assert requires_python_specifier.contains(f"{major}.{minor}.0", prereleases=True), (
+                    "pyproject.toml requires-python does not include the expected Python minor version"
+                )
+                if minor > 0:
+                    assert not requires_python_specifier.contains(f"{major}.{minor - 1}.0", prereleases=True), (
+                        "pyproject.toml requires-python must not include the previous Python minor version"
+                    )
+                assert not requires_python_specifier.contains(f"{major}.{minor + 1}.0", prereleases=True), (
+                    "pyproject.toml requires-python must not include the next Python minor version"
                 )
 
                 assert "dependencies" in pyproject["project"], (
@@ -84,7 +94,11 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                 )
 
             if (f := file.parent / "uv.lock.d").is_dir():
-                pylock = tomllib.loads(next(f.glob("pylock.*.toml")).read_text())
+                pylock_candidates = sorted(f.glob("pylock.*.toml"))
+                if pylock_candidates:
+                    pylock = tomllib.loads(pylock_candidates[0].read_text())
+                else:
+                    pylock = tomllib.loads(file.with_name("pylock.toml").read_text())
             else:
                 pylock = tomllib.loads(file.with_name("pylock.toml").read_text())
             pylock_packages: dict[str, dict[str, Any]] = {p["name"]: p for p in pylock["packages"]}
@@ -106,6 +120,11 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                     assert "version" in pylock_packages[requirement.name], (
                         f"Version missing for {requirement.name} in pylock.toml"
                     )
+                    version = pylock_packages[requirement.name]["version"]
+                    if requirement.specifier:
+                        assert requirement.specifier.contains(version), (
+                            f"Version of {d} in pyproject.toml does not match {version=} in pylock.toml"
+                        )
 
             with subtests.test(msg="checking imagestream manifest consistency with pylock.toml", pyproject=file):
                 _skip_unimplemented_manifests(directory)
@@ -187,6 +206,14 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
 
                         # TODO(jdanek): intentional?
                         if manifest.metadata.scope == "pytorch+llmcompressor" and name == "Codeflare-SDK":
+                            continue
+                        # Runtime llmcompressor currently resolves via lm-eval constraints to 0.9.x
+                        # while the workbench line can resolve to 0.10.x.
+                        if (
+                            manifest.metadata.scope == "pytorch+llmcompressor"
+                            and manifest.metadata.type == manifests.NotebookType.RUNTIME
+                            and name == "LLM-Compressor"
+                        ):
                             continue
 
                         if name == "rstudio-server":
@@ -308,53 +335,39 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
             requirement = packaging.requirements.Requirement(d)
             requirements[requirement.name].append(requirement.specifier)
 
-    # list of packages and their versions where we need to have multiple versions of the same package
-    #  do not add/maintain entries with a single version here, delete such items directly
-    ignored_exceptions: tuple[tuple[str, tuple[str, ...]], ...] = (
-        # ("package name", ("allowed specifier 1", "allowed specifier 2", ...))
-        ("setuptools", ("~=80.9.0", "==80.9.0")),
-        ("wheel", ("==0.46.3", "~=0.46.3")),
-        ("tensorboard", ("~=2.18.0", "~=2.20.0")),
-        ("torchvision", ("==0.24.1", "~=0.24.1")),
-        ("triton", ("~=3.5.1", "==3.5.1")),
-        (
-            "numpy",
-            (
-                ">=1.26.4",  # allow the latest possible, see the pylock.toml check for precise pins
-                "==2.3.5",  # llmcompressor pins exact version
-            ),
-        ),
-        ("jupyterlab-lsp", ("~=5.1.0", "~=5.1.1")),
-        ("transformers", ("~=5.3.0", "==4.57.3")),
-        ("datasets", ("~=4.5.0", "==4.4.1")),
-        ("accelerate", ("~=1.12.0", "==1.12.0")),
-        ("requests", ("~=2.32.5", "==2.32.5")),
-    )
+    # Packages allowed to use multiple dependency specifiers across pyproject.toml files.
+    # Keep only package names here to avoid coupling tests to specific version values.
+    ignored_exceptions: set[str] = {
+        "setuptools",
+        "wheel",
+        "tensorboard",
+        "torchvision",
+        "triton",
+        "numpy",
+        "jupyterlab-lsp",
+        "transformers",
+        "datasets",
+        "accelerate",
+        "requests",
+    }
 
     for name, data in requirements.items():
-        exception = next((it for it in ignored_exceptions if it[0] == name), None)
         actual_specs = {str(spec) for spec in data}
+        # Unpinned specs are intentionally version-agnostic and should not
+        # trigger alignment failures on their own.
+        non_empty_specs = {spec for spec in actual_specs if spec}
 
-        if len(actual_specs) == 1:
-            # Only one version found - check we're not expecting multiple
-            if exception and len(exception[1]) > 1:
-                with subtests.test(msg=f"checking stale ignored_exceptions entry for {name}"):
-                    pytest.fail(
-                        f"{name} now has single specifier {actual_specs} but ignored_exceptions expects multiple: {set(exception[1])}. "
-                        f"Please update ignored_exceptions."
-                    )
+        if len(non_empty_specs) <= 1:
             continue
 
         with subtests.test(msg=f"checking versions of {name} across all pyproject.tomls"):
-            if exception:
-                # exception may save us from failing
-                expected_specs = set(exception[1])
-                assert actual_specs == expected_specs, (
-                    f"{name} is allowed to have {expected_specs} but actually has {actual_specs}"
-                )
+            if name in ignored_exceptions:
                 continue
             # all hope is lost, the check has failed
-            pytest.fail(f"{name} has multiple specifiers: {pprint.pformat(data)}")
+            pytest.fail(
+                f"{name} has multiple non-empty specifiers across pyproject.toml files: "
+                f"{non_empty_specs}. Full breakdown: {pprint.pformat(data)}"
+            )
 
 
 def test_files_that_should_be_same_are_same(subtests: pytest_subtests.plugin.SubTests):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://redhat.atlassian.net/browse/RHAIENG-3668 

## Description
<!--- Describe your changes in detail -->
This PR decouples pyproject checks from tests and rely only on pylocks also fixes some old warnings failures: PytestConfigWarning: collect_ignore is not a valid option in pytest.ini. It’s now set in tests/conftest.py so tests/containers stays ignored by default and collection stays fast.
DeprecationWarning: Replaced the deprecated @wait_container_is_ready decorator in WorkbenchContainer with the recommended structured wait: waiting_for(HttpWaitStrategy(port).for_status_code(200)) from testcontainers.core.wait_strategies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation logic for Python version requirements and dependency specifications to ensure consistency.
  * Improved test error reporting and filtering for dependency alignment checks.
  * Added runtime-specific adjustments to accommodate environment-dependent resolution differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->