### PR TITLE
[RHAIENG-3668] (test) warn on pylock pin drift for multispecifier-ignored packages

### DIFF
--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -377,15 +377,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "8d6123438226d7ce10b4f30c701b3a3b1e4926d52cd5ad88caf13cf68d26f13d" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "6540c1fba0d0901b3273c81ff5486fa5e4b48c56027e502b0531bc2f27c9e8ae" } }]
 
 [[packages]]
 name = "kiwisolver"

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -721,15 +721,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "8d6123438226d7ce10b4f30c701b3a3b1e4926d52cd5ad88caf13cf68d26f13d" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "6540c1fba0d0901b3273c81ff5486fa5e4b48c56027e502b0531bc2f27c9e8ae" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -1849,6 +1849,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "33314ca5a10f1423a78aed02ff7247466a279075b8ccffc67d4cd0f5eedd23ed" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9999871f289b099c90196e06edf6aa69eace3af46d5dcb06c2bb36899980dfc5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "ccb5da5a1167b1fe46febc653753515d50d3a92fd39e66087d958c58a7225a62" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "131d99d551599d502d0c3e9768cd2620bd44da224c5efc4b74d9befc9de6adba" } },
 ]
 
 [[packages]]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -726,4 +726,8 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "33314ca5a10f1423a78aed02ff7247466a279075b8ccffc67d4cd0f5eedd23ed" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9999871f289b099c90196e06edf6aa69eace3af46d5dcb06c2bb36899980dfc5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "ccb5da5a1167b1fe46febc653753515d50d3a92fd39e66087d958c58a7225a62" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "131d99d551599d502d0c3e9768cd2620bd44da224c5efc4b74d9befc9de6adba" } },
 ]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -698,4 +698,6 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda13.0-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "38fe3a72af8e5a190d58d09bb05c4be78d7339a0cb0e73b9a9d779145f04894b" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda13.0-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "855f06d0f5857b3e57b2c7ccf1a810c57506ed230ab20bc212e30a5c8b4e39a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda13.0-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "09099d745e3d3e73a8fffa1d10b0fada9b74fcf13f9f85f5f8f4a42a697d72b7" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda13.0-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "daa4cca81ef6295f546694bb4cf7dd8256de4f731008f20e06dc888db128536c" } },
 ]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -656,4 +656,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "yarl"
 version = "1.23.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b47711ee24a58c958d2c0c7ec1ddd19950c62ba6a094383f5c87d5821868453d" } },
+]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -726,15 +726,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/kfp_pipeline_spec-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "fb96a8655d56db1562f7bcdad0f562772af2d5c420ec2a570b499d1097869c71" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/kfp_server_api-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "211f8e6703253e22de2283cfd0690e2ef9b34c288ca1ec42be1ed2ebe3ce793c" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -846,6 +846,12 @@ name = "mbstrdecoder"
 version = "1.1.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/mbstrdecoder-1.1.4-8-py3-none-any.whl", hashes = { sha256 = "1e7853cacb5bdf764eb660637fece4d8374e3642bd4bb3916639031e8f1c9a28" } }]
+
+[[packages]]
+name = "micropipenv"
+version = "1.10.0"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/micropipenv-1.10.0-8-py3-none-any.whl", hashes = { sha256 = "d1ce0b6b413dacf8265c1f960ab872b1a73e2ff9da6966b2e98ef52246c7b68e" } }]
 
 [[packages]]
 name = "minio"
@@ -1116,6 +1122,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/pillow-12.1.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "4e1a4124807100d20450e3162d669452770ad0b88e79fbd263c8880db757b3b7" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/pillow-12.1.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e36472982caff8290b8980981bf5e58fa7da320f987fe6e17c3de37d16c971ab" } },
 ]
+
+[[packages]]
+name = "pip"
+version = "26.0.1"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/pip-26.0.1-8-py3-none-any.whl", hashes = { sha256 = "ba88a1ae1e0ecc877077d3c93780e6e3a5ea17541f68c6a733fe7c81eb96b6f0" } }]
 
 [[packages]]
 name = "platformdirs"
@@ -1774,6 +1786,15 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/urllib3-2.6.3-8-py3-none-any.whl", hashes = { sha256 = "2da4b0962c7dd53cc97e7166208cf1f4272cddc59be890b689aaf7da91f8a869" } }]
 
 [[packages]]
+name = "uv"
+version = "0.10.8"
+marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/uv-0.10.8-8-py3-none-linux_aarch64.whl", hashes = { sha256 = "9dcba8a31c74ffa50331e60e6e12da157e2244929eb6ea35b2f65912ecd820b5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/uv-0.10.8-8-py3-none-linux_x86_64.whl", hashes = { sha256 = "7f874c8d3afdd3fc3724964bb7f667a7fe655dd402fde8f0acb6ef3415ec1456" } },
+]
+
+[[packages]]
 name = "uvicorn"
 version = "0.34.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1888,6 +1909,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3f5c05557bab8c3ebb8d95e863e62b621d262a71c73aa00ef1785d5c63300b61" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c4c922a0eb39a1a8b74f68adedf613ed2faeab2df57560d110681507ab8da3d" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -708,15 +708,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/kfp_pipeline_spec-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "fb96a8655d56db1562f7bcdad0f562772af2d5c420ec2a570b499d1097869c71" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/kfp_server_api-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "211f8e6703253e22de2283cfd0690e2ef9b34c288ca1ec42be1ed2ebe3ce793c" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -1845,6 +1845,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3f5c05557bab8c3ebb8d95e863e62b621d262a71c73aa00ef1785d5c63300b61" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c4c922a0eb39a1a8b74f68adedf613ed2faeab2df57560d110681507ab8da3d" } },
 ]
 
 [[packages]]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -672,15 +672,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/kfp_pipeline_spec-2.16.0-12-py3-none-any.whl", hashes = { sha256 = "1adfd37bf676b60ff30610a4b03c454d4555e34a9559c35458e8f76c5429e88e" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/kfp_server_api-2.16.0-12-py3-none-any.whl", hashes = { sha256 = "78eb47ca35579faee891854744b8a7ce9aa8d575ba3ea10c1ee322ad429dd051" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -1688,7 +1688,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "yarl"
 version = "1.23.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b47711ee24a58c958d2c0c7ec1ddd19950c62ba6a094383f5c87d5821868453d" } },
+]
 
 [[packages]]
 name = "yaspin"

--- a/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -747,15 +747,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/kfp_pipeline_spec-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "fb96a8655d56db1562f7bcdad0f562772af2d5c420ec2a570b499d1097869c71" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/kfp_server_api-2.16.0-8-py3-none-any.whl", hashes = { sha256 = "211f8e6703253e22de2283cfd0690e2ef9b34c288ca1ec42be1ed2ebe3ce793c" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -1867,6 +1867,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3f5c05557bab8c3ebb8d95e863e62b621d262a71c73aa00ef1785d5c63300b61" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c4c922a0eb39a1a8b74f68adedf613ed2faeab2df57560d110681507ab8da3d" } },
 ]
 
 [[packages]]

--- a/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -702,15 +702,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "kfp-pipeline-spec"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "dd1ed0d13f80acc9e37182e2b7852dc054ef5e3146c32642e022287415b5229f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_pipeline_spec-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "8d6123438226d7ce10b4f30c701b3a3b1e4926d52cd5ad88caf13cf68d26f13d" } }]
 
 [[packages]]
 name = "kfp-server-api"
-version = "2.15.2"
+version = "2.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.15.2-2-py3-none-any.whl", hashes = { sha256 = "22eec65cff69604b67a1cf3c0df3858c0c3ffe97314bc31db362d3b46793833e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/kfp_server_api-2.16.0-2-py3-none-any.whl", hashes = { sha256 = "6540c1fba0d0901b3273c81ff5486fa5e4b48c56027e502b0531bc2f27c9e8ae" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -1794,6 +1794,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "33314ca5a10f1423a78aed02ff7247466a279075b8ccffc67d4cd0f5eedd23ed" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9999871f289b099c90196e06edf6aa69eace3af46d5dcb06c2bb36899980dfc5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "ccb5da5a1167b1fe46febc653753515d50d3a92fd39e66087d958c58a7225a62" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "131d99d551599d502d0c3e9768cd2620bd44da224c5efc4b74d9befc9de6adba" } },
 ]
 
 [[packages]]

--- a/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -1398,6 +1398,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "33314ca5a10f1423a78aed02ff7247466a279075b8ccffc67d4cd0f5eedd23ed" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9999871f289b099c90196e06edf6aa69eace3af46d5dcb06c2bb36899980dfc5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "ccb5da5a1167b1fe46febc653753515d50d3a92fd39e66087d958c58a7225a62" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "131d99d551599d502d0c3e9768cd2620bd44da224c5efc4b74d9befc9de6adba" } },
 ]
 
 [[packages]]

--- a/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -539,6 +539,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "33314ca5a10f1423a78aed02ff7247466a279075b8ccffc67d4cd0f5eedd23ed" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "9999871f289b099c90196e06edf6aa69eace3af46d5dcb06c2bb36899980dfc5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "ccb5da5a1167b1fe46febc653753515d50d3a92fd39e66087d958c58a7225a62" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cpu-ubi9-test/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "131d99d551599d502d0c3e9768cd2620bd44da224c5efc4b74d9befc9de6adba" } },
 ]
 
 # The following packages were excluded from the output:

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1339,6 +1339,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3f5c05557bab8c3ebb8d95e863e62b621d262a71c73aa00ef1785d5c63300b61" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c4c922a0eb39a1a8b74f68adedf613ed2faeab2df57560d110681507ab8da3d" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1398,6 +1398,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3f5c05557bab8c3ebb8d95e863e62b621d262a71c73aa00ef1785d5c63300b61" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c4c922a0eb39a1a8b74f68adedf613ed2faeab2df57560d110681507ab8da3d" } },
 ]
 
 [[packages]]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1250,7 +1250,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "yarl"
 version = "1.23.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/yarl-1.23.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b47711ee24a58c958d2c0c7ec1ddd19950c62ba6a094383f5c87d5821868453d" } },
+]
 
 [[packages]]
 name = "zipp"

--- a/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1432,6 +1432,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3f5c05557bab8c3ebb8d95e863e62b621d262a71c73aa00ef1785d5c63300b61" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9-test/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c4c922a0eb39a1a8b74f68adedf613ed2faeab2df57560d110681507ab8da3d" } },
 ]
 
 [[packages]]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,6 +46,7 @@ def _stderr_color_wrap_yellow(text: str) -> str:
         return text
     return f"{_ANSI_YELLOW}{text}{_ANSI_RESET}"
 
+
 # Normalized PyPI names: allowed to use different dependency specifiers across
 # pyproject.toml files. Pylock pins for these are still compared (warning-only)
 # in test_image_pyprojects_version_alignment — across all image pylocks (every
@@ -66,6 +67,7 @@ PYPROJECT_MULTISPEC_IGNORED_PACKAGES: frozenset[str] = frozenset(
         "requests",
     }
 )
+
 
 def _iter_image_pyproject_pylock_files() -> Iterator[pathlib.Path]:
     """Yield every pylock.toml / uv.lock.d/pylock.*.toml for image and dependencies trees."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,14 +5,13 @@ import json
 import logging
 import os
 import pathlib
-import sys
 import pprint
 import re
 import shutil
 import subprocess
+import sys
 import tomllib
 from collections import defaultdict
-from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import allure
@@ -25,7 +24,7 @@ import yaml
 from tests import PROJECT_ROOT, manifests
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
     from typing import Any
 
     import pytest_subtests
@@ -37,9 +36,7 @@ _LOG = logging.getLogger(__name__)
 # Bold yellow + reset; used for pylock mismatch headline and per-package summary lines when stderr is a TTY.
 _ANSI_YELLOW = "\033[1;33m"
 _ANSI_RESET = "\033[0m"
-_PYLOCK_MISMATCH_HEADLINE = (
-    "⚠️ Pylock version mismatches for allowed multispecifier packages "
-)
+_PYLOCK_MISMATCH_HEADLINE = "⚠️ Pylock version mismatches for allowed multispecifier packages"
 
 
 def _stderr_color_wrap_yellow(text: str) -> str:
@@ -69,7 +66,6 @@ PYPROJECT_MULTISPEC_IGNORED_PACKAGES: frozenset[str] = frozenset(
         "requests",
     }
 )
-
 
 def _iter_image_pyproject_pylock_files() -> Iterator[pathlib.Path]:
     """Yield every pylock.toml / uv.lock.d/pylock.*.toml for image and dependencies trees."""
@@ -106,7 +102,7 @@ def _warn_on_pylock_version_mismatch_for_packages(package_names: frozenset[str])
     mismatches: list[tuple[str, dict[str, str]]] = []
     for pkg_name in sorted(versions_by_pkg):
         mapping = versions_by_pkg[pkg_name]
-        if len({v for v in mapping.values()}) <= 1:
+        if len(set(mapping.values())) <= 1:
             continue
         mismatches.append((pkg_name, mapping))
 
@@ -117,7 +113,7 @@ def _warn_on_pylock_version_mismatch_for_packages(package_names: frozenset[str])
     for i, (pkg_name, mapping) in enumerate(mismatches):
         if i:
             lines.append("")
-        versions_joined = ", ".join(sorted({v for v in mapping.values()}))
+        versions_joined = ", ".join(sorted(set(mapping.values())))
         lines.append(_stderr_color_wrap_yellow(f"Package {pkg_name!r}"))
         lines.append(_stderr_color_wrap_yellow(f"  Pinned versions: {versions_joined}"))
         lines.append("  Per lockfile:")
@@ -451,10 +447,7 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
             continue
 
         with subtests.test(
-            msg=(
-                f"checking pyproject [project.dependencies] specifiers for {name} "
-                "across pyproject.toml files"
-            )
+            msg=(f"checking pyproject [project.dependencies] specifiers for {name} across pyproject.toml files")
         ):
             # all hope is lost, the check has failed
             pytest.fail(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,12 +5,14 @@ import json
 import logging
 import os
 import pathlib
+import sys
 import pprint
 import re
 import shutil
 import subprocess
 import tomllib
 from collections import defaultdict
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import allure
@@ -29,6 +31,99 @@ if TYPE_CHECKING:
     import pytest_subtests
 
 MAKE = shutil.which("gmake") or shutil.which("make")
+
+_LOG = logging.getLogger(__name__)
+
+# Bold yellow + reset; used for pylock mismatch headline and per-package summary lines when stderr is a TTY.
+_ANSI_YELLOW = "\033[1;33m"
+_ANSI_RESET = "\033[0m"
+_PYLOCK_MISMATCH_HEADLINE = (
+    "⚠️ Pylock version mismatches for allowed multispecifier packages "
+)
+
+
+def _stderr_color_wrap_yellow(text: str) -> str:
+    if os.environ.get("NO_COLOR", "").strip():
+        return text
+    if not sys.stderr.isatty():
+        return text
+    return f"{_ANSI_YELLOW}{text}{_ANSI_RESET}"
+
+# Normalized PyPI names: allowed to use different dependency specifiers across
+# pyproject.toml files. Pylock pins for these are still compared (warning-only)
+# in test_image_pyprojects_version_alignment — across all image pylocks (every
+# cpu/cuda/rocm/... file) so cross-workbench drift is visible.
+PYPROJECT_MULTISPEC_IGNORED_PACKAGES: frozenset[str] = frozenset(
+    {
+        "setuptools",
+        "wheel",
+        "tensorboard",
+        "torch",
+        "torchvision",
+        "triton",
+        "numpy",
+        "jupyterlab-lsp",
+        "transformers",
+        "datasets",
+        "accelerate",
+        "requests",
+    }
+)
+
+
+def _iter_image_pyproject_pylock_files() -> Iterator[pathlib.Path]:
+    """Yield every pylock.toml / uv.lock.d/pylock.*.toml for image and dependencies trees."""
+    for pyproject_path in PROJECT_ROOT.glob("**/pyproject.toml"):
+        directory = pyproject_path.parent
+        if not is_image_directory(directory) and not is_dependencies_directory(pyproject_path):
+            continue
+        lock_dir = directory / "uv.lock.d"
+        if lock_dir.is_dir():
+            yield from sorted(lock_dir.glob("pylock.*.toml"))
+        else:
+            yield pyproject_path.with_name("pylock.toml")
+
+
+def _warn_on_pylock_version_mismatch_for_packages(package_names: frozenset[str]) -> None:
+    """Log a warning when a package is pinned to different versions across image pylocks.
+
+    All ``pylock*.toml`` files are merged per package name (cpu, cuda, rocm, etc.), so
+    drift between workbench images appears under one ``Package`` section; lock path shows flavor.
+    """
+    versions_by_pkg: dict[str, dict[str, str]] = defaultdict(dict)
+    for lock_path in _iter_image_pyproject_pylock_files():
+        if not lock_path.is_file():
+            continue
+        doc = tomllib.loads(lock_path.read_text())
+        rel = str(lock_path.relative_to(PROJECT_ROOT))
+        for pkg in doc.get("packages", []):
+            name = pkg.get("name")
+            version = pkg.get("version")
+            if name is None or version is None or name not in package_names:
+                continue
+            versions_by_pkg[name][rel] = version
+
+    mismatches: list[tuple[str, dict[str, str]]] = []
+    for pkg_name in sorted(versions_by_pkg):
+        mapping = versions_by_pkg[pkg_name]
+        if len({v for v in mapping.values()}) <= 1:
+            continue
+        mismatches.append((pkg_name, mapping))
+
+    if not mismatches:
+        return
+
+    lines: list[str] = [_stderr_color_wrap_yellow(_PYLOCK_MISMATCH_HEADLINE)]
+    for i, (pkg_name, mapping) in enumerate(mismatches):
+        if i:
+            lines.append("")
+        versions_joined = ", ".join(sorted({v for v in mapping.values()}))
+        lines.append(_stderr_color_wrap_yellow(f"Package {pkg_name!r}"))
+        lines.append(_stderr_color_wrap_yellow(f"  Pinned versions: {versions_joined}"))
+        lines.append("  Per lockfile:")
+        for rel_path, ver in sorted(mapping.items()):
+            lines.append(f"    {rel_path}  ->  {ver}")
+    _LOG.warning("\n".join(lines))
 
 
 def test_dockerfiles_unintended_subscription_manager_pattern():
@@ -333,22 +428,13 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
             requirement = packaging.requirements.Requirement(d)
             requirements[requirement.name].append(requirement.specifier)
 
-    # Packages allowed to use multiple dependency specifiers across pyproject.toml files.
-    # Keep only package names here to avoid coupling tests to specific version values.
-    ignored_exceptions: set[str] = {
-        "setuptools",
-        "wheel",
-        "tensorboard",
-        "torch",
-        "torchvision",
-        "triton",
-        "numpy",
-        "jupyterlab-lsp",
-        "transformers",
-        "datasets",
-        "accelerate",
-        "requests",
-    }
+    with subtests.test(
+        msg=(
+            "pylock.toml pinned versions for multispecifier-ignored packages "
+            "(compare across all image lockfiles; logging.warning if pins differ)"
+        )
+    ):
+        _warn_on_pylock_version_mismatch_for_packages(PYPROJECT_MULTISPEC_IGNORED_PACKAGES)
 
     for name, data in requirements.items():
         actual_specs = {str(spec) for spec in data}
@@ -359,9 +445,17 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
         if len(non_empty_specs) <= 1:
             continue
 
-        with subtests.test(msg=f"checking versions of {name} across all pyproject.tomls"):
-            if name in ignored_exceptions:
-                continue
+        # Multispecifier packages are intentionally allowed to differ in pyproject.toml;
+        # their pylock pins are checked above (warning-only).
+        if name in PYPROJECT_MULTISPEC_IGNORED_PACKAGES:
+            continue
+
+        with subtests.test(
+            msg=(
+                f"checking pyproject [project.dependencies] specifiers for {name} "
+                "across pyproject.toml files"
+            )
+        ):
             # all hope is lost, the check has failed
             pytest.fail(
                 f"{name} has multiple non-empty specifiers across pyproject.toml files: "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Related to : https://redhat.atlassian.net/browse/RHAIENG-3668
follow up for: https://github.com/opendatahub-io/notebooks/pull/3103 
## Description
<!--- Describe your changes in detail -->
Added back the logs for the version drifts but as highlighted WARNINGS with nice yellow colors. 
<img width="1109" height="113" alt="Screenshot 2026-03-19 at 15 49 15" src="https://github.com/user-attachments/assets/f73d2b0d-4ef8-41d3-9a35-7b82a1d5e32c" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
GHA run: https://github.com/opendatahub-io/notebooks/actions/runs/23303476977/job/67770872556?pr=3156#step:6:589

Local run: Full logs of how the Warnings looks now on the test logs. 

```
 ....
 
WARNING:tests.test_main:⚠️ Pylock version mismatches for allowed multispecifier packages 
Package 'datasets'
  Pinned versions: 4.4.1, 4.5.0
  Per lockfile:
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  4.4.1
    jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  4.5.0
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  4.4.1

Package 'numpy'
  Pinned versions: 2.0.2, 2.3.5, 2.4.3
  Per lockfile:
    codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  2.4.3
    jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  2.4.3
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.3.5
    jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.4.3
    jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  2.4.3
    jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml  ->  2.0.2
    jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.4.3
    jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  2.4.3
    runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  2.4.3
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.3.5
    runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.4.3
    runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  2.4.3
    runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml  ->  2.0.2
    runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.4.3

Package 'setuptools'
  Pinned versions: 80.10.2, 80.9.0
  Per lockfile:
    codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.9.0
    jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.9.0
    jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.10.2
    jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.10.2
    jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  80.10.2
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  80.9.0
    jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml  ->  80.9.0
    jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.9.0
    rstudio/c9s-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.9.0
    rstudio/c9s-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    rstudio/rhel9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.9.0
    rstudio/rhel9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.9.0
    runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  80.10.2
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0
    runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  80.9.0
    runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml  ->  80.9.0
    runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  80.9.0

Package 'tensorboard'
  Pinned versions: 2.18.0, 2.20.0
  Per lockfile:
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.20.0
    jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.20.0
    jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  2.20.0
    jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml  ->  2.18.0
    jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.20.0
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.20.0
    runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.20.0
    runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  2.20.0
    runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml  ->  2.18.0
    runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.20.0

Package 'torch'
  Pinned versions: 2.10.0, 2.9.1
  Per lockfile:
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.9.1
    jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.9.1
    jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  2.9.1
    jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  2.10.0
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.9.1
    runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  2.9.1
    runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  2.9.1

Package 'transformers'
  Pinned versions: 4.57.3, 5.3.0
  Per lockfile:
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  4.57.3
    jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  5.3.0
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  4.57.3

Package 'triton'
  Pinned versions: 3.5.1, 3.6.0
  Per lockfile:
    jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  3.5.1
    jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  3.5.1
    jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  3.5.1
    jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml  ->  3.6.0
    runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  3.5.1
    runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml  ->  3.5.1
    runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml  ->  3.5.1
```

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test utilities and colorized logging for clearer output.
  * Added warnings when a package is pinned to different versions across multiple lockfiles; certain alignment checks now skip known packages while still warning.

* **Chores**
  * Bumped kfp-pipeline-spec and kfp-server-api to 2.16.0 across runtimes.
  * Expanded platform wheel availability for yarl and added/update some locked packages (e.g., pip, micropipenv, uv) in relevant lockfiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->