### PR TITLE
tests: assert on empty uv.lock.d instead of falling back to pylock.toml

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,10 +95,12 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
 
             if (f := file.parent / "uv.lock.d").is_dir():
                 pylock_candidates = sorted(f.glob("pylock.*.toml"))
-                if pylock_candidates:
-                    pylock = tomllib.loads(pylock_candidates[0].read_text())
-                else:
-                    pylock = tomllib.loads(file.with_name("pylock.toml").read_text())
+                assert pylock_candidates, (
+                    f"uv.lock.d directory exists at {f} but contains no pylock.*.toml files. "
+                    f"This likely means pylocks_generator.py failed. "
+                    f"Delete the empty uv.lock.d directory or re-run the lockfile generator."
+                )
+                pylock = tomllib.loads(pylock_candidates[0].read_text())
             else:
                 pylock = tomllib.loads(file.with_name("pylock.toml").read_text())
             pylock_packages: dict[str, dict[str, Any]] = {p["name"]: p for p in pylock["packages"]}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
follow up for https://github.com/opendatahub-io/notebooks/pull/3103

## Description
<!--- Describe your changes in detail -->
Test behavior:
Empty uv.lock.d → test fails with a direct, actionable error.
No uv.lock.d → behavior unchanged: still use pylock.toml in the parent directory.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced lock file validation in test suite. Tests now enforce stricter requirements for lock file handling, mandating presence of specific lock file types when lock directories are present. Previous fallback mechanisms for alternative lock file locations have been removed to ensure consistent behavior and early error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->