### PR TITLE
chore(deps): require pydantic>=2.10.0 for Python 3.14 compatibility due to typing changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dev = [
     "pytest-subtests",
 
     "pyfakefs",
-    "pydantic",
+    # Python 3.14 changed the internal typing._eval_type() function signature - it now includes a new prefer_fwd_module parameter
+    # and so pydantic 2.10+ is required to work with from __future__ import annotations on Python 3.14
+    "pydantic>=2.10.0",
     "requests",
 
     "pyyaml",

--- a/uv.lock
+++ b/uv.lock
@@ -931,7 +931,7 @@ dev = [
     { name = "openshift-python-wrapper" },
     { name = "podman" },
     { name = "prek" },
-    { name = "pydantic" },
+    { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyfakefs" },
     { name = "pyright" },
     { name = "pytest" },


### PR DESCRIPTION
* https://github.com/red-hat-data-services/notebooks/actions/runs/23043428717/job/66926757135?pr=1949

## Description

Based on the error log you provided, I can see the issue clearly. This is a **Python 3.14 compatibility problem with Pydantic** caused by `from __future__ import annotations`.

## The Problem

The error occurs because:

1. **Python 3.14** changed the internal `typing._eval_type()` function signature - it now includes a new `prefer_fwd_module` parameter
2. The code uses `from __future__ import annotations` which converts all type annotations to strings
3. **Pydantic** tries to evaluate these string annotations using `typing._eval_type()`, but the current version of Pydantic in your environment doesn't support Python 3.14's new signature

The key error:
```
TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'
Unable to evaluate type annotation 'str'.
```

## Solutions

### Option 1: Upgrade Pydantic (Recommended)
Python 3.14 support was added in **Pydantic 2.10.0+**. Upgrade your dependencies:

```bash
uv add --upgrade pydantic>=2.10.0
# or if using pip
pip install --upgrade pydantic>=2.10.0
```

### Option 2: Remove `from __future__ import annotations`
If you can't upgrade Pydantic, modify `tests/containers/pydantic_schemas/podman_info.py` to remove the future import:

```python
# Remove this line:
# from __future__ import annotations

# Then use actual types instead of string annotations
from typing import Optional, List

class Conmon(BaseModel):
    version: str  # instead of 'str' as a string
    # ... etc
```

### Option 3: Use Python 3.12 or 3.13
Since your `RELEASE_PYTHON_VERSION` is 3.12 but `UV_PYTHON` is set to 3.14, align them:

```bash
export UV_PYTHON=3.12
uv run pytest ...
```

### Option 4: Add `defer_build` to Pydantic models
As a temporary workaround, you can defer model building:

```python
from pydantic import BaseModel, ConfigDict

class Conmon(BaseModel):
    model_config = ConfigDict(defer_build=True)
    version: str
```

## Recommended Fix

Given your environment variables show `RELEASE_PYTHON_VERSION: 3.12` but `UV_PYTHON: 3.14`, the simplest fix is to **pin Python to 3.12**:

```yaml
# In your GitHub Actions workflow
- name: Set up Python
  uses: actions/setup-python@v5
  with:
    python-version: '3.12'  # Pin to 3.12 instead of 3.14

# Or with uv
- run: uv python install 3.12
- run: uv run --python 3.12 pytest ...
```

Or upgrade Pydantic to a version compatible with Python 3.14 (2.10.0 or later).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pydantic minimum version requirement to 2.10.0 or higher in project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->