### PR TITLE
RHAIENG-4285, RHAIENG-4287: SHA-pin all GitHub Actions, add pinact CI check, enable Renovate

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,56 @@
+# AI Agents Guide for GitHub Actions
+
+This guide applies when modifying files under `.github/workflows/` or `.github/actions/`.
+
+## SHA pinning requirement
+
+All third-party GitHub Action references must use full commit SHAs with a version comment:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+```
+
+**Never use mutable tags** like `@v6` or `@main`. See ADR 0008 for rationale (Trivy supply
+chain attack, RHAIENG-3913 audit).
+
+## Pinning workflow
+
+After adding or changing any `uses:` line:
+
+```bash
+# Pin all actions to SHAs (requires GitHub token for API calls)
+GITHUB_TOKEN=$(gh auth token) pinact run
+
+# Verify everything is pinned and SHAs match version comments
+GITHUB_TOKEN=$(gh auth token) pinact run --check --verify
+```
+
+Install pinact: `brew install pinact` (macOS/Linux) or
+`go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0`.
+
+## Comment spacing
+
+Use **two spaces** before `#` in version comments (yamllint `comments` rule):
+
+```yaml
+# Correct (two spaces before #)
+uses: actions/checkout@de0fac2e...  # v6.0.2
+
+# Wrong (one space before #)
+uses: actions/checkout@de0fac2e... # v6.0.2
+```
+
+The `.pinact.yaml` at repo root configures this automatically.
+
+## Automated updates
+
+Renovate/MintMaker is configured (`enabledManagers` includes `github-actions`) to
+automatically propose SHA pin updates when new action versions are released.
+
+## Actions without major tags
+
+Some actions only publish exact version tags (no `v8` major tag, only `v8.0.0`):
+- `astral-sh/setup-uv` — use `@v8.0.0`, not `@v8`
+- `actions/add-to-project` — use `@v1.0.2`, not `@v1`
+
+Renovate has package rules to track these correctly.

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -20,7 +20,7 @@ runs:
         sudo mkdir -p /home/linuxbrew
         sudo chown -R "$(whoami):$(whoami)" /home/linuxbrew
 
-    - uses: actions/cache@v5
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
       # https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
       # https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
       id: cached-linuxbrew

--- a/.github/actions/playwright-test/action.yml
+++ b/.github/actions/playwright-test/action.yml
@@ -119,7 +119,7 @@ runs:
 
     - name: Upload Playwright report
       if: ${{ !cancelled() && inputs.upload-report == 'true' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/playwright-report/

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,7 @@
     "tekton",
     "dockerfile",
     "custom.regex",
+    "github-actions",
   ],
 
   // Tekton task digest updates in .tekton/ pipeline definitions
@@ -118,6 +119,26 @@
   ],
 
   "packageRules": [
+    {
+      "description": "Group GitHub Actions digest updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "pinDigests": true,
+    },
+    {
+      // astral-sh/setup-uv uses exact version tags (v8.0.0), not major tags (v8).
+      "description": "Track exact versions for setup-uv (no major tags published)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["astral-sh/setup-uv"],
+      "versioning": "semver",
+    },
+    {
+      // actions/add-to-project uses exact version tags (v1.0.2), not major tags (v1).
+      "description": "Track exact versions for add-to-project (no major tags published)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/add-to-project"],
+      "versioning": "semver",
+    },
     {
       // Group all base image build updates into a single PR
       "description": "Group quay.io base image updates from build-args conf files",

--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -11,15 +11,15 @@ jobs:
     steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@v3
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc  # v3.0.0
         with:
           app_id: ${{ secrets.DEVOPS_APP_ID }}
           private_key: ${{ secrets.DEVOPS_APP_PRIVATE_KEY }}
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
         with:
           project-url: https://github.com/orgs/opendatahub-io/projects/40
           github-token: ${{ steps.app-token.outputs.token }}
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
         with:
           project-url: https://github.com/orgs/opendatahub-io/projects/45
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/build-browser-tests.yaml
+++ b/.github/workflows/build-browser-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Build container image
         id: build
@@ -55,7 +55,7 @@ jobs:
 
       - name: Login to Quay.io
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.push_image == true
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
@@ -75,7 +75,7 @@ jobs:
       contents: read
     steps:
       - name: Login to Quay.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >>${GITHUB_ENV}
           echo "CACHE=${CACHE,,}" >>${GITHUB_ENV}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: ${{ fromJson(inputs.github).event_name != 'pull_request_target' }}
         with:
           lfs: ${{ contains(inputs.target, 'codeserver') }}
@@ -87,7 +87,7 @@ jobs:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
       # we need to checkout the pr branch, not pr target (the default for pull_request_target)
       # user access check is done in calling workflow
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: ${{ fromJson(inputs.github).event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ fromJson(inputs.github).event.number }}/merge"
@@ -150,7 +150,7 @@ jobs:
           SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 
       # for bin/buildinputs in scripts/sandbox.py and check-payload FIPS scan
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "stable"
           cache-dependency-path: |
@@ -158,7 +158,7 @@ jobs:
             scripts/check-payload/go.mod
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -386,7 +386,7 @@ jobs:
       # Single place we install from uv.lock (dev deps include structlog for scripts/sandbox.py).
       # Make and later pytest steps all use this venv.
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check collaborator permission
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           # language=javascript
           script: |
@@ -71,17 +71,17 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: ${{ github.event_name != 'pull_request_target' }}
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check collaborator permission
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           # language=javascript
           script: |
@@ -70,17 +70,17 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: ${{ github.event_name != 'pull_request_target' }}
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -28,11 +28,11 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -38,9 +38,9 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "stable"
           cache-dependency-path: "scripts/buildinputs/go.mod"

--- a/.github/workflows/check-image-availability.yaml
+++ b/.github/workflows/check-image-availability.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install skopeo
         uses: ./.github/actions/apt-install
@@ -20,7 +20,7 @@ jobs:
           update: 'false'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"
@@ -42,7 +42,7 @@ jobs:
       issues: write
     steps:
       - name: Create or update GitHub issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           # language=javascript
           script: |

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -12,11 +12,11 @@ jobs:
   check-generated-code:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"
@@ -41,11 +41,11 @@ jobs:
   pytest-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Python coverage to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: opendatahub-io/notebooks
@@ -74,17 +74,17 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   go-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: scripts/buildinputs/go.mod
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload Go coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: opendatahub-io/notebooks
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Go test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: scripts/buildinputs/junit-go.xml
@@ -115,7 +115,7 @@ jobs:
   code-static-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Do not check secrets, they are encrypted
         run: rm -rf ./ci/secrets
@@ -168,17 +168,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: "Cache prek"
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.cache/prek
           key: prek-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -193,3 +193,28 @@ jobs:
           exit_code="${PIPESTATUS[0]}"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit "$exit_code"
+
+  action-pin-check:
+    name: GitHub Actions SHA pinning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PINACT_VERSION: "3.9.0"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install pinact
+        run: |
+          curl -sL "https://github.com/suzuki-shunsuke/pinact/releases/download/v${PINACT_VERSION}/pinact_linux_amd64.tar.gz" \
+            | tar xz -C /usr/local/bin
+      - name: Check all actions are SHA-pinned
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify SHAs match version comments
+        # aquasecurity org has an IP allowlist that blocks GHA runners
+        run: pinact run --verify --exclude '^aquasecurity/trivy-action$'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Generate notebooks release

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,11 +16,11 @@ jobs:
     name: Generate list of images for release notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           python-version: "3.14"

--- a/.github/workflows/notebooks-digest-updater.yaml
+++ b/.github/workflows/notebooks-digest-updater.yaml
@@ -39,7 +39,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.BRANCH_NAME }}
           persist-credentials: true
@@ -61,7 +61,7 @@ jobs:
          git push --set-upstream origin ${{ env.TMP_BRANCH }}
 
       - name: Checkout release branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.TMP_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/notebooks-release.yaml
+++ b/.github/workflows/notebooks-release.yaml
@@ -72,7 +72,7 @@ jobs:
       pr_merged_m: ${{ steps.check_pr.outputs.pr_merged }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
       pr_merged_b: ${{ steps.check_pr.outputs.pr_merged }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/notify-team-to-review-pr.yml
+++ b/.github/workflows/notify-team-to-review-pr.yml
@@ -20,7 +20,7 @@ jobs:
       # SECURITY: never clone untrusted code in pull_request_target workflows
 
       - name: Add review-requested label
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # language=javascript

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -23,7 +23,7 @@ jobs:
   validation-of-params-env-odh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         uses: ./.github/actions/apt-install
@@ -38,7 +38,7 @@ jobs:
   validation-of-params-env-rhoai:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         uses: ./.github/actions/apt-install

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.BRANCH }}
           persist-credentials: false
@@ -70,12 +70,12 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
 

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: '0'
       - name: Install skopeo
@@ -22,7 +22,7 @@ jobs:
         with:
           packages: skopeo
       - name: Get Pull Request Number
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         id: get_pr_number
         with:
           script: |

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checkout the branch
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.BRANCH_NAME }}
           persist-credentials: true
@@ -52,7 +52,7 @@ jobs:
 
       # Get the latest weekly build commit hash: https://github.com/opendatahub-io/notebooks/commits/2023b
       - name: Checkout upstream notebooks repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N }}
@@ -64,7 +64,7 @@ jobs:
           echo "HASH_N=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: Checkout "N - 1" branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N_1 }}
@@ -76,7 +76,7 @@ jobs:
           echo "HASH_N_1=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
       - name: Checkout "main" branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: opendatahub-io/notebooks.git
           ref: main
@@ -89,13 +89,13 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SEC_SCAN_BRANCH }}
           persist-credentials: true
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version-file: '.python-version'
 
@@ -127,10 +127,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: pull-request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5  # v2.12.1
         with:
           source_branch: ${{ env.SEC_SCAN_BRANCH }}
           destination_branch: ${{ env.BRANCH_NAME}}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version-file: uv.toml
           activate-environment: false
@@ -32,7 +32,7 @@ jobs:
       - run: find . -name pyproject.toml -execdir uv lock \;
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # 0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
         with:
           scan-type: 'fs'
           format: 'sarif'
@@ -42,6 +42,6 @@ jobs:
           ignore-unfixed: false
 
       - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/software-versions.yaml
+++ b/.github/workflows/software-versions.yaml
@@ -25,7 +25,7 @@ jobs:
       # Some pieces of code (image pulls for example) in podman consult TMPDIR or default to /var/tmp
       TMPDIR: /home/runner/.local/share/containers/tmpdir
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Mount lvm overlay for podman operations
         run: |

--- a/.github/workflows/sync-branches-through-pr.yml
+++ b/.github/workflows/sync-branches-through-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.inputs.target }}
           fetch-depth: 0

--- a/.github/workflows/test-install-podman.yaml
+++ b/.github/workflows/test-install-podman.yaml
@@ -22,7 +22,7 @@ jobs:
   test-install:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Podman
         uses: './.github/actions/install-podman-action'

--- a/.github/workflows/test-playwright-action.yaml
+++ b/.github/workflows/test-playwright-action.yaml
@@ -25,7 +25,7 @@ jobs:
       CONTAINER_HOST: unix:///var/run/podman/podman.sock
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Extract default test image from playwright.config.ts
         id: get-image

--- a/.github/workflows/test-provision-k8s.yaml
+++ b/.github/workflows/test-provision-k8s.yaml
@@ -16,7 +16,7 @@ jobs:
   test-provisioning:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Provision K8s cluster
         uses: ./.github/actions/provision-k8s

--- a/.github/workflows/test-trivy-scan-action.yaml
+++ b/.github/workflows/test-trivy-scan-action.yaml
@@ -22,7 +22,7 @@ jobs:
       TEST_IMAGE: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9:2025b-v1.40
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Detect missing dependencies
         id: detect-packages
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Test Trivy scan on filesystem
         uses: ./.github/actions/trivy-scan-action

--- a/.github/workflows/update-buildconfigs.yaml
+++ b/.github/workflows/update-buildconfigs.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -22,7 +22,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true

--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: main
           fetch-depth: 0

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,8 @@
+---
+# pinact configuration
+# https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Two spaces before # to satisfy yamllint's "comments" rule
+# (too few spaces before comment: expected 2)
+separator: "  # "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,10 @@ When working with this project, ensure these tools are available:
 - **Package Manager**: uv (preferred) or pipenv
 - **Build System**: make (gmake on macOS)
 - **Version Control**: git with proper signing
+- **pinact**: for GitHub Actions SHA pinning (`brew install pinact`)
+
+> **GitHub Actions changes:** See [`.github/AGENTS.md`](.github/AGENTS.md) for SHA pinning
+> requirements, tooling, and workflow.
 
 ### Build Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,24 @@ If you're on **Fedora** and the auto-download fails with a `GOSUMDB=off` error, 
 - Run `export GOSUMDB=sum.golang.org` before `make`, or
 - Install Go 1.26+ manually from https://go.dev/dl/
 
+### GitHub Actions
+
+All third-party actions must be pinned by full commit SHA with a version comment:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+```
+
+After adding or modifying any `uses:` line in `.github/`, run:
+
+```bash
+# Install: brew install pinact (or: go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0)
+GITHUB_TOKEN=$(gh auth token) pinact run
+```
+
+CI enforces this via `pinact run --check --verify` in the code-quality workflow.
+See [ADR 0008](docs/architecture/decisions/0008-harden-github-actions-pin-sha-digests.md) for background.
+
 ### Working with linters
 
 - Run prek before you commit, to lint the Python sources that have been put under its management

--- a/Makefile
+++ b/Makefile
@@ -505,6 +505,11 @@ test:
 	./uv run pytest -m 'not buildonlytest'
 	@./scripts/check_dockerfile_alignment.sh
 
+.PHONY: check-actions
+check-actions:
+	@echo "Checking GitHub Actions SHA pinning"
+	@set +x; GITHUB_TOKEN=$$(gh auth token) pinact run --check --verify
+
 .PHONY: test-unit
 test-unit:
 	@echo "Running Python unit tests"

--- a/docs/architecture/decisions/0008-harden-github-actions-pin-sha-digests.md
+++ b/docs/architecture/decisions/0008-harden-github-actions-pin-sha-digests.md
@@ -1,0 +1,169 @@
+# 8. Harden GitHub Actions: pin SHA digests
+
+Date: 2026-04-04
+
+## Status
+
+Proposed
+
+## Context
+
+The March 2026 Trivy supply chain attack ([GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23))
+demonstrated that mutable Git tags on GitHub Actions are a high-value attack vector. An
+attacker force-pushed 75 of 76 version tags in `aquasecurity/trivy-action`, turning trusted
+tag references into credential-stealing malware. Any workflow referencing these by tag
+silently ran an infostealer that dumped secrets from the GitHub Actions Runner.
+
+Our repo was not directly affected — `trivy-action` was already SHA-pinned. However, an
+audit ([RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913)) found that the
+majority of our ~70 third-party action references across 31 workflow files use mutable tags
+(`@v6`, `@v8`), making them vulnerable to the same class of attack.
+
+### Pinning actions alone is not sufficient
+
+An action pinned by SHA can still reference mutable dependencies internally:
+- A GitHub Action that uses a Docker container image by tag (e.g., `docker://aquasec/trivy:0.68.2`)
+  is only as trustworthy as that tag. Docker tags are mutable — they can be re-pushed, just
+  like Git tags.
+- Actions that download binaries via `curl | bash` or fetch installers from URLs are similarly
+  exposed.
+
+Full immutability requires pinning the entire dependency chain: action SHAs, Docker image
+digests (`image@sha256:...`), and ideally checksummed binary downloads.
+
+### Developer experience matters
+
+SHA digests are opaque. `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` tells a human nothing.
+Without good tooling, SHA pinning becomes a maintenance burden that developers work around
+rather than embrace. The approach must include:
+- Human-readable version comments alongside SHAs
+- Automated tools for pinning and updating
+- CI enforcement that catches regressions before merge
+
+### State of SHA pinning in opendatahub-io
+
+An audit of the organization (April 2026) found:
+- **opendatahub-io/opendatahub-operator** — most thorough: all actions SHA-pinned with version
+  comments, done manually (no tooling).
+- **opendatahub-io/models-as-a-service**, **opendatahub-io/ODH-Build-Config** — also SHA-pinned,
+  likely copied from operator.
+- **opendatahub-io/notebooks**, **opendatahub-io/odh-dashboard**, and most other repos — use
+  mutable tag references exclusively.
+- **No repo in the org uses pinact, ratchet, or any automated pinning tool.** Renovate/MintMaker
+  is deployed for Tekton and Dockerfile updates, but `github-actions` is not in `enabledManagers`.
+- In the broader Red Hat ecosystem (redhat-appstudio, konflux-ci), only one repo
+  (`release-review-rot`) uses step-security/harden-runner. No pinact or ratchet adoption found.
+
+## Decision
+
+### Pin all GitHub Actions by full commit SHA with version comment
+
+Use the format recognized by both Renovate and pinact:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+```
+
+### Use `pinact` for local workflow and CI enforcement
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) (v3.9.0+) is a Go binary that:
+- Resolves tag references to SHA + version comment (`pinact run`)
+- Verifies existing pins match their claimed version (`pinact run --verify`)
+- Detects unpinned actions in CI (`pinact run --check`, exits non-zero)
+- Updates to latest versions (`pinact run --update`)
+- Outputs SARIF for GitHub Code Scanning integration (`--format sarif`)
+
+**Installation:** `brew install pinact` (macOS/Linux). Not available via npm; it is a Go
+binary. `go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@latest` works on any
+platform with Go installed.
+
+**Authentication:** pinact requires `GITHUB_TOKEN` for authenticated API access (avoids
+rate limiting). In CI, use `${{ secrets.GITHUB_TOKEN }}`. Locally, `gh auth token` works.
+
+**CI enforcement:** Add a `pinact run --check --verify` step to the code-quality workflow.
+This catches both unpinned actions and tampered SHA-to-version mappings.
+
+### Enable Renovate `github-actions` manager for automated updates
+
+Add `"github-actions"` to `enabledManagers` in `.github/renovate.json5` so Renovate/MintMaker
+automatically proposes PRs when new action versions are released — updating both the SHA and
+the version comment. Without this, SHA pins would require manual maintenance.
+
+```json5
+"enabledManagers": [
+    "tekton",
+    "dockerfile",
+    "custom.regex",
+    "github-actions",  // NEW: auto-update SHA-pinned actions
+],
+```
+
+### Supply chain audit of CI action runners
+
+When evaluating GitHub Actions for CI use, we audited whether the actions themselves
+"pin all the way down" — i.e., whether SHA-pinning the action ref is sufficient to
+guarantee immutability of everything that executes.
+
+**suzuki-shunsuke/pinact-action@v2.0.0 — pins all the way down:**
+
+The action uses `runs: using: node24` with a bundled `dist/index.js` (compiled via ncc).
+All NPM dependencies are frozen at build time inside the bundle — the SHA pin covers them.
+At runtime, the action downloads three binaries, each with cryptographic verification:
+
+1. **Aqua bootstrap (v2.55.1):** SHA-256 checksum hardcoded in the bundled JS per platform.
+   Downloaded binary is verified before execution.
+2. **Aqua self-update (v2.56.1):** Verified via SLSA provenance attestation
+   (`multiple.intoto.jsonl`). This is stronger than checksum-only verification — it
+   proves the binary was built by the official CI pipeline from the expected source.
+3. **pinact (v3.9.0) and reviewdog (v0.21.0):** Installed via aqua with
+   `checksum: { enabled: true, require_checksum: true }` in the bundled `aqua.yaml`.
+   Aqua refuses to install if the SHA-256 checksum (from the committed
+   `aqua-checksums.json`) doesn't match.
+
+**jdx/mise-action@v4 — does NOT pin all the way down:**
+
+The action also uses `runs: using: node24` with bundled JS, but has significant gaps:
+
+1. **Version resolution:** By default (no `version` input), it fetches
+   `https://mise.jdx.dev/VERSION` — a **mutable URL** returning the current latest version.
+2. **Binary download:** Downloads from `mise.jdx.dev` or GitHub Releases with **no checksum
+   verification by default**. The `sha256` input exists but is optional and empty by default.
+3. **No signature/provenance verification:** No Cosign, SLSA, or sigstore checks of any kind.
+4. **Mutable tag:** The `v4` tag is a moving major-version tag, not an immutable release.
+
+To use mise-action safely, a caller would need to: (a) SHA-pin the action ref,
+(b) specify a fixed `version` input, and (c) provide the `sha256` input. Most users
+(and the official docs) do none of these.
+
+### Future: pin Docker images by digest in workflows
+
+Docker image references in workflow files (e.g., `docker.io/nginx`, `registry.access.redhat.com/ubi9/ubi`)
+should be pinned by digest (`@sha256:...`). This is tracked in [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913)
+items 3 and 5, and is a separate effort from action SHA pinning.
+
+## Consequences
+
+- **Security:** Eliminates mutable-tag supply chain risk for GitHub Actions. The remaining
+  attack surface (Docker images, curl|bash installers) is acknowledged and tracked separately.
+- **Developer experience:** `pinact run` handles pinning locally. Renovate handles updates.
+  CI enforces compliance. Developers never need to manually look up SHAs.
+- **Maintenance:** Renovate PRs will be more frequent (one per action update instead of
+  silent tag-following). Grouping all action updates into a single PR mitigates this.
+- **Onboarding:** New contributors adding an action by tag will get a CI failure with a clear
+  message pointing them to `pinact run`.
+
+## Known limitations
+
+- **Verification gaps:** `aquasecurity/trivy-action` cannot be verified by `pinact --verify`
+  in CI because the `aquasecurity` org has a GitHub IP allowlist that blocks GHA runner IPs.
+  This action is excluded via `--exclude '^aquasecurity/trivy-action$'`. If other actions
+  from this org are added, they may need similar exclusion — verify manually first.
+
+## References
+
+- [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913) — Harden GitHub Actions
+  workflows against supply chain attacks (comprehensive audit)
+- [Trivy supply chain attack advisory](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)
+- [StepSecurity analysis](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release)
+- [pinact](https://github.com/suzuki-shunsuke/pinact) — GitHub Actions SHA pinning tool
+- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)


### PR DESCRIPTION
Refs: [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913)

## Summary

Pin all 81 GitHub Action references across 31 workflow files and 2 composite actions to full commit SHAs with version comments. Add CI enforcement via pinact, configure Renovate for automated updates, update developer docs, and include ADR 0008 documenting the decision.

## Motivation

The March 2026 Trivy supply chain attack ([GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)) demonstrated that mutable Git tags on GitHub Actions are a high-value attack vector. An attacker force-pushed 75 version tags in `aquasecurity/trivy-action`, turning trusted `@v0.69.1` references into credential-stealing malware.

Our repo had ~70 mutable tag references across 31 workflow files. See [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913) for the full audit.

## Changes

### 1. SHA-pin all actions (pinact v3.9.0)

```yaml
# Before
uses: actions/checkout@v6

# After
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
```

The `  # v6.0.2` comment (double space before `#`) preserves human readability and satisfies yamllint's `comments` rule. Both Renovate and pinact understand this format ([renovatebot/renovate#31360](https://github.com/renovatebot/renovate/issues/31360)).

### 2. `.pinact.yaml` configuration

```yaml
---
version: 3
separator: "  # "
```

Ensures `pinact run` uses double-space before `#` comments, matching yamllint expectations.

### 3. CI enforcement (code-quality.yaml)

New `action-pin-check` job with explicit `permissions: contents: read`:
- `pinact run --check` — exits non-zero if any action uses a mutable tag
- `pinact run --verify --exclude 'aquasecurity/.*'` — exits non-zero if a SHA doesn't match its version comment. The `aquasecurity` org has an IP allowlist that blocks GHA runners from API access, so trivy-action is excluded from automated verification.

### 4. Renovate github-actions manager (.github/renovate.json5)

- Added `"github-actions"` to `enabledManagers` so MintMaker proposes SHA pin updates automatically
- Added package rules for `astral-sh/setup-uv` and `actions/add-to-project` which use exact version tags (no major tags published)
- All GHA updates grouped into a single PR

### 5. Developer docs

- **`.github/AGENTS.md`** (new) — GHA-specific AI agent instructions: SHA pinning requirement, pinact workflow, double-space comment rule, actions without major tags
- **`AGENTS.md`** — Added pinact to prerequisites, link to `.github/AGENTS.md`
- **`CONTRIBUTING.md`** — New "GitHub Actions" section: pin format, pinact install/run commands, ADR link
- **`Makefile`** — `make check-actions` target running `pinact run --check --verify`

### 6. ADR 0008

Documents the decision, tooling choices, org-wide audit findings, and supply chain analysis of CI actions:

- **pinact-action** pins all the way down: aqua bootstrap checksum-verified, aqua self-update uses SLSA provenance, pinact/reviewdog binaries use `require_checksum: true`
- **mise-action** does NOT pin all the way down: downloads from mutable URL, no checksum by default
- **Known limitation:** `aquasecurity/trivy-action` cannot be verified by `pinact --verify` in CI due to org IP allowlist

## Fixed along the way

- `actions/add-to-project@v1` → `@v1.0.2` (no `v1` major tag exists)
- `aquasecurity/trivy-action` comment: `# 0.33.1` → `# v0.33.1` (consistent v-prefix)
- All SHA-pinned comments: single space → double space for yamllint compliance

## How Has This Been Tested?

- `pinact run --check` exits 0 (all pinned)
- `pinact run --verify --exclude 'aquasecurity/.*'` exits 0 (all verifiable SHAs match)
- `grep -rn 'uses:.*@v[0-9]' .github/` returns 0 matches
- `make check-actions` passes (macOS, gmake)
- yamllint passes (double-space comment format)

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third‑party GitHub Action references to immutable SHAs across workflows, enabled Renovate to manage action updates, and added CI checks to verify pins.
  * Added a CI job and Makefile target to run pin verification.

* **Documentation**
  * Added an architecture decision, contributor guidance, and repository agent guide describing the SHA‑pinning policy and pinact-based verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->