### PR TITLE
[RHAIENG-2818] fix(ci) widen Jupyter probes for emulated ppc64le

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -442,6 +442,14 @@ jobs:
             sed -i'' 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' {} \;
           git diff
 
+      # RHAIENG-2818: emulated ppc64le starts Jupyter too slowly for default probes; widen only in CI.
+      - name: "Widen Jupyter probes for emulated ppc64le CI"
+        if: ${{ !cancelled() && steps.make-target.outcome == 'success' && inputs.platform == 'linux/ppc64le' }}
+        run: |
+          set -Eeuxo pipefail
+          uv run python ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py
+          git diff -- jupyter/
+
       # [INFO] Running command (('make deploy9-runtimes-rocm-tensorflow-ubi9-python-3.11',), {'shell': True})
       # Deploying notebook from runtimes/rocm/tensorflow/ubi9-python-3.11/kustomize/base directory...
       # sed: can't read runtimes/rocm/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml: No such file or directory
@@ -470,6 +478,10 @@ jobs:
           # for make deploy, mandatory to specify for the more exotic cases
           NOTEBOOK_TAG: "${{ inputs.target }}-${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
           KONFLUX: "${{ inputs.konflux && 'yes' || 'no' }}"
+          # RHAIENG-2818: allow long Jupyter startup under QEMU user-mode on GHA ppc64le
+          MAKE_TEST_POD_READY_WAIT_SEC_1: ${{ inputs.platform == 'linux/ppc64le' && '900' || '100' }}
+          MAKE_TEST_POD_READY_WAIT_SEC_2: ${{ inputs.platform == 'linux/ppc64le' && '600' || '50' }}
+          MAKE_TEST_POD_READY_WAIT_SEC_3: ${{ inputs.platform == 'linux/ppc64le' && '600' || '50' }}
 
       # endregion
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,8 @@ Key CI files:
 - `.github/workflows/` - GitHub Actions workflows
 - `ci/` - Custom CI scripts and configurations
 
+**Emulated ppc64le (RHAIENG-2818):** GitHub-hosted runners use QEMU user-mode; Jupyter starts slowly. CI widens StatefulSet probes via `ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py` and longer `wait_for_stability` timeouts—production `kustomize/base` probe values stay unchanged.
+
 ### Deployment
 
 1. **Local Development**:

--- a/ci/cached-builds/make_test.py
+++ b/ci/cached-builds/make_test.py
@@ -2,6 +2,7 @@
 import argparse
 import contextlib
 import functools
+import os
 import re
 import subprocess
 import sys
@@ -77,7 +78,7 @@ def run_tests(target: str) -> None:
     check_call("timeout 10s bash -c 'until kubectl get serviceaccount/default; do sleep 1; done'", shell=True)
 
     check_call(f"make {deploy}-{deploy_target}", shell=True)
-    wait_for_stability(pod, target)
+    wait_for_stability(pod)
 
     try:
         if target.startswith("runtime-"):
@@ -140,23 +141,22 @@ def execute(executor: typing.Callable, args: tuple, kwargs: dict) -> int:
     return result
 
 
-# Heavy images (e.g. datascience, trustyai) need more time to become Ready on constrained nodes.
-_HEAVY_TARGETS = ("jupyter-datascience", "jupyter-trustyai")
-
-
 # TODO(jdanek) this is a dumb impl, needs to be improved
-def wait_for_stability(pod: str, target: str = "") -> None:
+def wait_for_stability(pod: str) -> None:
     """Waits for the pod to be stable. Often I'm seeing that the probes initially fail.
     > error: Internal error occurred: error executing command in container: container is not created or running
     > error: unable to upgrade connection: container not found ("notebook")
+
+    MAKE_TEST_POD_READY_WAIT_SEC_{1,2,3}: outer timeout seconds per attempt (CI emulated ppc64le).
     """
-    timeout = 200 if any(h in target for h in _HEAVY_TARGETS) else 100
-    for _ in range(3):
+    t1 = int(os.environ.get("MAKE_TEST_POD_READY_WAIT_SEC_1", "100"))
+    t2 = int(os.environ.get("MAKE_TEST_POD_READY_WAIT_SEC_2", "50"))
+    t3 = int(os.environ.get("MAKE_TEST_POD_READY_WAIT_SEC_3", "50"))
+    for timeout in (t1, t2, t3):
         call(
             f"timeout {timeout}s bash -c 'until kubectl wait --for=condition=Ready pods --all --timeout 5s; do sleep 1; done'",
             shell=True,
         )
-        timeout = 50
         time.sleep(3)
 
 

--- a/ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py
+++ b/ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Widen Jupyter StatefulSet probes for slow CI (emulated ppc64le on GitHub-hosted runners).
+
+RHAIENG-2818: under QEMU user-mode emulation, Jupyter can take many minutes to listen on
+8888. Default liveness probes restart the container before startup completes.
+
+This script is intended for CI only. Production / native-hardware deployments keep the
+committed probe values in kustomize/base.
+
+Usage:
+  uv run python ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+# Generous but bounded: first liveness check after 8m; ~12m more slack before restart.
+_LIVENESS = {
+    "initialDelaySeconds": 480,
+    "periodSeconds": 15,
+    "timeoutSeconds": 5,
+    "successThreshold": 1,
+    "failureThreshold": 48,
+}
+_READINESS = {
+    "initialDelaySeconds": 480,
+    "periodSeconds": 15,
+    "timeoutSeconds": 5,
+    "successThreshold": 1,
+    "failureThreshold": 60,
+}
+
+
+def patch_statefulset(path: Path, yaml: YAML) -> bool:
+    with path.open() as f:
+        doc = yaml.load(f)
+    if not doc or doc.get("kind") != "StatefulSet":
+        return False
+    containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    if not containers:
+        return False
+    c0 = containers[0]
+    changed = False
+    for key, template in (("livenessProbe", _LIVENESS), ("readinessProbe", _READINESS)):
+        if key not in c0:
+            continue
+        probe = c0[key]
+        for k, v in template.items():
+            if k in ("tcpSocket", "httpGet", "exec"):
+                continue
+            if probe.get(k) != v:
+                probe[k] = v
+                changed = True
+    if changed:
+        with path.open("w") as f:
+            yaml.dump(doc, f)
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print paths that would be patched")
+    args = parser.parse_args()
+    root: Path = args.root
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    paths = sorted(root.glob("jupyter/**/kustomize/base/statefulset.yaml"))
+    if not paths:
+        print("No jupyter statefulset.yaml files found", file=sys.stderr)
+        return 1
+
+    patched: list[Path] = []
+    for p in paths:
+        if args.dry_run:
+            print(f"would patch: {p.relative_to(root)}")
+            continue
+        if patch_statefulset(p, yaml):
+            patched.append(p)
+
+    if args.dry_run:
+        print(f"dry-run: {len(paths)} file(s)")
+        return 0
+
+    for p in patched:
+        print(f"patched probes: {p.relative_to(root)}")
+    if not patched:
+        print("no files required probe updates (unexpected)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_patch_jupyter_statefulset_probes.py
+++ b/tests/test_patch_jupyter_statefulset_probes.py
@@ -1,0 +1,48 @@
+"""Tests for RHAIENG-2818 CI probe widening script."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "patch_jupyter_probes",
+    _REPO_ROOT / "ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py",
+)
+assert _SPEC and _SPEC.loader
+_mod = importlib.util.module_from_spec(_SPEC)
+sys.modules["patch_jupyter_probes"] = _mod
+_SPEC.loader.exec_module(_mod)
+patch_statefulset = _mod.patch_statefulset
+
+
+@pytest.fixture
+def minimal_statefulset_src() -> Path:
+    p = _REPO_ROOT / "jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml"
+    assert p.is_file()
+    return p
+
+
+def test_patch_statefulset_updates_probes(minimal_statefulset_src: Path) -> None:
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "statefulset.yaml"
+        shutil.copy(minimal_statefulset_src, path)
+        assert patch_statefulset(path, yaml) is True
+        with path.open() as f:
+            doc = yaml.load(f)
+        c0 = doc["spec"]["template"]["spec"]["containers"][0]
+        assert c0["livenessProbe"]["initialDelaySeconds"] == 480
+        assert c0["livenessProbe"]["failureThreshold"] == 48
+        assert c0["readinessProbe"]["initialDelaySeconds"] == 480
+        assert c0["readinessProbe"]["failureThreshold"] == 60
+        assert "tcpSocket" in c0["livenessProbe"]
+        assert "httpGet" in c0["readinessProbe"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
keeps production kustomize/base StatefulSet probe settings unchanged and applies CI-only relaxations on emulated ppc64le.
`ci/cached-builds/patch_jupyter_statefulset_probes_emulated_arch.py`: Widens liveness/readiness timing on all jupyter/**/kustomize/base/statefulset.yaml when the script is run

`.github/workflows/build-notebooks-TEMPLATE.yaml`:
- New step “Widen Jupyter probes for emulated ppc64le CI” when inputs.platform == 'linux/ppc64le' (after uv sync, before K8s tests).
- For ppc64le Makefile tests: MAKE_TEST_POD_READY_WAIT_SEC_{1,2,3} so wait_for_stability allows long Jupyter startup before kubectl wait … Ready.
`ci/cached-builds/make_test.py`: wait_for_stability() honors MAKE_TEST_POD_READY_WAIT_SEC_1/2/3 (defaults unchanged for other platforms).

`tests/test_patch_jupyter_statefulset_probes.py`: Unit test that the patch updates probes and preserves tcpSocket / httpGet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://github.com/mtchoum1/notebooks/actions/runs/23251593937/job/67595852392#step:31:826

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with support for emulated ppc64le architecture, including configurable timeout parameters and extended Jupyter startup probes.
  * Improved reliability for slower emulated build environments through adjustable probe thresholds.

* **Tests**
  * Added test coverage for Jupyter StatefulSet probe configuration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->