### PR TITLE
RHAIENG-3948: fix(tests): stop swallowing exceptions in test infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,11 @@ make test-${NOTEBOOK_NAME} # Specific notebook tests
    - Use type hints where appropriate
    - Run `ruff` for linting
    - Use `pyright` for type checking
+   - This project requires Python 3.14. PEP 758 allows `except ExcA, ExcB:` without
+     parentheses to catch multiple exception types. This is NOT the old Python 2 syntax
+     for `except ExcA as ExcB`. Parentheses are still required when binding with `as`:
+     use `except (ExcA, ExcB) as e:`, not `except ExcA, ExcB as e:`. Ruff format
+     enforces the parenthesis-free style when there is no `as` clause.
 
 2. **Dockerfiles**:
    - Minimize layers

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -68,13 +68,8 @@ class TestBaseImage:
         try:
             container.start()
             yield container
-            return
-        except Exception as e:
-            pytest.fail(f"Unexpected exception in test: {e}")
         finally:
             docker_utils.NotebookContainer(container).stop(timeout=0)
-
-        raise RuntimeError("Cannot happen: the test did not pass as expected.")
 
     def test_elf_files_can_link_runtime_libs(self, subtests: pytest_subtests.SubTests, image):
         def test_fn(container: testcontainers.core.container.DockerContainer):

--- a/tests/containers/docker_utils.py
+++ b/tests/containers/docker_utils.py
@@ -34,7 +34,9 @@ class NotebookContainer:
         """Stop container with customizable timeout.
 
         DockerContainer.stop() has unchangeable 10s timeout between SIGSTOP and SIGKILL."""
-        self.testcontainer.get_wrapped_container().stop(timeout=timeout)
+        wrapped = self.testcontainer.get_wrapped_container()
+        if wrapped is not None:
+            wrapped.stop(timeout=timeout)
         self.testcontainer.stop()
 
     def wait_for_exit(self) -> int:

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -10,7 +10,6 @@ import time
 import traceback
 from typing import TYPE_CHECKING, Any, Literal, Self
 
-import kubernetes
 import kubernetes.client.api.core_v1_api
 import kubernetes.dynamic.exceptions
 import kubernetes.stream.ws_client
@@ -51,24 +50,11 @@ LOGGER = logging.getLogger(__name__)
 
 def get_client() -> kubernetes.dynamic.DynamicClient:
     try:
-        # client = kubernetes.dynamic.DynamicClient(client=kubernetes.config.new_client_from_config())
-        # probably same as above
         client = ocp_resources.resource.get_client()
         return client
-    except kubernetes.config.ConfigException as e:
-        # probably bad config
-        logging.error(e)
-    except kubernetes.dynamic.exceptions.UnauthorizedError as e:
-        # wrong or expired credentials
-        logging.error(e)
-    except kubernetes.client.ApiException as e:
-        # unexpected, we catch unauthorized above
-        logging.error(e)
     except Exception as e:
-        # unexpected error, assert here
         logging.error(e)
-
-    raise RuntimeError("Failed to instantiate client")
+        raise RuntimeError("Failed to instantiate client") from e
 
 
 def get_username(client: kubernetes.dynamic.DynamicClient) -> str:
@@ -417,6 +403,7 @@ class Wait:
         new_exception_appearance: int = 0
 
         stack_trace_error: str | None = None
+        last_exception: Exception | None = None
 
         while True:
             try:
@@ -426,6 +413,7 @@ class Wait:
             except SyntaxError:  # this actually won't happen, but it's good to keep in mind
                 raise  # quick exit in cases developer obviously screwed up
             except Exception as e:
+                last_exception = e
                 exception_message = str(e)
 
                 exception_count += 1
@@ -461,7 +449,7 @@ class Wait:
                     on_timeout()
                 wait_exception: WaitError = WaitError(f"Timeout after {timeout} s waiting for {description}")
                 logging.error(wait_exception)
-                raise wait_exception
+                raise wait_exception from last_exception
 
             sleep_time: float = min(poll_interval, time_left)
             time.sleep(sleep_time)


### PR DESCRIPTION
https://redhat.atlassian.net/jira/browse/RHAIENG-3948

## Description

Exception-swallowing patterns in the test infrastructure produce misleading pytest summaries. When container tests fail (e.g. due to stale registry credentials or missing images), the real error is hidden behind `AttributeError: 'NoneType' object has no attribute 'stop'` or a flat `pytest.fail()` message.

This was reported in [Slack](https://redhat-internal.slack.com/archives/C096ZR053RQ/p1774294223091349?thread_ts=1762874870.367099&cid=C096ZR053RQ) where a colleague got 19 identical `AttributeError` failures when the real problem was stale ghcr.io credentials causing `500 Server Error: "unable to retrieve auth token: unauthorized"`.

### Root cause

When `container.start()` fails (image can't be pulled, auth error, etc.), `self._container` in testcontainers' `DockerContainer` is never assigned and stays `None`. The `finally` cleanup calls `NotebookContainer.stop()` → `get_wrapped_container().stop()` → `NoneType.stop()` → `AttributeError`. This secondary error **replaces** the real one in the pytest summary.

### Changes

1. **`_test_container` in `base_image_test.py`** — Removed the broad `except Exception` that caught every error from `container.start()` and the yielded test body, replacing the original traceback with `pytest.fail("Unexpected exception in test: ...")`. Also removed dead code (`raise RuntimeError("Cannot happen...")`) after the context manager.

2. **`NotebookContainer.stop()` in `docker_utils.py`** — Added a `None` guard so cleanup doesn't blow up when a container was never started. This is the direct fix for the `'NoneType' object has no attribute 'stop'` error.

3. **`get_client()` in `kubernetes_utils.py`** — Four separate `except` clauses all did `logging.error(e)` then fell through to `raise RuntimeError("Failed to instantiate client")` without exception chaining. Collapsed to a single `except` with `raise ... from e`.

4. **`Wait.until()` in `kubernetes_utils.py`** — When timeout was reached after exceptions during polling, `WaitError` was raised without chaining the last caught exception. Added `last_exception` tracking and `raise ... from last_exception`.

5. **`AGENTS.md`** — Added note about PEP 758 (Python 3.14 allows `except ExcA, ExcB:` without parentheses).

### Before vs After

**Before** (pytest summary):
```
FAILED tests/.../test_spinner_html_loaded[...] - AttributeError: 'NoneType' object has no attribute 'stop'
```

**After** (pytest summary):
```
ERROR tests/.../test_spinner_html_loaded[...] - docker.errors.APIError: 500 Server Error ... "unable to retrieve auth token: invalid username/password: unauthorized"
```

## How Has This Been Tested?

- Reproduced the original failure by running `docker logout ghcr.io` and then running the container tests with a ghcr.io image — confirmed the `AttributeError` is gone and the real error is now visible
- `gmake test` passes clean

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Python 3.14 requirement and updated guidance on multi-exception syntax handling.

* **Tests**
  * Simplified test teardown so unexpected exceptions now propagate instead of being converted to test failures.
  * Made container shutdown safer by skipping stop calls when not applicable.
  * Improved error reporting in orchestration utilities by preserving original exception context on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->