### PR TITLE
[RHAIENG-3690] ci(manfest) refresh ImageStream dependency annotations from pylocks in lockfile renewal

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -41,6 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so tests/test_pylock_downgrade.py can `git show origin/main:…/pylock.toml`.
+          fetch-depth: 0
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
@@ -52,8 +55,12 @@ jobs:
         id: install-deps
         run: uv sync --locked
 
-      - run: make test
+      - name: Static tests (pytest + Dockerfile alignment)
+        run: make test
         if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
+        env:
+          # Prefer the PR base commit so fork PRs compare pylocks to upstream main, not the fork's main.
+          NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha }}
 
       - name: Upload Python coverage to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -63,6 +63,7 @@ jobs:
         with:
           ref: ${{ env.BRANCH }}
           persist-credentials: false
+          fetch-depth: 0  # update_imagestream_annotations_from_pylock.py uses git show for tag SHAs
 
       - name: Configure Git
         run: |
@@ -88,6 +89,14 @@ jobs:
           ./uv run scripts/dockerfile_fragments.py
           ./uv run manifests/tools/generate_kustomization.py
 
+      - name: Refresh ImageStream notebook dependency annotations from pylocks
+        run: |
+          ./uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant odh
+          ./uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant rhoai
+
+      - name: Validate manifests (make test)
+        run: make test
+
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -100,15 +109,15 @@ jobs:
 
           BRANCH_NAME="lockfile-update-$(date +%Y%m%d-%H%M)"
           git checkout -b "$BRANCH_NAME"
-          git commit -m "Update lock files"
+          git commit -m "Update lock files and ImageStream dependency annotations"
           # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#using-an-installation-access-token-to-authenticate-as-an-app-installation
           git push -u "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH_NAME"
 
           gh pr create \
-            --title "Update lock files" \
+            --title "Update lock files and ImageStream dependency annotations" \
             --head "$BRANCH_NAME" \
             --body "$(cat <<'EOF'
-          Automated lock file update.
+          Automated lock file update, Dockerfile/kustomization regeneration, and ImageStream `notebook-python-dependencies` / `notebook-software` annotations from pylocks.
 
           **Auto-merge policy:** This PR will be automatically merged after 1 working day unless:
           - Moved to draft status

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ endef
 #######################################        Build helpers                 #######################################
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
-skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files scan-image-vulnerabilities print-release
+skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files sync-commit-env-files update-imagestream-annotations refresh-imagestream-metadata scan-image-vulnerabilities print-release
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
 $(SELF): bin/buildinputs
 endif
@@ -465,6 +465,35 @@ refresh-lock-files:
 		PIP_LOCK_EXTRA_INDEX_URL="$(PIP_EXTRA_INDEX_URL)" \
 		env -u UV_EXTRA_INDEX_URL -u PIP_EXTRA_INDEX_URL \
 		./uv run scripts/pylocks_generator.py $(INDEX_MODE) $(DIR)
+
+# ======================================================================================
+#   gmake update-imagestream-annotations
+#   gmake update-imagestream-annotations IMAGESTREAM_VARIANT=rhoai DRY_RUN=1
+# Prerequisites:
+#   - ./uv sync --locked (or make setup) so scripts run in the project venv
+#   - skopeo on PATH (sync-commit-env-files inspects images from params*.env)
+#   - For private registry pulls: mkdir -p ~/.config/containers &&
+#       cp ci/secrets/pull-secret.json ~/.config/containers/auth.json
+#   - Full clone / fetch-depth 0 helps update-imagestream-annotations when git show needs SHAs
+#       not already in the local object database (script can fetch from GitHub when needed).
+# ======================================================================================
+IMAGESTREAM_VARIANT ?=
+DRY_RUN ?=
+.PHONY: update-imagestream-annotations
+update-imagestream-annotations:
+	@echo "==================================================================="
+	@echo "📋 Refreshing ImageStream notebook dependency annotations (IMAGESTREAM_VARIANT=$(or $(IMAGESTREAM_VARIANT),odh+rhoai))"
+	@echo "==================================================================="
+	@cd $(ROOT_DIR) && \
+	if [[ -n "$(IMAGESTREAM_VARIANT)" ]]; then \
+		./uv run python manifests/tools/update_imagestream_annotations_from_pylock.py \
+			--variant "$(IMAGESTREAM_VARIANT)" $(if $(filter 1 true yes,$(DRY_RUN)),--dry-run,); \
+	else \
+		./uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant odh \
+			$(if $(filter 1 true yes,$(DRY_RUN)),--dry-run,) && \
+		./uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant rhoai \
+			$(if $(filter 1 true yes,$(DRY_RUN)),--dry-run,); \
+	fi
 
 # This is only for the workflow action
 # For running manually, set the required environment variables

--- a/manifests/tools/commit_env_refs.py
+++ b/manifests/tools/commit_env_refs.py
@@ -1,0 +1,34 @@
+"""Helpers for mapping manifest param keys to commit ConfigMap keys and env files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def commit_field_key(base_key: str, suffix: str) -> str:
+    """ConfigMap key for a commit hash (e.g. ``...-commit-n``, ``...-commit-2025-2``)."""
+    return f"{base_key}-commit{suffix}"
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    """Load ``KEY=value`` lines from a ``*.env`` file."""
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        out[k.strip()] = v.strip()
+    return out
+
+
+def commit_env_path_for_suffix(suffix: str) -> str:
+    """``-n`` (latest) uses ``commit-latest.env``; all other versions use ``commit.env``."""
+    return "commit-latest.env" if suffix == "-n" else "commit.env"

--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -108,11 +108,17 @@ def _parse_imagestream_name(yaml_path: Path) -> str | None:
     """Extract ``metadata.name`` from an ImageStream YAML file.
 
     Uses a simple regex to avoid a PyYAML dependency at runtime.
+    Multi-line annotation values (e.g. folded ``notebook-image-desc``) break a
+    naive walk from ``metadata:`` to ``name:``; we isolate the metadata block
+    up to ``spec:`` and match ``name`` there instead.
     """
     text = yaml_path.read_text()
-    # Match the top-level "  name: <value>" line that follows "metadata:"
-    m = re.search(r"^metadata:\s*\n(?:\s+\S+:.*\n)*?\s+name:\s+(\S+)", text, re.MULTILINE)
-    return m.group(1) if m else None
+    m = re.search(r"(?ms)^metadata:.*?(?=^spec:)", text)
+    if not m:
+        return None
+    block = m.group(0)
+    m2 = re.search(r"^  name:\s+(\S+)", block, re.MULTILINE)
+    return m2.group(1) if m2 else None
 
 
 def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[str], list[Runtime]]:

--- a/manifests/tools/update_imagestream_annotations_from_pylock.py
+++ b/manifests/tools/update_imagestream_annotations_from_pylock.py
@@ -1,0 +1,616 @@
+"""Refresh ``notebook-python-dependencies`` (and Python stack in ``notebook-software``) from pylock files at git commits recorded in commit env files.
+
+For each workbench ImageStream tag, resolves the git tree-ish as:
+
+- Latest tag (suffix ``-n``): versions are taken from the **working tree** lockfile first (same files
+  ``make test`` uses: ``uv.lock.d/pylock.<cpu|cuda|rocm>.toml`` or ``pylock.toml``). That matches local
+  ``pylock.toml`` pins. If no file exists on disk, the SHA from ``commit-latest.env`` is used with
+  ``git show`` (fetching from the canonical repo if needed): ``https://github.com/opendatahub-io/notebooks.git``
+  (``--variant odh``) or ``https://github.com/red-hat-data-services/notebooks.git`` (``--variant rhoai``).
+- Older tags (e.g. ``-2025-2``): SHA from ``commit.env`` (``<base>-commit-2025-2``).
+
+Those SHAs match ``manifests/tools/generate_kustomization.py`` / ConfigMap keys.
+
+Dependency *names* and ordering are taken from the existing manifest; versions are updated from
+the resolved lockfile at each ref (same translation rules as ``tests/test_main.py``). Older commits
+may only have ``requirements.txt`` (e.g. ``jupyter/rocm/tensorflow/.../requirements.txt``) instead of
+``pylock.toml`` / ``uv.lock.d/pylock.*.toml``; those are parsed as pinned PEP 508 requirements.
+
+JSON annotations are written as YAML literal blocks (``|``) with the same bracket layout as
+``opendatahub-io`` / ``mtchoum1`` ImageStreams: opening ``[`` on the first line of the block, two
+spaces before each ``{...}`` line, closing ``]`` aligned with ``[`` — see e.g.
+https://github.com/mtchoum1/notebooks/blob/main/manifests/odh/base/jupyter-datascience-notebook-imagestream.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import packaging.markers
+import packaging.version
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from manifests.tools.commit_env_refs import parse_env_file  # noqa: E402
+from manifests.tools.generate_kustomization import Workbench, discover_config  # noqa: E402
+from tests.manifests import (  # noqa: E402
+    extract_metadata_from_path,
+    get_source_of_truth_filepath,
+)
+
+logger = logging.getLogger(__name__)
+
+_MANIFEST_TO_PYLOCK = {
+    "LLM-Compressor": "llmcompressor",
+    "PyTorch": "torch",
+    "ROCm-PyTorch": "torch",
+    "Sklearn-onnx": "skl2onnx",
+    "Nvidia-CUDA-CU12-Bundle": "nvidia-cuda-runtime-cu12",
+    "MySQL Connector/Python": "mysql-connector-python",
+}
+
+# Force accelerator flavor when resolving ImageStream paths. ``extract_metadata_from_path`` may
+# infer "cuda" from Dockerfile.cuda even for the CPU ImageStream (same tree builds both), and
+# RStudio ImageStreams are not represented in ``get_source_of_truth_filepath`` (buildconfig-only).
+_ACCELERATOR_OVERRIDE_FOR_RESOURCE: dict[str, str | None] = {
+    "jupyter-minimal-notebook-imagestream.yaml": None,
+    "jupyter-minimal-gpu-notebook-imagestream.yaml": "cuda",
+    "jupyter-datascience-notebook-imagestream.yaml": None,
+    "jupyter-pytorch-notebook-imagestream.yaml": "cuda",
+    "jupyter-tensorflow-notebook-imagestream.yaml": "cuda",
+    "jupyter-trustyai-notebook-imagestream.yaml": None,
+    "code-server-notebook-imagestream.yaml": None,
+    "jupyter-rocm-minimal-notebook-imagestream.yaml": "rocm",
+    "jupyter-rocm-pytorch-notebook-imagestream.yaml": "rocm",
+    "jupyter-rocm-tensorflow-notebook-imagestream.yaml": "rocm",
+    "jupyter-pytorch-llmcompressor-imagestream.yaml": "cuda",
+}
+
+_RSTUDIO_NOTEBOOK_RESOURCES = frozenset(
+    {
+        "rstudio-notebook-imagestream.yaml",
+        "rstudio-gpu-notebook-imagestream.yaml",
+    }
+)
+
+# Canonical Git URLs for ``git fetch`` when the ``-n`` tag commit is not already in the local object DB.
+_CANONICAL_REPO_URL: dict[str, str] = {
+    "odh": "https://github.com/opendatahub-io/notebooks.git",
+    "rhoai": "https://github.com/red-hat-data-services/notebooks.git",
+}
+
+# Commit values from *.env must look like hex object IDs before passing to git (avoid ref injection).
+# Repo env files use short SHAs (7+ chars); full 40-char hashes are also accepted.
+_GIT_HEX_OBJECT_ID = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def _is_under_jupyter_rocm_tree(directory: Path) -> bool:
+    parts = directory.parts
+    try:
+        j = parts.index("jupyter")
+    except ValueError:
+        return False
+    return len(parts) > j + 1 and parts[j + 1] == "rocm"
+
+
+def _is_under_jupyter_minimal_tree(directory: Path) -> bool:
+    """``jupyter/minimal/<os>-python-*/`` (ROCm minimal uses the same tree as CPU; lockfile is ``pylock.rocm.toml``)."""
+    parts = directory.parts
+    try:
+        j = parts.index("jupyter")
+    except ValueError:
+        return False
+    return len(parts) > j + 1 and parts[j + 1] == "minimal"
+
+
+def _workbench_dir_consistent_with_rocm_policy(wb: Workbench, directory: Path) -> bool:
+    """Skip ``jupyter/rocm/...`` source trees when the ImageStream is not a ROCm workbench."""
+    rf = wb.resource_file
+    rocm_tree = _is_under_jupyter_rocm_tree(directory)
+
+    # ROCm minimal ImageStream is built from jupyter/minimal/..., not jupyter/rocm/minimal/...
+    if rf == "jupyter-rocm-minimal-notebook-imagestream.yaml":
+        return _is_under_jupyter_minimal_tree(directory)
+
+    if rf.startswith("jupyter-rocm-"):
+        return rocm_tree
+    if rf.startswith("jupyter-") and rocm_tree:
+        return False
+    return True
+
+
+_MANIFEST_CAP = {
+    "Accelerate",
+    "Boto3",
+    "Codeflare-SDK",
+    "Datasets",
+    "Feast",
+    "JupyterLab",
+    "Kafka-Python-ng",
+    "Kfp",
+    "Kubeflow-Training",
+    "Matplotlib",
+    "Numpy",
+    "Odh-Elyra",
+    "Pandas",
+    "Psycopg",
+    "PyMongo",
+    "Pyodbc",
+    "Scikit-learn",
+    "Scipy",
+    "TensorFlow",
+    "Tensorboard",
+    "Torch",
+    "Transformers",
+    "TrustyAI",
+    "TensorFlow-ROCm",
+    "MLflow",
+}
+
+
+def _is_image_directory(directory: Path) -> bool:
+    try:
+        _ubi, _lang, _python = directory.name.split("-")
+    except ValueError:
+        return False
+    else:
+        return True
+
+
+def _manifests_variant_dir(variant: str) -> Path:
+    return ROOT / "manifests" / variant
+
+
+def _iter_candidate_dirs() -> list[Path]:
+    globs = [
+        ROOT.glob("jupyter/**/pyproject.toml"),
+        ROOT.glob("codeserver/**/pyproject.toml"),
+        ROOT.glob("rstudio/**/pyproject.toml"),
+    ]
+    out: list[Path] = []
+    for g in globs:
+        for pyproject in g:
+            d = pyproject.parent
+            if _is_image_directory(d):
+                out.append(d)
+    return out
+
+
+def _dirs_for_workbench(manifests_dir: Path, wb: Workbench) -> list[Path]:
+    target = (manifests_dir / "base" / wb.resource_file).resolve()
+    if wb.resource_file in _RSTUDIO_NOTEBOOK_RESOURCES:
+        return [d for d in _iter_candidate_dirs() if "rstudio" in d.parts]
+
+    found: list[Path] = []
+    for d in _iter_candidate_dirs():
+        if not _workbench_dir_consistent_with_rocm_policy(wb, d):
+            continue
+        try:
+            meta = extract_metadata_from_path(d)
+            if wb.resource_file in _ACCELERATOR_OVERRIDE_FOR_RESOURCE:
+                meta = dataclasses.replace(
+                    meta,
+                    accelerator_flavor=_ACCELERATOR_OVERRIDE_FOR_RESOURCE[wb.resource_file],
+                )
+            truth = get_source_of_truth_filepath(manifests_dir, meta)
+        except ValueError:
+            continue
+        if truth.resolve() == target:
+            found.append(d)
+    return found
+
+
+def _pick_dir_for_base_key(candidates: list[Path], base_key: str) -> Path | None:
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    m_os = re.search(r"-py(\d)(\d+)-(c9s|rhel9|ubi9|ubi8)(?:$|-)", base_key)
+    if m_os:
+        py = f"{m_os.group(1)}.{m_os.group(2)}"
+        os_flavor = m_os.group(3)
+        want = f"{os_flavor}-python-{py}"
+        for d in candidates:
+            if d.name == want:
+                return d
+        return None
+
+    m = re.search(r"-py(\d)(\d+)-", base_key)
+    if not m:
+        return None
+    py = f"{m.group(1)}.{m.group(2)}"
+    matching = [d for d in candidates if f"python-{py}" in d.name]
+    if len(matching) == 1:
+        return matching[0]
+    if len(matching) > 1:
+        return None
+    return None
+
+
+def _pylock_kind_from_tag(wb_resource_file: str, base_key: str) -> str:
+    if "-rocm-" in base_key or "jupyter-rocm-" in wb_resource_file:
+        return "rocm"
+    if wb_resource_file in _RSTUDIO_NOTEBOOK_RESOURCES:
+        if "gpu" in wb_resource_file or "-cuda-" in base_key:
+            return "cuda"
+        return "cpu"
+    if "-cuda-" in base_key or "-minimal-cuda-" in base_key:
+        return "cuda"
+    if wb_resource_file in (
+        "jupyter-minimal-gpu-notebook-imagestream.yaml",
+        "jupyter-pytorch-notebook-imagestream.yaml",
+        "jupyter-tensorflow-notebook-imagestream.yaml",
+        "jupyter-pytorch-llmcompressor-imagestream.yaml",
+    ):
+        return "cuda"
+    return "cpu"
+
+
+def _pylock_candidate_rel_paths(notebook_dir: Path, kind: str) -> list[str]:
+    """Paths to try with ``git show`` (``uv.lock.d``, ``pylock.toml``, then legacy ``requirements.txt``)."""
+    rel_uv = notebook_dir / "uv.lock.d" / f"pylock.{kind}.toml"
+    rel_legacy = notebook_dir / "pylock.toml"
+    rel_req = notebook_dir / "requirements.txt"
+    out: list[str] = [
+        str(rel_uv.relative_to(ROOT)),
+        str(rel_legacy.relative_to(ROOT)),
+        str(rel_req.relative_to(ROOT)),
+    ]
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for p in out:
+        if p not in seen:
+            seen.add(p)
+            deduped.append(p)
+    return deduped
+
+
+def _worktree_read_first_existing(rel_paths: list[str]) -> tuple[str, str] | None:
+    """Read the first existing path under ``ROOT`` (for ``-n`` tags: match ``make test`` / local pins)."""
+    for rel in rel_paths:
+        rel = rel.replace("\\", "/")
+        path = ROOT / rel
+        if not path.is_file():
+            continue
+        try:
+            return rel, path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+    return None
+
+
+def _git_show_first_existing(rev: str, rel_paths: list[str]) -> tuple[str, str] | None:
+    for rel in rel_paths:
+        text = _git_show_text(rev, rel)
+        if text is not None:
+            return rel, text
+    return None
+
+
+def _git_commit_exists(rev: str) -> bool:
+    p = subprocess.run(
+        ["git", "-C", str(ROOT), "cat-file", "-e", f"{rev}^{{commit}}"],
+        capture_output=True,
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def _git_fetch_commit_from(url: str, rev: str) -> bool:
+    p = subprocess.run(
+        ["git", "-C", str(ROOT), "fetch", "--quiet", "--no-tags", url, rev],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def _ensure_n_tag_commit_from_canonical_upstream(variant: str, rev: str) -> bool:
+    """Ensure ``rev`` is available for ``git show`` using the ODH or RHDS canonical ``.git`` URL for ``-n`` tags."""
+    url = _CANONICAL_REPO_URL[variant]
+    if _git_commit_exists(rev):
+        return True
+    return _git_fetch_commit_from(url, rev)
+
+
+def _git_show_text(rev: str, rel_path: str) -> str | None:
+    rel_path = rel_path.replace("\\", "/")
+    p = subprocess.run(
+        ["git", "-C", str(ROOT), "show", f"{rev}:{rel_path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if p.returncode != 0:
+        return None
+    return p.stdout
+
+
+def _normalized_pkg_name(manifest_name: str) -> str:
+    if manifest_name in _MANIFEST_TO_PYLOCK:
+        return _MANIFEST_TO_PYLOCK[manifest_name]
+    if manifest_name in _MANIFEST_CAP:
+        return manifest_name.lower()
+    return manifest_name
+
+
+def _format_dep_version(pep440: str) -> str:
+    v = packaging.version.Version(pep440)
+    return f"{v.major}.{v.minor}"
+
+
+def _load_pylock_packages(pylock_text: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    doc = tomllib.loads(pylock_text)
+    marker_env = {
+        "python_full_version": f"{python_minor}.0",
+        "python_version": python_minor,
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+    }
+    packages: dict[str, dict[str, Any]] = {}
+    for p in doc.get("packages", []):
+        if "marker" in p and not packaging.markers.Marker(p["marker"]).evaluate(marker_env):
+            continue
+        name = p["name"]
+        if name in packages:
+            raise ValueError(f"duplicate package in lockfile: {name}")
+        packages[name] = p
+    return packages
+
+
+def _parse_requirements_txt_packages(text: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    """Parse pip-tools / pip ``requirements.txt`` (pinned ``pkg==ver`` lines; skips hash/index options)."""
+    marker_env = {
+        "python_full_version": f"{python_minor}.0",
+        "python_version": python_minor,
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+    }
+    packages: dict[str, dict[str, Any]] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("--"):
+            continue
+        if line.startswith("-"):
+            continue
+        if "\\" in line:
+            line = line.split("\\", 1)[0].strip()
+        if "@" in line and "==" not in line:
+            continue
+        if "==" not in line:
+            continue
+        try:
+            req = Requirement(line)
+        except (InvalidRequirement, ValueError) as e:
+            logger.debug("skip unparseable requirement line %r: %s", line, e)
+            continue
+        if req.marker is not None and not req.marker.evaluate(marker_env):
+            continue
+        pinned: str | None = None
+        for spec in req.specifier:
+            if spec.operator == "==":
+                pinned = spec.version
+                break
+        if pinned is None:
+            continue
+        key = canonicalize_name(req.name)
+        packages[key] = {"name": key, "version": pinned}
+    return packages
+
+
+def _load_lockfile_packages(text: str, source_rel_path: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    if Path(source_rel_path).name == "requirements.txt":
+        return _parse_requirements_txt_packages(text, python_minor)
+    return _load_pylock_packages(text, python_minor)
+
+
+def _python_minor_from_dir(notebook_dir: Path) -> str:
+    _u, _l, py = notebook_dir.name.split("-")
+    return py.removeprefix("python-")
+
+
+# JSON inside YAML literal blocks: match upstream ImageStream style (``|`` not ``|2``); see
+# ``jupyter-datascience-notebook-imagestream.yaml`` in opendatahub-io / mtchoum1 forks.
+_JSON_OBJECT_SEP = (", ", ": ")
+
+
+def _format_notebook_annotation_json(items: list[dict[str, Any]]) -> LiteralScalarString:
+    """Format ``notebook-software`` / ``notebook-python-dependencies`` as a multiline literal block."""
+    lines = ["["]
+    pad = "  "
+    for i, item in enumerate(items):
+        blob = json.dumps(
+            {"name": item["name"], "version": item["version"]},
+            separators=_JSON_OBJECT_SEP,
+            ensure_ascii=False,
+        )
+        suffix = "," if i < len(items) - 1 else ""
+        lines.append(f"{pad}{blob}{suffix}")
+    lines.append("]")
+    text = "\n".join(lines) + "\n"
+    return LiteralScalarString(text)
+
+
+def _update_tag_annotations(
+    tag: dict[str, Any],
+    pylock_pkgs: dict[str, dict[str, Any]],
+    python_display: str,
+) -> None:
+    ann = tag.get("annotations") or {}
+    sw_raw = ann.get("opendatahub.io/notebook-software")
+    dep_raw = ann.get("opendatahub.io/notebook-python-dependencies")
+    if not sw_raw or not dep_raw:
+        return
+    sw = json.loads(str(sw_raw).strip())
+    deps = json.loads(str(dep_raw).strip())
+    for d in deps:
+        name = d.get("name")
+        if not name:
+            continue
+        norm = _normalized_pkg_name(name)
+        pkg = pylock_pkgs.get(norm)
+        if pkg is None:
+            pkg = pylock_pkgs.get(canonicalize_name(norm))
+        if pkg is None or "version" not in pkg:
+            continue
+        d["version"] = _format_dep_version(pkg["version"])
+
+    # Keep ``notebook-software`` in sync with ``notebook-python-dependencies`` for the same display
+    # name (``test_image_pyprojects`` requires matching strings). Only Python / accelerators are special-cased.
+    sw_version_skip = frozenset({"CUDA", "ROCm", "R", "code-server"})
+    dep_version_by_name = {d["name"]: d["version"] for d in deps if d.get("name")}
+    for s in sw:
+        n = s.get("name")
+        if n == "Python":
+            s["version"] = f"v{python_display}"
+        elif n in sw_version_skip:
+            continue
+        elif n in dep_version_by_name:
+            s["version"] = dep_version_by_name[n]
+
+    ann["opendatahub.io/notebook-software"] = _format_notebook_annotation_json(sw)
+    ann["opendatahub.io/notebook-python-dependencies"] = _format_notebook_annotation_json(deps)
+
+
+def _sha_for_tag(
+    base_key: str,
+    suffix: str,
+    latest: dict[str, str],
+    released: dict[str, str],
+) -> str | None:
+    ck = f"{base_key}-commit{suffix}"
+    sha = latest.get(ck) if suffix == "-n" else released.get(ck)
+    if sha is None:
+        return None
+    normalized = sha.strip().lower()
+    if not _GIT_HEX_OBJECT_ID.fullmatch(normalized):
+        print(
+            f"invalid commit SHA for {ck!r} (expected 7-40 hex chars): {sha!r}",
+            file=sys.stderr,
+        )
+        return None
+    return normalized
+
+
+def run_variant(variant: str, dry_run: bool) -> int:
+    manifests_dir = _manifests_variant_dir(variant)
+    base = manifests_dir / "base"
+    latest = parse_env_file(base / "commit-latest.env")
+    released = parse_env_file(base / "commit.env")
+    _all, workbenches, _rt_files, _runtimes = discover_config(base)
+
+    yml = YAML()
+    yml.preserve_quotes = True
+    # Default width is 80; long scalars (e.g. notebook-image-desc, DockerImage names) get reflowed
+    # onto the next line. Match manifests on main: single-line values where possible.
+    yml.width = 1024 * 1024
+    # Emit a YAML document start marker like other manifests in this repo (see main branch).
+    yml.explicit_start = True
+    yml.indent(mapping=2, sequence=4, offset=2)
+
+    changed = 0
+    lockfile_errors: list[str] = []
+    for wb in workbenches:
+        candidates = _dirs_for_workbench(manifests_dir, wb)
+        path = base / wb.resource_file
+        if not path.is_file():
+            continue
+        with path.open("r", encoding="utf-8") as f:
+            docs = list(yml.load_all(f))
+        if not docs:
+            continue
+        doc = docs[0]
+        tags = doc.get("spec", {}).get("tags") or []
+        for idx, (base_key, suffix) in enumerate(wb.versions):
+            if idx >= len(tags):
+                break
+            sha = _sha_for_tag(base_key, suffix, latest, released)
+            nb_dir = _pick_dir_for_base_key(candidates, base_key)
+            if nb_dir is None:
+                print(f"skip {path.name} tag {idx}: no notebook dir for {base_key}", file=sys.stderr)
+                continue
+            kind = _pylock_kind_from_tag(wb.resource_file, base_key)
+            rel_paths = _pylock_candidate_rel_paths(nb_dir, kind)
+
+            shown: tuple[str, str] | None
+            if suffix == "-n":
+                shown = _worktree_read_first_existing(rel_paths)
+            else:
+                shown = None
+
+            if shown is None:
+                if not sha:
+                    print(f"skip {path.name} tag {idx}: no SHA for {base_key}{suffix}", file=sys.stderr)
+                    continue
+                if suffix == "-n" and not _ensure_n_tag_commit_from_canonical_upstream(variant, sha):
+                    print(
+                        f"skip {path.name} tag {idx}: could not resolve commit {sha} via "
+                        f"{_CANONICAL_REPO_URL[variant]}",
+                        file=sys.stderr,
+                    )
+                    continue
+                shown = _git_show_first_existing(sha, rel_paths)
+            if shown is None:
+                print(
+                    f"skip {path.name} tag {idx}: no lockfile (tried worktree/git {'; '.join(rel_paths)})",
+                    file=sys.stderr,
+                )
+                continue
+            rel_used, text = shown
+            py_minor = _python_minor_from_dir(nb_dir)
+            try:
+                pkgs = _load_lockfile_packages(text, rel_used, py_minor)
+            except Exception as e:
+                lockfile_errors.append(f"{path.name} tag {idx}: lockfile parse error: {e}")
+                continue
+            _update_tag_annotations(tags[idx], pkgs, py_minor)
+            changed += 1
+
+        if not dry_run:
+            with path.open("w", encoding="utf-8") as f:
+                if len(docs) > 1:
+                    yml.dump_all(docs, f)
+                else:
+                    yml.dump(docs[0], f)
+    if lockfile_errors:
+        for err in lockfile_errors:
+            print(err, file=sys.stderr)
+        print(
+            f"Aborting: {len(lockfile_errors)} lockfile parse error(s) for variant={variant!r}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Updated {changed} tag annotation block(s) for variant={variant!r} (dry_run={dry_run})")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=("odh", "rhoai"), required=True)
+    parser.add_argument("--dry-run", action="store_true", help="Parse and validate only; do not write YAML")
+    args = parser.parse_args()
+    raise SystemExit(run_variant(args.variant, args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pylock_downgrade.py
+++ b/tests/test_pylock_downgrade.py
@@ -1,0 +1,206 @@
+"""Fail when tracked user-facing pins in image pylocks regress vs a git baseline (typically main).
+
+Compares each ``pylock*.toml`` to the same path at ``NOTEBOOKS_DOWNGRADE_BASE_REF`` (default:
+``origin/main`` if present) so accidental downgrades (e.g. pandas 2.3 → 2.1) are caught in
+``make test`` once the baseline ref is available locally or in CI.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from typing import TYPE_CHECKING
+
+import packaging.markers
+import packaging.utils
+import packaging.version
+import pytest
+
+from tests import PROJECT_ROOT
+from tests.test_main import _iter_image_pyproject_pylock_files
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Iterator
+
+# PyPI names for packages we advertise in ImageStream ``notebook-python-dependencies``
+# (same intent as ``tests.test_main`` / ``manifests/tools/update_imagestream_annotations_from_pylock``).
+_TRACKED_PYPI_RAW: tuple[str, ...] = (
+    "accelerate",
+    "boto3",
+    "codeflare-sdk",
+    "datasets",
+    "feast",
+    "jupyterlab",
+    "kafka-python-ng",
+    "kfp",
+    "kubeflow-training",
+    "matplotlib",
+    "mlflow",
+    "numpy",
+    "odh-elyra",
+    "pandas",
+    "psycopg",
+    "pymongo",
+    "pyodbc",
+    "scikit-learn",
+    "scipy",
+    "tensorboard",
+    "tensorflow",
+    "tensorflow-rocm",
+    "torch",
+    "torchvision",
+    "transformers",
+    "trustyai",
+    "llmcompressor",
+    "skl2onnx",
+    "nvidia-cuda-runtime-cu12",
+    "mysql-connector-python",
+)
+
+TRACKED_PACKAGES_CANONICAL: frozenset[str] = frozenset(packaging.utils.canonicalize_name(n) for n in _TRACKED_PYPI_RAW)
+
+
+def _resolve_base_ref() -> str | None:
+    env = (os.environ.get("NOTEBOOKS_DOWNGRADE_BASE_REF") or "").strip()
+    candidates: list[str | None] = [
+        env or None,
+        "origin/main",
+        "main",
+    ]
+    for ref in candidates:
+        if not ref:
+            continue
+        if _git_commit_exists(ref):
+            return ref
+    return None
+
+
+def _git_commit_exists(ref: str) -> bool:
+    p = subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        capture_output=True,
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def _git_show_text(ref: str, rel_path: str) -> str | None:
+    p = subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), "show", f"{ref}:{rel_path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if p.returncode != 0:
+        return None
+    return p.stdout
+
+
+def _python_full_from_image_dir(directory: pathlib.Path) -> str:
+    name = directory.name
+    try:
+        _ubi, _lang, pyver = name.split("-")
+    except ValueError as e:
+        raise ValueError(f"Expected ubi9-python-X.Y directory name, got {name!r}") from e
+    return pyver
+
+
+def _parse_pylock_versions_for_linux(pylock_text: str, python_full: str) -> dict[str, str]:
+    doc = tomllib.loads(pylock_text)
+    marker_env = {
+        "python_full_version": f"{python_full}.0",
+        "python_version": python_full,
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+    }
+    out: dict[str, str] = {}
+    for p in doc.get("packages", []):
+        name = p.get("name")
+        version = p.get("version")
+        if name is None or version is None:
+            continue
+        if "marker" in p and not packaging.markers.Marker(p["marker"]).evaluate(marker_env):
+            continue
+        if name in out:
+            raise AssertionError(f"Duplicate package {name!r} after marker filter (python {python_full})")
+        out[name] = version
+    return out
+
+
+def _iter_downgrades(
+    current: dict[str, str], baseline: dict[str, str]
+) -> Iterator[tuple[str, packaging.version.Version, packaging.version.Version]]:
+    for raw_name, cur_s in current.items():
+        cn = packaging.utils.canonicalize_name(raw_name)
+        if cn not in TRACKED_PACKAGES_CANONICAL:
+            continue
+        base_s = baseline.get(raw_name)
+        if base_s is None:
+            # Baseline may use a different normalized spelling; try canonical key scan
+            for bk, bv in baseline.items():
+                if packaging.utils.canonicalize_name(bk) == cn:
+                    base_s = bv
+                    break
+            else:
+                continue
+        try:
+            cur_v = packaging.version.parse(cur_s)
+            base_v = packaging.version.parse(base_s)
+        except packaging.version.InvalidVersion:
+            continue
+        if cur_v < base_v:
+            yield (raw_name, cur_v, base_v)
+
+
+def test_pylock_tracked_packages_not_downgraded_vs_git_base(subtests):
+    if os.environ.get("NOTEBOOKS_DOWNGRADE_CHECK", "").strip().lower() in ("0", "false", "no"):
+        pytest.skip("NOTEBOOKS_DOWNGRADE_CHECK disabled")
+
+    if not (PROJECT_ROOT / ".git").exists():
+        pytest.skip("Not a git checkout; downgrade check skipped")
+
+    base_ref = _resolve_base_ref()
+    if base_ref is None:
+        pytest.skip(
+            "No git baseline ref found (tried NOTEBOOKS_DOWNGRADE_BASE_REF, origin/main, main). "
+            "Fetch the default branch, e.g. `git fetch origin main:refs/remotes/origin/main`, "
+            "or set NOTEBOOKS_DOWNGRADE_BASE_REF to a local commit."
+        )
+
+    for lock_path in sorted(_iter_image_pyproject_pylock_files()):
+        if not lock_path.is_file():
+            continue
+        rel = str(lock_path.relative_to(PROJECT_ROOT)).replace("\\", "/")
+        pyproject_dir = lock_path.parent
+        if pyproject_dir.name == "uv.lock.d":
+            pyproject_dir = pyproject_dir.parent
+        try:
+            python_full = _python_full_from_image_dir(pyproject_dir)
+        except ValueError:
+            continue
+
+        base_text = _git_show_text(base_ref, rel)
+        if base_text is None:
+            continue
+
+        current_text = lock_path.read_text(encoding="utf-8")
+        try:
+            cur_map = _parse_pylock_versions_for_linux(current_text, python_full)
+            base_map = _parse_pylock_versions_for_linux(base_text, python_full)
+        except (tomllib.TOMLDecodeError, AssertionError) as e:
+            with subtests.test(msg=rel):
+                raise AssertionError(f"Failed to parse pylock for downgrade check: {rel}") from e
+
+        downgrades = list(_iter_downgrades(cur_map, base_map))
+        with subtests.test(msg=rel):
+            if not downgrades:
+                continue
+            lines = [
+                f"Tracked package downgrade(s) vs {base_ref} in {rel}:",
+                "  (pin is older than baseline — if intentional, bump baseline or adjust pins explicitly)",
+            ]
+            for name, cur_v, base_v in sorted(downgrades, key=lambda t: t[0].lower()):
+                lines.append(f"  - {name}: {cur_v} < {base_v} (baseline)")
+            pytest.fail("\n".join(lines))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This work adds automation and tooling so ImageStream annotations stay aligned with pylock files at the git commits recorded in commit-latest.env / commit.env

- added `update_imagestream_annotations_from_pylock.py`: Resolves each workbench tag’s lockfile from the worktree (for -n) or via git show at the SHA from the commit env files (for older tags), updates dependency versions in the existing manifest lists, and writes JSON annotations as YAML literal blocks.
- added `commit_env_refs.py`: Shared helpers for param/commit keys and parsing *.env files (kept in sync with kustomize generation conventions).
- updated `piplock-renewal.yaml`: fetch-depth: 0 on checkout so git show in the annotation updater can resolve SHAs. After Dockerfile fragments / kustomization generation, runs update_imagestream_annotations_from_pylock.py for odh and rhoai, then make test. PR title, commit message, and body text updated to mention lockfiles, regeneration, and ImageStream annotations.
- updated `Makefile`: Extends skip-init-for so metadata refresh targets do not force bin/buildinputs.Documents and implements update-imagestream-annotations with optional VARIANT and DRY_RUN, mirroring the way refresh-lock-files is invoked locally.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
gmake test / make test — static tests and manifest checks after regenerating or touching ImageStreams.
./uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant odh --dry-run (and rhoai) — smoke validation without writing YAML.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now refreshes ImageStream notebook dependency annotations alongside lockfile/regeneration for both variants, running manifest validation before PR creation.
  * Added a user-invocable make target to update ImageStream annotations with variant and dry-run options.
  * Improved manifest parsing to handle complex multi-line annotation structures reliably.

* **Tests**
  * New test to prevent unintended downgrades of tracked PyPI dependency pins versus a git baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->