### PR TITLE
fix(ci): regenerate Dockerfiles after lockfile renewal to keep uv version in sync

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -85,6 +85,16 @@ jobs:
         env:
           FORCE_LOCKFILES_UPGRADE: ${{ env.FORCE_LOCKFILES_UPGRADE }}
 
+      # Regenerate Dockerfiles after lockfile changes.
+      # Lockfiles may bump package versions (e.g. uv) that dockerfile_fragments.py
+      # derives and embeds in Dockerfiles. Without this step, Dockerfiles drift
+      # out of sync and check-generated-code fails.
+      # See: commit 41aed2702 (lockfile-derived versions), PR #3239 (broke main).
+      - name: Regenerate Dockerfiles from updated lockfiles
+        run: |
+          ./uv run scripts/dockerfile_fragments.py
+          ./uv run manifests/tools/generate_kustomization.py
+
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -276,7 +276,7 @@ fi
 EOF
 
 # Install micropipenv and uv from cachi2 pip cache
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 # Other apps and tools installed as default user
 USER 1001

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -276,7 +276,7 @@ fi
 EOF
 
 # Install micropipenv and uv from cachi2 pip cache
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -43,7 +43,7 @@ RUN dnf install -y perl mesa-libGL skopeo compat-openssl11 openshift-clients \
     && rm -rf /var/cache/yum
 
 # Install micropipenv/uv from Cachi2 as root.
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 ####################
 # jupyter-minimal  #

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -42,7 +42,7 @@ rm -rf /var/cache/yum
 EOF
 
 # Install micropipenv/uv from Cachi2 as root.
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 #########################
 # cuda-jupyter-minimal  #

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -43,7 +43,7 @@ RUN dnf install -y perl mesa-libGL skopeo compat-openssl11 openshift-clients \
     && rm -rf /var/cache/yum
 
 # Install micropipenv/uv from Cachi2 as root.
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 ####################
 # jupyter-minimal  #

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -42,7 +42,7 @@ rm -rf /var/cache/yum
 EOF
 
 # Install micropipenv/uv from Cachi2 as root.
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 #########################
 # cuda-jupyter-minimal  #

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -41,7 +41,7 @@ rm -rf /var/cache/yum
 EOF
 
 # Install micropipenv/uv from Cachi2 as root.
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 # Create unversioned .so symlinks for ROCm libs (RHAIENG-2643)
 COPY jupyter/rocm/tensorflow/ubi9-python-3.12/utils/link-solibs.py /tmp/link-solibs.py

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -41,7 +41,7 @@ rm -rf /var/cache/yum
 EOF
 
 # Install micropipenv/uv from Cachi2 as root.
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.2"
 
 # Create unversioned .so symlinks for ROCm libs (RHAIENG-2643)
 COPY jupyter/rocm/tensorflow/ubi9-python-3.12/utils/link-solibs.py /tmp/link-solibs.py

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -70,7 +70,7 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
 RUN dnf install -y perl mesa-libGL skopeo compat-openssl11 openshift-clients \
     && dnf clean all \
     && rm -rf /var/cache/yum
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.3"
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -70,7 +70,7 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
 RUN dnf install -y perl mesa-libGL skopeo compat-openssl11 openshift-clients \
     && dnf clean all \
     && rm -rf /var/cache/yum
-RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.0"
+RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.3"
 
 # Other apps and tools installed as default user
 USER 1001


### PR DESCRIPTION
## Problem

The `check-generated-code` CI check has been broken on main since PR #3239 (April 3).

**Root cause:** PR #3239 updated lockfiles to `uv==0.11.2`, but the Dockerfiles still have `uv==0.11.0`. Since commit 41aed2702 ("derive micropipenv/uv versions from lockfiles"), `dockerfile_fragments.py` reads package versions from pylock files and embeds them in Dockerfiles. When lockfiles change but Dockerfiles aren't regenerated, they drift out of sync.

The lockfile renewal workflow (`piplock-renewal.yaml`) runs `make refresh-lock-files` but does NOT regenerate Dockerfiles afterward, so every lockfile update that bumps `uv` or `micropipenv` versions breaks `check-generated-code`.

## Fix

1. **Add regeneration steps to lockfile renewal workflow** — run `dockerfile_fragments.py` and `generate_kustomization.py` after `make refresh-lock-files`, so Dockerfiles and manifests stay in sync.

2. **Regenerate Dockerfiles now** — updates `uv==0.11.0` → `uv==0.11.2` in 10 Dockerfiles to fix the immediate mismatch.

## Why not `bash ci/generate_code.sh`?

`generate_code.sh` runs three things: `dockerfile_fragments.py`, `generate_kustomization.py`, and `pylocks_generator.py`. The third is essentially the same as `make refresh-lock-files` (which already ran), so calling `generate_code.sh` would redundantly re-run the lockfile generation. We only need the Dockerfile and manifest regeneration steps.

## How Has This Been Tested?

- `bash ci/generate_code.sh` produces no further changes after this fix (Dockerfiles are in sync)
- `git diff` after running shows only the expected `uv==0.11.0` → `uv==0.11.2` changes

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `uv` Python package manager to version 0.11.2/0.11.3 across Docker build images.
  * Enhanced build automation to regenerate Docker-derived artifacts from updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->