### PR TITLE
Update aipcc base images to the latest

### DIFF
--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-1773425522
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-1774635924
 PYLOCK_FLAVOR=cuda

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1773425440
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1774635772
 PYLOCK_FLAVOR=rocm

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1773425440
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1774635772
 PYLOCK_FLAVOR=rocm

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1773425440
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1774635772
 PYLOCK_FLAVOR=rocm

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/rstudio/rhel9-python-3.12/build-args/konflux.cpu.conf
+++ b/rstudio/rhel9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/rstudio/rhel9-python-3.12/build-args/konflux.cuda.conf
+++ b/rstudio/rhel9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1773428606
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932
 PYLOCK_FLAVOR=cpu

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1773425440
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1774635772
 PYLOCK_FLAVOR=rocm

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1773425440
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-6.4-el9.6:3.4.0-1774635772
 PYLOCK_FLAVOR=rocm

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,4 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda12.9-ubi9/simple/
 CPU_INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1773425523
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-1774635920
 PYLOCK_FLAVOR=cuda


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New set of image tags were available from Friday 27 March. Updating our repo with those to be up to date 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated base container images across Jupyter variants, RStudio, Code Server, and runtime builds for CUDA, ROCm, and CPU platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->