### PR TITLE
fix(cve): Team (AAIET Notebooks) and CVE label on RHAIENG trackers

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,7 +121,13 @@ python scripts/cve/sbom_analyze.py sbom.json esbuild --json
 
 Create CVE tracker issues in the RHAIENG Jira project. The script finds CVE issues in RHOAIENG that don't have a parent tracker in RHAIENG, groups them by CVE ID and version, and creates one tracker per version with JQL links to the blocked child issues.
 
-Requires `JIRA_TOKEN` environment variable. `JIRA_URL` defaults to `https://issues.redhat.com`.
+Each new tracker is created with:
+
+- **Labels:** `CVE`, the CVE id (e.g. `CVE-2026-28498`), and `security`, so CVE work is distinguishable from other Bugs.
+- **Team:** Jira field `customfield_10001` set to the **AAIET Notebooks** team id as a **plain string** (required by the [REST create API](https://developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api/); default id from RHAIENG-3752). Override with **`JIRA_RHAIENG_TEAM_OPTION_ID`** if your site differs.
+- **Component:** `Notebooks` (unchanged).
+
+Requires Jira auth (e.g. `JIRA_EMAIL` + `JIRA_API_TOKEN`, or `JIRA_TOKEN` / OAuth per [`scripts/cve/jira_auth.py`](cve/jira_auth.py)). `JIRA_URL` defaults to `https://redhat.atlassian.net` in code; some docs still mention `issues.redhat.com` for legacy flows.
 
 ### Examples
 

--- a/scripts/cve/create_cve_trackers.py
+++ b/scripts/cve/create_cve_trackers.py
@@ -6,6 +6,10 @@ This script finds CVE issues in RHOAIENG that don't have a parent tracker in RHA
 analyzes the versions from linked issues, and creates tracker issues with accurate
 version suffixes (e.g., [rhoai-2.25, rhoai-3.0]).
 
+New trackers always get the literal label ``CVE`` (plus the CVE id and ``security``)
+so they are distinguishable from other Bugs, and the Jira **Team** field set to
+**AAIET Notebooks** (``customfield_10001``), matching RHAIENG process.
+
 Usage:
     # Dry run - show what would be created
     python scripts/cve/create_cve_trackers.py --dry-run
@@ -33,7 +37,27 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from scripts.cve.jira_auth import JiraAuthError
-from scripts.cve.jira_client import JiraClient, JIRA_DEFAULT_URL
+from scripts.cve.jira_client import JIRA_DEFAULT_URL, JiraClient
+
+# Jira "Team" on RHAIENG (verified via RHAIENG-3752 changelog).
+RHAIENG_TEAM_CUSTOM_FIELD = "customfield_10001"
+# Option id for team name "AAIET Notebooks" (override if Jira admin changes teams).
+RHAIENG_TEAM_OPTION_ID_DEFAULT = "ec74d716-af36-4b3c-950f-f79213d08f71-62"
+
+
+def build_tracker_labels(cve_id: str) -> list[str]:
+    """Labels for new CVE trackers: keep literal ``CVE`` first (team Jira hygiene)."""
+    return ["CVE", cve_id, "security"]
+
+
+def build_tracker_team_extra_fields() -> dict[str, str]:
+    """REST ``fields`` fragment for Team = AAIET Notebooks.
+
+    Jira expects a **plain Team ID string** on create/update, not ``{\"id\": ...}``.
+    See https://developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api/
+    """
+    option_id = os.environ.get("JIRA_RHAIENG_TEAM_OPTION_ID", RHAIENG_TEAM_OPTION_ID_DEFAULT).strip()
+    return {RHAIENG_TEAM_CUSTOM_FIELD: option_id}
 
 
 @dataclass
@@ -60,13 +84,13 @@ class CVEInfo:
 
 def extract_cve_id(text: str) -> str | None:
     """Extract CVE ID from text."""
-    match = re.search(r'CVE-\d{4}-\d+', text)
+    match = re.search(r"CVE-\d{4}-\d+", text)
     return match.group() if match else None
 
 
 def extract_version(summary: str) -> str | None:
     """Extract version suffix from issue summary."""
-    match = re.search(r'\[rhoai-(\d+\.\d+)]', summary)
+    match = re.search(r"\[rhoai-(\d+\.\d+)]", summary)
     if match:
         return f"rhoai-{match.group(1)}"
     return None
@@ -80,13 +104,13 @@ def extract_description(summary: str, cve_id: str) -> str:
         desc = desc.split(cve_id, 1)[1].strip()
 
     # Remove EMBARGOED prefix if present
-    desc = re.sub(r'^EMBARGOED\s+', '', desc)
+    desc = re.sub(r"^EMBARGOED\s+", "", desc)
 
     # Remove component prefix (e.g., "rhoai/odh-xxx:")
-    desc = re.sub(r'^rhoai/[^:]+:\s*', '', desc)
+    desc = re.sub(r"^rhoai/[^:]+:\s*", "", desc)
 
     # Remove version suffix
-    desc = re.sub(r'\s*\[rhoai-[\d.]+]\s*$', '', desc)
+    desc = re.sub(r"\s*\[rhoai-[\d.]+]\s*$", "", desc)
 
     return desc.strip()
 
@@ -252,10 +276,7 @@ def find_orphan_cves(client: JiraClient, max_results: int = 1000) -> dict[tuple[
                     break
 
     # Filter to only orphans (CVE+version combos where no issues have a parent tracker)
-    orphans = {}
-    for group_key, info in cve_groups.items():
-        if not info.has_tracker:
-            orphans[group_key] = info
+    orphans = {group_key: info for group_key, info in cve_groups.items() if not info.has_tracker}
 
     return orphans
 
@@ -271,12 +292,15 @@ def create_tracker_issue(client: JiraClient, cve_info: CVEInfo, jira_url: str = 
 
     description = build_description(cve_info, base_url=jira_url)
 
-    labels = ["CVE", cve_info.cve_id, "security"]
+    labels = build_tracker_labels(cve_info.cve_id)
+    team_extra = build_tracker_team_extra_fields()
 
     print(f"\n{'[DRY RUN] ' if dry_run else ''}Creating tracker for {cve_info.cve_id}:")
     print(f"  Summary: {summary}")
     print(f"  Version: {cve_info.version}")
     print(f"  Child issues: {cve_info.issue_count}")
+    print(f"  Labels: {' '.join(labels)}")
+    print(f"  Team field ({RHAIENG_TEAM_CUSTOM_FIELD}): {team_extra[RHAIENG_TEAM_CUSTOM_FIELD]!r}")
 
     if dry_run:
         return None
@@ -289,13 +313,19 @@ def create_tracker_issue(client: JiraClient, cve_info: CVEInfo, jira_url: str = 
             description=description,
             labels=labels,
             components=["Notebooks"],
-            security_level="Red Hat Employee"
+            security_level="Red Hat Employee",
+            extra_fields=team_extra,
         )
         tracker_key = result.get("key")
         print(f"  Created: {tracker_key}")
         return tracker_key
     except Exception as e:
         print(f"  ERROR creating issue: {e}")
+        resp = getattr(e, "response", None)
+        if resp is not None:
+            text = getattr(resp, "text", None) or ""
+            if text.strip():
+                print(f"  API response: {text[:4000]}")
         return None
 
 
@@ -343,6 +373,8 @@ Environment variables:
   JIRA_API_TOKEN            Atlassian API token (recommended for scripts/CI)
   JIRA_OAUTH_CLIENT_SECRET  OAuth 2.0 client secret (interactive browser flow)
   JIRA_TOKEN                Legacy Bearer token (issues.redhat.com PAT)
+  JIRA_RHAIENG_TEAM_OPTION_ID  Optional. Jira Team option id for AAIET Notebooks
+                            (default: RHAIENG value verified on RHAIENG-3752)
 """
     )
     parser.add_argument("--dry-run", action="store_true",

--- a/scripts/cve/jira_client.py
+++ b/scripts/cve/jira_client.py
@@ -19,13 +19,18 @@ try:
     HAS_REQUESTS = True
 except ImportError:
     import urllib.request
-    import urllib.error
+
     HAS_REQUESTS = False
 
 
 _SSL_CONTEXT = create_ssl_context() if not HAS_REQUESTS else None
 
 JIRA_DEFAULT_URL = "https://redhat.atlassian.net"
+
+# Keys set explicitly by create_issue(); extra_fields may not override these.
+_CREATE_ISSUE_PROTECTED_FIELD_KEYS = frozenset({
+    "project", "summary", "issuetype", "description", "labels", "components", "security",
+})
 
 
 class JiraClient:
@@ -136,8 +141,14 @@ class JiraClient:
     def create_issue(self, project_key: str, summary: str, issue_type: str,
                      description: dict | None = None, labels: list[str] | None = None,
                      components: list[str] | None = None,
-                     security_level: str | None = None) -> dict:
-        """Create a new Jira issue (API v3, ADF description)."""
+                     security_level: str | None = None,
+                     extra_fields: dict[str, Any] | None = None) -> dict:
+        """Create a new Jira issue (API v3, ADF description).
+
+        ``extra_fields`` are merged into the REST ``fields`` object for custom
+        fields (e.g. Team). Keys in ``_CREATE_ISSUE_PROTECTED_FIELD_KEYS`` are
+        ignored so callers cannot override project, summary, labels, etc.
+        """
         fields: dict[str, Any] = {
             "project": {"key": project_key},
             "summary": summary,
@@ -155,6 +166,13 @@ class JiraClient:
 
         if security_level:
             fields["security"] = {"name": security_level}
+
+        if extra_fields:
+            fields.update({
+                k: v
+                for k, v in extra_fields.items()
+                if k not in _CREATE_ISSUE_PROTECTED_FIELD_KEYS
+            })
 
         data = {"fields": fields}
         return self._request("POST", "/rest/api/3/issue", data=data)


### PR DESCRIPTION
## Summary

CVE tracker creation script now sets Jira **Team** to **AAIET Notebooks** (`customfield_10001`) and keeps the literal **`CVE`** label (plus CVE id and `security`) on new RHAIENG issues, matching team process ([RHAIENG-3752](https://redhat.atlassian.net/browse/RHAIENG-3752) changelog / Slack).

## Changes

- **`JiraClient.create_issue`**: optional `extra_fields` merged into REST `fields`; cannot override `project`, `summary`, `issuetype`, `description`, `labels`, `components`, or `security`.
- **`create_cve_trackers.py`**: `build_tracker_labels()`, `build_tracker_team_extra_fields()` with default Team option id; override via **`JIRA_RHAIENG_TEAM_OPTION_ID`**; dry-run prints labels and Team payload.
- **`scripts/README.md`**: document behavior and env var.

## Testing

```
❯ ./uv run /Users/jdanek/IdeaProjects/notebooks/scripts/cve/create_cve_trackers.py
Connecting to https://redhat.atlassian.net...
Searching for CVE issues in RHOAIENG...
Found 394 RHOAIENG CVE issues

Found 2 orphan CVE/version trackers needed:
--------------------------------------------------------------------------------
  CVE-2026-33236 rhoai-2.25: 2 issues
    Description: NLTK: Arbitrary file overwrite and creation via path travers...
  CVE-2026-33236 rhoai-3.3: 2 issues
    Description: NLTK: Arbitrary file overwrite and creation via path travers...

================================================================================
CREATING TRACKER ISSUES
================================================================================

Creating tracker for CVE-2026-33236:
  Summary: CVE-2026-33236 NLTK: Arbitrary file overwrite and creation via path traversal in XML index files [rhoai-2.25]
  Version: rhoai-2.25
  Child issues: 2
  Labels: CVE CVE-2026-33236 security
  Team field (customfield_10001): 'ec74d716-af36-4b3c-950f-f79213d08f71-62'
  Created: RHAIENG-4014
  Linked: RHAIENG-4014 blocks RHOAIENG-54740
  Linked: RHAIENG-4014 blocks RHOAIENG-54738
  Updated description with dynamic JQL link

Creating tracker for CVE-2026-33236:
  Summary: CVE-2026-33236 NLTK: Arbitrary file overwrite and creation via path traversal in XML index files [rhoai-3.3]
  Version: rhoai-3.3
  Child issues: 2
  Labels: CVE CVE-2026-33236 security
  Team field (customfield_10001): 'ec74d716-af36-4b3c-950f-f79213d08f71-62'
  Created: RHAIENG-4015
  Linked: RHAIENG-4015 blocks RHOAIENG-54743
  Linked: RHAIENG-4015 blocks RHOAIENG-54742
  Updated description with dynamic JQL link

================================================================================
Summary: Created 2 tracker issues
         Linked 4 child issues
================================================================================
```

* https://redhat.atlassian.net/browse/RHAIENG-4014
* https://redhat.atlassian.net/browse/RHAIENG-4015

Self checklist (from repo template):
- [x] `make test` / `gmake test` as appropriate
- [x] ODH vs Konflux: script-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CVE tracker creation docs: Jira auth options (`JIRA_EMAIL`+`JIRA_API_TOKEN`, or `JIRA_TOKEN`/OAuth), corrected default Jira URL, and described tracker labels and Team assignment behavior.
* **Refactor**
  * Standardized tracker metadata so new trackers consistently include CVE and security labels and set the Team field (defaulting to AAIET Notebooks with an override).
* **Bug Fixes**
  * Improved error output for tracker creation by surfacing API response snippets for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->