### PR TITLE
AIPCC-12382: fix(tests): update cowsay test after AIPCC onboarding

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -202,30 +202,21 @@ class TestBaseImage:
     def test_pip_install_cowsay_runs(self, image: str):
         """Checks that the Python virtualenv in the image is writable.
 
-        Images whose source tree uses ``uv.lock.d`` are treated as AIPCC-style for
-        dependency pinning, but runtime ``pip`` may still use the RHOAI mirror, which
-        can include packages like ``cowsay``. If ``pip install cowsay`` fails, we assert
-        the usual resolver error; if it succeeds (mirror carries the package), we assert
-        ``cowsay`` runs — same end state as the non-AIPCC path.
+        The cowsay package is available both on public PyPI and on the AIPCC
+        restricted index (AIPCC-12698), so it should install successfully
+        on all images.
         """
-        has_uv_lock_d = self._has_uv_lock_d(image)
 
         def test_fn(container: testcontainers.core.container.DockerContainer):
             ecode, output = container.exec(["python3", "-m", "pip", "install", "cowsay"])
             output_str = output.decode()
             logging.debug(output_str)
 
-            if has_uv_lock_d and ecode != 0:
-                assert (
-                    "Could not find a version that satisfies the requirement cowsay" in output_str
-                    or "No matching distribution found for cowsay" in output_str
-                ), f"Expected resolver error for cowsay, got: {output_str}"
-            else:
-                assert ecode == 0, f"Expected pip install cowsay to succeed, got: {output_str}"
+            assert ecode == 0, f"Expected pip install cowsay to succeed, got: {output_str}"
 
-                ecode, output = container.exec(["python3", "-m", "cowsay", "--text", "Hello world"])
-                logging.debug(output.decode())
-                assert ecode == 0
+            ecode, output = container.exec(["python3", "-m", "cowsay", "--text", "Hello world"])
+            logging.debug(output.decode())
+            assert ecode == 0
 
         self._run_test(image=image, test_fn=test_fn)
 


### PR DESCRIPTION
Simplifies

* https://github.com/opendatahub-io/notebooks/pull/3190

## Summary

- Fix CI failure in `test_pip_install_cowsay_runs` caused by cowsay being onboarded to the AIPCC restricted package index

## Problem

The `test_pip_install_cowsay_runs` test had two branches:
- **Non-AIPCC images**: expect `pip install cowsay` to succeed (cowsay is on public PyPI)
- **AIPCC-enabled images**: expect `pip install cowsay` to **fail** (cowsay was not on the restricted AIPCC index)

After cowsay was onboarded to the AIPCC index, the install succeeds on AIPCC images too, breaking the assertion:

```
FAILED tests/containers/base_image_test.py::TestBaseImage::test_pip_install_cowsay_runs[...] 
  Failed: Unexpected exception in test: Expected pip install cowsay to fail on AIPCC-enabled image
  assert 0 != 0
```

## Root cause

Cowsay was onboarded to the AIPCC restricted package index:
- [AIPCC-12382](https://issues.redhat.com/browse/AIPCC-12382) — cowsay package update request (Review)
- [AIPCC-12698](https://issues.redhat.com/browse/AIPCC-12698) — Add cowsay into the RHAI pipeline onboarding collection (Closed)
- [AIPCC-12699](https://issues.redhat.com/browse/AIPCC-12699) — QE testing for cowsay (Closed)

## Fix

Since cowsay is now available on both public PyPI and the AIPCC restricted index, simplify the test to expect success on all images. The test continues to verify that the Python virtualenv is writable and pip install works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified package installation test logic to validate that pip install consistently succeeds across all image types.
  * Removed environment-specific detection conditions and branching that previously expected installation failures on certain configurations.
  * Test now validates successful module execution regardless of image variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->