### PR TITLE
RHAIENG-3534: fix update-tags workflow to use dispatch branch

### DIFF
--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -85,6 +85,6 @@ jobs:
             --title "chore: update image tags ${prev_tag} → ${new_tag}" \
             --body "$body" \
             --head "$branch" \
-            --base main
+            --base "${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-3534

## Summary

The `update-tags.yaml` workflow had `ref: main` hardcoded in the checkout step. Dispatching it on `stable` or `rhoai-*` branches still checked out `main`, where `.tekton/` files have different tag formats — causing the tag regex to find no matches and fail.

**Fix:** `ref: main` → `ref: ${{ github.ref }}`

**Observed failure:** https://github.com/opendatahub-io/notebooks/actions/runs/24012327180

## Test plan

- [ ] Dispatch `update-tags` on `stable` branch → should find and replace tags in `.tekton/*.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow so automation now respects the current branch when checking out code and when creating update pull requests.
  * PR creation now targets the branch being operated on (instead of always defaulting to the main branch), improving branch-specific automation and reducing incorrect PR targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->