### PR TITLE
chore(base-images/aipcc.sh): update dependency installation list with new packages and version constraints

### DIFF
--- a/base-images/utils/aipcc.sh
+++ b/base-images/utils/aipcc.sh
@@ -22,7 +22,12 @@ function install_packages() {
     # additional tools
     PKGS+=("skopeo" "jq" "nvtop")
     # additional developer tools
-    PKGS+=("make" "ninja-build >= 1.11.1" "gdb")
+    # COPR has ninja-build 1.11.1+, ubi9 CRB only has 1.10.2
+    if [[ "${os_vendor}" == "centos" ]]; then
+        PKGS+=("make" "ninja-build >= 1.11.1" "gdb")
+    else
+        PKGS+=("make" "ninja-build" "gdb")
+    fi
     # PKGS+=("vim")
 
     # for LANG / LC_ALL=en_US.UTF-8


### PR DESCRIPTION
## Summary

Update `base-images/utils/aipcc.sh` dependency list with new packages and UBI9 compatibility fixes.

### New dependencies
- `gcc-c++`, `gdb`, `make`, `ninja-build` — compiler and developer tools
- `gdal-libs`, `proj` — geospatial support ([AIPCC-6717](https://redhat.atlassian.net/browse/AIPCC-6717))
- `libzip` — required by tacozip ([AIPCC-9953](https://redhat.atlassian.net/browse/AIPCC-9953))
- `glog` — nixl UCCL backend ([AIPCC-11329](https://redhat.atlassian.net/browse/AIPCC-11329))
- `libunwind` — for memray
- `mariadb-connector-c` — for mysqlclient
- `ffmpeg-free-rhai` — for opencv-python-headless, torchaudio, torchvision
- `protobuf` — for onnx
- `libpdfium` — for pypdfium2

### UBI9 compatibility
Several packages are not available in UBI9 repos (only in CentOS COPR/CRB), so they are conditionally installed:
- **CentOS-only** (not in UBI9 repos): `libpdfium`, `ffmpeg-free-rhai`, `gdal-libs`, `proj`, `protobuf`
- **Version-constrained on CentOS only**: `ninja-build >= 1.11.1` (UBI9 CRB has 1.10.2), `zeromq >= 4.3.5` (UBI9 EPEL has 4.3.4)
- COPR repo (`aaiet-notebooks/rhelai-el9`) stays CentOS-only — enabling on UBI9 causes dep failures (e.g. autoconf needs gettext-devel)

### Cleanup
- Remove duplicate `gcc-c++` and `mariadb-connector-c` from `install_scl_packages()` (already in `install_packages()`)

## How Has This Been Tested?

- Verified package availability on UBI9 (without RHEL subscription) and CentOS Stream 9
- Tested COPR repo enablement on both distros
- Confirmed `libzmq.so.5` is provided by both zeromq 4.3.4 (EPEL) and 4.3.5 (COPR)

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work