### PR TITLE
fix(renovate): block bogus go-toolset upgrade, document MintMaker interaction

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,6 @@
   "vulnerabilityAlerts": {
     "enabled": false,
   },
-  "baseBranches": ["main"],
   "additionalBranchPrefix": "{{baseBranch}}/",
   "branchPrefix": "konflux/mintmaker/",
   "enabledManagers": [
@@ -138,6 +137,19 @@
       // Exception: allow major/minor on main branch of upstream repo only.
       // main is the development branch where version bumps are expected.
       // Forks (e.g. red-hat-data-services/notebooks) and release branches stay blocked.
+      //
+      // NOTE: Renovate warns "You must configure baseBranchPatterns in order to
+      // use them inside matchBaseBranches."  This warning is cosmetic:
+      //   - MintMaker sets baseBranchPatterns per-branch at the self-hosted level
+      //     (konflux-ci/mintmaker internal/component/github/github.go), so
+      //     matchBaseBranches works correctly at runtime.
+      //   - Do NOT add a top-level baseBranches/baseBranchPatterns here — repo-level
+      //     baseBranchPatterns overrides MintMaker's per-branch config, breaking
+      //     release branch processing on the downstream fork
+      //     (red-hat-data-services/notebooks: rhoai-2.25, rhoai-3.3, etc.).
+      //     Ref: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1774946461904449
+      //   - Local dry-runs (--platform=local) cannot evaluate matchBaseBranches;
+      //     this is a known limitation of local mode.
       "description": "Allow major/minor base image upgrades on upstream main",
       "matchManagers": ["custom.regex"],
       "matchUpdateTypes": ["major", "minor"],


### PR DESCRIPTION
## Summary

Two fixes for the Renovate config, discovered while investigating [Dependency Dashboard #3246](https://github.com/opendatahub-io/notebooks/issues/3246):

- **Block bogus go-toolset version proposals** — Red Hat publishes `ubi9/go-toolset` with two tag schemes: Go version (`1.24`, `1.25`) and UBI/RHEL version (`9.7`). Renovate can't distinguish them and proposes `1.24 → 9.7` as a "major" upgrade. Added `allowedVersions: "/^1\\./"` to restrict to Go version tags.

- **Document why `baseBranches` must NOT be set in this config** — The `matchBaseBranches: ["main"]` rule in packageRules[2] triggers a Renovate validation warning about missing `baseBranchPatterns`. Investigation of [MintMaker source code](https://github.com/konflux-ci/mintmaker) (`internal/component/github/github.go`) reveals this warning is cosmetic:
  - MintMaker creates one Renovate PipelineRun per (repo, branch) pair and sets `baseBranchPatterns: [currentBranch]` at the self-hosted config level
  - So `matchBaseBranches` works correctly at runtime — MintMaker provides the branch context
  - Setting `baseBranches` in the repo config would **override** MintMaker's per-branch config and break release branch processing on the downstream fork (`red-hat-data-services/notebooks`: `rhoai-2.25`, `rhoai-3.3`, etc.)
  - Local dry-runs (`--platform=local`) cannot evaluate `matchBaseBranches` — this is a known limitation of local mode, not a config bug

## Why no base image update PRs have appeared on main yet

The custom.regex manager config was added only 4 days ago (2026-03-30). Most `quay.io/aipcc/*` images are already at the latest build — no updates available. The one update found locally (`registry.redhat.io/rhai/base-image-cpu-rhel9` 3.2.0 → 3.3.0) should appear on the next MintMaker run.

The tekton task updates (task-init 0.3→0.4, task-prefetch-dependencies 0.2→0.3, etc.) are scheduled for `"after 5am on saturday"` — the first Saturday since config addition is 2026-04-05.

## Remaining dashboard warnings (not addressed here)

- **"Found renovate config warnings"**: 6 global-only options (`onboarding`, `requireConfig`, etc.) that belong in MintMaker's global config. Harmless.
- **"Dependency name is unset, skipping"**: Expected — caused by `FROM ${BASE_IMAGE}` in Dockerfiles. Handled by the custom.regex manager via `build-args/konflux.*.conf` files instead.
- **"packageRules[2]: You must configure baseBranchPatterns"**: Cosmetic — MintMaker provides baseBranchPatterns at runtime (see above).

## Test plan

- [x] Ran `scripts/renovate_check_updates.py` locally — go-toolset `9.7` proposal gone, only `1.25.8` minor remains
- [x] Verified `baseBranchPatterns` validation warning is present and understood as cosmetic
- [ ] After merge, verify MintMaker creates PRs on release branches of downstream fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Constrained automated dependency updates to restrict the Go toolset used in Docker builds to the 1.x series.
  * Clarified dependency-update behavior across branches with expanded comments describing per-branch base-branch patterns and dry-run limitations.
  * Warned against using top-level baseBranch settings that can interfere with per-branch release processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->