### PR TITLE
fix(tests): allow cowsay pip install when RHOAI mirror has package

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -202,8 +202,11 @@ class TestBaseImage:
     def test_pip_install_cowsay_runs(self, image: str):
         """Checks that the Python virtualenv in the image is writable.
 
-        For AIPCC-enabled images, cowsay is not available on the restricted index,
-        so we expect the install to fail with a specific error message.
+        Images whose source tree uses ``uv.lock.d`` are treated as AIPCC-style for
+        dependency pinning, but runtime ``pip`` may still use the RHOAI mirror, which
+        can include packages like ``cowsay``. If ``pip install cowsay`` fails, we assert
+        the usual resolver error; if it succeeds (mirror carries the package), we assert
+        ``cowsay`` runs — same end state as the non-AIPCC path.
         """
         has_uv_lock_d = self._has_uv_lock_d(image)
 
@@ -212,15 +215,12 @@ class TestBaseImage:
             output_str = output.decode()
             logging.debug(output_str)
 
-            if has_uv_lock_d:
-                # AIPCC-enabled: cowsay should NOT be available
-                assert ecode != 0, "Expected pip install cowsay to fail on AIPCC-enabled image"
+            if has_uv_lock_d and ecode != 0:
                 assert (
                     "Could not find a version that satisfies the requirement cowsay" in output_str
                     or "No matching distribution found for cowsay" in output_str
-                ), f"Expected AIPCC error message, got: {output_str}"
+                ), f"Expected resolver error for cowsay, got: {output_str}"
             else:
-                # Non-AIPCC: cowsay should install and run successfully
                 assert ecode == 0, f"Expected pip install cowsay to succeed, got: {output_str}"
 
                 ecode, output = container.exec(["python3", "-m", "cowsay", "--text", "Hello world"])


### PR DESCRIPTION
allow cowsay pip install when RHOAI mirror has package

## Description
Images with uv.lock.d may still resolve pip against a mirror that includes cowsay. Match failure with resolver errors; on success, assert cowsay runs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validation logic for pip package installation behavior across different image configurations to accurately reflect runtime resolution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->