### PR TITLE
ISSUE#3119: add error context wrapping in CI and scripts utilities

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -53,7 +53,7 @@ def _query_build(make_target: str, query: str, env: dict[str, str] | None = None
             if m := pattern.match(line):
                 results.append(m["result"])
     except subprocess.CalledProcessError as e:
-        print(e.stderr, e.stdout)
+        print(f"make --just-print for target {make_target!r} failed: {e.stderr}\n{e.stdout}")
         raise
 
     if len(results) != 1:

--- a/ci/cached-builds/makefile_helper.py
+++ b/ci/cached-builds/makefile_helper.py
@@ -23,22 +23,27 @@ def exec_makefile(target: str, makefile_dir: pathlib.Path | str, options: Sequen
     else:
         make_command = "make"
 
+    cmd = [make_command, *options, target]
     try:
         # Run the make (or gmake) command and capture the output
         result = subprocess.run(
-            [make_command, *options, target],
+            cmd,
             capture_output=True,
             text=True,
             check=True,
             cwd=makefile_dir,
         )
     except subprocess.CalledProcessError as e:
-        # Handle errors if the make command fails
-        print(f"{make_command} failed with return code: {e.returncode}:\n{e.stderr}", file=sys.stderr)
+        print(
+            f"Command {cmd!r} in {makefile_dir!r} failed with return code {e.returncode}:\n{e.stderr}",
+            file=sys.stderr,
+        )
         raise
     except Exception as e:
-        # Handle any other exceptions
-        print(f"Error occurred attempting to parse Makefile:\n{e!s}", file=sys.stderr)
+        print(
+            f"Error executing command {cmd!r} in {makefile_dir!r}:\n{e!s}",
+            file=sys.stderr,
+        )
         raise
 
     return result.stdout

--- a/ci/check-software-versions.py
+++ b/ci/check-software-versions.py
@@ -82,13 +82,13 @@ def get_variable_value(variable_name, params_file_path=[PARAMS_LATEST_ENV_PATH, 
             for line in params_file:
                 if variable_name in line:
                     return line.split("=")[1].strip()
-        log.error(f"Variable '{variable_name}' not found in '{params_file_path}'!")
+        log.error(f"Variable {variable_name!r} not found in {params_file_path!r}!")
         return None
     except FileNotFoundError:
-        log.error(f"'{params_file_path}' not found!")
+        log.error(f"{params_file_path!r} not found while looking up variable {variable_name!r}!")
         return None
     except Exception as e:
-        log.error(f"An unexpected error occurred: {e}")
+        log.error(f"An unexpected error occurred while looking up {variable_name!r} in {params_file_path!r}: {e}")
         return None
 
 
@@ -148,7 +148,7 @@ def parse_json_string(json_string):
     try:
         return json.loads(json_string)
     except (json.JSONDecodeError, Exception) as e:
-        log.error(f"Error parsing JSON: {e}")
+        log.error(f"Error parsing JSON string {str(json_string)[:100]!r}: {e}")
         return None
 
 

--- a/ci/validate_json.py
+++ b/ci/validate_json.py
@@ -16,10 +16,10 @@ def validate_json_file(filepath: Path) -> bool:
         return True
     except json.JSONDecodeError as e:
         # Print specific error for easier debugging
-        print(f"  > Invalid JSON: {e}", file=sys.stderr)
+        print(f"  > Invalid JSON in {filepath}: {e}", file=sys.stderr)
         return False
     except OSError as e:
-        print(f"  > Error reading file: {e}", file=sys.stderr)
+        print(f"  > Error reading file {filepath}: {e}", file=sys.stderr)
         return False
 
 

--- a/scripts/generate_pull_request_pipelineruns.py
+++ b/scripts/generate_pull_request_pipelineruns.py
@@ -232,7 +232,7 @@ def transform_build_pipeline_to_pr_pipeline(push_pipeline_path: pathlib.Path):
             yaml.dump(pr_pipeline, f)
         print(f"  - Successfully generated: {pr_pipeline_path}")
     except Exception as e:
-        print(f"  - Error writing new file: {e}")
+        print(f"  - Error writing new file {pr_pipeline_path!r}: {e}")
 
 
 def get_exact_formatted_value(lines: list[str], key: list[int], val: list[int]):

--- a/scripts/lockfile-generators/create-artifact-lockfile.py
+++ b/scripts/lockfile-generators/create-artifact-lockfile.py
@@ -81,7 +81,7 @@ def load_artifact_input(input_path: Path) -> list[Any]:
         with open(input_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        print(f"Failed to parse YAML input: {e}", file=sys.stderr)
+        print(f"Failed to parse YAML input {input_path!r}: {e}", file=sys.stderr)
         sys.exit(1)
     except OSError as e:
         print(f"Failed to read {input_path}: {e}", file=sys.stderr)

--- a/scripts/new_python_based_image.py
+++ b/scripts/new_python_based_image.py
@@ -484,7 +484,7 @@ def run_pipenv_lock(pipfile_path: str, target_version: str) -> bool:
         LOGGER.debug(result.stdout)
         return True
     except subprocess.CalledProcessError as e:
-        LOGGER.debug(e.stderr)
+        LOGGER.warning(f"pipenv lock failed for {pipfile_path!r} (exit code {e.returncode}): {e.stderr}")
         return False
 
 


### PR DESCRIPTION
## Summary
- Adds file paths, target names, and other contextual information to error messages in `ci/` and `scripts/` Python utilities
- Makes it easier for both humans and AI agents to trace errors back to the specific input that caused them

### Files changed
- `ci/validate_json.py` — include filepath in JSON decode and file read errors
- `ci/check-software-versions.py` — include variable name and params file in lookup errors; include truncated input in JSON parse error (None-safe)
- `ci/cached-builds/makefile_helper.py` — include target and directory in make errors
- `ci/cached-builds/gha_pr_changed_files.py` — include target in make --just-print error
- `scripts/generate_pull_request_pipelineruns.py` — include path in file write error
- `scripts/lockfile-generators/create-artifact-lockfile.py` — include path in YAML parse error
- `scripts/new_python_based_image.py` — include pipfile path and exit code in pipenv lock error

Closes #3119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved error reporting across CI, build and helper scripts: logs now include clearer context such as command, directory, file or variable identifiers, return codes, and snippets of failing content to aid troubleshooting without changing program behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->