### PR TITLE
ISSUE#3253: fix(ci): show ODH/RHOAI variant in GHA job names and step summary

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -48,6 +48,7 @@ name: Build & Publish Notebook Servers (TEMPLATE)
 
 jobs:
   build:
+    name: "${{ inputs.konflux && 'rhoai' || 'odh' }}"
     # https://docs.github.com/en/actions/how-tos/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
     runs-on: ${{ fromJSON(inputs.PLATFORM_RUNNERS)[inputs.platform] || 'no-such-runner' }}
     env:
@@ -262,8 +263,42 @@ jobs:
               f.write(f"IMAGE_TAG={image_tag}\n")
               f.write(f"OUTPUT_IMAGE={env.REGISTRY}:{full_tag}\n")
               f.write(f"SANITIZED_PLATFORM={sanitized_platform}\n")
+              f.write(f"BUILD_TYPE={build_type}\n")
 
       # endregion
+
+      - name: "${{ steps.calculated_vars.outputs.BUILD_TYPE }} · ${{ inputs.target }}"
+        shell: python
+        env:
+          BUILD_TYPE: ${{ steps.calculated_vars.outputs.BUILD_TYPE }}
+          TARGET: ${{ inputs.target }}
+          PLATFORM: ${{ inputs.platform }}
+          OUTPUT_IMAGE: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
+        # language=python
+        run: |
+          import os, sys
+          from dataclasses import dataclass
+          from typing import TextIO
+
+          @dataclass
+          class BuildInfo:
+              BUILD_TYPE: str
+              TARGET: str
+              PLATFORM: str
+              OUTPUT_IMAGE: str
+
+              @classmethod
+              def from_env(cls):
+                  return cls(**{k: os.environ[k] for k in cls.__annotations__})
+
+              def write(self, f: TextIO):
+                  for attr, value in self.__dict__.items():
+                      key = attr.title().replace("_", " ")
+                      f.write(f"**{key}**: {value}\n")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write("### Build Info\n")
+              BuildInfo.from_env().write(f)
 
       # region Image build
 

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -107,6 +107,7 @@ jobs:
         shell: bash
 
   build:
+    name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["authorize", "gen"]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -105,6 +105,7 @@ jobs:
         shell: bash
 
   build:
+    name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["authorize", "gen"]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -57,6 +57,7 @@ jobs:
         shell: bash
 
   build:
+    name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["gen"]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -56,6 +56,7 @@ jobs:
         shell: bash
 
   build:
+    name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["gen"]
     strategy:
       fail-fast: false
@@ -71,6 +72,7 @@ jobs:
     secrets: inherit
 
   build-aipcc:
+    name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["gen"]
     strategy:
       fail-fast: false


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4240

## Problem

* https://github.com/opendatahub-io/notebooks/issues/3253

When a GHA build fails, the job name shows:
```
build (jupyter-minimal-ubi9-python-3.12, 3.12, linux/amd64, false) / build
```

The `false` is the `subscription` boolean — opaque. The inner `/ build` is wasted space (always just "build"). To determine whether this is an ODH (CentOS Stream) or RHOAI (RHEL/AIPCC) build, you have to cross-reference `build-args/*.conf`.

This slowed down debugging of the cache contamination issue in #3251, where knowing the variant was critical to understanding why RHEL repos appeared in an ODH build.

## Fix

### 1. Custom inner job name

Replace the static `build` inner job name with the variant:

```
Before: ... / build
After:  ... / odh        (or / rhoai for Konflux builds)
```

Uses `inputs.konflux` (not `inputs.subscription`) as the signal — subscription builds like rstudio-rhel9 use RHEL subscriptions but are still ODH variant.

### 2. Build info step summary

A diagnostic step writes variant, target, platform, and output image to `$GITHUB_STEP_SUMMARY`. The step name itself (`odh · jupyter-minimal-ubi9-python-3.12`) is visible in the sidebar even when collapsed.

### 3. BUILD_TYPE output

Exports the already-computed `build_type` variable as a step output for downstream use.

## Scope

1 file changed: `.github/workflows/build-notebooks-TEMPLATE.yaml`

No changes to matrix generation, calling workflows, or the `subscription` parameter.

Closes #3253

## How Has This Been Tested?

CI will validate the workflow syntax. The job name change is visible in the GHA UI on the PR build itself.

<img width="1627" height="990" alt="Screenshot 2026-04-04 at 9 20 20 PM" src="https://github.com/user-attachments/assets/fbe13da4-97e3-44d2-8eab-d580a5a785a8" />

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to show per-run job names combining target and platform for clearer build identification.
  * Build runs now compute and expose the build variant and append a “Build Info” summary showing variant, target, platform, and the produced image, improving visibility into build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->