### PR TITLE
ISSUE#3116: add Workbench Image Digest field to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,7 @@ labels: 'kind/bug'
 - OpenDatahub Version: (please check the operator version)
 - Workbench: (all, data-science, etc)
 - Workbench Version: (2023.1, etc)
+- Workbench Image Digest: (run `podman inspect <image> | grep -i digest` or check the workbench deployment)
 - Specific tool: (jupyterlab, rstudio server, code-server, elyra-pipelines,etc)
 - Notebook-Controller Version: (please check the image version in notebook-controller deployment)
 


### PR DESCRIPTION
## Summary
- Adds a "Workbench Image Digest" field to the bug report issue template
- Helps reporters specify the exact image digest for reproducibility, since image tags are mutable

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report template to include a new Environment field for Workbench Image Digest, with instructions for users to obtain this diagnostic information when filing bug reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->