### PR TITLE
fix: _copy_tree respects .dockerignore patterns to avoid OSError on long paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# NOTE: scripts/sandbox.py uses a limited parser that only extracts
+# single-segment directory patterns (name/ or **/name/) from this file.
+# Negation (!), globs (*.ext), and multi-segment paths are ignored.
+
 bin/
 ci/
 tests/

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -94,7 +94,41 @@ def buildinputs(
     return prereqs
 
 
-def _copy_tree(src: pathlib.Path, dst: pathlib.Path):
+def _load_dockerignore(root: pathlib.Path) -> list[str]:
+    """Read .dockerignore from *root* and return the non-comment, non-empty lines."""
+    dockerignore = root / ".dockerignore"
+    if not dockerignore.exists():
+        return []
+    lines = []
+    for line in dockerignore.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            lines.append(line)
+    return lines
+
+
+def _ignored_dir_names(root: pathlib.Path) -> set[str]:
+    """Return a set of bare directory names that should be skipped during os.walk.
+
+    Only ``**/name/`` patterns are handled — these unambiguously mean "skip a
+    directory named *name* at any depth".  Root-relative patterns such as
+    ``node_modules/`` (no ``**/`` prefix) are intentionally excluded because
+    they only apply at the root of the build context, not inside nested
+    prerequisite directories.
+    """
+    ignored: set[str] = set()
+    for pattern in _load_dockerignore(root):
+        # Only accept "**/<name>/" – i.e., starts with "**/" and ends with "/"
+        # with no additional "/" in between.
+        if not pattern.startswith("**/") or not pattern.endswith("/"):
+            continue
+        name = pattern[3:-1]  # strip leading "**/" and trailing "/"
+        if name and "/" not in name:
+            ignored.add(name)
+    return ignored
+
+
+def _copy_tree(src: pathlib.Path, dst: pathlib.Path, dir_ignore_names: set[str] | None = None):
     """Copy a directory tree, copying only file content (no metadata/xattrs).
 
     shutil.copytree's internal copystat() on directories fails on macOS with
@@ -102,8 +136,17 @@ def _copy_tree(src: pathlib.Path, dst: pathlib.Path):
     on the destination.  Walking manually with shutil.copy avoids this.
     Directories that cannot be created (e.g. macOS EPERM on certain dotfiles
     in temp directories) are logged and skipped.
+
+    *dir_ignore_names* is an optional set of bare directory names (e.g.
+    ``{"node_modules", ".pnpm-store"}``) that will be pruned from each
+    ``dirnames`` list during the walk so that os.walk never descends into them.
+    This mirrors the ``**/name/`` patterns in ``.dockerignore`` and avoids the
+    ``OSError: [Errno 63] File name too long`` crash caused by deeply-nested
+    content-addressed stores such as ``.pnpm-store``.
     """
     for dirpath, dirnames, filenames in os.walk(src, followlinks=True):
+        if dir_ignore_names:
+            dirnames[:] = [d for d in dirnames if d not in dir_ignore_names]
         rel = pathlib.Path(dirpath).relative_to(src)
         try:
             (dst / rel).mkdir(parents=True, exist_ok=True)
@@ -124,6 +167,8 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
     if gitignore.exists():
         shutil.copy(gitignore, tmpdir)
 
+    dir_ignore_names = _ignored_dir_names(ROOT_DIR)
+
     for dep in prereqs:
         if dep.is_absolute():
             dep = dep.relative_to(ROOT_DIR)
@@ -141,7 +186,7 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
                 m_path = pathlib.Path(m)
                 (tmpdir / m_path.parent).mkdir(parents=True, exist_ok=True)
                 if m_path.is_dir():
-                    _copy_tree(m_path, tmpdir / m_path)
+                    _copy_tree(m_path, tmpdir / m_path, dir_ignore_names=dir_ignore_names)
                 else:
                     shutil.copy(m_path, tmpdir / m_path.parent)
             continue
@@ -151,7 +196,7 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
             sys.exit(1)
 
         if dep.is_dir():
-            _copy_tree(dep, tmpdir / dep)
+            _copy_tree(dep, tmpdir / dep, dir_ignore_names=dir_ignore_names)
         else:
             (tmpdir / dep.parent).mkdir(parents=True, exist_ok=True)
             shutil.copy(dep, tmpdir / dep.parent)

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -94,7 +94,40 @@ def buildinputs(
     return prereqs
 
 
-def _copy_tree(src: pathlib.Path, dst: pathlib.Path):
+def _load_dockerignore(root: pathlib.Path) -> list[str]:
+    """Read .dockerignore from *root* and return the non-comment, non-empty lines."""
+    dockerignore = root / ".dockerignore"
+    if not dockerignore.exists():
+        return []
+    return [
+        stripped
+        for line in dockerignore.read_text().splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#") and not stripped.startswith("!")
+    ]
+
+
+def _ignored_dir_names(root: pathlib.Path) -> set[str]:
+    """Return a set of bare directory names that should be skipped during os.walk.
+
+    Both ``**/name/`` and root-relative ``name/`` patterns are accepted —
+    any single-segment pattern ending with ``/`` is treated as a directory
+    name to prune at any depth.  Multi-segment paths (e.g. ``a/b/``) and
+    file-glob patterns (e.g. ``*.log``) are excluded.
+
+    TODO: negation patterns (``!name``) are filtered out, not honored as re-inclusions.
+    TODO: followlinks=True in _copy_tree can still loop on circular symlinks.
+    """
+    ignored: set[str] = set()
+    for pattern in _load_dockerignore(root):
+        if not pattern.endswith("/"):
+            continue
+        name = pattern.removeprefix("**/").removesuffix("/")
+        if name and "/" not in name and not any(c in name for c in ("*", "?", "[")):
+            ignored.add(name)
+    return ignored
+
+
+def _copy_tree(src: pathlib.Path, dst: pathlib.Path, dir_ignore_names: set[str] | None = None):
     """Copy a directory tree, copying only file content (no metadata/xattrs).
 
     shutil.copytree's internal copystat() on directories fails on macOS with
@@ -102,8 +135,17 @@ def _copy_tree(src: pathlib.Path, dst: pathlib.Path):
     on the destination.  Walking manually with shutil.copy avoids this.
     Directories that cannot be created (e.g. macOS EPERM on certain dotfiles
     in temp directories) are logged and skipped.
+
+    *dir_ignore_names* is an optional set of bare directory names (e.g.
+    ``{"node_modules", ".pnpm-store"}``) that will be pruned from each
+    ``dirnames`` list during the walk so that os.walk never descends into them.
+    This mirrors the ``**/name/`` patterns in ``.dockerignore`` and avoids the
+    ``OSError: [Errno 63] File name too long`` crash caused by deeply-nested
+    content-addressed stores such as ``.pnpm-store``.
     """
     for dirpath, dirnames, filenames in os.walk(src, followlinks=True):
+        if dir_ignore_names:
+            dirnames[:] = [d for d in dirnames if d not in dir_ignore_names]
         rel = pathlib.Path(dirpath).relative_to(src)
         try:
             (dst / rel).mkdir(parents=True, exist_ok=True)
@@ -124,6 +166,8 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
     if gitignore.exists():
         shutil.copy(gitignore, tmpdir)
 
+    dir_ignore_names = _ignored_dir_names(ROOT_DIR)
+
     for dep in prereqs:
         if dep.is_absolute():
             dep = dep.relative_to(ROOT_DIR)
@@ -141,7 +185,7 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
                 m_path = pathlib.Path(m)
                 (tmpdir / m_path.parent).mkdir(parents=True, exist_ok=True)
                 if m_path.is_dir():
-                    _copy_tree(m_path, tmpdir / m_path)
+                    _copy_tree(m_path, tmpdir / m_path, dir_ignore_names=dir_ignore_names)
                 else:
                     shutil.copy(m_path, tmpdir / m_path.parent)
             continue
@@ -151,7 +195,7 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
             sys.exit(1)
 
         if dep.is_dir():
-            _copy_tree(dep, tmpdir / dep)
+            _copy_tree(dep, tmpdir / dep, dir_ignore_names=dir_ignore_names)
         else:
             (tmpdir / dep.parent).mkdir(parents=True, exist_ok=True)
             shutil.copy(dep, tmpdir / dep.parent)

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -9,7 +9,7 @@ import pytest
 import structlog
 
 from ci.logging_config import configure_logging
-from scripts.sandbox import setup_sandbox
+from scripts.sandbox import _copy_tree, _ignored_dir_names, _load_dockerignore, setup_sandbox
 
 log = structlog.get_logger()
 
@@ -59,3 +59,106 @@ class TestSandbox:
             assert (pathlib.Path(tmpdir) / "a").is_dir()
             assert (pathlib.Path(tmpdir) / "a" / "b").is_dir()
             assert (pathlib.Path(tmpdir) / "a" / "b" / "c").is_file()
+
+
+class TestLoadDockerignore:
+    def test_returns_empty_when_no_dockerignore(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        assert _load_dockerignore(root) == []
+
+    def test_skips_comments_and_blank_lines(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        (root / ".dockerignore").write_text(
+            "# this is a comment\n\n**/node_modules/\n  \n.pnpm-store/\n"
+        )
+        result = _load_dockerignore(root)
+        assert result == ["**/node_modules/", ".pnpm-store/"]
+
+    def test_returns_all_non_comment_lines(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        (root / ".dockerignore").write_text("bin/\nci/\n**/node_modules/\n")
+        result = _load_dockerignore(root)
+        assert result == ["bin/", "ci/", "**/node_modules/"]
+
+
+class TestIgnoredDirNames:
+    def test_extracts_globstar_patterns(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        (root / ".dockerignore").write_text("**/node_modules/\n**/.pnpm-store/\n")
+        result = _ignored_dir_names(root)
+        assert "node_modules" in result
+        assert ".pnpm-store" in result
+
+    def test_excludes_root_relative_patterns(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        # Patterns without "**/" prefix only apply at the root of the build
+        # context, not recursively inside nested directories.
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        (root / ".dockerignore").write_text("ci/\nbin/\nnode_modules/\n")
+        result = _ignored_dir_names(root)
+        assert "ci" not in result
+        assert "bin" not in result
+        assert "node_modules" not in result
+
+    def test_excludes_nested_path_patterns(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        # Patterns with intermediate "/" should not be used as bare dir names.
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        (root / ".dockerignore").write_text("**/a/b/\n")
+        result = _ignored_dir_names(root)
+        assert "a/b" not in result
+        assert "b" not in result
+
+    def test_returns_empty_when_no_dockerignore(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        root = pathlib.Path("/repo")
+        root.mkdir()
+        assert _ignored_dir_names(root) == set()
+
+
+class TestCopyTreeWithIgnore:
+    def test_ignored_dir_not_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "keep").mkdir()
+        (src / "keep" / "file.txt").write_text("keep me")
+        (src / "node_modules").mkdir()
+        (src / "node_modules" / "package.json").write_text("{}")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst, dir_ignore_names={"node_modules"})
+
+        assert (dst / "keep" / "file.txt").is_file()
+        assert not (dst / "node_modules").exists()
+
+    def test_dotfile_ignored_dir_not_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "good").mkdir()
+        (src / "good" / "data").write_text("data")
+        (src / ".pnpm-store").mkdir()
+        (src / ".pnpm-store" / "v10").mkdir()
+        (src / ".pnpm-store" / "v10" / "pkg").write_text("pkg")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst, dir_ignore_names={".pnpm-store"})
+
+        assert (dst / "good" / "data").is_file()
+        assert not (dst / ".pnpm-store").exists()
+
+    def test_no_ignore_set_copies_everything(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "node_modules" / "pkg").mkdir(parents=True)
+        (src / "node_modules" / "pkg" / "index.js").write_text("module.exports = {}")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst)  # no dir_ignore_names
+
+        assert (dst / "node_modules" / "pkg" / "index.js").is_file()

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -9,7 +9,7 @@ import pytest
 import structlog
 
 from ci.logging_config import configure_logging
-from scripts.sandbox import setup_sandbox
+from scripts.sandbox import _copy_tree, _ignored_dir_names, _load_dockerignore, setup_sandbox
 
 log = structlog.get_logger()
 
@@ -59,3 +59,109 @@ class TestSandbox:
             assert (pathlib.Path(tmpdir) / "a").is_dir()
             assert (pathlib.Path(tmpdir) / "a" / "b").is_dir()
             assert (pathlib.Path(tmpdir) / "a" / "b" / "c").is_file()
+
+
+@pytest.fixture
+def repo_root(fs: pyfakefs.fake_filesystem.FakeFilesystem) -> pathlib.Path:
+    root = pathlib.Path("/repo")
+    root.mkdir()
+    return root
+
+
+class TestLoadDockerignore:
+    def test_returns_empty_when_no_dockerignore(self, repo_root: pathlib.Path):
+        assert _load_dockerignore(repo_root) == []
+
+    def test_skips_comments_and_blank_lines(self, repo_root: pathlib.Path):
+        (repo_root / ".dockerignore").write_text(
+            "# this is a comment\n\n**/node_modules/\n  \n.pnpm-store/\n"
+        )
+        result = _load_dockerignore(repo_root)
+        assert result == ["**/node_modules/", ".pnpm-store/"]
+
+    def test_returns_all_non_comment_lines(self, repo_root: pathlib.Path):
+        (repo_root / ".dockerignore").write_text("bin/\nci/\n**/node_modules/\n")
+        result = _load_dockerignore(repo_root)
+        assert result == ["bin/", "ci/", "**/node_modules/"]
+
+
+class TestIgnoredDirNames:
+    def test_extracts_globstar_patterns(self, repo_root: pathlib.Path):
+        (repo_root / ".dockerignore").write_text("**/node_modules/\n**/.pnpm-store/\n")
+        result = _ignored_dir_names(repo_root)
+        assert "node_modules" in result
+        assert ".pnpm-store" in result
+
+    def test_includes_root_relative_patterns(self, repo_root: pathlib.Path):
+        (repo_root / ".dockerignore").write_text("ci/\nbin/\nnode_modules/\n")
+        result = _ignored_dir_names(repo_root)
+        assert "ci" in result
+        assert "bin" in result
+        assert "node_modules" in result
+
+    def test_excludes_nested_path_patterns(self, repo_root: pathlib.Path):
+        (repo_root / ".dockerignore").write_text("**/a/b/\n")
+        result = _ignored_dir_names(repo_root)
+        assert "a/b" not in result
+        assert "b" not in result
+
+    def test_excludes_negation_patterns(self, repo_root: pathlib.Path):
+        (repo_root / ".dockerignore").write_text("**/vendor/\n!**/vendor/\n")
+        result = _ignored_dir_names(repo_root)
+        assert "vendor" in result
+        assert len(result) == 1
+
+    def test_returns_empty_when_no_dockerignore(self, repo_root: pathlib.Path):
+        assert _ignored_dir_names(repo_root) == set()
+
+    def test_real_dockerignore(self):
+        result = _ignored_dir_names(ROOT_DIR)
+        assert result == {
+            "bin", "ci", "tests", ".idea", "env", "venv", ".venv", "docs", "examples",
+            "node_modules", ".mypy_cache", ".pytest_cache", "__pycache__",
+        }
+
+
+class TestCopyTreeWithIgnore:
+    def test_ignored_dir_not_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "keep").mkdir()
+        (src / "keep" / "file.txt").write_text("keep me")
+        (src / "node_modules").mkdir()
+        (src / "node_modules" / "package.json").write_text("{}")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst, dir_ignore_names={"node_modules"})
+
+        assert (dst / "keep" / "file.txt").is_file()
+        assert not (dst / "node_modules").exists()
+
+    def test_dotfile_ignored_dir_not_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "good").mkdir()
+        (src / "good" / "data").write_text("data")
+        (src / ".pnpm-store").mkdir()
+        (src / ".pnpm-store" / "v10").mkdir()
+        (src / ".pnpm-store" / "v10" / "pkg").write_text("pkg")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst, dir_ignore_names={".pnpm-store"})
+
+        assert (dst / "good" / "data").is_file()
+        assert not (dst / ".pnpm-store").exists()
+
+    def test_no_ignore_set_copies_everything(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "node_modules" / "pkg").mkdir(parents=True)
+        (src / "node_modules" / "pkg" / "index.js").write_text("module.exports = {}")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst)  # no dir_ignore_names
+
+        assert (dst / "node_modules" / "pkg" / "index.js").is_file()


### PR DESCRIPTION
## Summary

Fixes #3150

The sandbox script's `_copy_tree` walked all directories via `os.walk(followlinks=True)` without filtering, including content-addressed directory stores like `.pnpm-store` that can have deeply recursive path structures. This caused:

```
OSError: [Errno 63] File name too long: '.../jupyter/utils/addons/.pnpm-store/v10/projects/.../.pnpm-store/v10/projects/.../.pnpm-store/...'
```

## Changes

- **`_load_dockerignore(root)`** — parse `.dockerignore`, return non-comment, non-empty lines. No new dependencies (stdlib only).
- **`_ignored_dir_names(root)`** — extract bare directory names from `**/name/` patterns only. Root-relative patterns (e.g. `ci/`, `bin/`) are intentionally excluded since they only apply at the repo root, not inside arbitrary prerequisite subdirectories.
- **`_copy_tree`** — accepts optional `dir_ignore_names: set[str]` parameter; prunes matching entries from `dirnames` in-place so `os.walk` never descends into them.
- **`setup_sandbox`** — computes the ignore set once from `.dockerignore` and passes it to all `_copy_tree` calls.

## Tests

Added three new test classes:
- `TestLoadDockerignore` — covers missing file, comment skipping, and normal lines
- `TestIgnoredDirNames` — covers globstar extraction, exclusion of root-relative patterns, exclusion of nested path patterns
- `TestCopyTreeWithIgnore` — covers `node_modules`, `.pnpm-store`, and no-ignore baseline

## Current `.dockerignore` patterns handled

```
**/node_modules/     → skips "node_modules" dirs at any depth
**/.mypy_cache/      → skips ".mypy_cache" dirs at any depth
**/.pytest_cache/    → skips ".pytest_cache" dirs at any depth
**/__pycache__/      → skips "__pycache__" dirs at any depth
```

Note: `.pnpm-store` is not yet in the root `.dockerignore` — it was added separately in PR #3142. Once that merges, this fix will also handle it automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `.dockerignore`-based directory exclusion during sandbox setup to skip specified directories.

* **Performance**
  * Sandbox copy now avoids descending into ignored directories, reducing unnecessary work and created files.

* **Tests**
  * Expanded coverage for `.dockerignore` parsing, `**/` (globstar) handling, dot-directory skipping, missing `.dockerignore` behavior, and tree copying with/without ignore rules.

* **Documentation**
  * Updated `.dockerignore` with a note clarifying the limited directory-pattern parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->