### PR TITLE
NO-JIRA: fix pr-notifications workflow (403 + missing GH_REPO)

### DIFF
--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -41,33 +41,50 @@ jobs:
       # SECURITY: never clone untrusted code in pull_request_target workflows
 
       - name: Post guidance comment (once)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-          REPO: ${{ github.repository }}
-          # gh cli needs this (no checkout)
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -Eeuxo pipefail
-          # Check both author and unique marker to avoid false positives from
-          # code review bots (e.g. CodeRabbit) that quote the marker in reviews
-          if gh pr view "$PR_NUMBER" --json comments \
-              --jq '.comments[] | select(.author.login == "github-actions") | .body' \
-              | grep -q 'fork-pr-guidance-posted-by-bot'; then
-            echo "Guidance comment already posted"
-            exit 0
-          fi
-          gh pr comment "$PR_NUMBER" --body "<!-- fork-pr-guidance-posted-by-bot -->
-          @$AUTHOR — This PR is from a fork. The \`build-rhoai\` CI job was skipped because subscription builds (RHEL, AIPCC) need secrets unavailable to forks. ODH builds and code quality checks still ran.
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # language=javascript
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const marker = 'fork-pr-guidance-posted-by-bot';
 
-          **Recommended:** Push your branch to the main repo for full CI:
-          \`\`\`
-          git remote add upstream https://github.com/$REPO.git
-          git push upstream HEAD:$AUTHOR/your-branch-name
-          \`\`\`
-          Then open a new PR from that branch.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
 
-          **No push access?** A maintainer will cherry-pick and test your changes.
+            if (comments.some(c => c.user?.login === 'github-actions[bot]' && c.body?.includes(marker))) {
+              core.info('Guidance comment already posted');
+              return;
+            }
 
-          See [CONTRIBUTING.md](https://github.com/$REPO/blob/main/CONTRIBUTING.md#contributing-from-branches-vs-forks) for details."
+            const body = [
+              `<!-- ${marker} -->`,
+              `@${author} — This PR is from a fork.`,
+              'The `build-rhoai` CI job was skipped because subscription',
+              'builds (RHEL, AIPCC) need secrets unavailable to forks.',
+              'ODH builds and code quality checks still ran.',
+              '',
+              '**Recommended:** Push your branch to the main repo for full CI:',
+              '```',
+              `git remote add upstream https://github.com/${repo}.git`,
+              `git push upstream HEAD:${author}/your-branch-name`,
+              '```',
+              'Then open a new PR from that branch.',
+              '',
+              '**No push access?** A maintainer will cherry-pick and test your changes.',
+              '',
+              `See [CONTRIBUTING.md](https://github.com/${repo}/blob/main/CONTRIBUTING.md#contributing-from-branches-vs-forks) for details.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body
+            });


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in #3277:

- **add-label 403**: `pull-requests: write` was removed from the `add-label` job when moving to per-job permissions. The `addLabels` API on PRs needs it despite GitHub docs listing `issues: write` as sufficient.
- **fork-guidance "not a git repository"**: `gh pr view` and `gh pr comment` can't detect the repo without a checkout (intentionally omitted for security in `pull_request_target`). Added `GH_REPO` env var so the gh CLI knows the target repo.

Observed in: https://github.com/opendatahub-io/notebooks/actions/runs/24004954364

## Test plan

- [ ] Open a fork PR → `add-label` succeeds (no 403), `fork-guidance` posts comment (no git error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow for pull request handling: granted additional permissions for labeling and improved the guidance-comment step to reliably post fork guidance once per PR using the platform API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->