### PR TITLE
RHAIENG-3722: remove 3.4-v1.43 additional-tag from main branch push pipelineruns

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-odh-main-push.yaml
@@ -35,7 +35,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-odh-main-push.yaml
@@ -35,7 +35,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-odh-main-push.yaml
@@ -38,7 +38,6 @@ spec:
     - name: additional-tags
       value:
         - '{{target_branch}}-{{revision}}'
-        - 3.4-v1.43
   taskRunSpecs:
     - pipelineTaskName: build-images
       stepSpecs:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
@@ -38,7 +38,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-odh-main-push.yaml
@@ -47,7 +47,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   - name: build-platforms
     value:
     - linux-d160-m4xlarge/amd64

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-odh-main-push.yaml
@@ -35,7 +35,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-odh-main-push.yaml
@@ -36,7 +36,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-odh-main-push.yaml
@@ -35,7 +35,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-odh-main-push.yaml
@@ -38,7 +38,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   - name: build-platforms
     value:
     - linux-d160-m4xlarge/amd64

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-odh-main-push.yaml
@@ -35,7 +35,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-push.yaml
@@ -56,7 +56,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   # Added taskRunSpecs to increase compute resources
   taskRunSpecs:
   - pipelineTaskName: build-images

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-odh-main-push.yaml
@@ -35,7 +35,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
@@ -36,7 +36,6 @@ spec:
     - name: additional-tags
       value:
         - '{{target_branch}}-{{revision}}'
-        - 3.4-v1.43
   taskRunSpecs:
     - pipelineTaskName: build-images
       stepSpecs:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
@@ -38,7 +38,6 @@ spec:
     - name: additional-tags
       value:
         - '{{target_branch}}-{{revision}}'
-        - 3.4-v1.43
   taskRunSpecs:
     - pipelineTaskName: build-images
       stepSpecs:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-odh-main-push.yaml
@@ -38,7 +38,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-odh-main-push.yaml
@@ -37,7 +37,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 3.4-v1.43
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Problem

The `3.4-v1.43` additional-tag is now applied by the stable branch builds in [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central). Keeping it on the main branch push pipelineruns would cause tag clashes between images built from the two branches.

## Change

Removed the `- 3.4-v1.43` line from `additional-tags` in 22 push pipelinerun files. The `{{target_branch}}-{{revision}}` tag is preserved.

Companion PR: https://github.com/opendatahub-io/odh-konflux-central/pull/209

Ref: [RHAIENG-3722](https://redhat.atlassian.net/browse/RHAIENG-3722)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed static image tag `3.4-v1.43` from multiple pipeline configurations. Container images will now be tagged only with dynamic branch and revision identifiers instead of the additional fixed tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->