### PR TITLE
chore: exclude manifest_validation tests from image build jobs

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -462,7 +462,7 @@ jobs:
         if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           set -Eeuxo pipefail
-          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
+          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"

--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ ifeq ($(PYTEST_ARGS),)
 	$(error Usage: make test-integration PYTEST_ARGS="--image=<image>")
 endif
 	@echo "Running container integration tests"
-	./uv run pytest tests/containers -m 'not openshift and not cuda and not rocm' $(PYTEST_ARGS)
+	./uv run pytest tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' $(PYTEST_ARGS)
 
 .PHONY: unit-test integration-test
 unit-test: test-unit


### PR DESCRIPTION
This PR fixes an issue in PR #3338 where `test_old_tag_annotations_match_image_content` was running inside the container image build jobs in GHA. Because it was marked with `@pytest.mark.manifest_validation`, it was no longer excluded by the `-m 'not openshift and not cuda and not rocm'` filter.

This updates `.github/workflows/build-notebooks-TEMPLATE.yaml` and `Makefile` to explicitly exclude tests marked with `manifest_validation`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test suite configuration to exclude additional test markers from running in CI/CD pipelines and local testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->