### PR TITLE
ISSUE#3256: fix(prefetch): disable RHDS auto-switch in CI to prevent layer cache contamination

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -52,10 +52,11 @@ USER 0
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
-# COPY committed lockfile so this layer invalidates when RPM prefetch input changes.
-COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
-
 # [HERMETIC] Configure package repos for local hermeto testing (Konflux injects repos when LOCAL_BUILD is false).
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -96,7 +97,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
-COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
+
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
@@ -141,10 +145,12 @@ WORKDIR /opt/app-root/bin
 
 USER 0
 
-# Invalidate cached layer when RPM prefetch input changes.
-COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
 
 # [HERMETIC] Configure package repos for local hermeto testing (Konflux injects repos when LOCAL_BUILD is false).
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -52,10 +52,11 @@ USER 0
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
-# COPY committed lockfile so this layer invalidates when RPM prefetch input changes.
-COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
-
 # [HERMETIC] Configure package repos for local hermeto testing (Konflux injects repos when LOCAL_BUILD is false).
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -96,7 +97,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
-COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
+
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
@@ -139,10 +143,12 @@ WORKDIR /opt/app-root/bin
 
 USER 0
 
-# Invalidate cached layer when RPM prefetch input changes.
-COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
 
 # [HERMETIC] Configure package repos for local hermeto testing (Konflux injects repos when LOCAL_BUILD is false).
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -26,6 +26,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -73,6 +77,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -24,6 +24,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -72,6 +76,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -26,6 +26,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -71,6 +75,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -24,6 +24,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -70,6 +74,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -23,6 +23,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -73,6 +77,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -23,6 +23,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -75,6 +79,10 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-9 || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or Konflux-injected repos.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -55,6 +55,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -94,6 +98,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -131,6 +139,10 @@ WORKDIR /opt/app-root/bin
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -55,6 +55,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -94,6 +98,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \
@@ -131,6 +139,10 @@ WORKDIR /opt/app-root/bin
 # [HERMETIC] Configure package repos: local hermeto repos for testing, or enable nodejs:22 module for Konflux.
 # Hermeto organises RPMs into per-arch sub-repos (baseos, crb, ubi-*, …), each with
 # its own repodata/. The generated hermeto.repo already points at the correct file:// paths.
+# Bust layer cache when prefetched RPM set changes
+COPY prefetch-input/odh/rpms.lock.yaml /dev/null
+COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
+
 RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
         rm -f /etc/yum.repos.d/*.repo \
         && cp /cachi2/output/deps/rpm/"$(uname -m)"/repos.d/*.repo /etc/yum.repos.d/; \

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -164,11 +164,12 @@ fi
 # (upstream, CentOS Stream packages) and optionally rhds/ (downstream, RHEL).
 # The variant determines which lockfiles are used for all four steps.
 #
-# In GHA CI, the template passes --rhds explicitly for subscription builds.
-# For standalone/local use, auto-detect: if the caller provided subscription
-# credentials and the rhds lockfiles exist, switch automatically.
+# In GHA CI, the template passes --rhds explicitly for subscription builds;
+# secrets are globally available so auto-detection would wrongly switch ODH
+# builds to RHDS, contaminating the layer cache (see #3256).
+# For standalone/local use, auto-detect from credentials when not in CI.
 PREFETCH_DIR="$COMPONENT_DIR/prefetch-input"
-if [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
+if [[ -z "${CI:-}" ]] && [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
   echo "Subscription credentials provided — switching to RHDS variant"
   VARIANT="rhds"
 fi


### PR DESCRIPTION
## Summary

Fix `prefetch-all.sh` auto-switching to RHDS variant in CI when subscription secrets are present, and add cache-busting COPY instructions to prevent stale layer reuse across variants.

## Problem

`prefetch-all.sh` line 171 auto-detects subscription credentials and switches from ODH to RHDS variant:

```bash
if [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
  echo "Subscription credentials provided — switching to RHDS variant"
  VARIANT="rhds"
fi
```

In GHA CI, `SUBSCRIPTION_ACTIVATION_KEY` and `SUBSCRIPTION_ORG` secrets are available to **all** jobs, including non-subscription ODH builds. This causes:

1. **Nightly push build** (`subscription: false`): Prefetch auto-switches to RHDS, downloads RHEL RPMs, bakes RHEL repo definitions (`rhel-9-for-x86_64-appstream-rpms`) into the layer cache via `--cache-to`
2. **PR build** (`subscription: false`, no secrets): Prefetch stays on ODH, downloads only UBI/CentOS repos. But `--cache-from` reuses the nightly's cached `LOCAL_BUILD` layer which has RHEL repos in `/etc/yum.repos.d/`
3. **dnf fails**: The cached RHEL repos point to `file:///cachi2/output/deps/rpm/.../rhel-9-for-x86_64-appstream-rpms/` paths that don't exist in the PR's ODH-only `cachi2/output`

### Evidence

**Nightly** (job [69800469614](https://github.com/opendatahub-io/notebooks/actions/runs/23931897351/job/69800469614)) for `jupyter-minimal-ubi9-python-3.12, subscription: false`:
```
+ scripts/lockfile-generators/prefetch-all.sh --component-dir jupyter/minimal/ubi9-python-3.12 --flavor cpu
Subscription credentials provided — switching to RHDS variant
  variant   : rhds
```

**PR build** (job [69846103481](https://github.com/opendatahub-io/notebooks/actions/runs/23947240109/job/69846103481)) for same target:
```
+ scripts/lockfile-generators/prefetch-all.sh --component-dir jupyter/minimal/ubi9-python-3.12 --flavor rocm
  variant   : odh
```

Same Dockerfile instruction text for `LOCAL_BUILD` → cached layer from nightly reused → RHEL repos in `/etc/yum.repos.d/` → dnf fails.

## Fix

### 1. Guard auto-switch with `CI` check

```diff
-if [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
+if [[ -z "${CI:-}" ]] && [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
```

GHA sets `CI=true` automatically. The auto-switch is preserved for local/standalone use (where it's a useful convenience), but disabled in CI where the workflow already passes `--rhds` explicitly when `subscription: true`.

### 2. Add cache-busting COPY before `LOCAL_BUILD` repo setup

```dockerfile
COPY prefetch-input/odh/rpms.lock.yaml prefetch-input/rhds/rpms.lock.yaml /dev/null
RUN if [ "${LOCAL_BUILD}" = "true" ]; then ...
```

This ensures the layer cache is invalidated when either lockfile changes. COPY to `/dev/null` leaves zero bytes in the image. Added to all 10 Dockerfiles that have `LOCAL_BUILD` blocks. Replaces the old `COPY ... /tmp/.docker-stamp-rpms-lock` pattern in datascience (which only tracked the ODH lockfile and left the file in the image).

## How Has This Been Tested?

- Verified `CI=true` is set in GHA (standard default env var, also used by `scripts/buildinputs/buildinputs.go:25`)
- Verified `COPY ... /dev/null` works with podman build (tested on Fedora with podman 5.7.1)
- Verified each multi-stage Dockerfile has the COPY in every stage (required because stages have independent cache lineages)

Fixes: #3256

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build behavior so image-layer cache invalidation now depends on both sets of prefetched RPM lock inputs across multiple build stages, improving rebuild correctness for various image variants.
  * Modified prefetching script to disable automatic variant auto-switching in CI, requiring explicit selection when running in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->