### PR TITLE
chore(renovate): enable dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,10 +10,6 @@
   "extends": [
     "config:recommended",
     ":gitSignOff",
-    ":disableDependencyDashboard",
-  ],
-  "ignorePresets": [
-    ":dependencyDashboard",
   ],
   "onboarding": false,
   "requireConfig": "optional",
@@ -165,6 +161,6 @@
     "^rpm-lockfile-prototype rpms.in.yaml$",
   ],
   "updateNotScheduled": false,
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "stopUpdatingLabel": "konflux-nudge",
 }


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C07SBP17R7Z/p1774883190029089?thread_ts=1774883072.749099&cid=C07SBP17R7Z

## Summary
- Remove `:disableDependencyDashboard` preset from `extends`
- Remove `ignorePresets` block that was suppressing `:dependencyDashboard`
- Set `dependencyDashboard` to `true`

This enables Renovate's dependency dashboard, which creates a tracking issue listing all pending updates and their status.

## Test plan
- [ ] Verify Renovate creates a "Dependency Dashboard" issue after the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management tracking by enabling the dependency dashboard feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->