### PR TITLE
chore(ci): update GitHub Actions to latest major versions

### DIFF
--- a/.github/actions/playwright-test/action.yml
+++ b/.github/actions/playwright-test/action.yml
@@ -119,7 +119,7 @@ runs:
 
     - name: Upload Playwright report
       if: ${{ !cancelled() && inputs.upload-report == 'true' }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/playwright-report/

--- a/.github/workflows/build-browser-tests.yaml
+++ b/.github/workflows/build-browser-tests.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Login to Quay.io
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.push_image == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
@@ -75,7 +75,7 @@ jobs:
       contents: read
     steps:
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -158,7 +158,7 @@ jobs:
             scripts/check-payload/go.mod
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -386,7 +386,7 @@ jobs:
       # Single place we install from uv.lock (dev deps include structlog for scripts/sandbox.py).
       # Make and later pytest steps all use this venv.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check collaborator permission
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           # language=javascript
           script: |

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check collaborator permission
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           # language=javascript
           script: |

--- a/.github/workflows/check-image-availability.yaml
+++ b/.github/workflows/check-image-availability.yaml
@@ -20,7 +20,7 @@ jobs:
           update: 'false'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -16,7 +16,7 @@ jobs:
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"
@@ -45,7 +45,7 @@ jobs:
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Python coverage to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: opendatahub-io/notebooks
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: scripts/buildinputs/go.mod
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload Go coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: opendatahub-io/notebooks
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -75,7 +75,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -21,7 +21,7 @@ jobs:
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: uv.toml
           activate-environment: false
@@ -42,6 +42,6 @@ jobs:
           ignore-unfixed: false
 
       - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

Bump all external GitHub Actions to their latest major versions, in both `.github/workflows/` and `.github/actions/`.

| Action | From | To | Location |
|--------|------|----|----------|
| `actions/setup-go` | v5 | v6 | workflows |
| `actions/github-script` | v7 | v8 | workflows |
| `astral-sh/setup-uv` | v7 | v8 | workflows |
| `codecov/codecov-action` | v5 | v6 | workflows |
| `docker/login-action` | v3 | v4 | workflows |
| `github/codeql-action/upload-sarif` | v3 | v4 | workflows |
| `actions/upload-artifact` | v6 | v7 | actions/playwright-test |

Actions already at latest major: `actions/checkout@v6`, `actions/setup-python@v6`, `actions/cache@v5`, `codecov/test-results-action@v1`, `snok/container-retention-policy@v3.0.1` (SHA-pinned).

## Release notes review

### actions/setup-go v5 → v6

**Breaking:** Sets `GOTOOLCHAIN=local` (prevents Go from auto-downloading a newer toolchain). Cache key default changed from `go.sum` to `go.mod`. No impact on us — we use `go-version-file: go.mod` and `go-version: "stable"`.

**New:** `.tool-versions` file support, custom Go download mirrors via `go-download-base-url`.

### actions/github-script v7 → v8

Node.js 20 → 24 runtime bump only. Zero API changes. Drop-in replacement.

### astral-sh/setup-uv v7 → v8

**Breaking:** "Immutable releases" — supply chain hardening. The `@v8` major tag may not be published; official recommendation is to pin `@v8.0.0` or commit SHA. Old custom manifest format removed (we don't use it).

**Note:** Consider pinning to exact version (`@v8.0.0`) if the `@v8` tag stops resolving.

### codecov/codecov-action v5 → v6

Node.js 20 → 24 runtime bump only. Drop-in replacement.

### docker/login-action v3 → v4

Node.js 20 → 24 runtime bump only. Internally upgraded to `@actions/core` 3.0 and ESM. Drop-in replacement.

### github/codeql-action/upload-sarif v3 → v4

Node.js 20 → 24 runtime bump. The `add-snippets` input was removed from the `analyze` sub-action (not relevant — we only use `upload-sarif`). Drop-in replacement for our usage.

### actions/upload-artifact v6 → v7

ESM migration (internal). **New:** `archive: false` parameter for direct (unzipped) single-file uploads. Drop-in replacement for existing usage.

## How Has This Been Tested?

CI will validate all workflows use compatible APIs. All bumps are either drop-in (Node.js runtime only) or have been verified against our current parameter usage.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD and automation actions to newer stable releases: container login, Python tooling setup (uv), GitHub script, code coverage upload, Go tool setup, Playwright artifact upload, and security SARIF upload. These maintenance updates improve workflow reliability, tooling compatibility, and security scanning consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->