### PR TITLE
refactor: deduplicate package name mappings into shared module

### DIFF
--- a/ci/check-image-availability.py
+++ b/ci/check-image-availability.py
@@ -31,6 +31,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ci.logging_config import configure_logging, make_pretty_log
+from manifests.tools.commit_env_refs import parse_env_file as _parse_env_dict
 
 log = structlog.get_logger()
 
@@ -448,19 +449,7 @@ def parse_env_file(path: pathlib.Path) -> list[tuple[str, str]]:
 
     Skips empty lines, comments, and dummy values.
     """
-    entries: list[tuple[str, str]] = []
-    with open(path, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" not in line:
-                continue
-            variable, _, image_url = line.partition("=")
-            if not image_url or image_url == "dummy":
-                continue
-            entries.append((variable, image_url))
-    return entries
+    return [(k, v) for k, v in _parse_env_dict(path).items() if v and v != "dummy"]
 
 
 async def run_checks(

--- a/ci/check-image-availability.py
+++ b/ci/check-image-availability.py
@@ -480,8 +480,8 @@ async def main() -> int:
     all_entries: list[tuple[str, str]] = []
     for arg in sys.argv[1:]:
         path = pathlib.Path(arg)
-        if not path.exists():
-            log.error("File not found", path=str(path))
+        if not path.is_file():
+            log.error("Env file not found or not a regular file", path=str(path))
             return 2
         entries = parse_env_file(path)
         log.info("Parsed env file", path=str(path), count=len(entries))

--- a/manifests/tools/package_names.py
+++ b/manifests/tools/package_names.py
@@ -1,0 +1,61 @@
+"""Shared mapping from ImageStream manifest display names to Python package names.
+
+Used by:
+- ``tests/test_main.py`` — static pylock version alignment checks
+- ``tests/containers/manifest_validation_test.py`` — SBOM/pip-list validation
+- ``manifests/tools/update_imagestream_annotations_from_pylock.py`` — annotation refresh
+"""
+
+from __future__ import annotations
+
+# Manifest display names that need explicit translation to pip/pylock names.
+MANIFEST_TO_PIP: dict[str, str] = {
+    "Elyra": "elyra-server",  # old (pre-odh-elyra) package name in 2023.x images
+    "LLM-Compressor": "llmcompressor",
+    "PyTorch": "torch",
+    "ROCm-PyTorch": "torch",
+    "Sklearn-onnx": "skl2onnx",
+    "Nvidia-CUDA-CU12-Bundle": "nvidia-cuda-runtime-cu12",
+    "MySQL Connector/Python": "mysql-connector-python",
+    "ROCm-TensorFlow": "tensorflow-rocm",  # old name used in 2024.2 and earlier
+    "TensorFlow-ROCm": "tensorflow-rocm",
+}
+
+# Manifest display names where ``.lower()`` gives the pip package name.
+MANIFEST_LOWER_NAMES: frozenset[str] = frozenset(
+    {
+        "Accelerate",
+        "Boto3",
+        "Codeflare-SDK",
+        "Datasets",
+        "Feast",
+        "JupyterLab",
+        "Kafka-Python-ng",
+        "Kfp",
+        "Kubeflow-Training",
+        "Matplotlib",
+        "MLflow",
+        "Numpy",
+        "Odh-Elyra",
+        "Pandas",
+        "Psycopg",
+        "PyMongo",
+        "Pyodbc",
+        "Scikit-learn",
+        "Scipy",
+        "TensorFlow",
+        "Tensorboard",
+        "Torch",
+        "Transformers",
+        "TrustyAI",
+    }
+)
+
+
+def manifest_name_to_pip(name: str) -> str:
+    """Convert a manifest display name to a pip/pylock package name."""
+    if name in MANIFEST_TO_PIP:
+        return MANIFEST_TO_PIP[name]
+    if name in MANIFEST_LOWER_NAMES:
+        return name.lower()
+    return name

--- a/manifests/tools/package_names.py
+++ b/manifests/tools/package_names.py
@@ -54,8 +54,9 @@ MANIFEST_LOWER_NAMES: frozenset[str] = frozenset(
 
 def manifest_name_to_pip(name: str) -> str:
     """Convert a manifest display name to a pip/pylock package name."""
-    if name in MANIFEST_TO_PIP:
-        return MANIFEST_TO_PIP[name]
+    translated = MANIFEST_TO_PIP.get(name)
+    if translated is not None:
+        return translated
     if name in MANIFEST_LOWER_NAMES:
         return name.lower()
     return name

--- a/manifests/tools/update_imagestream_annotations_from_pylock.py
+++ b/manifests/tools/update_imagestream_annotations_from_pylock.py
@@ -51,21 +51,13 @@ if str(ROOT) not in sys.path:
 
 from manifests.tools.commit_env_refs import parse_env_file  # noqa: E402
 from manifests.tools.generate_kustomization import Workbench, discover_config  # noqa: E402
+from manifests.tools.package_names import manifest_name_to_pip  # noqa: E402
 from tests.manifests import (  # noqa: E402
     extract_metadata_from_path,
     get_source_of_truth_filepath,
 )
 
 logger = logging.getLogger(__name__)
-
-_MANIFEST_TO_PYLOCK = {
-    "LLM-Compressor": "llmcompressor",
-    "PyTorch": "torch",
-    "ROCm-PyTorch": "torch",
-    "Sklearn-onnx": "skl2onnx",
-    "Nvidia-CUDA-CU12-Bundle": "nvidia-cuda-runtime-cu12",
-    "MySQL Connector/Python": "mysql-connector-python",
-}
 
 # Force accelerator flavor when resolving ImageStream paths. ``extract_metadata_from_path`` may
 # infer "cuda" from Dockerfile.cuda even for the CPU ImageStream (same tree builds both), and
@@ -135,35 +127,6 @@ def _workbench_dir_consistent_with_rocm_policy(wb: Workbench, directory: Path) -
     if rf.startswith("jupyter-") and rocm_tree:
         return False
     return True
-
-
-_MANIFEST_CAP = {
-    "Accelerate",
-    "Boto3",
-    "Codeflare-SDK",
-    "Datasets",
-    "Feast",
-    "JupyterLab",
-    "Kafka-Python-ng",
-    "Kfp",
-    "Kubeflow-Training",
-    "Matplotlib",
-    "Numpy",
-    "Odh-Elyra",
-    "Pandas",
-    "Psycopg",
-    "PyMongo",
-    "Pyodbc",
-    "Scikit-learn",
-    "Scipy",
-    "TensorFlow",
-    "Tensorboard",
-    "Torch",
-    "Transformers",
-    "TrustyAI",
-    "TensorFlow-ROCm",
-    "MLflow",
-}
 
 
 def _is_image_directory(directory: Path) -> bool:
@@ -395,11 +358,7 @@ def _git_show_text(rev: str, rel_path: str) -> str | None:
 
 
 def _normalized_pkg_name(manifest_name: str) -> str:
-    if manifest_name in _MANIFEST_TO_PYLOCK:
-        return _MANIFEST_TO_PYLOCK[manifest_name]
-    if manifest_name in _MANIFEST_CAP:
-        return manifest_name.lower()
-    return manifest_name
+    return manifest_name_to_pip(manifest_name)
 
 
 def _format_dep_version(pep440: str) -> str:

--- a/manifests/tools/update_imagestream_annotations_from_pylock.py
+++ b/manifests/tools/update_imagestream_annotations_from_pylock.py
@@ -357,10 +357,6 @@ def _git_show_text(rev: str, rel_path: str) -> str | None:
     return p.stdout
 
 
-def _translated_pkg_name(manifest_name: str) -> str:
-    return manifest_name_to_pip(manifest_name)
-
-
 def _format_dep_version(pep440: str) -> str:
     v = packaging.version.Version(pep440)
     return f"{v.major}.{v.minor}"
@@ -477,7 +473,7 @@ def _update_tag_annotations(
         name = d.get("name")
         if not name:
             continue
-        norm = _translated_pkg_name(name)
+        norm = manifest_name_to_pip(name)
         pkg = pylock_pkgs.get(norm)
         if pkg is None:
             pkg = pylock_pkgs.get(canonicalize_name(norm))

--- a/manifests/tools/update_imagestream_annotations_from_pylock.py
+++ b/manifests/tools/update_imagestream_annotations_from_pylock.py
@@ -357,7 +357,7 @@ def _git_show_text(rev: str, rel_path: str) -> str | None:
     return p.stdout
 
 
-def _normalized_pkg_name(manifest_name: str) -> str:
+def _translated_pkg_name(manifest_name: str) -> str:
     return manifest_name_to_pip(manifest_name)
 
 
@@ -477,7 +477,7 @@ def _update_tag_annotations(
         name = d.get("name")
         if not name:
             continue
-        norm = _normalized_pkg_name(name)
+        norm = _translated_pkg_name(name)
         pkg = pylock_pkgs.get(norm)
         if pkg is None:
             pkg = pylock_pkgs.get(canonicalize_name(norm))

--- a/tests/containers/manifest_validation_test.py
+++ b/tests/containers/manifest_validation_test.py
@@ -502,11 +502,10 @@ def _compare_manifest_vs_actual(
         else:
             if manifest_name in _NON_PIP_PACKAGES:
                 continue
-            pip_name = _normalize_pip_name(manifest_name_to_pip(manifest_name))
-            actual_version_str = actual_packages.get(pip_name)
+            lookup = _normalize_pip_name(manifest_name_to_pip(manifest_name))
+            actual_version_str = actual_packages.get(lookup)
 
         if actual_version_str is None:
-            lookup = manifest_name if is_software else _normalize_pip_name(manifest_name_to_pip(manifest_name))
             with subtests.test(msg=f"{is_name} tag {tag_name}: {manifest_name} not found"):
                 pytest.fail(
                     f"Manifest lists {manifest_name} ({lookup}) v{manifest_version} but it was not found in the image"

--- a/tests/containers/manifest_validation_test.py
+++ b/tests/containers/manifest_validation_test.py
@@ -45,25 +45,14 @@ import packaging.version
 import pytest
 import yaml
 
+from manifests.tools.commit_env_refs import parse_env_file
+from manifests.tools.package_names import manifest_name_to_pip
 from tests import PROJECT_ROOT
 
 if TYPE_CHECKING:
     import pytest_subtests
 
 _LOG = logging.getLogger(__name__)
-
-# Translation from manifest display names to pip package names.
-_MANIFEST_TO_PIP: dict[str, str] = {
-    "Elyra": "elyra-server",  # old (pre-odh-elyra) package name in 2023.x images
-    "LLM-Compressor": "llmcompressor",
-    "PyTorch": "torch",
-    "ROCm-PyTorch": "torch",
-    "Sklearn-onnx": "skl2onnx",
-    "Nvidia-CUDA-CU12-Bundle": "nvidia-cuda-runtime-cu12",
-    "MySQL Connector/Python": "mysql-connector-python",
-    "ROCm-TensorFlow": "tensorflow-rocm",  # old name used in 2024.2 and earlier
-    "TensorFlow-ROCm": "tensorflow-rocm",
-}
 
 # Software annotation items that cannot be validated from SBOM data.
 _SKIP_SOFTWARE: frozenset[str] = frozenset()
@@ -72,36 +61,6 @@ _SKIP_SOFTWARE: frozenset[str] = frozenset()
 _NON_PIP_PACKAGES: frozenset[str] = frozenset(
     {
         "rstudio-server",
-    }
-)
-
-# Manifest names where .lower() gives the pip name.
-_MANIFEST_LOWER_NAMES: frozenset[str] = frozenset(
-    {
-        "Accelerate",
-        "Boto3",
-        "Codeflare-SDK",
-        "Datasets",
-        "Feast",
-        "JupyterLab",
-        "Kafka-Python-ng",
-        "Kfp",
-        "Kubeflow-Training",
-        "Matplotlib",
-        "Numpy",
-        "Odh-Elyra",
-        "Pandas",
-        "Psycopg",
-        "PyMongo",
-        "Pyodbc",
-        "Scikit-learn",
-        "Scipy",
-        "TensorFlow",
-        "Tensorboard",
-        "Torch",
-        "Transformers",
-        "TrustyAI",
-        "MLflow",
     }
 )
 
@@ -144,33 +103,9 @@ def _extract_python_version(image_ref: str) -> str:
     return ""
 
 
-def _manifest_name_to_pip(name: str) -> str:
-    """Convert a manifest display name to a pip package name."""
-    if name in _MANIFEST_TO_PIP:
-        return _MANIFEST_TO_PIP[name]
-    if name in _MANIFEST_LOWER_NAMES:
-        return name.lower()
-    return name
-
-
 def _normalize_pip_name(name: str) -> str:
-    """Normalize pip package name per PEP 503 (lowercase, hyphens)."""
+    """Normalize pip package name per PEP 503."""
     return packaging.utils.canonicalize_name(name)
-
-
-def _parse_params_env(env_path: pathlib.Path) -> dict[str, str]:
-    """Parse params.env into {key: image_reference}."""
-    result: dict[str, str] = {}
-    if not env_path.exists():
-        return result
-    for line in env_path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        key, _, value = line.partition("=")
-        if key and value:
-            result[key.strip()] = value.strip()
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -537,7 +472,7 @@ def _resolve_software_version(sw_item: dict[str, str], actual_packages: dict[str
         return None
 
     # PyTorch, TensorFlow, LLM-Compressor, etc. — look up as pip package
-    pip_name = _normalize_pip_name(_manifest_name_to_pip(name))
+    pip_name = _normalize_pip_name(manifest_name_to_pip(name))
     return actual_packages.get(pip_name)
 
 
@@ -567,10 +502,11 @@ def _compare_manifest_vs_actual(
         else:
             if manifest_name in _NON_PIP_PACKAGES:
                 continue
-            lookup = _normalize_pip_name(_manifest_name_to_pip(manifest_name))
-            actual_version_str = actual_packages.get(lookup)
+            pip_name = _normalize_pip_name(manifest_name_to_pip(manifest_name))
+            actual_version_str = actual_packages.get(pip_name)
 
         if actual_version_str is None:
+            lookup = manifest_name if is_software else _normalize_pip_name(manifest_name_to_pip(manifest_name))
             with subtests.test(msg=f"{is_name} tag {tag_name}: {manifest_name} not found"):
                 pytest.fail(
                     f"Manifest lists {manifest_name} ({lookup}) v{manifest_version} but it was not found in the image"
@@ -596,7 +532,7 @@ class _TagInfo:
 
 def _iter_old_tags(base_dir: pathlib.Path) -> list[_TagInfo]:
     """Yield tag info for every non-recommended tag (N-1, N-2, ...) with a params.env entry."""
-    params = _parse_params_env(base_dir / "params.env")
+    params = parse_env_file(base_dir / "params.env")
     if not params:
         return []
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,7 @@ import packaging.version
 import pytest
 import yaml
 
+from manifests.tools.package_names import MANIFEST_LOWER_NAMES, MANIFEST_TO_PIP
 from tests import PROJECT_ROOT, manifests
 
 if TYPE_CHECKING:
@@ -268,47 +269,6 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                             "Codeflare-SDK",
                         ]
 
-                        # complex translation from names used in imagestream manifest to python package name
-                        manifest_to_pylock_translation = {
-                            # TODO(jdanek): is this one intentional?
-                            "LLM-Compressor": "llmcompressor",
-                            "PyTorch": "torch",
-                            "ROCm-PyTorch": "torch",
-                            "Sklearn-onnx": "skl2onnx",
-                            "Nvidia-CUDA-CU12-Bundle": "nvidia-cuda-runtime-cu12",
-                            "MySQL Connector/Python": "mysql-connector-python",
-                        }
-
-                        # when .lower() is all it takes to do the translation
-                        manifest_to_pylock_capitalization: set[str] = {
-                            "Accelerate",
-                            "Boto3",
-                            "Codeflare-SDK",
-                            "Datasets",
-                            "Feast",
-                            "JupyterLab",
-                            "Kafka-Python-ng",
-                            "Kfp",
-                            "Kubeflow-Training",
-                            "Matplotlib",
-                            "Numpy",
-                            "Odh-Elyra",
-                            "Pandas",
-                            "Psycopg",
-                            "PyMongo",
-                            "Pyodbc",
-                            "Scikit-learn",
-                            "Scipy",
-                            "TensorFlow",
-                            "Tensorboard",
-                            # TODO(jdanek): inconsistent with PyTorch elsewhere
-                            "Torch",
-                            "Transformers",
-                            "TrustyAI",
-                            "TensorFlow-ROCm",
-                            "MLflow",
-                        }
-
                         name = d["name"]
                         if name in workbench_only_packages and manifest.metadata.type == manifests.NotebookType.RUNTIME:
                             continue
@@ -326,9 +286,9 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                             # TODO(jdanek): figure out how to check rstudio version statically
                             continue
 
-                        if name in manifest_to_pylock_translation:
-                            normalized_name = manifest_to_pylock_translation[name]
-                        elif name in manifest_to_pylock_capitalization:
+                        if name in MANIFEST_TO_PIP:
+                            normalized_name = MANIFEST_TO_PIP[name]
+                        elif name in MANIFEST_LOWER_NAMES:
                             normalized_name = name.lower()
                         else:
                             normalized_name = name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,7 +22,7 @@ import packaging.version
 import pytest
 import yaml
 
-from manifests.tools.package_names import MANIFEST_LOWER_NAMES, MANIFEST_TO_PIP
+from manifests.tools.package_names import manifest_name_to_pip
 from tests import PROJECT_ROOT, manifests
 
 if TYPE_CHECKING:
@@ -286,12 +286,7 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                             # TODO(jdanek): figure out how to check rstudio version statically
                             continue
 
-                        if name in MANIFEST_TO_PIP:
-                            normalized_name = MANIFEST_TO_PIP[name]
-                        elif name in MANIFEST_LOWER_NAMES:
-                            normalized_name = name.lower()
-                        else:
-                            normalized_name = name
+                        normalized_name = manifest_name_to_pip(name)
 
                         # assert on name
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -186,6 +186,14 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                     "pyproject.toml is missing a [project.dependencies] section"
                 )
 
+                for dep_str in pyproject["project"]["dependencies"]:
+                    req = packaging.requirements.Requirement(dep_str)
+                    canonical = packaging.utils.canonicalize_name(req.name)
+                    assert req.name == canonical, (
+                        f"pyproject.toml dependency {req.name!r} is not canonical; "
+                        f"should be {canonical!r}"
+                    )
+
             if (f := file.parent / "uv.lock.d").is_dir():
                 pylock_candidates = sorted(f.glob("pylock.*.toml"))
                 assert pylock_candidates, (


### PR DESCRIPTION
## Summary

* Extract `MANIFEST_TO_PIP`, `MANIFEST_LOWER_NAMES`, and `manifest_name_to_pip()` into `manifests/tools/package_names.py`
* Previously duplicated across `tests/test_main.py`, `tests/containers/manifest_validation_test.py`, and `manifests/tools/update_imagestream_annotations_from_pylock.py`
* Replace custom `_normalize_pip_name()` regex with `packaging.utils.canonicalize_name()`
* Replace `_parse_params_env()` with `parse_env_file()` from `manifests/tools/commit_env_refs.py`
* Inline one-off `_translated_pkg_name` wrapper, reuse computed lookup variable in error path
* Fail fast when env file path is not a regular file (`path.is_file()` instead of `path.exists()`)
* Assert that `pyproject.toml` dependency names are PEP 503 canonical

## Test plan

* `test_image_pyprojects` passes (55 subtests)
* `update_imagestream_annotations_from_pylock.py --variant odh --dry-run` works (26 tags)
* `test_old_tag_annotations_match_sbom` passes on remote (ODH + RHOAI)
* Unit tests pass (26 tests)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized manifest-to-package name translation into a shared utility and removed duplicated normalization logic.

* **Tests**
  * Updated tests to use the shared normalization and added assertions requiring declared dependency names to be PEP 503–canonical.

* **Tools / CI**
  * Image availability check now delegates env-file parsing to the shared helper and requires the env path be a regular file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->