### PR TITLE
RHAIENG-3860: add Playwright smoke test for OCP console + fix CI push

### DIFF
--- a/.github/workflows/build-browser-tests.yaml
+++ b/.github/workflows/build-browser-tests.yaml
@@ -48,7 +48,6 @@ jobs:
             "${CONTEXT}"
 
       - name: Smoke-test the image (list tests)
-        if: matrix.arch == 'amd64'
         run: |
           podman run --rm \
             "${IMAGE_REGISTRY}/${IMAGE_NAME}:latest-${{ matrix.arch }}" \


### PR DESCRIPTION
## Summary

- Add Playwright-based browser smoke test for OCP console with shift-left Dockerfile
- Fix CI workflow to use correct Quay.io secrets (`QUAY_ROBOT_USERNAME`/`QUAY_ROBOT_TOKEN` instead of nonexistent `QUAY_USERNAME`/`QUAY_PASSWORD`)
- Add `push_image` workflow_dispatch input to allow manual image pushes without merging to main

## CI fix details

The `Login to Quay.io` step was failing with `Username and password required` because the workflow referenced `QUAY_USERNAME`/`QUAY_PASSWORD` secrets that don't exist in the repo. The actual secrets are `QUAY_ROBOT_USERNAME` and `QUAY_ROBOT_TOKEN`.

## Test plan

- [ ] Trigger workflow_dispatch manually with `push_image: false` — should build and smoke-test only
- [ ] Trigger workflow_dispatch manually with `push_image: true` — should build, smoke-test, login, and push
- [ ] Verify push-to-main path still works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build automation now supports manual image deployment triggers in addition to automatic deployments on main branch updates.
  * Container images are built for multiple CPU architectures and published with per-architecture tags; a unified multi-architecture image tag is created for broad compatibility.
  * Registry authentication for image publishing has been updated to use a robot/service account for improved credential management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->