### PR TITLE
NO-JIRA: docs: add guides for subscribed AIPCC builds and macOS Rosetta setup

### DIFF
--- a/docs/macos-podman-rosetta.md
+++ b/docs/macos-podman-rosetta.md
@@ -1,0 +1,89 @@
+# Enabling Rosetta for x86_64 Container Images on macOS (Apple Silicon)
+
+Some container images in this project (notably the CUDA and aipcc-based images) are built only for
+`linux/amd64`. On Apple Silicon Macs, podman uses QEMU by default to emulate x86_64, which can be
+slow or crash with large images (segfaults are common with CUDA base images under QEMU).
+
+Apple's **Rosetta** translation layer is significantly faster and more stable. Podman supports
+Rosetta but ships with it **disabled by default** due to a past incompatibility between Rosetta and
+Linux kernels 6.13+. Apple fixed the kernel-side crash in **macOS Tahoe** (macOS 26), but
+podman-machine-os has not yet re-enabled Rosetta by default
+([containers/podman-machine-os#212](https://github.com/containers/podman-machine-os/issues/212)),
+so the manual trigger below is still required.
+
+> [!NOTE]
+> Rosetta support in the podman machine VM requires Podman 5.1.0 or later.
+
+## Enabling Rosetta
+
+Create the trigger file inside the podman machine VM and activate the systemd service:
+
+```bash
+# Create the trigger file and activate Rosetta (no machine restart needed)
+podman machine ssh "sudo touch /etc/containers/enable-rosetta && sudo systemctl start rosetta-activation.service"
+
+# Verify Rosetta is active
+podman machine ssh "cat /proc/sys/fs/binfmt_misc/rosetta"
+# Expected output starts with: enabled
+```
+
+This survives `podman machine stop` / `start` cycles (the trigger file is on `/etc` which persists).
+However, `podman machine rm` followed by `podman machine init` wipes the VM state, so you need to
+run the commands again after recreating a machine.
+
+### Known issue: `podman machine inspect` may be misleading
+
+`podman machine inspect` reports a `Rosetta` field in the machine config, but this config flag does
+not reliably control whether Rosetta is actually active inside the VM
+([containers/podman#28181](https://github.com/containers/podman/issues/28181)). Always verify with
+the binfmt check above.
+
+## Verifying it works
+
+```bash
+podman run --rm --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi uname -m
+# Should print: x86_64
+```
+
+If this prints `x86_64` without segfaulting, Rosetta is working.
+
+## Troubleshooting
+
+### QEMU segfault with CUDA images
+
+If you see `qemu: uncaught target signal 11 (Segmentation fault) - core dumped` when pulling or
+running a large amd64 image, enable Rosetta as described above.
+
+### Rosetta activation fails
+
+If `cat /proc/sys/fs/binfmt_misc/rosetta` shows nothing after the steps above, check:
+
+```bash
+podman machine ssh "systemctl status rosetta-activation.service"
+podman machine ssh "ls -la /var/mnt/rosetta 2>/dev/null || echo 'rosetta mount missing'"
+```
+
+The Rosetta VirtioFS mount must be present at `/var/mnt/rosetta`. This requires macOS Tahoe (26)
+or later.
+
+### Installing packages inside the podman machine VM
+
+The podman machine runs Fedora CoreOS, which has a read-only `/usr` filesystem. To install
+debugging tools:
+
+```bash
+podman machine ssh
+sudo bootc usr-overlay   # creates a transient writable overlay on /usr (lost on reboot)
+sudo dnf install htop    # now works
+```
+
+Note: `/etc` is always writable -- no special command needed for config files there.
+
+## References
+
+- [Podman 5.6 Rosetta blog post](https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/)
+- [Podman Desktop Rosetta docs](https://podman-desktop.io/docs/podman/rosetta)
+- [containers/podman#28181](https://github.com/containers/podman/issues/28181) -- Rosetta binfmt
+  registration silently fails despite config showing `true`
+- [containers/podman-machine-os#212](https://github.com/containers/podman-machine-os/issues/212) --
+  Re-enable Rosetta discussion

--- a/docs/subscribed-builds.md
+++ b/docs/subscribed-builds.md
@@ -1,0 +1,186 @@
+# Building with RHEL-Subscribed (AIPCC) Base Images
+
+The `Dockerfile.konflux.*` files build from AIPCC RHEL-based base images
+(`quay.io/aipcc/base-images/...`) instead of the ODH CentOS Stream base images. These RHEL base
+images require an active Red Hat subscription for `dnf` operations (upgrade, install).
+
+This guide explains how to set up the subscription for local builds. The CI workflow
+(`.github/workflows/build-notebooks-TEMPLATE.yaml`, lines 127-148) does the same thing
+automatically using GitHub secrets.
+
+## Prerequisites
+
+- **podman** installed and running
+- **macOS only**: Rosetta enabled for x86_64 emulation (see [macos-podman-rosetta.md](macos-podman-rosetta.md))
+- Red Hat subscription credentials (org ID + activation key)
+
+## Step 1: Extract Entitlement Certificates
+
+Run `subscription-manager register` inside a UBI9 container, mounting host directories to capture
+the generated certificates:
+
+```bash
+mkdir -p entitlement consumer
+
+# On macOS (Apple Silicon), --platform=linux/amd64 is needed because UBI9 defaults
+# to the native arm64 image which won't produce x86_64 entitlement certs.
+# On Linux x86_64, you can omit --platform.
+podman run \
+  --platform=linux/amd64 \
+  -v "${PWD}/entitlement:/etc/pki/entitlement:Z" \
+  -v "${PWD}/consumer:/etc/pki/consumer:Z" \
+  --rm -t registry.access.redhat.com/ubi9/ubi \
+  /usr/sbin/subscription-manager register \
+    --org=18631088 --activationkey=YOUR_ACTIVATION_KEY
+```
+
+Ask your team lead for the activation key, or create one at
+[Red Hat Console > Activation Keys](https://console.redhat.com/insights/connector/activation-keys).
+
+After this, `entitlement/` and `consumer/` contain the PEM certificate files.
+
+## Step 2: Configure Podman to Auto-Mount Certificates
+
+Tell podman to mount the certificates into every container it builds. The `mounts.conf` format
+does not support quoting, so **run these commands from a directory whose path contains no spaces or
+special characters**.
+
+**macOS** (via podman machine SSH -- `/etc` is writable, `/usr` is not):
+
+```bash
+podman machine ssh "printf '$(pwd)/entitlement:/etc/pki/entitlement\n$(pwd)/consumer:/etc/pki/consumer\n' | sudo tee /etc/containers/mounts.conf"
+```
+
+**Linux**:
+
+```bash
+printf "%s/entitlement:/etc/pki/entitlement\n%s/consumer:/etc/pki/consumer\n" "${PWD}" "${PWD}" \
+  | sudo tee /etc/containers/mounts.conf
+```
+
+> [!NOTE]
+> The CI workflow writes to `/usr/share/containers/mounts.conf`, which also works on Linux.
+> This guide uses `/etc/containers/mounts.conf` because it works on both Linux and macOS
+> (the podman machine VM has a read-only `/usr`).
+
+### Verify
+
+```bash
+podman run --rm --platform=linux/amd64 --user 0 quay.io/aipcc/base-images/cpu:3.4.0-1774635932 \
+  bash -c "subscription-manager identity && subscription-manager refresh && dnf repolist"
+```
+
+You should see the system identity, "All local data refreshed", and a list of RHEL repos (including
+EUS repos like `rhel-9-for-x86_64-appstream-eus-rpms`). If the certs are not mounted correctly,
+you will see only UBI repos and an "Unable to read consumer identity" warning instead.
+
+> [!TIP]
+> The command above uses the CPU base image. If you are building a CUDA or ROCm target,
+> substitute the matching base image from your target's `build-args/konflux.*.conf`.
+
+For a stricter pass/fail check that actually validates CDN access (including EUS entitlements),
+download metadata from one small EUS repo (~16 MB, ~6 seconds):
+
+```bash
+podman run --rm --platform=linux/amd64 --user 0 quay.io/aipcc/base-images/cpu:3.4.0-1774635932 \
+  bash -c "subscription-manager refresh \
+    && dnf makecache --repo=codeready-builder-for-rhel-9-x86_64-eus-rpms"
+```
+
+This will fail with a 403 error if the entitlement is missing or does not include EUS access.
+
+## Step 3: Build
+
+Build with the Konflux Dockerfile and the AIPCC base image. The build-args config files in
+`build-args/konflux.*.conf` specify the correct base image and index URLs.
+
+```bash
+# Example: runtime-minimal CPU
+podman build --no-cache \
+  --platform=linux/amd64 \
+  -f runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu \
+  --build-arg BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1774635932 \
+  --build-arg PYLOCK_FLAVOR=cpu \
+  -t my-runtime-minimal:latest \
+  .
+```
+
+The build may take 30 seconds or more before producing any output while podman copies the build
+context and inspects the base image. This is normal -- do not abort.
+
+**Important: always use `--no-cache` for the first build after setting up subscription.** The
+Dockerfile's `subscription-manager refresh` step always exits successfully (even when certs are
+missing) and gets cached. If you previously ran a build without subscription set up, that broken
+layer is cached and will be reused silently -- causing `dnf upgrade` to fail with 403 errors later
+in the build. See [#3241](https://github.com/opendatahub-io/notebooks/issues/3241) for details.
+
+The Makefile does **not** pass `--no-cache` by default, so if you had prior failed builds, run
+the podman command directly with `--no-cache` first, then switch to the Makefile:
+
+```bash
+make runtime-minimal-ubi9-python-3.12 KONFLUX=yes
+```
+
+## Cleanup
+
+When done, unregister the subscription to free the entitlement:
+
+```bash
+podman run \
+  --platform=linux/amd64 \
+  -v "${PWD}/entitlement:/etc/pki/entitlement:Z" \
+  -v "${PWD}/consumer:/etc/pki/consumer:Z" \
+  --rm -t registry.access.redhat.com/ubi9/ubi \
+  /usr/sbin/subscription-manager unregister
+```
+
+And remove the mounts config:
+
+```bash
+# macOS
+podman machine ssh "sudo rm /etc/containers/mounts.conf"
+
+# Linux
+sudo rm /etc/containers/mounts.conf
+```
+
+## Troubleshooting
+
+### 403 errors on EUS repos
+
+```text
+Status code: 403 for https://cdn.redhat.com/content/eus/rhel9/...
+```
+
+The entitlement certificates are not being mounted into the build container, or the
+`subscription-manager refresh` step in the Dockerfile is using stale data. Fix:
+
+1. Verify certs exist: `ls entitlement/ consumer/`
+2. Verify mounts work: run the verify command from Step 2
+3. Build with `--no-cache` to avoid cached layers from failed attempts
+
+### QEMU segfault on macOS
+
+See [macos-podman-rosetta.md](macos-podman-rosetta.md) to enable Rosetta.
+
+### Which Dockerfile and base image to use?
+
+Each image directory has `build-args/` configs:
+
+| Config file | Base image source | Dockerfile |
+|---|---|---|
+| `cpu.conf` / `cuda.conf` | ODH CentOS Stream | `Dockerfile.cpu` / `Dockerfile.cuda` |
+| `konflux.cpu.conf` / `konflux.cuda.conf` | AIPCC RHEL (needs subscription) | `Dockerfile.konflux.cpu` / `Dockerfile.konflux.cuda` |
+| `konflux.rocm.conf` | AIPCC RHEL (needs subscription) | `Dockerfile.konflux.rocm` |
+
+## How the CI Does It
+
+The CI workflow (`.github/workflows/build-notebooks-TEMPLATE.yaml`) follows the same pattern:
+
+1. Runs `subscription-manager register` inside a UBI9 container ("Add subscriptions from GitHub secret" step)
+2. Writes `mounts.conf` (same step)
+3. Copies pull-secret for quay.io/aipcc access (same step)
+4. Builds with `KONFLUX=yes` ("Build: make" step)
+
+The `build-notebooks-pr-aipcc.yaml` workflow triggers these builds for PRs with
+`subscription: true` and `konflux: true`.


### PR DESCRIPTION
## Summary

Add two developer reference documents for locally building images that use RHEL-subscribed AIPCC base images (`Dockerfile.konflux.*` variants):

- **`docs/subscribed-builds.md`**: Step-by-step guide covering RHEL subscription registration, entitlement certificate extraction via podman, `mounts.conf` configuration, build commands, cleanup, and troubleshooting (403 on EUS repos, cached layers, etc.)
- **`docs/macos-podman-rosetta.md`**: Instructions for enabling Apple Rosetta in the podman machine VM on Apple Silicon Macs, needed because AIPCC/CUDA base images are amd64-only and QEMU emulation segfaults on them.

## Motivation

While investigating [RHAIENG-4241](https://redhat.atlassian.net/browse/RHAIENG-4241) (TensorFlow 2.21 protobuf descriptor crash on AIPCC base images), we needed to reproduce the issue locally by building with the `Dockerfile.konflux.cuda` and the `quay.io/aipcc/base-images/cuda-12.9-el9.6:3.4.0-...` base image. The setup for subscribed builds was non-obvious:

- The CI workflow (`.github/workflows/build-notebooks-TEMPLATE.yaml` lines 127-148) does this automatically using GitHub secrets, but developers had no local equivalent documented
- On macOS, QEMU segfaults when running the large amd64 CUDA base images; Rosetta must be enabled first
- The podman machine VM uses Fedora CoreOS with a read-only `/usr`, so `mounts.conf` must go in `/etc/containers/` instead of `/usr/share/containers/`

## Tested

Both flows verified end-to-end:
- **macOS**: Apple Silicon, podman 5.8.1, Rosetta enabled, Fedora CoreOS 43 VM. Built `runtime-minimal` with `Dockerfile.konflux.cpu` and aipcc base. `dnf makecache` with all 4 RHEL repos (including EUS) confirmed.
- **Linux**: Fedora 42, podman 5.7.1. Built `cuda-jupyter-tensorflow` with `Dockerfile.konflux.cuda` and aipcc base. Full pylock install confirmed.

## Related

- [RHAIENG-4241](https://redhat.atlassian.net/browse/RHAIENG-4241): TF 2.21 protobuf crash (motivating investigation)
- [RHAIENG-4240](https://redhat.atlassian.net/browse/RHAIENG-4240): Improve visual distinction of AIPCC CI checks
- PR #3210: TF 2.21 upgrade where the crash was discovered

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New guide: Enable and verify Apple Rosetta to run linux/amd64 containers on Apple Silicon with Podman — activation steps, binfmt verification, persistence/lifecycle notes, VirtioFS requirement, in-VM package-install workaround, and QEMU troubleshooting.
  * New guide: Build Konflux notebooks/runtimes using RHEL-subscribed base images — subscription registration and certificate mounting, host-to-container mount configuration, local build and cleanup workflows, verification commands, CI mapping, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->