### PR TITLE
RHAIENG-3914: fix context injection and reduce permissions in insta-merge.yaml

### DIFF
--- a/.github/workflows/insta-merge.yaml
+++ b/.github/workflows/insta-merge.yaml
@@ -10,12 +10,11 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   instant-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: insta-merge


### PR DESCRIPTION
Refs: [RHAIENG-3914](https://redhat.atlassian.net/browse/RHAIENG-3914), [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913)

## Problem

`insta-merge.yaml` has a context injection vulnerability (CWE-94) at line 29:

```yaml
run: |
  gh pr merge --merge --admin ${{ github.event.pull_request.html_url }}
```

`github.event.pull_request.html_url` is interpolated directly into a shell command. While the step is gated on `sender.login == 'red-hat-konflux[bot]'`, direct interpolation is unsafe syntax — if the gate is ever bypassed (e.g., token compromise), an attacker could inject arbitrary shell commands via a crafted PR URL.

The workflow also requests 5 permissions (`contents`, `pull-requests`, `checks`, `security-events`, `statuses`) when `gh pr merge` only needs 2 (`contents:write`, `pull-requests:write`).

## Fix

1. **Context injection**: Move `html_url` to `env:` and quote it in the shell command
2. **Permissions**: Reduce from 5 to 2 scopes (least privilege)

## Context

This is part of the [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913) GHA hardening audit. The main `pull_request_target` context injection fixes were already applied in the AIPCC and RHEL PR workflows. This PR addresses the remaining finding in `insta-merge.yaml`.

**Can we replace `pull_request_target` with `pull_request`?** No — `red-hat-data-services/notebooks` is a public fork that accepts fork PRs (jiridanek/notebooks, odh-on-pz/notebooks-downstream). Fork PRs on `pull_request` don't receive secrets. The current `pull_request_target` + authorization gate pattern is necessary.

## How Has This Been Tested?

The workflow is gated on Konflux bot PRs touching `manifests/base/params-latest.env`. The fix preserves identical behavior — just moves the value to an env var.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined automated merge workflow to tighten permissions and reduce unnecessary scopes.
  * Improved merge-step environment handling for more reliable, secure automated merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->