### PR TITLE
RHAIENG-3914: replace contributor allowlist with standard permission gate

### DIFF
--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -25,6 +25,7 @@ jobs:
   # RHAIENG-3914: standard permission gate recognized by security scanners
   authorize:
     name: Authorize
+    permissions: {}  # only needs implicit metadata:read for getCollaboratorPermissionLevel
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
@@ -43,16 +44,21 @@ jobs:
               core.setOutput('authorized', 'true');
               return;
             }
-            // Fork PRs require write/admin/maintain permission
+            // Fork PRs require the PR author to have write/admin/maintain permission.
+            // NOTE: use pull_request.user.login, NOT context.actor — context.actor is
+            // whoever triggered the event (e.g. a maintainer reopening the PR), not the
+            // PR author. Checking context.actor would bypass the gate if a maintainer
+            // interacts with a fork PR.
+            const prAuthor = context.payload.pull_request.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              username: context.actor,
+              username: prAuthor,
             });
             const allowed = ['write', 'admin', 'maintain'].includes(data.permission);
             core.setOutput('authorized', String(allowed));
             if (!allowed) {
-              core.warning(`Fork PR from ${context.actor} has '${data.permission}' permission, requires write/admin/maintain`);
+              core.warning(`Fork PR author ${prAuthor} has '${data.permission}' permission, requires write/admin/maintain`);
             }
 
   gen:

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -25,6 +25,7 @@ jobs:
   # RHAIENG-3914: standard permission gate recognized by security scanners
   authorize:
     name: Authorize
+    permissions: {}  # only needs implicit metadata:read for getCollaboratorPermissionLevel
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
@@ -43,16 +44,21 @@ jobs:
               core.setOutput('authorized', 'true');
               return;
             }
-            // Fork PRs require write/admin/maintain permission
+            // Fork PRs require the PR author to have write/admin/maintain permission.
+            // NOTE: use pull_request.user.login, NOT context.actor — context.actor is
+            // whoever triggered the event (e.g. a maintainer reopening the PR), not the
+            // PR author. Checking context.actor would bypass the gate if a maintainer
+            // interacts with a fork PR.
+            const prAuthor = context.payload.pull_request.user.login;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              username: context.actor,
+              username: prAuthor,
             });
             const allowed = ['write', 'admin', 'maintain'].includes(data.permission);
             core.setOutput('authorized', String(allowed));
             if (!allowed) {
-              core.warning(`Fork PR from ${context.actor} has '${data.permission}' permission, requires write/admin/maintain`);
+              core.warning(`Fork PR author ${prAuthor} has '${data.permission}' permission, requires write/admin/maintain`);
             }
 
   gen:


### PR DESCRIPTION
## Summary

Replace the custom hardcoded contributor JSON allowlist in `pull_request_target` workflows with a standard `authorize` job that combines a same-repo check with GitHub's `getCollaboratorPermissionLevel` API. This eliminates the last 2 findings from the `actions-scanner` PwnRequest vulnerability scanner.

### What changed

- **Removed**: top-level `env.contributors` JSON array with 19 hardcoded usernames
- **Removed**: the "Check permissions and deny untrusted users" step with custom `contains(fromJSON(...))` logic
- **Added**: new `authorize` job using `actions/github-script` that:
  - Automatically authorizes same-repo PRs (covers bots like dependabot, konflux-internal-p02, and all team members pushing branches)
  - Checks fork PRs via `getCollaboratorPermissionLevel` API, requiring write/admin/maintain access
- **Added**: `needs: [authorize]` + `if: needs.authorize.outputs.authorized == 'true'` on the `gen` job
- **Updated**: `build` job `needs` to include `authorize`

### Files changed

- `.github/workflows/build-notebooks-pr-aipcc.yaml`
- `.github/workflows/build-notebooks-pr-rhel.yaml`

### Why

The March 2026 Trivy supply chain attack exploited a `pull_request_target` workflow (the "[Pwn Request](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)" pattern). Our workflows use `pull_request_target` because they need RHEL subscription secrets for building. The existing contributor allowlist was a valid mitigation but:

1. **Not recognized by security scanners** — `actions-scanner` flagged both workflows as "exploitable, no protection" because it doesn't detect `contains(fromJSON(env.contributors), github.actor)` as a gate
2. **Maintenance burden** — the hardcoded list must be manually updated when team membership changes
3. **Weaker security model** — relies on a static list rather than GitHub's live permission system

### Scanner results

**Before** (after PR #3167 context injection fix):
```
Exploitable (no protection): 2
Permission-gated:            0
```

**After this PR**:
```
Exploitable (no protection): 0
Permission-gated:            2
```

The scanner now reports: `protection: permission — Job 'authorize' verifies collaborator has write/admin/maintain access`

### Gate patterns recognized by actions-scanner

We chose a **combined same-repo + permission check** pattern because it handles both same-repo PRs (bots, team members) and fork PRs (external contributors with write access) without any hardcoded lists.

| Gate | Protection level | Exploitable? | How scanner detects it | Why not chosen |
|------|-----------------|:---:|---|---|
| **Permission check** | `permission` | No | `github-script` calling `getCollaboratorPermissionLevel` + checking `write`/`admin`/`maintain`, output gating via `needs.*.outputs.authorized == 'true'` | **Chosen** (combined with same-repo) |
| Actor gate | `actor` | No | `github.actor == 'dependabot[bot]'` or similar `[bot]` suffix in `if:` | Only works for specific bot actors, requires maintaining a list |
| Merged PR gate | `merged` | No | `github.event.pull_request.merged == true` in `if:` | We need to build *before* merge |
| Same-repo check | `same_repo` | No | `head.repo.full_name ==` or `head.repo.fork == false` in `if:` | Used as first check inside the authorize job; alone it would block all fork PRs |
| Environment protection | `environment` | No | Job has `environment:` key (GitHub deployment protection rules) | Requires admin access to configure; adds manual approval friction per PR |
| Label gate | `label` | **Yes** | `github.event.action == 'labeled'` in `if:`, or `github-script` checking `.labels` + `core.setFailed` | Scanner considers it exploitable (social engineering) |
| Label + synchronize | `none` | **Yes** | Label gate detected but workflow also triggers on `synchronize` | TOCTOU bypass: attacker gets label on safe code, pushes malicious code |

### How the new gate works

```yaml
authorize:
  steps:
    - uses: actions/github-script@v7
      with:
        script: |
          // Same-repo PRs are trusted (not from a fork)
          const headRepo = context.payload.pull_request.head.repo.full_name;
          const baseRepo = context.payload.pull_request.base.repo.full_name;
          if (headRepo === baseRepo) {
            core.info(`Same-repo PR (${headRepo}) — authorized`);
            core.setOutput('authorized', 'true');
            return;
          }
          // Fork PRs require write/admin/maintain permission
          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({...});
          const allowed = ['write', 'admin', 'maintain'].includes(data.permission);
          core.setOutput('authorized', String(allowed));

gen:
  needs: [authorize]
  if: needs.authorize.outputs.authorized == 'true'
  # ... checkout and build matrix generation
```

Same-repo PRs (including bots like dependabot, konflux-internal-p02) pass automatically. Fork PRs are checked via the GitHub API — only authors with write/admin/maintain access are authorized.

JIRA: https://redhat.atlassian.net/browse/RHAIENG-3914

## Test plan

- [ ] Verify PR builds still trigger correctly for same-repo PRs on `opendatahub-io/notebooks`
- [ ] Verify PR builds still trigger correctly on `red-hat-data-services/notebooks`
- [ ] Verify bot PRs (dependabot, konflux) are authorized via the same-repo check
- [ ] Verify unauthorized fork PRs are skipped (not failed) — the `gen` job shows "Skipped" in Actions UI
- [ ] Run `actions-scanner` and confirm 0 exploitable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI authorization: added a dedicated authorization job that verifies contributor permissions before running notebook-generation and build stages, replacing the previous static allowlist and early-exit checks. Downstream jobs now run only when authorization succeeds, and unauthorized attempts emit a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->