### PR TITLE
fix: add platform and build type to image tags to prevent collisions

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -208,6 +208,7 @@ jobs:
           TARGET: ${{ inputs.target }}
           REGISTRY: ${{ env.IMAGE_REGISTRY }}
           PLATFORM: ${{ inputs.platform }}
+          KONFLUX: ${{ inputs.konflux }}
         # language=python
         run: |
           import os, re, sys
@@ -220,6 +221,7 @@ jobs:
               TARGET: str
               REGISTRY: str
               PLATFORM: str
+              KONFLUX: str
 
               @classmethod
               def from_env(cls):
@@ -235,22 +237,31 @@ jobs:
           env = Env.from_env()
 
           sanitized_ref = sanitize(env.REF_NAME)
+          sanitized_platform = sanitize(env.PLATFORM)
 
-          # Total tag length = len(target) + 1(-) + len(ref) + 1(_) + len(sha) <= 128
-          # Therefore, max_ref_len = 128 - len(env.TARGET) - len(env.SHA) - 2
-          max_ref_len = 128 - len(env.TARGET) - len(env.SHA) - 2
+          # Build a suffix from build type and platform so that different
+          # odh/rhoai builds and architectures get distinct tags.
+          build_type = "rhoai" if env.KONFLUX == "true" else "odh"
+          suffix = f"{build_type}_{sanitized_platform}"
+
+          # 7-char SHA prefix is enough to identify a commit uniquely
+          short_sha = env.SHA[:7]
+
+          # Total tag = {target}-{ref}_{short_sha}_{suffix}
+          # Separators: 1 '-' + 2 '_' = 3 fixed chars
+          max_ref_len = 128 - len(env.TARGET) - len(short_sha) - len(suffix) - 3
 
           if max_ref_len < 1:
               print(f"::error::Target name '{env.TARGET}' ({len(env.TARGET)} chars) is too long to accommodate a branch name and commit SHA within the 128-character Docker tag limit.", file=sys.stderr)
               sys.exit(1)
 
-          image_tag = f"{sanitized_ref[:max_ref_len]}_{env.SHA}"
+          image_tag = f"{sanitized_ref[:max_ref_len]}_{short_sha}_{suffix}"
           full_tag = f"{env.TARGET}-{image_tag}"
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"IMAGE_TAG={image_tag}\n")
               f.write(f"OUTPUT_IMAGE={env.REGISTRY}:{full_tag}\n")
-              f.write(f"SANITIZED_PLATFORM={sanitize(env.PLATFORM)}\n")
+              f.write(f"SANITIZED_PLATFORM={sanitized_platform}\n")
 
       # endregion
 

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,10 @@ endef
 define push_image
 	$(eval IMAGE_NAME := $(IMAGE_REGISTRY):$(subst /,-,$(1))-$(IMAGE_TAG))
 	$(info # Pushing $(IMAGE_NAME) image...)
-	$(CONTAINER_ENGINE) push $(IMAGE_NAME)
+	DIGEST_FILE=$$(mktemp)
+	$(CONTAINER_ENGINE) push --digestfile="$${DIGEST_FILE}" $(IMAGE_NAME)
+	echo "# Pushed $(IMAGE_NAME)@$$(cat $${DIGEST_FILE})"
+	rm -f "$${DIGEST_FILE}"
 endef
 
 # Build and push the notebook images:


### PR DESCRIPTION
## Summary
- Image tags now include build type (`odh`/`rhoai`) and platform (`linux_amd64`, etc.) as a suffix, preventing different builds from overwriting each other in the registry
- SHA in tags shortened from 40 to 7 chars to stay within the 128-char Docker tag limit
- `podman push` now prints the digest (`image@sha256:...`) after each push via `--digestfile`

Example tags:
- `jupyter-minimal-ubi9-python-3.12-main_a1b2c3d_odh_linux_amd64`
- `jupyter-minimal-ubi9-python-3.12-main_a1b2c3d_rhoai_linux_arm64`

## Test plan
- [x] Run `workflow_dispatch` with odh=true (konflux=false) — tags contain `_odh_linux_amd64` ✓
- [x] Run `workflow_dispatch` with rhds=true (konflux=true) — tags contain `_rhoai_linux_amd64` ✓
- [x] Verify digest is printed in push step logs ✓
- [x] Verify tags are distinct across platforms (amd64, arm64, ppc64le, s390x) ✓
- [x] All failures are pre-existing and unrelated (see [validation comment](https://github.com/opendatahub-io/notebooks/pull/3233#issuecomment-4176185199))

🤖 Generated with [Claude Code](https://claude.com/claude-code)