### PR TITLE
ci(renovate): add self-hosted Renovate workflow and refine config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,9 +123,9 @@
       "matchStrings": [
         "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>\\S+)",
       ],
-      // Template is only the replacement text; the locate step still uses the
-      // extracted full-match replaceString (lib/workers/repository/update/branch/auto-replace.ts).
-      // Regex manager field name: lib/modules/manager/custom/regex/types.ts
+      // Renovate's auto-replace locates the full match (replaceString) first, then
+      // substitutes with this template.  Without it the default template may not
+      // reconstruct the BASE_IMAGE=… line correctly.
       "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}",
       "datasourceTemplate": "docker",
       // Parses 3.4.0-1773428606 as major=3, minor=4, patch=0, build=1773428606

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,11 +123,10 @@
       "matchStrings": [
         "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>\\S+)",
       ],
-      // Rebuild the line from depName + newVersion instead of replacing a cached
-      // full-line literal — avoids "Cannot find replaceString" when main moved
-      // ahead or grouped PR state lags behind the file on disk.
+      // Template is only the replacement text; the locate step still uses the
+      // extracted full-match replaceString (lib/workers/repository/update/branch/auto-replace.ts).
       // Regex manager field name: lib/modules/manager/custom/regex/types.ts
-      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newVersion}}}",
+      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}",
       "datasourceTemplate": "docker",
       // Parses 3.4.0-1773428606 as major=3, minor=4, patch=0, build=1773428606
       // so Renovate can correctly classify update types and block cross-version upgrades.
@@ -157,10 +156,14 @@
       "versioning": "semver",
     },
     {
-      // Group all base image build updates into a single PR
-      "description": "Group quay.io base image updates from build-args conf files",
+      // One PR per quay.io/aipcc image (cpu, cuda-*, …); registry.redhat.io/rhai
+      // uses the packageRule below.
+      "description": "Group konflux build-args by image (custom.regex / docker)",
       "matchManagers": ["custom.regex"],
-      "groupName": "quay.io image updates",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["/^quay\\.io\\/aipcc\\//"],
+      "groupName": "konflux BASE_IMAGE {{{depNameSanitized}}}",
+      "recreateWhen": "always",
       "semanticCommits": "enabled",
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,6 +111,11 @@
       "matchStrings": [
         "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>\\S+)",
       ],
+      // Rebuild the line from depName + newVersion instead of replacing a cached
+      // full-line literal — avoids "Cannot find replaceString" when main moved
+      // ahead or grouped PR state lags behind the file on disk.
+      // Regex manager field name: lib/modules/manager/custom/regex/types.ts
+      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newVersion}}}",
       "datasourceTemplate": "docker",
       // Parses 3.4.0-1773428606 as major=3, minor=4, patch=0, build=1773428606
       // so Renovate can correctly classify update types and block cross-version upgrades.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,6 +75,18 @@
         "rebaseWhen": "behind-base-branch",
       },
       {
+        // Bundle refs are image:tag@sha256:… Renovate can propose both a digest
+        // bump (newValue still the tag, e.g. 0.1) and a tag bump (e.g. 0.1→0.3).
+        // branchify.ts dedupes by packageFile:depName:currentValue and logs
+        // "Ignoring upgrade collision" while dropping one. Prefer task version
+        // bumps; new tags ship with the correct digest for Konflux catalog tasks.
+        "description": "Tekton bundles: disable digest-only updates (avoid collision with tag bumps)",
+        "matchManagers": ["tekton"],
+        "matchDatasources": ["docker"],
+        "matchUpdateTypes": ["digest"],
+        "enabled": false,
+      },
+      {
         "matchManagers": [
           "gomod",
         ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -208,6 +208,15 @@
       "allowedVersions": "/^1\\./",
     },
     {
+      // Fedora 45 is not yet released but registry.fedoraproject.org publishes
+      // a rawhide/development tag for it, causing Renovate to propose 43 → 45.
+      // Pin to current stable release until Fedora 45 GA.
+      "description": "Pin Fedora to current stable release (43)",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["registry.fedoraproject.org/fedora"],
+      "allowedVersions": "/^43$/",
+    },
+    {
       "description": "Track registry.redhat.io base images",
       "matchManagers": ["custom.regex"],
       "matchDatasources": ["docker"],

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -15,10 +15,10 @@
 # If inheritConfig fails without Mend, set "inheritConfig": false there or add
 #   RENOVATE_INHERIT_CONFIG=false under env on the Run Renovate step.
 #
-# Registry auth: renovatebot/github-action runs Renovate in Docker. By default it does
-# not pass DOCKER_CONFIG into the container (env-regex). We set env-regex below and keep
-# config under /tmp so the default /tmp:/tmp mount exposes the same files on host and
-# in the container (workspace paths are not always mounted identically).
+# Registry auth: renovatebot/github-action runs Renovate in Docker. We pass DOCKER_CONFIG
+# (env-regex) and keep config under /tmp so /tmp:/tmp is shared with the container.
+# Renovate still often skips docker config for HTTP registry lookups — we export
+# RENOVATE_HOST_RULES from the merged config.json so quay.io / registry.redhat.io resolve.
 name: Renovate (self-hosted)
 
 permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
@@ -75,6 +75,9 @@ jobs:
           fi
           echo "${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}" | docker login quay.io/aipcc \
             -u "${{ secrets.AIPCC_QUAY_BOT_USERNAME }}" --password-stdin
+
+      - name: Export RENOVATE_HOST_RULES from Docker config
+        run: python3 scripts/ci/docker_config_to_renovate_host_rules.py >> "$GITHUB_ENV"
 
       - name: Run Renovate
         uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d  # v46.1.8

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -15,10 +15,9 @@
 # If inheritConfig fails without Mend, set "inheritConfig": false there or add
 #   RENOVATE_INHERIT_CONFIG=false under env on the Run Renovate step.
 #
-# Registry auth: renovatebot/github-action runs Renovate in Docker. We pass DOCKER_CONFIG
-# (env-regex) and keep config under /tmp so /tmp:/tmp is shared with the container.
-# Renovate still often skips docker config for HTTP registry lookups — we export
-# RENOVATE_HOST_RULES from the merged config.json so quay.io / registry.redhat.io resolve.
+# Registry auth: scripts/ci/renovate_run.py runs the Renovate image with Docker (CONTAINER_ENGINE).
+# DOCKER_CONFIG points at /tmp; we export RENOVATE_HOST_RULES from merged config.json so
+# quay.io / registry.redhat.io resolve (docker datasource + hostRules).
 name: Renovate (self-hosted)
 
 permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
@@ -59,7 +58,9 @@ jobs:
     if: github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'
     runs-on: ubuntu-latest
     env:
-      # Shared with Renovate container via /tmp mount + env-regex (see Run Renovate step).
+      CONTAINER_ENGINE: docker
+      # Pin with scripts/ci/renovate_run.py default; bump both when upgrading Renovate.
+      RENOVATE_IMAGE: ghcr.io/renovatebot/renovate:43
       DOCKER_CONFIG: /tmp/renovate-docker-config
     permissions:
       contents: read
@@ -111,14 +112,9 @@ jobs:
           fi
 
       - name: Run Renovate
-        uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d  # v46.1.8
         env:
           LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.log_level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_GIT_AUTHOR: "ide-developer <rhoai-ide-konflux@redhat.com>"
-        with:
-          configurationFile: .github/renovate.json5
-          token: ${{ secrets.RENOVATE_TOKEN }}
-          # Default only passes RENOVATE_* / LOG_LEVEL / proxy vars — not DOCKER_CONFIG.
-          env-regex: >-
-            ^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|DOCKER_CONFIG|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+        run: python3 scripts/ci/renovate_run.py remote

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -25,6 +25,28 @@ permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
+    inputs:
+      renovate_dry_run:
+        description: >-
+          Leave empty for a normal run (branches and PRs). Otherwise pick a Renovate dry-run mode.
+        type: choice
+        options:
+          - ""
+          - lookup
+          - full
+          - extract
+        default: ""
+      log_level:
+        description: Renovate log level
+        type: choice
+        options:
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+          - fatal
+        default: info
   schedule:
     - cron: "0 5 * * *"  # daily 05:00 UTC
 
@@ -79,10 +101,19 @@ jobs:
       - name: Export RENOVATE_HOST_RULES from Docker config
         run: python3 scripts/ci/docker_config_to_renovate_host_rules.py >> "$GITHUB_ENV"
 
+      - name: Apply workflow_dispatch Renovate options
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RENOVATE_DRY_RUN_INPUT: ${{ github.event.inputs.renovate_dry_run }}
+        run: |
+          if [[ -n "${RENOVATE_DRY_RUN_INPUT}" ]]; then
+            echo "RENOVATE_DRY_RUN=${RENOVATE_DRY_RUN_INPUT}" >> "${GITHUB_ENV}"
+          fi
+
       - name: Run Renovate
         uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d  # v46.1.8
         env:
-          LOG_LEVEL: info
+          LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.log_level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_GIT_AUTHOR: "ide-developer <rhoai-ide-konflux@redhat.com>"
         with:

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -109,8 +109,10 @@ jobs:
         run: python3 scripts/ci/docker_config_to_renovate_host_rules.py >> "$GITHUB_ENV"
 
       - name: Set base branches per repository
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          case "${{ github.repository }}" in
+          case "${REPO}" in
             red-hat-data-services/notebooks)
               echo 'RENOVATE_BASE_BRANCHES=["rhoai-2.25","rhoai-3.3"]' >> "$GITHUB_ENV" ;;
           esac

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -94,13 +94,16 @@ jobs:
 
       - name: Login to quay.io/aipcc (if secrets present)
         shell: bash
+        env:
+          AIPCC_USER: ${{ secrets.AIPCC_QUAY_BOT_USERNAME }}
+          AIPCC_PASS: ${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}
         run: |
-          if [[ "${{ secrets.AIPCC_QUAY_BOT_USERNAME }}" == "" ]]; then
+          if [[ -z "${AIPCC_USER}" ]]; then
             echo "AIPCC_QUAY_BOT_USERNAME is not set, skipping quay.io/aipcc login"
             exit 0
           fi
-          echo "${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}" | docker login quay.io/aipcc \
-            -u "${{ secrets.AIPCC_QUAY_BOT_USERNAME }}" --password-stdin
+          echo "${AIPCC_PASS}" | docker login quay.io/aipcc \
+            -u "${AIPCC_USER}" --password-stdin
 
       - name: Export RENOVATE_HOST_RULES from Docker config
         run: python3 scripts/ci/docker_config_to_renovate_host_rules.py >> "$GITHUB_ENV"

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -25,16 +25,18 @@ permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
-      renovate_dry_run:
-        description: >-
-          Leave empty for a normal run (branches and PRs). Otherwise pick a Renovate dry-run mode.
+      dry_run:
+        description: "Enable dry-run mode (no branches or PRs will be created)"
+        type: boolean
+        default: false
+      dry_run_mode:
+        description: "Dry-run mode (only used when dry-run is enabled)"
         type: choice
         options:
-          - ""
           - lookup
           - full
           - extract
-        default: ""
+        default: lookup
       log_level:
         description: Renovate log level
         type: choice
@@ -118,13 +120,10 @@ jobs:
           esac
 
       - name: Apply workflow_dispatch Renovate options
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
         env:
-          RENOVATE_DRY_RUN_INPUT: ${{ github.event.inputs.renovate_dry_run }}
-        run: |
-          if [[ -n "${RENOVATE_DRY_RUN_INPUT}" ]]; then
-            echo "RENOVATE_DRY_RUN=${RENOVATE_DRY_RUN_INPUT}" >> "${GITHUB_ENV}"
-          fi
+          DRY_RUN_MODE: ${{ github.event.inputs.dry_run_mode }}
+        run: echo "RENOVATE_DRY_RUN=${DRY_RUN_MODE}" >> "${GITHUB_ENV}"
 
       - name: Run Renovate
         env:

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -1,0 +1,81 @@
+# yamllint disable rule:line-length
+---
+# Self-hosted Renovate when MintMaker does not run on opendatahub-io/notebooks.
+# - workflow_dispatch: any fork/org (manual runs).
+# - schedule: opendatahub-io only (avoids surprise cron + secrets use on forks).
+# If MintMaker later covers upstream, drop the schedule or remove this workflow to avoid
+# duplicate PRs.
+#
+# Secrets (repository):
+#   - RENOVATE_TOKEN — PAT (repo + workflow or fine-grained) so PRs run CI
+#   - GIT_CRYPT_KEY — base64-encoded git-crypt key (same as build workflows)
+#   - AIPCC_QUAY_BOT_USERNAME / AIPCC_QUAY_BOT_PASSWORD — optional; quay.io/aipcc login
+#
+# Config: .github/renovate.json5
+# If inheritConfig fails without Mend, set "inheritConfig": false there or add
+#   RENOVATE_INHERIT_CONFIG=false under env on the Run Renovate step.
+name: Renovate (self-hosted)
+
+permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"  # daily 05:00 UTC
+
+concurrency:
+  group: renovate-self-hosted-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    if: github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'
+    runs-on: ubuntu-latest
+    env:
+      # Merged registry auth (pull-secret + optional docker login) for Renovate image lookups.
+      DOCKER_CONFIG: ${{ github.workspace }}/.docker-renovate
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install git-crypt
+        uses: ./.github/actions/apt-install
+        with:
+          packages: git-crypt
+          update: "false"
+
+      - name: Unlock encrypted secrets with git-crypt
+        run: |
+          echo "${GIT_CRYPT_KEY}" | base64 --decode > ./git-crypt-key
+          trap 'rm -f ./git-crypt-key' EXIT
+          git-crypt unlock ./git-crypt-key
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: Configure registry auth for Renovate (pull-secret)
+        run: |
+          mkdir -p "${DOCKER_CONFIG}"
+          cp ci/secrets/pull-secret.json "${DOCKER_CONFIG}/config.json"
+
+      - name: Login to quay.io/aipcc (if secrets present)
+        shell: bash
+        run: |
+          if [[ "${{ secrets.AIPCC_QUAY_BOT_USERNAME }}" == "" ]]; then
+            echo "AIPCC_QUAY_BOT_USERNAME is not set, skipping quay.io/aipcc login"
+            exit 0
+          fi
+          echo "${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}" | docker login quay.io/aipcc \
+            -u "${{ secrets.AIPCC_QUAY_BOT_USERNAME }}" --password-stdin
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d  # v46.1.8
+        env:
+          LOG_LEVEL: info
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+        with:
+          configurationFile: .github/renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -14,6 +14,11 @@
 # Config: .github/renovate.json5
 # If inheritConfig fails without Mend, set "inheritConfig": false there or add
 #   RENOVATE_INHERIT_CONFIG=false under env on the Run Renovate step.
+#
+# Registry auth: renovatebot/github-action runs Renovate in Docker. By default it does
+# not pass DOCKER_CONFIG into the container (env-regex). We set env-regex below and keep
+# config under /tmp so the default /tmp:/tmp mount exposes the same files on host and
+# in the container (workspace paths are not always mounted identically).
 name: Renovate (self-hosted)
 
 permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
@@ -32,8 +37,8 @@ jobs:
     if: github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'
     runs-on: ubuntu-latest
     env:
-      # Merged registry auth (pull-secret + optional docker login) for Renovate image lookups.
-      DOCKER_CONFIG: ${{ github.workspace }}/.docker-renovate
+      # Shared with Renovate container via /tmp mount + env-regex (see Run Renovate step).
+      DOCKER_CONFIG: /tmp/renovate-docker-config
     permissions:
       contents: read
     steps:
@@ -76,6 +81,10 @@ jobs:
         env:
           LOG_LEVEL: info
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GIT_AUTHOR: "ide-developer <rhoai-ide-konflux@redhat.com>"
         with:
           configurationFile: .github/renovate.json5
           token: ${{ secrets.RENOVATE_TOKEN }}
+          # Default only passes RENOVATE_* / LOG_LEVEL / proxy vars — not DOCKER_CONFIG.
+          env-regex: >-
+            ^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|DOCKER_CONFIG|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -55,7 +55,10 @@ concurrency:
 
 jobs:
   renovate:
-    if: github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'
+    if: >-
+      github.event_name != 'schedule'
+      || github.repository_owner == 'opendatahub-io'
+      || github.repository == 'red-hat-data-services/notebooks'
     runs-on: ubuntu-latest
     env:
       CONTAINER_ENGINE: docker
@@ -101,6 +104,13 @@ jobs:
 
       - name: Export RENOVATE_HOST_RULES from Docker config
         run: python3 scripts/ci/docker_config_to_renovate_host_rules.py >> "$GITHUB_ENV"
+
+      - name: Set base branches per repository
+        run: |
+          case "${{ github.repository }}" in
+            red-hat-data-services/notebooks)
+              echo 'RENOVATE_BASE_BRANCHES=["rhoai-2.25","rhoai-3.3"]' >> "$GITHUB_ENV" ;;
+          esac
 
       - name: Apply workflow_dispatch Renovate options
         if: github.event_name == 'workflow_dispatch'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ make test-${NOTEBOOK_NAME} # Specific notebook tests
 
 2. **Package Management**:
    - Use `pyproject.toml` and `pylock.toml` for Python dependencies
-   - Always regenerate lock files after dependency changes by running `make refresh-pipfilelock-files`
+   - Always regenerate lock files after dependency changes by running `make refresh-lock-files`
 
 3. **Testing**:
    - Run `make test` and analyze logs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,7 @@ The project uses GitHub Actions for:
 Key CI files:
 - `.github/workflows/` - GitHub Actions workflows
 - `ci/` - Custom CI scripts and configurations
+- `scripts/ci/renovate_run.py` - Self-hosted Renovate (Podman or Docker via `CONTAINER_ENGINE`, same detection order as the Makefile); see `.github/workflows/renovate-self-hosted.yaml` and ADR 0013
 
 ### Deployment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Pull requests are the best way to propose changes to the notebooks repository:
     jupyter-${NOTEBOOK_NAME}-ubi8-python-3.8: jupyter-minimal-ubi8-python-3.8
 	$(call image,$@,jupyter/${NOTEBOOK_NAME}/ubi8-python-3.8,$<)
     ```
-- Add the paths of the new pipfiles under `refresh-pipfilelock-files`
+- Add the paths of the new pipfiles under `refresh-lock-files`
 - Run the [piplock-renewal.yaml](https://github.com/opendatahub-io/notebooks/blob/main/.github/workflows/piplock-renewal.yaml) against your fork branch, check [here](https://github.com/opendatahub-io/notebooks/blob/main/README.md) for more info.
 - Test the changes locally, by manually running the `$ make jupyter-${NOTEBOOK_NAME}-ubi8-python-3.8` from the terminal.
 

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -104,8 +104,39 @@ processing this remote.
 
 Configure repository secrets before the workflow can succeed. Using the [GitHub CLI](https://cli.github.com/):
 
+### RENOVATE_TOKEN: GitHub PAT permissions
+
+Renovate clones with the token, **pushes** update branches, and opens or updates **pull requests**. A read-only or metadata-only token can still “work” until the first `git push`, which then fails with **HTTP 403** (`Permission denied` / `unable to access`).
+
+GitHub publishes the same scope names for **classic PATs** as in [Scopes for OAuth apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes) (see the **Available scopes** table).
+
+**Classic PAT (tokens “classic”)**
+
+| Scope | When you need it |
+| --- | --- |
+| **`repo`** | Full read/write to **public and private** repositories you can access, including code. Use for **private** repos or when you want one broad scope. ([`repo`](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes)) |
+| **`public_repo`** | Read/write limited to **public** repositories only—narrower than `repo` when Renovate targets only a **public** fork (for example `YOUR_USER/notebooks`). ([`public_repo`](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes)) |
+| **`workflow`** | Required when commits change **GitHub Actions workflow** files under `.github/workflows/`. This repository enables the **`github-actions`** Renovate manager, so PRs often retarget action SHAs in workflows; without `workflow`, pushes that touch those files can be rejected. ([`workflow`](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes)) |
+
+For PRs from Renovate to run **GitHub Actions** checks on the fork, the token must be allowed to do that (the workflow already documents **`workflow`** on the classic PAT; org policies may still block workflows from forks).
+
+**Fine-grained PAT**
+
+1. Under **Repository access**, choose **Only select repositories** and include **exactly** the repo Renovate updates (for example your fork).
+2. Under **Repository permissions**, set at least:
+   - **Contents**: **Read and write** — push branches and commits (GitHub’s token UI labels this “Read and write”; the REST prefill parameter is `contents=write`). See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and the permissions table under **Repository Permissions** (`contents`, `pull_requests`, `workflows`).
+   - **Pull requests**: **Read and write** — create and update PRs.
+   - **Workflows**: **Write** (the only access level GitHub documents for this permission) — same reason as classic `workflow` when Renovate updates `.github/workflows/**`.
+3. Optional: **Issues**: **Read and write** — only if you rely on Renovate’s **dependency dashboard** (`dependencyDashboard`), which creates an issue.
+4. **Metadata** is read-only and always included.
+
+GitHub’s own “update code and open a PR” template pre-selects **`contents=write`**, **`pull_requests=write`**, and **`workflows=write`** ([link to token creation with those parameters](https://github.com/settings/personal-access-tokens/new?name=Core-loop+token&description=Write%20code%20and%20push%20it%20to%20main%21%20Includes%20permission%20to%20edit%20workflow%20files%20for%20Actions%20-%20remove%20%60workflows%3Awrite%60%20if%20you%20don%27t%20need%20to%20do%20that&contents=write&pull_requests=write&workflows=write)).
+
+Fine-grained PATs **cannot do everything** classic PATs can (for example some org/outside-collaborator and public-repo scenarios). See [Fine-grained personal access tokens limitations](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens-limitations). Renovate’s bot also documents tradeoffs (for example some GraphQL/Checks-related behavior) in [renovatebot/renovate discussions](https://github.com/renovatebot/renovate/discussions/25545).
+
 ```bash
-# PAT: classic `repo` + `workflow` (or fine-grained equivalent on this repo only).
+# PAT: classic — typically `public_repo` or `repo`, plus `workflow` (see table above).
+# Or fine-grained — Contents + Pull requests + Workflows (and optional Issues) on this repo only.
 # Prefer reading from a file or env var; do not commit the token.
 gh secret set RENOVATE_TOKEN --repo OWNER/REPO < pat-renovate.txt
 
@@ -121,6 +152,7 @@ Replace `OWNER/REPO` (for example `jiridanek/notebooks` on a fork or `opendatahu
 
 ### Self-hosted run log quirks (forks)
 
+- **HTTP 403 on `git push`** — The PAT can read the repo but cannot **write** contents (or **workflows** when workflow files change). Fix scopes or fine-grained permissions per **RENOVATE_TOKEN: GitHub PAT permissions** above; **Contents: Read-only** on a fine-grained token is a common cause.
 - **Private image lookups (`no-result`)** — The workflow merges pull-secret (and optional `quay.io/aipcc` login) into **`config.json` under `DOCKER_CONFIG`**, passes **`DOCKER_CONFIG`** via **`env-regex`**, and runs **`scripts/ci/docker_config_to_renovate_host_rules.py`** to set **`RENOVATE_HOST_RULES`** so the docker datasource uses explicit registry credentials (Renovate often still reports `no-result` for private tags when only `DOCKER_CONFIG` is present).
 - **`allowedCommands`, `inheritConfig`, `onboarding`, … “global only”** — Those keys exist for **MintMaker’s** merged global config. Self-hosted runs **warn** when they appear in repo `renovate.json5`; MintMaker continues to use them upstream. Harmless noise unless something actually fails.
 - **`matchBaseBranches` / `baseBranchPatterns`** — Same as upstream comment in `renovate.json5`: top-level `baseBranchPatterns` is avoided so MintMaker’s per-branch behavior is not overridden; local dry-runs may warn.

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -1,0 +1,127 @@
+# 13. Renovate: MintMaker config and optional self-hosted GitHub Actions
+
+Date: 2026-04-11
+
+## Status
+
+Accepted
+
+## Context
+
+### Mend MintMaker (Konflux)
+
+Red Hat AI/Konflux uses **Mend MintMaker**—a managed Renovate deployment—to open PRs
+for dependency and base-image updates on GitHub repos that are wired into the Konflux
+release pipeline. Maintainer documentation:
+
+- [MintMaker user guide](https://konflux.pages.redhat.com/docs/users/mintmaker/user.html)
+- [Upstream MintMaker Renovate preset](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json)
+
+Enabling Renovate for a component often involves **Konflux release data** changes (for
+example, GitLab MRs under `releng/konflux-release-data`) so MintMaker tracks the correct
+repository and branches—not only committing `renovate.json5` to the repo.
+
+### Repository config (this repo)
+
+The bot reads **`.github/renovate.json5`**. It extends MintMaker-oriented settings and
+enables managers for **Tekton** (`.tekton/**`), **Dockerfile** `FROM` updates, a
+**custom regex** manager for `BASE_IMAGE=` in Konflux `build-args/konflux.*.conf` files,
+and **GitHub Actions** digest pinning (see [ADR 0008](0008-harden-github-actions-pin-sha-digests.md)).
+Python notebook lockfiles are **not** managed by Renovate; they are refreshed by
+`make refresh-lock-files` and
+[`piplock-renewal.yaml`](../../../.github/workflows/piplock-renewal.yaml).
+
+`inheritConfig: true` and other globals are intended to cooperate with **server-side**
+MintMaker configuration; local `renovate --dry-run` may warn about options that belong in
+the hosted bot config.
+
+### Operational gap: ODH vs RHDS GitHub org
+
+In practice, MintMaker **does not always run against every GitHub remote** for a given
+codebase. Maintainers observed that Renovate was **not** opening updates on
+**`opendatahub-io/notebooks`** while it **was** running for **`red-hat-data-services/notebooks`**.
+
+Discussion (internal Slack, including investigation of missing PRs, `dependencyDashboard`,
+`baseBranches` / `matchBaseBranches`, and Tekton schedule):
+
+- [Thread in `#C07SBP17R7Z`](https://redhat-internal.slack.com/archives/C07SBP17R7Z/p1774883190029089?thread_ts=1774883072.749099&cid=C07SBP17R7Z)
+
+That gap is the main reason to add an **optional, self-hosted** Renovate path on the ODH
+repository: contributors still get automated dependency PRs when the org bot is not
+processing this remote.
+
+## Decision
+
+1. **Keep `.github/renovate.json5` as the repo-local Renovate contract** for MintMaker
+   when it *does* run (managers, `packageRules`, branch prefixes, schedules, allowed
+   digest/grouping rules).
+
+2. **Add `.github/workflows/renovate-self-hosted.yaml`** (optional) to run
+   `renovatebot/github-action` on a schedule and `workflow_dispatch`, using the same
+   config file and a **`RENOVATE_TOKEN`** PAT so PRs can trigger normal CI.
+
+3. **The self-hosted workflow** uses a split gate:
+   `github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'`
+   (any manual trigger; scheduled runs only on `opendatahub-io`).
+
+4. **On `opendatahub-io/notebooks`**, if MintMaker is later confirmed to run reliably,
+   **remove the self-hosted workflow schedule** (or delete the workflow) to avoid
+   **duplicate PRs** for the same updates.
+
+5. **Use the Dependency Dashboard** (`dependencyDashboard` in config) when diagnosing
+   silent failures (auth, regex, schedule, or ignored rules)—as recommended in the same
+   thread and exercised in
+   [#3240](https://github.com/opendatahub-io/notebooks/pull/3240),
+   [#3246](https://github.com/opendatahub-io/notebooks/issues/3246),
+   [#3257](https://github.com/opendatahub-io/notebooks/pull/3257).
+
+## Consequences
+
+### Positive
+
+- ODH maintainers get Renovate PRs even when MintMaker is only attached to the RHDS fork.
+- Single config file (`.github/renovate.json5`) for both MintMaker and self-hosted runs.
+- Manual **Run workflow** allows on-demand runs without waiting for MintMaker’s queue.
+
+### Negative / risks
+
+- **Forks** do not get scheduled runs; they can still use **Run workflow** manually if
+  they configure secrets.
+- **Duplicate PRs** if both MintMaker and self-hosted Renovate run against the same repo;
+  operators must disable one path.
+- **PAT hygiene**: `RENOVATE_TOKEN` must be scoped and rotated; it is more powerful than
+  `GITHUB_TOKEN` for PR creation and check triggering.
+- **inheritConfig**: self-hosted runs may lack Mend’s parent config; if runs error or
+  behave differently, set `RENOVATE_INHERIT_CONFIG=false` in the workflow env or adjust
+  `renovate.json5` (see comments in `renovate-self-hosted.yaml`).
+
+### Non-goals
+
+- Moving Python **pylock** / **`uv pip compile`** renewal into Renovate (remains the
+  lockfile renewal workflow and `scripts/pylocks_generator.py`).
+
+## Operational setup (fork or upstream)
+
+Configure repository secrets before the workflow can succeed. Using the [GitHub CLI](https://cli.github.com/):
+
+```bash
+# PAT: classic `repo` + `workflow` (or fine-grained equivalent on this repo only).
+# Prefer reading from a file or env var; do not commit the token.
+gh secret set RENOVATE_TOKEN --repo OWNER/REPO < pat-renovate.txt
+
+# Same base64-encoded key as other workflows that unlock ci/secrets (see build workflows).
+gh secret set GIT_CRYPT_KEY --repo OWNER/REPO < git-crypt-key.b64.txt
+
+# Optional: quay.io/aipcc robot for Renovate image lookups (skip if unused).
+gh secret set AIPCC_QUAY_BOT_USERNAME --repo OWNER/REPO --body 'robot$...'
+gh secret set AIPCC_QUAY_BOT_PASSWORD --repo OWNER/REPO < aipcc-password.txt
+```
+
+Replace `OWNER/REPO` (for example `jiridanek/notebooks` on a fork or `opendatahub-io/notebooks` upstream). Use `gh auth refresh -s write:packages` if `gh secret set` fails on scope.
+
+## References
+
+- `.github/renovate.json5`
+- `.github/workflows/renovate-self-hosted.yaml`
+- `.github/workflows/piplock-renewal.yaml`
+- [ADR 0008 — Pin GitHub Actions by SHA](0008-harden-github-actions-pin-sha-digests.md)

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -57,8 +57,7 @@ processing this remote.
    digest/grouping rules).
 
 2. **Add `.github/workflows/renovate-self-hosted.yaml`** (optional) to run
-   `renovatebot/github-action` on a schedule and `workflow_dispatch`, using the same
-   config file and a **`RENOVATE_TOKEN`** PAT so PRs can trigger normal CI.
+   [`scripts/ci/renovate_run.py`](../../../scripts/ci/renovate_run.py) (Renovate container via Docker on CI, `CONTAINER_ENGINE=docker`) on a schedule and `workflow_dispatch`, using the same config file and a **`RENOVATE_TOKEN`** PAT so PRs can trigger normal CI. The workflow no longer uses `renovatebot/github-action`; the Renovate **image tag** is pinned with **`RENOVATE_IMAGE`** (default `ghcr.io/renovatebot/renovate:43`), so bump that env var in the workflow or script when upgrading.
 
 3. **The self-hosted workflow** uses a split gate:
    `github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'`
@@ -153,7 +152,7 @@ Replace `OWNER/REPO` (for example `jiridanek/notebooks` on a fork or `opendatahu
 ### Self-hosted run log quirks (forks)
 
 - **HTTP 403 on `git push`** — The PAT can read the repo but cannot **write** contents (or **workflows** when workflow files change). Fix scopes or fine-grained permissions per **RENOVATE_TOKEN: GitHub PAT permissions** above; **Contents: Read-only** on a fine-grained token is a common cause.
-- **Private image lookups (`no-result`)** — The workflow merges pull-secret (and optional `quay.io/aipcc` login) into **`config.json` under `DOCKER_CONFIG`**, passes **`DOCKER_CONFIG`** via **`env-regex`**, and runs **`scripts/ci/docker_config_to_renovate_host_rules.py`** to set **`RENOVATE_HOST_RULES`** so the docker datasource uses explicit registry credentials (Renovate often still reports `no-result` for private tags when only `DOCKER_CONFIG` is present).
+- **Private image lookups (`no-result`)** — The workflow merges pull-secret (and optional `quay.io/aipcc` login) into **`config.json` under `DOCKER_CONFIG`**, mounts that directory read-only into the container, runs **`scripts/ci/docker_config_to_renovate_host_rules.py`** to set **`RENOVATE_HOST_RULES`**, and **`renovate_run.py`** forwards both to the Renovate process (Renovate often still reports `no-result` for private tags when only `DOCKER_CONFIG` is present).
 - **`allowedCommands`, `inheritConfig`, `onboarding`, … “global only”** — Those keys exist for **MintMaker’s** merged global config. Self-hosted runs **warn** when they appear in repo `renovate.json5`; MintMaker continues to use them upstream. Harmless noise unless something actually fails.
 - **`matchBaseBranches` / `baseBranchPatterns`** — Same as upstream comment in `renovate.json5`: top-level `baseBranchPatterns` is avoided so MintMaker’s per-branch behavior is not overridden; local dry-runs may warn.
 - **`gitAuthor` / unverified commits** — Set **`RENOVATE_GIT_AUTHOR`** in the workflow env (or `gitAuthor` in config) to your own **`Name <email>`** if you dislike the default Mend address.

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -119,6 +119,14 @@ gh secret set AIPCC_QUAY_BOT_PASSWORD --repo OWNER/REPO < aipcc-password.txt
 
 Replace `OWNER/REPO` (for example `jiridanek/notebooks` on a fork or `opendatahub-io/notebooks` upstream). Use `gh auth refresh -s write:packages` if `gh secret set` fails on scope.
 
+### Self-hosted run log quirks (forks)
+
+- **Private image lookups (`no-result`)** — `renovatebot/github-action` runs Renovate in Docker and, by default, **does not pass `DOCKER_CONFIG`** into the container. The workflow sets **`env-regex`** to include `DOCKER_CONFIG` and stores merged **`config.json` under `/tmp`** so the action’s default **`/tmp:/tmp`** mount exposes registry auth inside the container.
+- **`allowedCommands`, `inheritConfig`, `onboarding`, … “global only”** — Those keys exist for **MintMaker’s** merged global config. Self-hosted runs **warn** when they appear in repo `renovate.json5`; MintMaker continues to use them upstream. Harmless noise unless something actually fails.
+- **`matchBaseBranches` / `baseBranchPatterns`** — Same as upstream comment in `renovate.json5`: top-level `baseBranchPatterns` is avoided so MintMaker’s per-branch behavior is not overridden; local dry-runs may warn.
+- **`gitAuthor` / unverified commits** — Set **`RENOVATE_GIT_AUTHOR`** in the workflow env (or `gitAuthor` in config) to your own **`Name <email>`** if you dislike the default Mend address.
+- **Dependency dashboard issue** — Requires **GitHub Issues enabled** on the repository; enable on the fork or ignore the log line.
+
 ## References
 
 - `.github/renovate.json5`

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -121,7 +121,7 @@ Replace `OWNER/REPO` (for example `jiridanek/notebooks` on a fork or `opendatahu
 
 ### Self-hosted run log quirks (forks)
 
-- **Private image lookups (`no-result`)** — `renovatebot/github-action` runs Renovate in Docker and, by default, **does not pass `DOCKER_CONFIG`** into the container. The workflow sets **`env-regex`** to include `DOCKER_CONFIG` and stores merged **`config.json` under `/tmp`** so the action’s default **`/tmp:/tmp`** mount exposes registry auth inside the container.
+- **Private image lookups (`no-result`)** — The workflow merges pull-secret (and optional `quay.io/aipcc` login) into **`config.json` under `DOCKER_CONFIG`**, passes **`DOCKER_CONFIG`** via **`env-regex`**, and runs **`scripts/ci/docker_config_to_renovate_host_rules.py`** to set **`RENOVATE_HOST_RULES`** so the docker datasource uses explicit registry credentials (Renovate often still reports `no-result` for private tags when only `DOCKER_CONFIG` is present).
 - **`allowedCommands`, `inheritConfig`, `onboarding`, … “global only”** — Those keys exist for **MintMaker’s** merged global config. Self-hosted runs **warn** when they appear in repo `renovate.json5`; MintMaker continues to use them upstream. Harmless noise unless something actually fails.
 - **`matchBaseBranches` / `baseBranchPatterns`** — Same as upstream comment in `renovate.json5`: top-level `baseBranchPatterns` is avoided so MintMaker’s per-branch behavior is not overridden; local dry-runs may warn.
 - **`gitAuthor` / unverified commits** — Set **`RENOVATE_GIT_AUTHOR`** in the workflow env (or `gitAuthor` in config) to your own **`Name <email>`** if you dislike the default Mend address.
@@ -131,5 +131,6 @@ Replace `OWNER/REPO` (for example `jiridanek/notebooks` on a fork or `opendatahu
 
 - `.github/renovate.json5`
 - `.github/workflows/renovate-self-hosted.yaml`
+- `scripts/ci/docker_config_to_renovate_host_rules.py`
 - `.github/workflows/piplock-renewal.yaml`
 - [ADR 0008 — Pin GitHub Actions by SHA](0008-harden-github-actions-pin-sha-digests.md)

--- a/scripts/ci/docker_config_to_renovate_host_rules.py
+++ b/scripts/ci/docker_config_to_renovate_host_rules.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import json
 import os
 import sys
@@ -19,8 +20,11 @@ from pathlib import Path
 
 
 def _auth_entry_to_credentials(entry: dict[str, str]) -> tuple[str, str] | None:
-    if "auth" in entry and entry["auth"]:
-        raw = base64.b64decode(entry["auth"]).decode()
+    if entry.get("auth"):
+        try:
+            raw = base64.b64decode(entry["auth"]).decode()
+        except binascii.Error, UnicodeDecodeError:
+            return None
         if ":" in raw:
             user, password = raw.split(":", 1)
             return (user, password)

--- a/scripts/ci/docker_config_to_renovate_host_rules.py
+++ b/scripts/ci/docker_config_to_renovate_host_rules.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Emit a GITHUB_ENV fragment (RENOVATE_HOST_RULES multiline) for GitHub Actions.
+
+Reads Docker config.json from $DOCKER_CONFIG/config.json (same layout the workflow
+prepares for Renovate) and converts auths entries into Renovate hostRules JSON.
+
+Renovate's docker datasource applies hostRules reliably; relying on DOCKER_CONFIG alone
+inside the renovate container is brittle across renovatebot/github-action versions.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _auth_entry_to_credentials(entry: dict[str, str]) -> tuple[str, str] | None:
+    if "auth" in entry and entry["auth"]:
+        raw = base64.b64decode(entry["auth"]).decode()
+        if ":" in raw:
+            user, password = raw.split(":", 1)
+            return (user, password)
+        return ("", raw)
+    user = entry.get("username")
+    password = entry.get("password")
+    if user is not None and password is not None:
+        return (str(user), str(password))
+    return None
+
+
+def docker_config_to_host_rules(config_path: Path) -> list[dict[str, str]]:
+    data = json.loads(config_path.read_text())
+    auths = data.get("auths") or {}
+    rules: list[dict[str, str]] = []
+    for raw_host, entry in auths.items():
+        if not isinstance(entry, dict):
+            continue
+        host = raw_host.removeprefix("https://").removeprefix("http://").rstrip("/")
+        creds = _auth_entry_to_credentials(entry)
+        if not creds:
+            continue
+        user, password = creds
+        rules.append(
+            {
+                "hostType": "docker",
+                "matchHost": host,
+                "username": user,
+                "password": password,
+            }
+        )
+    return rules
+
+
+def main() -> None:
+    docker_config = os.environ.get("DOCKER_CONFIG", "").strip()
+    if not docker_config:
+        print("DOCKER_CONFIG is not set", file=sys.stderr)
+        sys.exit(1)
+    path = Path(docker_config) / "config.json"
+    if not path.is_file():
+        print(f"Missing Docker config: {path}", file=sys.stderr)
+        sys.exit(1)
+    rules = docker_config_to_host_rules(path)
+    payload = json.dumps(rules, separators=(",", ":"))
+    delim = "RENOHOST"
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
+    print(f"RENOVATE_HOST_RULES<<{delim}")
+    print(payload)
+    print(delim)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/docker_config_to_renovate_host_rules.py
+++ b/scripts/ci/docker_config_to_renovate_host_rules.py
@@ -10,6 +10,7 @@ inside the renovate container is brittle across renovatebot/github-action versio
 
 from __future__ import annotations
 
+import argparse
 import base64
 import json
 import os
@@ -54,7 +55,24 @@ def docker_config_to_host_rules(config_path: Path) -> list[dict[str, str]]:
     return rules
 
 
+def _emit_github_env(rules: list[dict[str, str]]) -> None:
+    payload = json.dumps(rules, separators=(",", ":"))
+    delim = "RENOHOST"
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
+    print(f"RENOVATE_HOST_RULES<<{delim}")
+    print(payload)
+    print(delim)
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print compact JSON only (for RENOVATE_HOST_RULES in a shell env).",
+    )
+    args = parser.parse_args()
+
     docker_config = os.environ.get("DOCKER_CONFIG", "").strip()
     if not docker_config:
         print("DOCKER_CONFIG is not set", file=sys.stderr)
@@ -64,12 +82,10 @@ def main() -> None:
         print(f"Missing Docker config: {path}", file=sys.stderr)
         sys.exit(1)
     rules = docker_config_to_host_rules(path)
-    payload = json.dumps(rules, separators=(",", ":"))
-    delim = "RENOHOST"
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
-    print(f"RENOVATE_HOST_RULES<<{delim}")
-    print(payload)
-    print(delim)
+    if args.json:
+        print(json.dumps(rules, separators=(",", ":")))
+        return
+    _emit_github_env(rules)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/renovate_run.py
+++ b/scripts/ci/renovate_run.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Run Renovate in a container (Podman or Docker).
+
+Same entrypoint as .github/workflows/renovate-self-hosted.yaml and local dev.
+
+CONTAINER_ENGINE matches the Makefile (lines 65-74): if unset, use podman when
+found on PATH, else docker. Override with CONTAINER_ENGINE=podman|docker.
+
+  export GITHUB_MCP_PAT=ghp_...  # or RENOVATE_TOKEN (required for local/remote; optional for lookup)
+  python3 scripts/ci/renovate_run.py            # platform=local, current tree
+  python3 scripts/ci/renovate_run.py remote    # clone from GitHub
+  python3 scripts/ci/renovate_run.py lookup    # local + --dry-run=lookup, JSON logs on stdout
+
+Registry auth: DOCKER_CONFIG (default ~/.docker); sets RENOVATE_HOST_RULES from
+config.json unless RENOVATE_HOST_RULES is already set (e.g. from GITHUB_ENV in CI).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_CI = Path(__file__).resolve().parent
+ROOT = SCRIPTS_CI.parent.parent
+REMOTE_DEFAULT_REPO = "jiridanek/notebooks"
+DEFAULT_RENOVATE_IMAGE = "ghcr.io/renovatebot/renovate:43"
+DEFAULT_GIT_AUTHOR = "ide-developer <rhoai-ide-konflux@redhat.com>"
+
+OPTIONAL_ENV_PASSTHROUGH = (
+    "LOG_FORMAT",
+    "RENOVATE_TOKEN",
+    "RENOVATE_HOST_RULES",
+    "RENOVATE_REPOSITORIES",
+    "GITHUB_COM_TOKEN",
+    "NODE_OPTIONS",
+    "NO_COLOR",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+)
+
+
+def detect_engine() -> str:
+    raw = os.environ.get("CONTAINER_ENGINE", "").strip()
+    if raw:
+        if raw not in ("podman", "docker"):
+            print(f"error: CONTAINER_ENGINE must be podman or docker (got {raw})", file=sys.stderr)
+            sys.exit(1)
+        return raw
+    if shutil.which("podman"):
+        return "podman"
+    if shutil.which("docker"):
+        return "docker"
+    print("error: neither podman nor docker found on PATH", file=sys.stderr)
+    sys.exit(1)
+
+
+def maybe_load_host_rules(docker_config: str) -> None:
+    if os.environ.get("RENOVATE_HOST_RULES"):
+        return
+    cfg = Path(docker_config) / "config.json"
+    if not cfg.is_file():
+        return
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_CI / "docker_config_to_renovate_host_rules.py"), "--json"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "DOCKER_CONFIG": docker_config},
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        return
+    rules = result.stdout.strip()
+    if rules and rules != "[]":
+        os.environ["RENOVATE_HOST_RULES"] = rules
+
+
+def add_env_key(cmd: list[str], name: str) -> None:
+    val = os.environ.get(name)
+    if val is not None and val != "":
+        cmd.extend(["-e", name])
+
+
+def build_command(mode: str, engine: str, renovate_image: str, docker_config: str) -> list[str]:
+    cmd: list[str] = [engine, "run", "--rm"]
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        cmd.append("-t")
+    cmd.append("-i")
+
+    os.environ.setdefault("LOG_LEVEL", "info")
+    os.environ.setdefault("RENOVATE_INHERIT_CONFIG", "false")
+    os.environ.setdefault("RENOVATE_GIT_AUTHOR", DEFAULT_GIT_AUTHOR)
+
+    cmd.extend(["-e", "LOG_LEVEL", "-e", "RENOVATE_INHERIT_CONFIG", "-e", "RENOVATE_GIT_AUTHOR"])
+
+    if mode == "remote":
+        os.environ.setdefault("RENOVATE_REPOSITORIES", REMOTE_DEFAULT_REPO)
+    if mode == "lookup":
+        os.environ.setdefault("LOG_FORMAT", "json")
+
+    dry_run_keys: tuple[str, ...] = ()
+    if mode in ("local", "remote"):
+        dry_run_keys = ("RENOVATE_DRY_RUN",)
+
+    for key in OPTIONAL_ENV_PASSTHROUGH + dry_run_keys:
+        add_env_key(cmd, key)
+
+    if Path(docker_config).is_dir():
+        cmd.extend(["-e", "DOCKER_CONFIG", "-v", f"{docker_config}:{docker_config}:ro"])
+
+    if mode == "local":
+        os.environ["RENOVATE_CONFIG_FILE"] = str(ROOT / ".github/renovate.json5")
+        cmd.extend(
+            [
+                "-v",
+                f"{ROOT}:{ROOT}",
+                "-w",
+                str(ROOT),
+                "-e",
+                "RENOVATE_CONFIG_FILE",
+                renovate_image,
+                "renovate",
+                "--platform=local",
+            ]
+        )
+    elif mode == "remote":
+        os.environ["RENOVATE_CONFIG_FILE"] = "/github-action/renovate.json5"
+        cmd.extend(
+            [
+                "-v",
+                f"{ROOT / '.github/renovate.json5'}:/github-action/renovate.json5:ro",
+                "-e",
+                "RENOVATE_CONFIG_FILE",
+                renovate_image,
+            ]
+        )
+    elif mode == "lookup":
+        os.environ["RENOVATE_CONFIG_FILE"] = str(ROOT / ".github/renovate.json5")
+        cmd.extend(
+            [
+                "-v",
+                f"{ROOT}:{ROOT}",
+                "-w",
+                str(ROOT),
+                "-e",
+                "RENOVATE_CONFIG_FILE",
+                renovate_image,
+                "renovate",
+                "--platform=local",
+                "--dry-run=lookup",
+            ]
+        )
+    else:
+        raise ValueError(mode)
+
+    return cmd
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        default="local",
+        choices=("local", "remote", "lookup"),
+        help="local: current tree; remote: clone repo; lookup: dry-run lookup + JSON logs",
+    )
+    args = parser.parse_args(argv)
+    mode = args.mode
+
+    engine = detect_engine()
+
+    docker_config = os.environ.get("DOCKER_CONFIG", str(Path.home() / ".docker"))
+    os.environ["DOCKER_CONFIG"] = docker_config
+
+    token = os.environ.get("RENOVATE_TOKEN") or ""
+    if mode != "lookup":
+        if not token:
+            print(f"error: set RENOVATE_TOKEN (required for {mode})", file=sys.stderr)
+            return 1
+        os.environ["RENOVATE_TOKEN"] = token
+    elif token:
+        os.environ["RENOVATE_TOKEN"] = token
+
+    if not (Path(docker_config) / "config.json").is_file():
+        print(
+            f"warning: missing {docker_config}/config.json — private registry lookups may fail",
+            file=sys.stderr,
+        )
+
+    maybe_load_host_rules(docker_config)
+
+    renovate_image = os.environ.get("RENOVATE_IMAGE", DEFAULT_RENOVATE_IMAGE)
+
+    cmd = build_command(mode, engine, renovate_image, docker_config)
+    proc = subprocess.run(cmd, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/renovate_run.py
+++ b/scripts/ci/renovate_run.py
@@ -33,6 +33,7 @@ DEFAULT_GIT_AUTHOR = "ide-developer <rhoai-ide-konflux@redhat.com>"
 OPTIONAL_ENV_PASSTHROUGH = (
     "LOG_FORMAT",
     "RENOVATE_TOKEN",
+    "RENOVATE_BASE_BRANCHES",
     "RENOVATE_HOST_RULES",
     "RENOVATE_REPOSITORIES",
     "GITHUB_COM_TOKEN",
@@ -116,7 +117,7 @@ def build_command(mode: str, engine: str, renovate_image: str, docker_config: st
     if Path(docker_config).is_dir():
         cmd.extend(["-e", "DOCKER_CONFIG", "-v", f"{docker_config}:{docker_config}:ro"])
 
-    if mode == "local":
+    if mode in ("local", "lookup"):
         os.environ["RENOVATE_CONFIG_FILE"] = str(ROOT / ".github/renovate.json5")
         cmd.extend(
             [
@@ -131,6 +132,8 @@ def build_command(mode: str, engine: str, renovate_image: str, docker_config: st
                 "--platform=local",
             ]
         )
+        if mode == "lookup":
+            cmd.append("--dry-run=lookup")
     elif mode == "remote":
         os.environ["RENOVATE_CONFIG_FILE"] = "/github-action/renovate.json5"
         cmd.extend(
@@ -140,22 +143,6 @@ def build_command(mode: str, engine: str, renovate_image: str, docker_config: st
                 "-e",
                 "RENOVATE_CONFIG_FILE",
                 renovate_image,
-            ]
-        )
-    elif mode == "lookup":
-        os.environ["RENOVATE_CONFIG_FILE"] = str(ROOT / ".github/renovate.json5")
-        cmd.extend(
-            [
-                "-v",
-                f"{ROOT}:{ROOT}",
-                "-w",
-                str(ROOT),
-                "-e",
-                "RENOVATE_CONFIG_FILE",
-                renovate_image,
-                "renovate",
-                "--platform=local",
-                "--dry-run=lookup",
             ]
         )
     else:
@@ -184,14 +171,9 @@ def main(argv: list[str] | None = None) -> int:
     docker_config = os.environ.get("DOCKER_CONFIG", str(Path.home() / ".docker"))
     os.environ["DOCKER_CONFIG"] = docker_config
 
-    token = os.environ.get("RENOVATE_TOKEN") or ""
-    if mode != "lookup":
-        if not token:
-            print(f"error: set RENOVATE_TOKEN (required for {mode})", file=sys.stderr)
-            return 1
-        os.environ["RENOVATE_TOKEN"] = token
-    elif token:
-        os.environ["RENOVATE_TOKEN"] = token
+    if mode != "lookup" and not os.environ.get("RENOVATE_TOKEN"):
+        print(f"error: set RENOVATE_TOKEN (required for {mode})", file=sys.stderr)
+        return 1
 
     if not (Path(docker_config) / "config.json").is_file():
         print(


### PR DESCRIPTION
## Description

MintMaker (Konflux's managed Renovate) does not always run against `opendatahub-io/notebooks` — it is wired to `red-hat-data-services/notebooks` only. This leaves the upstream repo without automated dependency PRs for base images, Tekton bundles, and GitHub Actions digests.

This PR adds a **self-hosted Renovate workflow** (`renovate-self-hosted.yaml`) that fills that gap, plus several refinements to the shared `renovate.json5` config discovered during testing.

### What's included

**New files:**
- `.github/workflows/renovate-self-hosted.yaml` — runs Renovate daily on schedule (opendatahub-io and red-hat-data-services) and on-demand via `workflow_dispatch` on any fork with secrets configured
- `scripts/ci/renovate_run.py` — container runner (Podman or Docker, matching the Makefile detection order) used by both CI and local dev
- `scripts/ci/docker_config_to_renovate_host_rules.py` — converts `$DOCKER_CONFIG/config.json` auths into `RENOVATE_HOST_RULES` JSON so private registries (quay.io/aipcc, registry.redhat.io) resolve correctly
- `docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md` — ADR documenting the decision, PAT scope requirements, and operational notes

**Config changes (`.github/renovate.json5`):**
- **Tekton digest-only updates disabled** — avoids "Ignoring upgrade collision" when both a digest bump and a tag bump exist for the same bundle ref; prefer tag bumps which ship the correct digest
- **`autoReplaceStringTemplate`** added to the regex manager — ensures the `BASE_IMAGE=…` line is reconstructed correctly during auto-replace
- **Per-image grouping** for `quay.io/aipcc` base images — one PR per image variant (cpu, cuda-12.9, cuda-13.0, rocm-6.4) instead of one monolithic PR
- **Fedora pinned to 43** — `registry.fedoraproject.org/fedora:45` exists as a rawhide tag but Fedora 45 is not released; prevents bogus major upgrade proposals
- **RHDS branch targeting** — workflow sets `RENOVATE_BASE_BRANCHES` for `red-hat-data-services/notebooks` to process only maintained release branches (rhoai-2.25, rhoai-3.3)

### Schedule gates

| Repository | Trigger | Branches |
|---|---|---|
| `opendatahub-io/notebooks` | schedule (daily 05:00 UTC) + manual | `main` (default) |
| `red-hat-data-services/notebooks` | schedule + manual | `rhoai-2.25`, `rhoai-3.3` |
| Forks | manual only | configurable |

### Required secrets

| Secret | Purpose |
|---|---|
| `RENOVATE_TOKEN` | PAT with Contents + Pull requests + Workflows write (see ADR for scope details) |
| `GIT_CRYPT_KEY` | Base64-encoded git-crypt key (same as build workflows) |
| `AIPCC_QUAY_BOT_USERNAME` / `PASSWORD` | Optional; quay.io/aipcc robot for private image lookups |

### Known issue: org ruleset blocks `POST /git/trees`

The `opendatahub-io` org has a file path restriction ruleset (from `security-config`) that blocks Renovate's platform-native commit API. Renovate's `pushFiles` sends the **entire repo tree** without `base_tree`, so GitHub validates all file paths — including protected files like `semgrep.yaml` — and returns 422 even when Renovate only changed unrestricted paths.

- **Upstream bug filed**: [renovatebot/renovate#42554](https://github.com/renovatebot/renovate/issues/42554)
- **Workaround**: add the Renovate PAT user (`ide-developer`) as a bypass actor on the org ruleset (same fix applied for `opendatahub-tests`)
- `platformCommit: "disabled"` does NOT help — `commitFiles()` always calls `pushFiles()`

## How Has This Been Tested?

Ran the self-hosted workflow against `jiridanek/notebooks` fork with debug logging. After fixing PAT scopes, Renovate successfully created PRs:

- jiridanek/notebooks#25 — `quay.io/aipcc/base-images/cpu` `3.4.0-1774635932` → `3.4.0-1775836626` (7 files)
- jiridanek/notebooks#26 — `quay.io/aipcc/base-images/cuda-12.9-el9.6` `3.4.0-1774635920` → `3.4.0-1775836619` (5 files)

On `opendatahub-io/notebooks`, the workflow runs successfully but branch pushes are blocked by the org ruleset (see "Known issue" above). The Dependency Dashboard ([#3357](https://github.com/opendatahub-io/notebooks/issues/3357)) is created and shows all detected dependencies correctly.

Full test run observations:
- Renovate correctly extracts 366 dependencies (44 regex, 109 dockerfile, 134 github-actions, 79 tekton)
- 7 PRs would be created in total (4 base image groups, 1 Tekton references, 1 GitHub Actions, 1 major GitHub Actions)
- Fedora 45 and go-toolset updates correctly filtered by schedule and `allowedVersions`
- "Cannot find replaceString" INFO messages are benign (branch already contains the target version from a prior run)

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-hosted Renovate workflow with scheduled daily runs, manual triggers, and a containerized Renovate runner CLI.

* **Documentation**
  * Added ADR documenting Renovate integration and self-hosted workflow; updated CI/agent contribution guidance.

* **Chores**
  * Refined Renovate rules for base-image updates, digest handling, and strict version pinning; added a utility to convert registry credentials into Renovate host-rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
