### PR TITLE
ISSUE#3120: add test-unit and test-integration Makefile targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,9 @@ uv venv --python $(which python3.14)
 uv sync --locked
 
 # Run tests
-make test # Non-container tests
+make test              # Quick static tests (pytest + Dockerfile alignment)
+make test-unit         # Python unit tests + doctests + Go tests (no container runtime)
+make test-integration PYTEST_ARGS="--image=<image>"  # Container integration tests
 make test-${NOTEBOOK_NAME} # Specific notebook tests
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -488,3 +488,20 @@ test:
 	@echo "Running quick static tests"
 	./uv run pytest -m 'not buildonlytest'
 	@./scripts/check_dockerfile_alignment.sh
+
+.PHONY: test-unit
+test-unit:
+	@echo "Running Python unit tests"
+	./uv run pytest -m 'not buildonlytest' --ignore=tests/containers tests/ ntb/
+	@echo "Running Go unit tests"
+	go test -C scripts/buildinputs ./...
+
+PYTEST_ARGS ?=
+
+.PHONY: test-integration
+test-integration:
+ifeq ($(PYTEST_ARGS),)
+	$(error Usage: make test-integration PYTEST_ARGS="--image=<image>")
+endif
+	@echo "Running container integration tests"
+	./uv run pytest tests/containers -m 'not openshift and not cuda and not rocm' $(PYTEST_ARGS)

--- a/README.md
+++ b/README.md
@@ -105,14 +105,15 @@ uv exits with a clear error telling you which version is required.
 
 </details>
 
-#### Running Python selftests in Pytest
-By completing configuration in previous section, you are able to run any tests that don't need to start a container using following command:
+#### Running tests
 
-```
-make test
-```
+By completing configuration in the previous section, you can run tests using the following targets (use `gmake` instead of `make` on macOS):
 
-Use `gmake test` if you're on macOS.
+```bash
+make test              # Quick static tests (pytest + Dockerfile alignment check)
+make test-unit         # Python unit tests + doctests + Go tests (no container runtime needed)
+make test-integration PYTEST_ARGS="--image=<image>"  # Container integration tests
+```
 
 ##### Container selftests
 


### PR DESCRIPTION
## Summary

Add dedicated Makefile targets for different test layers:

- `make test-unit` — runs Python pytest (unit tests + doctests) and Go tests
- `make test-integration` — runs container integration tests via testcontainers (pass image via `PYTEST_ARGS="--image=<img>"`)
- `make test` — unchanged (quick static tests + Dockerfile alignment check)

This gives 3 test-related Makefile targets, improving the One-Command Test Execution score in the [AI Bug Automation Readiness Report](https://github.com/opendatahub-io/notebooks/issues/3111) (80→100, +2.2 weighted points).

Closes #3120

## Test plan

- [x] `make test-unit` runs Python and Go tests successfully
- [x] `make test-integration PYTEST_ARGS="--image=<some-image>"` invokes container tests
- [ ] AI Bug Automation Readiness score for One-Command Test Execution improves to 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added new test targets to streamline testing: separate unit and container-based integration test commands, plus a configurable pytest-args variable and corresponding task declarations.

* **Documentation**
  * Consolidated and updated testing guidance with a new "Running tests" section, examples for unit vs. integration runs, and a macOS note for invoking the correct make tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->