### PR TITLE
Revert "ISSUE#3209: chore: enable gomod manager in Renovate to fix unreachable packageRule"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,6 @@
   "enabledManagers": [
     "tekton",
     "dockerfile",
-    "gomod",
     "custom.regex",
     "github-actions",
   ],


### PR DESCRIPTION
* Reverts opendatahub-io/notebooks#3220

This caused no reaction from renovate on odh-io, but rhds is completely spammed
* https://github.com/red-hat-data-services/notebooks/pull/2107
* https://github.com/red-hat-data-services/notebooks/pull/2106
* https://github.com/red-hat-data-services/notebooks/pull/2105
* ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to exclude Go module dependencies from automated scanning. Go module dependencies will no longer generate automatic update proposals, while other dependency managers for Tekton, Dockerfile, GitHub Actions, and custom patterns remain fully active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->