### PR TITLE
ISSUE#3121, ISSUE#3132: add ARCHITECTURE.md, ADR symlink, and module READMEs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# Architecture
+
+This document describes the high-level architecture of the OpenDataHub Notebooks repository.
+For AI agent-specific instructions, see [AGENTS.md](AGENTS.md).
+For contributing guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## What this repo produces
+
+The repository builds **container images** for interactive data science workbenches:
+Jupyter notebooks, RStudio, and Code-Server (VS Code in the browser).
+These images run on OpenShift as part of OpenDataHub (ODH) and Red Hat OpenShift AI (RHOAI).
+
+## Image inheritance model
+
+Images form a layered hierarchy where each level adds capabilities:
+
+```text
+Base images (cuda/, rocm/)
+  └── jupyter/minimal     ← Python, JupyterLab, basic packages
+        └── jupyter/datascience   ← NumPy, Pandas, SciPy, scikit-learn
+              ├── jupyter/pytorch         ← PyTorch + CUDA/ROCm
+              ├── jupyter/tensorflow      ← TensorFlow + CUDA
+              └── jupyter/trustyai        ← TrustyAI explainability
+```
+
+Each image directory (e.g. `jupyter/minimal/ubi9-python-3.12/`) contains:
+- `Dockerfile.*` — one per variant (cpu, cuda, rocm, konflux.cpu, etc.)
+- `Pipfile` or `pyproject.toml` — Python dependencies
+- `uv.lock.d/pylock.*.toml` — locked dependency files per variant
+- `build-args/` — build argument configuration per variant
+
+## Key directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `jupyter/` | Jupyter notebook image definitions, organized by flavor and accelerator |
+| `runtimes/` | Pipeline runtime images used by Elyra to execute notebook pipeline nodes |
+| `codeserver/` | Code-Server (VS Code in the browser) image definitions |
+| `rstudio/` | RStudio Server image definitions |
+| `ci/` | CI utility scripts — Makefile helpers, PR change detection, validation, cached build logic |
+| `scripts/` | Maintenance scripts — lockfile generation, CVE tracking, image analysis |
+| `ntb/` | Shared Python library — string utilities, assertions, constants used across CI and tests |
+| `tests/` | Test suite — unit tests, container integration tests (testcontainers), browser tests (Playwright) |
+| `manifests/` | Kubernetes ImageStream manifests for ODH (`manifests/odh/`) and RHOAI (`manifests/rhoai/`) |
+| `cuda/`, `rocm/` | GPU-specific configuration files, repo files, and licenses |
+| `docs/adr/` | Architecture Decision Records |
+
+## Build system
+
+The `Makefile` orchestrates image builds. Each image has a make target:
+
+```bash
+make jupyter-minimal-ubi9-python-3.12       # build one image
+make all-images                              # build everything
+make test                                    # run quick static tests (pytest + lint)
+```
+
+The build system supports two modes:
+- **ODH mode** (default): `KONFLUX=no`, uses standard Dockerfiles
+- **RHOAI/Konflux mode**: `KONFLUX=yes`, uses `Dockerfile.konflux.*` variants with prefetched dependencies
+
+## Testing layers
+
+| Layer | Location | What it tests | How to run |
+|-------|----------|---------------|-----------|
+| Unit tests | `tests/`, `ntb/` | CI scripts, utilities, doctests | `make test` |
+| Container tests | `tests/containers/` | Image startup, package imports, CLI tools | `pytest tests/containers --image=<img>` |
+| GPU tests | `tests/containers/workbenches/` | CUDA/ROCm library loading, GPU operations | Requires GPU hardware or fake GPU setup |
+| Browser tests | `tests/browser/` | JupyterLab, Code-Server UI via Playwright | `cd tests/browser && pnpm test` |
+| OpenShift tests | `tests/containers/` (marked `@openshift`) | Full pod lifecycle on a real cluster | Requires OpenShift cluster |
+
+## Languages
+
+- **Python** — CI scripts, tests, image dependency management
+- **Go** — `scripts/buildinputs/` tool that parses Dockerfiles to extract COPY/ADD dependencies
+- **TypeScript** — Browser tests (Playwright), Code-Server test models
+- **Bash** — Build scripts, CI checks
+- **Makefile** — Build orchestration

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,14 @@
+# ci/ — Continuous Integration utilities
+
+This directory contains Python scripts used by GitHub Actions workflows and the Makefile build system.
+
+## Key modules
+
+- `cached-builds/` — Logic for determining which images need rebuilding based on changed files
+  - `gha_pr_changed_files.py` — Detects changed files in PRs to skip unchanged image builds
+  - `gen_gha_matrix_jobs.py` — Generates GitHub Actions matrix job configurations
+  - `makefile_helper.py` — Wraps `make` dry-run to extract build variables
+  - `konflux_generate_component_*.py` — Generates Konflux/Tekton pipeline definitions
+- `check-software-versions.py` — Validates package versions inside built images against expectations
+- `validate_json.py` — Validates JSON files across the repository
+- `package_versions.py` — Parses and compares Python package version specifications

--- a/docs/adr
+++ b/docs/adr
@@ -1,0 +1,1 @@
+architecture/decisions

--- a/ntb/README.md
+++ b/ntb/README.md
@@ -1,0 +1,11 @@
+# ntb/ — Shared Python library
+
+Small utility library used across CI scripts and tests. Installed as the `notebooks` package via `uv sync`.
+
+## Modules
+
+- `__init__.py` — Re-exports key functions (`assert_subdict`)
+- `asserts.py` — Custom assertion helpers for tests
+- `constants.py` — Shared constants
+- `strings.py` — Template processing, string manipulation, blockinfile operations
+- `types.py` — Shared type definitions and Pydantic models


### PR DESCRIPTION
## Summary

- Add `ARCHITECTURE.md` documenting image inheritance model, build system, testing layers, and directory purposes
- Add `docs/adr` symlink → `docs/architecture/decisions/` so ADR scanners (including AI Bug Automation Readiness) can find existing ADRs
- Add module-level `README.md` for `ci/` and `ntb/` directories (`scripts/README.md` already existed)

These changes target the Architecture Documentation check in the [AI Bug Automation Readiness Report](https://github.com/opendatahub-io/notebooks/issues/3111) (currently 30/100, expected to reach 100/100).

Closes #3121
Closes #3132

## Test plan

- [x] `docs/adr` symlink resolves correctly to `docs/architecture/decisions/`
- [ ] AI Bug Automation Readiness score for Architecture Documentation improves from 30 to 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture docs describing repository layout, image build modes, supported runtimes, and example build/test commands.
  * Added CI utilities documentation describing tooling for change detection, job matrix generation, build helpers, and validation utilities.
  * Added architecture decision records.
  * Added documentation for the shared Python test/util library and its exported helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->