### PR TITLE
fix(texlive-tcolorbox): update EPEL 9 RPM from -37 to -38

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/jupyter/minimal/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -2181,13 +2181,13 @@ arches:
     name: pandoc-common
     evr: 2.14.0.3-17.el9
     sourcerpm: pandoc-2.14.0.3-17.el9.src.rpm
-  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/aarch64/Packages/t/texlive-tcolorbox-20200406-37.el9.noarch.rpm
+  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/aarch64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
     repoid: epel
-    size: 4824961
-    checksum: sha256:91a10ebf1931adab5ddd0a1bc32a9ed8c9d68d5890be4f3db9c20d6080a00b04
+    size: 4824930
+    checksum: sha256:b71faa57cf0e3ee1985fcd23ded89220dd38121b8fddd3ae678057672982a83e
     name: texlive-tcolorbox
-    evr: 9:20200406-37.el9
-    sourcerpm: texlive-extension-20200406-37.el9.src.rpm
+    evr: 9:20200406-38.el9
+    sourcerpm: texlive-extension-20200406-38.el9.src.rpm
   - url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.aarch64.rpm
     repoid: openshift-4-12
     size: 46412656
@@ -7029,13 +7029,13 @@ arches:
     name: pandoc-common
     evr: 2.14.0.3-17.el9
     sourcerpm: pandoc-2.14.0.3-17.el9.src.rpm
-  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/ppc64le/Packages/t/texlive-tcolorbox-20200406-37.el9.noarch.rpm
+  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/ppc64le/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
     repoid: epel
-    size: 4824961
-    checksum: sha256:91a10ebf1931adab5ddd0a1bc32a9ed8c9d68d5890be4f3db9c20d6080a00b04
+    size: 4824930
+    checksum: sha256:b71faa57cf0e3ee1985fcd23ded89220dd38121b8fddd3ae678057672982a83e
     name: texlive-tcolorbox
-    evr: 9:20200406-37.el9
-    sourcerpm: texlive-extension-20200406-37.el9.src.rpm
+    evr: 9:20200406-38.el9
+    sourcerpm: texlive-extension-20200406-38.el9.src.rpm
   - url: https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202301312133.p0.gb05f7d4.assembly.stream.el8.ppc64le.rpm
     repoid: openshift-4-12
     size: 41652072
@@ -11884,13 +11884,13 @@ arches:
     name: pandoc-common
     evr: 2.14.0.3-17.el9
     sourcerpm: pandoc-2.14.0.3-17.el9.src.rpm
-  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/s390x/Packages/t/texlive-tcolorbox-20200406-37.el9.noarch.rpm
+  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/s390x/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
     repoid: epel
-    size: 4824961
-    checksum: sha256:91a10ebf1931adab5ddd0a1bc32a9ed8c9d68d5890be4f3db9c20d6080a00b04
+    size: 4824930
+    checksum: sha256:b71faa57cf0e3ee1985fcd23ded89220dd38121b8fddd3ae678057672982a83e
     name: texlive-tcolorbox
-    evr: 9:20200406-37.el9
-    sourcerpm: texlive-extension-20200406-37.el9.src.rpm
+    evr: 9:20200406-38.el9
+    sourcerpm: texlive-extension-20200406-38.el9.src.rpm
   - url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202301312133.p0.gb05f7d4.assembly.stream.el8.s390x.rpm
     repoid: openshift-4-12
     size: 44410280
@@ -16746,13 +16746,13 @@ arches:
     name: pandoc-common
     evr: 2.14.0.3-17.el9
     sourcerpm: pandoc-2.14.0.3-17.el9.src.rpm
-  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-37.el9.noarch.rpm
+  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
     repoid: epel
-    size: 4824961
-    checksum: sha256:91a10ebf1931adab5ddd0a1bc32a9ed8c9d68d5890be4f3db9c20d6080a00b04
+    size: 4824930
+    checksum: sha256:b71faa57cf0e3ee1985fcd23ded89220dd38121b8fddd3ae678057672982a83e
     name: texlive-tcolorbox
-    evr: 9:20200406-37.el9
-    sourcerpm: texlive-extension-20200406-37.el9.src.rpm
+    evr: 9:20200406-38.el9
+    sourcerpm: texlive-extension-20200406-38.el9.src.rpm
   - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.x86_64.rpm
     repoid: openshift-4-12
     size: 48103288

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -2181,13 +2181,13 @@ arches:
     name: pandoc-common
     evr: 2.14.0.3-17.el9
     sourcerpm: pandoc-2.14.0.3-17.el9.src.rpm
-  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-37.el9.noarch.rpm
+  - url: https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
     repoid: epel
-    size: 4824961
-    checksum: sha256:91a10ebf1931adab5ddd0a1bc32a9ed8c9d68d5890be4f3db9c20d6080a00b04
+    size: 4824930
+    checksum: sha256:b71faa57cf0e3ee1985fcd23ded89220dd38121b8fddd3ae678057672982a83e
     name: texlive-tcolorbox
-    evr: 9:20200406-37.el9
-    sourcerpm: texlive-extension-20200406-37.el9.src.rpm
+    evr: 9:20200406-38.el9
+    sourcerpm: texlive-extension-20200406-38.el9.src.rpm
   - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.x86_64.rpm
     repoid: openshift-4-12
     size: 48103288

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -72,7 +72,7 @@ if [ -n "$(find /cachi2/output/deps/rpm/ -name 'texlive-tcolorbox*' 2>/dev/null)
 else
     dnf install -y cpio
     pushd /
-    texlive_toolbox_rpm=https://download.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-37.el9.noarch.rpm
+    texlive_toolbox_rpm=https://download.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
     curl -sSfL ${texlive_toolbox_rpm} | rpm2cpio /dev/stdin | cpio -idmv
     popd
 fi


### PR DESCRIPTION
## Summary
- The `texlive-tcolorbox-20200406-37.el9` RPM was removed from EPEL 9 mirrors, causing non-hermetic builds to fail with a 404 error during `install_pdf_deps.sh`
- Updated to `-38.el9` in the fallback download URL and all ODH lock files (minimal + pytorch+llmcompressor, all architectures)

## Test plan
- [ ] Verify non-hermetic image build succeeds (no more 404 from `install_pdf_deps.sh`)
- [ ] Verify hermetic build still uses Cachi2-prefetched RPM path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated TeX Live package dependencies to the latest available build version across multiple Jupyter container variants for improved stability and compatibility.
* Updated related metadata, checksums, and installation references to align with the latest package versions across all supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->