### PR TITLE
NO-JIRA: fix params-latest.env path in update-tags workflow

### DIFF
--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -44,7 +44,7 @@ jobs:
             xargs -0 -I{} perl -0777 -i -pe "s/\Q$prev_tag\E/$new_tag/g" "{}"
 
           # Update params-latest.env
-          perl -pi -e "s/\Q$prev_tag\E/$new_tag/g" manifests/base/params-latest.env
+          perl -pi -e "s/\Q$prev_tag\E/$new_tag/g" manifests/odh/base/params-latest.env
 
           # Export previous tag for later steps
           echo "previous_tag=$prev_tag" >> $GITHUB_OUTPUT
@@ -65,7 +65,7 @@ jobs:
           fi
 
           git checkout -b "$branch"
-          git add .tekton/*.yaml manifests/base/params-latest.env
+          git add .tekton/*.yaml manifests/odh/base/params-latest.env
           git commit -m "chore: update tags from ${prev_tag} to ${new_tag}"
           git push origin "$branch"
           echo "branch=$branch" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

The `update-tags.yaml` workflow referenced `manifests/base/params-latest.env` but the file lives at `manifests/odh/base/params-latest.env`. This caused `git add` to fail with `fatal: pathspec did not match any files` when dispatching the workflow.

Follow-up to #3291 which fixed the `ref: main` → `ref: ${{ github.ref }}` issue.

## Test plan

- [ ] Dispatch `update-tags` on `stable` branch → should complete without pathspec errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve tag management and environment parameter handling in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->