### PR TITLE
implemented the imb runners to address ppc64le timeout

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -13,6 +13,8 @@ We have [IBM PowerPC and Z runners](https://community.ibm.com/community/user/blo
 
 - **Linux**: `ubuntu-24.04-ppc64le`, `ubuntu-24.04-s390x`
 
+`build-notebooks-TEMPLATE.yaml` maps `linux/ppc64le` and `linux/s390x` to these labels by default. Callers can override input `PLATFORM_RUNNERS` (e.g. map those platforms back to `ubuntu-24.04`) to force QEMU on amd64 when IBM runners are unavailable.
+
 We have considered investigating custom runners, either just plain containers/VMs, or something fronting an OpenShift cluster, in
 
 * https://github.com/opendatahub-io/notebooks/issues/1389

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -36,12 +36,14 @@ name: Build & Publish Notebook Servers (TEMPLATE)
       PLATFORM_RUNNERS:
         required: false
         # language=json
+        # IBM hosted Power/Z: https://github.com/IBM/actionspz/blob/main/docs/onboarding.md
+        # Override linux/ppc64le|s390x to ubuntu-24.04 to use QEMU on GHA amd64 (e.g. forks without org runners).
         default: >-
           {
             "linux/amd64": "ubuntu-24.04",
             "linux/arm64": "ubuntu-24.04-arm",
-            "linux/ppc64le": "ubuntu-24.04",
-            "linux/s390x": "ubuntu-24.04"
+            "linux/ppc64le": "ubuntu-24.04-ppc64le",
+            "linux/s390x": "ubuntu-24.04-s390x"
           }
         description: "Available contexts for runs-on are: github, inputs, matrix, needs, strategy, vars. Let's use inputs"
         type: string
@@ -97,9 +99,14 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action?tab=readme-ov-file#about
       # https://www.itix.fr/blog/qemu-user-static-with-podman/
+      # Skip when using IBM native runners (labels ubuntu-24.04-ppc64le / ubuntu-24.04-s390x).
       - name: Set up QEMU for non-native architecture
-        if: ${{ contains(fromJSON('["linux/s390x", "linux/ppc64le"]'), inputs.platform) }}
-        run: docker run --rm --privileged tonistiigi/binfmt --install ${platform#*/}
+        if: >-
+          ${{ (inputs.platform == 'linux/ppc64le' &&  
+          !contains(toJSON(fromJSON(inputs.PLATFORM_RUNNERS)[inputs.platform]), 'ppc64le')) ||  
+          (inputs.platform == 'linux/s390x' &&  
+          !contains(toJSON(fromJSON(inputs.PLATFORM_RUNNERS)[inputs.platform]), 's390x')) }}
+        run: docker run --rm --privileged tonistiigi/binfmt@sha256:373093569471770a3f83b54e4c698f621754c20d225538314880f2716f55956d --install ${platform#*/} --verbose
         env:
           platform: ${{ inputs.platform }}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on configuring custom platform runner mappings for different architectures.

* **Chores**
  * Optimized default platform runner selection for non-native architectures.
  * Enhanced QEMU setup logic to activate only when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->