### PR TITLE
ci(manfest) updates the commit-latest script and action for the updated repo structure 

### DIFF
--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -10,7 +10,7 @@ name: Update commit-latest.env on params-latest.env change
       - main
       - rhoai-*
     paths:
-      - 'manifests/base/params-latest.env'
+      - 'manifests/odh/base/params-latest.env'
 
 jobs:
   sync-commit:
@@ -27,10 +27,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
 
+      - name: Install Skopeo CLI
+        uses: ./.github/actions/apt-install
+        with:
+          packages: skopeo
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
       - name: Update manifests/base/commit-latest.env
         id: update_env
         run: |
-          python3 scripts/update-commit-latest-env.py
+          ./uv run python scripts/update-commit-latest-env.py
 
       - name: Commit and push changes
         run: |

--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -101,7 +101,7 @@ async def inspect(images_to_inspect: typing.Iterable[str]) -> list[tuple[str, st
 
 
 async def main():
-    with open(PROJECT_ROOT / "manifests/base/params-latest.env", "rt") as file:
+    with open(PROJECT_ROOT / "manifests/odh/base/params-latest.env", "rt") as file:
         images_to_inspect: list[list[str]] = [line.strip().split('=', 1) for line in file.readlines()
                                               if line.strip() and not line.strip().startswith("#")]
 
@@ -116,7 +116,7 @@ async def main():
         _, commit_hash = result
         output.append((re.sub(r'-n$', "-commit-n", variable), commit_hash[:7]))
 
-    with open(PROJECT_ROOT / "manifests/base/commit-latest.env", "wt") as file:
+    with open(PROJECT_ROOT / "manifests/odh/base/commit-latest.env", "wt") as file:
         for line in sorted(output):
             print(*line, file=file, sep="=", end="\n")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
changed scripts/update-commit-latest-env.py to look at both odh and rhoai folders in manfest for params-latest
changed .github/workflows/update-commit-latest-env.yaml' to utilize the update of scripts/update-commit-latest-env.py`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated manifest update workflow now watches and updates an additional product variant and its config paths.
  * CI workflow installs required tooling (container inspection CLI and Python/runner setup) to ensure reliable manifest generation.
  * Manifest update invocation method adjusted; commit step still detects and commits generated manifest changes with clearer "no changes" reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->