### PR TITLE
chore: migrate deprecated fileMatch to managerFilePatterns

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,9 +39,9 @@
   // Tekton task digest updates in .tekton/ pipeline definitions
   "tekton": {
     "additionalBranchPrefix": "",
-    "fileMatch": [
-      "\\.yaml$",
-      "\\.yml$",
+    "managerFilePatterns": [
+      "/\\.yaml$/",
+      "/\\.yml$/",
     ],
     "includePaths": [
       ".tekton/**",
@@ -107,9 +107,9 @@
     {
       "customType": "regex",
       "description": "Update BASE_IMAGE in konflux build-args conf files",
-      "fileMatch": [
+      "managerFilePatterns": [
         // Workbenches and runtimes only — excludes base-images/
-        "(jupyter|rstudio|codeserver|runtimes)/.+/build-args/konflux\\..+\\.conf$",
+        "/(jupyter|rstudio|codeserver|runtimes)/.+/build-args/konflux\\..+\\.conf$/",
       ],
       "matchStrings": [
         "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>\\S+)",


### PR DESCRIPTION
## Summary
- Migrate deprecated `fileMatch` → `managerFilePatterns` in `.github/renovate.json5`
- Applies to both the `tekton` built-in manager and the `customManagers` regex entry
- Patterns wrapped in `/pattern/` delimiters per the new Renovate API (deprecated since v40.9.1+, PR #35799)

## Test plan
- [x] JSON5 syntax validated (`npx json5 .github/renovate.json5`)
- [ ] Verify Renovate bot still picks up tekton pipeline files in `.tekton/`
- [ ] Verify custom regex manager still matches `build-args/konflux.*.conf` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate bot configuration for more reliable dependency management automation across project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->