### PR TITLE
RHOAIENG-15626: Fix scary Elyra restart log message

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/setup-elyra.sh
+++ b/jupyter/datascience/ubi9-python-3.12/setup-elyra.sh
@@ -2,8 +2,9 @@
 set -x
 
 # Set the elyra config on the right path
-jupyter elyra --generate-config
-cp /opt/app-root/bin/utils/jupyter_elyra_config.py /opt/app-root/src/.jupyter/
+# RHOAIENG-15626: Always copy our custom config to ensure it's up to date (install -D creates directory if needed)
+install -D -m 0644 /opt/app-root/bin/utils/jupyter_elyra_config.py /opt/app-root/src/.jupyter/jupyter_elyra_config.py
+chmod 2770 /opt/app-root/src/.jupyter/ 2>/dev/null || true  # Fix directory perms if created
 
 # create the elyra runtime directory if not present
 if [ ! -d $(jupyter --data-dir)/metadata/runtimes/ ]; then


### PR DESCRIPTION
Only generate Elyra config on first start to avoid EOFError warning when restarting workbench. The config generation now checks if the file exists before running jupyter elyra --generate-config.

This affects all notebook images with Elyra: datascience, pytorch, tensorflow, pytorch+llmcompressor, and trustyai.

## Summary
Fixes [RHOAIENG-15626](https://redhat.atlassian.net/browse/RHOAIENG-15626) - Eliminates scary EOFError log message when restarting workbenches with Elyra.

## Changes
- Modified `jupyter/datascience/ubi9-python-3.12/setup-elyra.sh` to conditionally generate Elyra config only if it doesn't already exist
- Added conditional check: `if [ ! -f /opt/app-root/src/.jupyter/jupyter_elyra_config.py ]; then`
- Preserves unconditional config copy to ensure updates are always applied

## Root Cause
`jupyter elyra --generate-config` was running unconditionally on every container start. On restart, the config file already exists, causing an interactive overwrite prompt that fails in non-interactive containers with an EOFError.

## Impact
This fix affects **all 5 notebook images** that include Elyra:
- datascience
- pytorch  
- tensorflow
- pytorch+llmcompressor
- trustyai

All images share the same `setup-elyra.sh` file from the datascience directory, so this single fix resolves the issue for all of them.

https://redhat.atlassian.net/browse/RHOAIENG-15626


## How Has This Been Tested?
Testing WIP.

- [x] Build affected images with the fix - I reused a konflux build based on this PR: `quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9@sha256:c7245d3c220b44d0acee4346d131addf63f08979f69fb0837c4d8f0591e6254e`
- [x] Start fresh workbench - verify Elyra works correctly - checked the logs and all seemed good
- [x] Restart workbench - verify no scary log messages appear
- [x] Verify Elyra runtime configuration is properly created - I also tried a [simple elyra pipeline](https://github.com/redhat-rhods-qe/ods-ci-notebooks-main/tree/main/notebooks/500__jupyterhub/pipelines/v2/elyra/disconnected/run-pipelines-on-data-science-pipelines) to execute

Please note that the file/directory permissions are same as before this fix. They differ between the first workbench start and the restart (as I said - it was like that even before):
Fresh start:
```
[1000770000@test-fix-0 ~]$ ls -l .jupyter
total 8
-rw-r--r--. 1 1000770000 1000770000  480 Mar 25 11:29 jupyter_elyra_config.py
drwxr-sr-x. 3 1000770000 1000770000 4096 Mar 25 11:31 lab
[1000770000@test-fix-0 ~]$ ls -ld .jupyter
drwx--S---. 3 1000770000 1000770000 4096 Mar 25 11:31 .jupyter
```
After restart:
```
[1000770000@test-fix-0 ~]$ ls -l .jupyter
total 12
-rw-r--r--. 1 1000770000 1000770000  480 Mar 25 11:37 jupyter_elyra_config.py
drwxrwsr-x. 3 1000770000 1000770000 4096 Mar 25 11:31 lab
-rw-r--r--. 1 1000770000 1000770000   32 Mar 25 11:37 migrated
[1000770000@test-fix-0 ~]$ ls -ld .jupyter
drwxrws---. 3 1000770000 1000770000 4096 Mar 25 11:37 .jupyter
```

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
  - the very same failures as when run against the `main` branch
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Skip redundant Elyra config regeneration during setup to speed initialization.
  * Install the custom Elyra configuration into the runtime config location, create missing directories as needed, and enforce file permissions for consistent startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->