### PR TITLE
RHAIENG-3052: Update RStudio IDE version and R packages

### DIFF
--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -105,6 +105,10 @@ set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}
 dnf install -y ${RSTUDIO_RPM}
 rm ${RSTUDIO_RPM}
+# Remove statically-linked Copilot language server binaries (disabled by default,
+# flagged by check-payload as not dynamically linked)
+rm -f /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/arm64/rg \
+      /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/x64/rg
 dnf -y clean all  --enablerepo='*'
 # Specific RStudio config and fixes
 chmod 1777 /var/run/rstudio-server

--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -99,7 +99,7 @@ WORKDIR /tmp/
 COPY /rstudio/utils /tmp/utils
 
 # Install RStudio
-ARG RSTUDIO_RPM=rstudio-server-rhel-2025.09.0-387-x86_64.rpm
+ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -105,6 +105,10 @@ set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}
 dnf install -y ${RSTUDIO_RPM}
 rm ${RSTUDIO_RPM}
+# Remove statically-linked Copilot language server binaries (disabled by default,
+# flagged by check-payload as not dynamically linked)
+rm -f /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/arm64/rg \
+      /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/x64/rg
 dnf -y clean all  --enablerepo='*'
 # Specific RStudio config and fixes
 chmod 1777 /var/run/rstudio-server

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -99,7 +99,7 @@ WORKDIR /tmp/
 COPY /rstudio/utils /tmp/utils
 
 # Install RStudio
-ARG RSTUDIO_RPM=rstudio-server-rhel-2025.09.0-387-x86_64.rpm
+ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}

--- a/rstudio/c9s-python-3.12/install_packages.R
+++ b/rstudio/c9s-python-3.12/install_packages.R
@@ -13,8 +13,8 @@ if (!requireNamespace("remotes", quietly = TRUE)) {
 }
 
 # Install specific versions of packages
-remotes::install_version('Rcpp',       '1.0.14', lib = lib, dependencies = TRUE, upgrade = "never")
+remotes::install_version('Rcpp',       '1.1.1',  lib = lib, dependencies = TRUE, upgrade = "never")
 remotes::install_version('tidyverse',  '2.0.0',  lib = lib, dependencies = TRUE, upgrade = "never")
 remotes::install_version('tidymodels', '1.4.1',  lib = lib, dependencies = TRUE, upgrade = "never")
-remotes::install_version('vetiver',    '0.2.5',  lib = lib, dependencies = TRUE, upgrade = "never")
-remotes::install_version('devtools',   '2.4.5',  lib = lib, dependencies = TRUE, upgrade = "never")
+remotes::install_version('vetiver',    '0.2.7',  lib = lib, dependencies = TRUE, upgrade = "never")
+remotes::install_version('devtools',   '2.5.0',  lib = lib, dependencies = TRUE, upgrade = "never")

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -128,7 +128,7 @@ WORKDIR /tmp/
 COPY /rstudio/utils /tmp/utils
 
 # Install RStudio
-ARG RSTUDIO_RPM=rstudio-server-rhel-2025.09.0-387-x86_64.rpm
+ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN set -Eeuxo pipefail && \
     wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM} && \
     dnf install -y ${RSTUDIO_RPM} && \

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -133,6 +133,9 @@ RUN set -Eeuxo pipefail && \
     wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM} && \
     dnf install -y ${RSTUDIO_RPM} && \
     rm ${RSTUDIO_RPM} && \
+    # Remove statically-linked Copilot language server binaries (disabled by default, flagged by check-payload) \
+    rm -f /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/arm64/rg \
+          /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/x64/rg && \
     dnf -y clean all --enablerepo='*' && \
     chmod 1777 /var/run/rstudio-server && \
     mkdir -p /usr/share/doc/R && \

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -234,6 +234,9 @@ ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM} && \
     dnf install -y ${RSTUDIO_RPM} && \
     rm ${RSTUDIO_RPM} && \
+    # Remove statically-linked Copilot language server binaries (disabled by default, flagged by check-payload) \
+    rm -f /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/arm64/rg \
+          /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/x64/rg && \
     dnf -y clean all  --enablerepo='*' &&\
     # Specific RStudio config and fixes \
     chmod 1777 /var/run/rstudio-server && \

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -230,7 +230,7 @@ WORKDIR /tmp/
 COPY /rstudio/utils /tmp/utils
 
 # Install RStudio
-ARG RSTUDIO_RPM=rstudio-server-rhel-2025.09.0-387-x86_64.rpm
+ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM} && \
     dnf install -y ${RSTUDIO_RPM} && \
     rm ${RSTUDIO_RPM} && \

--- a/rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu
@@ -117,6 +117,10 @@ set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}
 dnf install -y ${RSTUDIO_RPM}
 rm ${RSTUDIO_RPM}
+# Remove statically-linked Copilot language server binaries (disabled by default,
+# flagged by check-payload as not dynamically linked)
+rm -f /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/arm64/rg \
+      /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/x64/rg
 dnf -y clean all  --enablerepo='*'
 # Specific RStudio config and fixes
 chmod 1777 /var/run/rstudio-server

--- a/rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu
@@ -111,7 +111,7 @@ WORKDIR /tmp/
 COPY /rstudio/utils /tmp/utils
 
 # Install RStudio
-ARG RSTUDIO_RPM=rstudio-server-rhel-2025.09.0-387-x86_64.rpm
+ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}

--- a/rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda
@@ -125,7 +125,7 @@ WORKDIR /tmp/
 COPY /rstudio/utils /tmp/utils
 
 # Install RStudio
-ARG RSTUDIO_RPM=rstudio-server-rhel-2025.09.0-387-x86_64.rpm
+ARG RSTUDIO_RPM=rstudio-server-rhel-2026.01.1-403-x86_64.rpm
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}

--- a/rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda
@@ -131,6 +131,10 @@ set -Eeuxo pipefail
 wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM}
 dnf install -y ${RSTUDIO_RPM}
 rm ${RSTUDIO_RPM}
+# Remove statically-linked Copilot language server binaries (disabled by default,
+# flagged by check-payload as not dynamically linked)
+rm -f /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/arm64/rg \
+      /usr/lib/rstudio-server/bin/copilot-language-server-js/bin/linux/x64/rg
 dnf -y clean all  --enablerepo='*'
 # Specific RStudio config and fixes
 chmod 1777 /var/run/rstudio-server

--- a/rstudio/rhel9-python-3.12/install_packages.R
+++ b/rstudio/rhel9-python-3.12/install_packages.R
@@ -13,8 +13,8 @@ if (!requireNamespace("remotes", quietly = TRUE)) {
 }
 
 # Install specific versions of packages
-remotes::install_version('Rcpp',       '1.0.14', lib = lib, dependencies = TRUE, upgrade = "never")
+remotes::install_version('Rcpp',       '1.1.1',  lib = lib, dependencies = TRUE, upgrade = "never")
 remotes::install_version('tidyverse',  '2.0.0',  lib = lib, dependencies = TRUE, upgrade = "never")
 remotes::install_version('tidymodels', '1.4.1',  lib = lib, dependencies = TRUE, upgrade = "never")
-remotes::install_version('vetiver',    '0.2.5',  lib = lib, dependencies = TRUE, upgrade = "never")
-remotes::install_version('devtools',   '2.4.5',  lib = lib, dependencies = TRUE, upgrade = "never")
+remotes::install_version('vetiver',    '0.2.7',  lib = lib, dependencies = TRUE, upgrade = "never")
+remotes::install_version('devtools',   '2.5.0',  lib = lib, dependencies = TRUE, upgrade = "never")


### PR DESCRIPTION
## Summary
- Update RStudio Server from 2025.09.0-387 to 2026.01.1-403 (from https://download2.rstudio.org/server/rhel9/x86_64/)
- Update R packages in install_packages.R:
  - Rcpp: 1.0.14 → 1.1.1
  - vetiver: 0.2.5 → 0.2.7
  - devtools: 2.4.5 → 2.5.0

## Files Updated
- `rstudio/c9s-python-3.12/Dockerfile.cpu`
- `rstudio/c9s-python-3.12/Dockerfile.cuda`
- `rstudio/c9s-python-3.12/install_packages.R`
- `rstudio/rhel9-python-3.12/Dockerfile.cpu`
- `rstudio/rhel9-python-3.12/Dockerfile.cuda`
- `rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu`
- `rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda`
- `rstudio/rhel9-python-3.12/install_packages.R`

## Jira Ticket
https://issues.redhat.com/browse/RHAIENG-3052

## Test plan
- [ ] Build RStudio c9s CPU image
- [ ] Build RStudio c9s CUDA image
- [ ] Build RStudio RHEL9 CPU image
- [ ] Build RStudio RHEL9 CUDA image
- [ ] Verify RStudio Server version shows 2026.01.1-403
- [ ] Verify R packages are installed with correct versions

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated RStudio Server to 2026.01.1 across CPU and CUDA images for multiple platforms
  * Bumped R package dependencies: Rcpp, vetiver, and devtools
  * Removed redundant Copilot language-server binaries from the RStudio images to reduce footprint
<!-- end of auto-generated comment: release notes by coderabbit.ai -->