### PR TITLE
ci: fix playwright artifact name collision

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -645,7 +645,7 @@ jobs:
           test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
           podman-socket: /var/run/podman/podman.sock
           upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
-          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
+          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
           grep-pattern: '@codeserver'
 
       # endregion


### PR DESCRIPTION
Resolves a `409 Conflict` error occurring during GitHub Actions workflow runs when uploading Playwright test reports. The conflict happens because the `build-odh` and `build-rhoai` parallel jobs (triggered via `build-notebooks-TEMPLATE.yaml`) both attempt to upload artifacts with the exact same name.

```
Run actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
With the provided path, there will be 4 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
* https://github.com/opendatahub-io/notebooks/actions/runs/24252725373/job/70816255259?pr=3346#step:36:15458

This PR fixes it by injecting the already calculated `BUILD_TYPE` into the string interpolation to ensure artifact names are globally unique per workflow run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced artifact naming to distinguish different build types in the build pipeline, improving organization and tracking of build outputs across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->