### PR TITLE
fix(tests): add --no-cache-dir to sample Dockerfiles for hadolint DL3042

### DIFF
--- a/tests/testdata/Dockerfile.sample-cpu
+++ b/tests/testdata/Dockerfile.sample-cpu
@@ -4,7 +4,7 @@ ARG PYLOCK_FLAVOR
 COPY pyproject.toml ./
 COPY uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 
-RUN pip install --no-deps --requirement=./pylock.toml
+RUN pip install --no-cache-dir --no-deps --requirement=./pylock.toml
 
 EXPOSE 8888
 CMD ["jupyter", "lab"]

--- a/tests/testdata/Dockerfile.sample-cuda
+++ b/tests/testdata/Dockerfile.sample-cuda
@@ -4,7 +4,7 @@ ARG PYLOCK_FLAVOR
 COPY pyproject.toml ./
 COPY uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 
-RUN pip install --no-deps --requirement=./pylock.toml
+RUN pip install --no-cache-dir --no-deps --requirement=./pylock.toml
 
 EXPOSE 8888
 CMD ["jupyter", "lab"]


### PR DESCRIPTION
## Summary

- Add `--no-cache-dir` to `pip install` in test sample Dockerfiles to fix hadolint DL3042 warning that was failing CI

## Test plan

- [ ] CI hadolint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Docker build configuration in test fixtures to optimize pip package caching behavior across CPU and CUDA variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->