### PR TITLE
 RHAIENG-4270: fix: drop unixODBC-devel to resolve version conflict with RHELAI base image

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -66,7 +66,7 @@ RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 BASE_PKGS=(perl mesa-libGL skopeo compat-openssl11 openshift-clients)
 if [ "$(uname -m)" = "s390x" ]; then
-    BASE_PKGS+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel)
+    BASE_PKGS+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel)
 fi
 dnf install -y "${BASE_PKGS[@]}"
 dnf clean all
@@ -150,7 +150,7 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
     fi
 
-RUN dnf install -y jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat protobuf \
+RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf \
     && dnf clean all \
     && rm -rf /var/cache/yum
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -66,7 +66,7 @@ RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 BASE_PKGS=(perl mesa-libGL skopeo compat-openssl11 openshift-clients)
 if [ "$(uname -m)" = "s390x" ]; then
-    BASE_PKGS+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel)
+    BASE_PKGS+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel)
 fi
 dnf install -y "${BASE_PKGS[@]}"
 dnf clean all
@@ -148,7 +148,7 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
     fi
 
-RUN dnf install -y jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat protobuf \
+RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf \
     && dnf clean all \
     && rm -rf /var/cache/yum
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -122,7 +122,7 @@ USER root
 # Install useful OS packages
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat
+dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 dnf clean all
 rm -rf /var/cache/yum
 EOF

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -122,7 +122,7 @@ USER root
 # Install useful OS packages
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat
+dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 dnf clean all
 rm -rf /var/cache/yum
 EOF

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -61,10 +61,10 @@ if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then
 fi
 # Additional dev tools only for s390x
 if [ "$TARGETARCH" = "s390x" ]; then
-    PACKAGES+=("gcc" "gcc-c++" "make" "openssl-devel" "autoconf" "automake" "libtool" "cmake" "python3-devel" "pybind11-devel" "openblas-devel" "unixODBC-devel" "openssl" "zlib-devel")
+    PACKAGES+=("gcc" "gcc-c++" "make" "openssl-devel" "autoconf" "automake" "libtool" "cmake" "python3-devel" "pybind11-devel" "openblas-devel" "openssl" "zlib-devel")
 fi
 if [ "$TARGETARCH" = "ppc64le" ]; then
-    PACKAGES+=(git gcc-toolset-13 make wget unzip rust cargo unixODBC-devel cmake ninja-build)
+    PACKAGES+=(git gcc-toolset-13 make wget unzip rust cargo cmake ninja-build)
 fi
 if [ -n "$PACKAGES" ]; then
     echo "Installing: $PACKAGES"

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -61,10 +61,10 @@ if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then
 fi
 # Additional dev tools only for s390x
 if [ "$TARGETARCH" = "s390x" ]; then
-    PACKAGES+=("gcc" "gcc-c++" "make" "openssl-devel" "autoconf" "automake" "libtool" "cmake" "python3-devel" "pybind11-devel" "openblas-devel" "unixODBC-devel" "openssl" "zlib-devel")
+    PACKAGES+=("gcc" "gcc-c++" "make" "openssl-devel" "autoconf" "automake" "libtool" "cmake" "python3-devel" "pybind11-devel" "openblas-devel" "openssl" "zlib-devel")
 fi
 if [ "$TARGETARCH" = "ppc64le" ]; then
-    PACKAGES+=(git gcc-toolset-13 make wget unzip rust cargo unixODBC-devel cmake ninja-build)
+    PACKAGES+=(git gcc-toolset-13 make wget unzip rust cargo cmake ninja-build)
 fi
 if [ -n "$PACKAGES" ]; then
     echo "Installing: $PACKAGES"


### PR DESCRIPTION
## Summary

- Remove `unixODBC-devel` from all Dockerfiles where it is installed. The RHELAI 3.3 base image ships `unixODBC-2.3.12`, but `unixODBC-devel` from `codeready-builder` requires exactly `unixODBC-2.3.9`, causing `dnf install` to fail on ppc64le (and potentially s390x).
- The `-devel` package provides only C header files, which are not needed at runtime since AIPCC wheels are pre-built.
- `unixODBC` (the runtime library) is kept in all images.

## Affected images

- `jupyter/datascience/ubi9-python-3.12` (Dockerfile.cpu, Dockerfile.konflux.cpu)
- `jupyter/trustyai/ubi9-python-3.12` (Dockerfile.cpu, Dockerfile.konflux.cpu)
- `runtimes/datascience/ubi9-python-3.12` (Dockerfile.cpu, Dockerfile.konflux.cpu)

## Test plan

- [x] ppc64le datascience image builds successfully (previously failing with dnf version conflict)
- [x] s390x datascience image builds successfully
- [ ] x86_64/aarch64 images unaffected (unixODBC runtime lib still installed)

Fixes: [RHAIENG-4270](https://issues.redhat.com/browse/RHAIENG-4270)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `unixODBC-devel` from container image builds across multiple runtime configurations while retaining `unixODBC`. Changes applied to datascience and trustyai container images for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->