### PR TITLE
RHAIENG-4347: chore(tests/browser): Playwright tag API for codeserver and OCP console

### DIFF
--- a/tests/browser/tests/codeserver.spec.ts
+++ b/tests/browser/tests/codeserver.spec.ts
@@ -60,48 +60,50 @@ const test = base.extend<TestFixtures>({
   }, {timeout: 10 * 60 * 1000}],
 });
 
-test.beforeAll(setupTestcontainers)
+test.describe('code-server', { tag: '@codeserver' }, () => {
+  test.beforeAll(setupTestcontainers)
 
-test('@codeserver open codeserver', async ({codeServer, page}) => {
-  await page.goto(codeServer.url)
+  test('open codeserver', async ({codeServer, page}) => {
+    await page.goto(codeServer.url)
 
-  await codeServer.isEditorVisible()
-})
-
-test('@codeserver wait for welcome screen to load', async ({codeServer, page}, testInfo) => {
-  await page.goto(codeServer.url);
-
-  await codeServer.isEditorVisible()
-  page.on("console", (msg) => log.info(msg.text()))
-
-  await codeServer.isEditorVisible()
-  await utils.waitForStableDOM(page, "div.monaco-workbench", 1000, 10000)
-  await utils.waitForNextRender(page)
-
-  await utils.takeScreenshot(page, testInfo, "welcome.png")
-})
-
-test('@codeserver use the terminal to run command', async ({codeServer, page}, _testInfo) => {
-  await page.goto(codeServer.url);
-
-  await test.step("Should always see the code-server editor", async () => {
-    expect(await codeServer.isEditorVisible()).toBe(true)
+    await codeServer.isEditorVisible()
   })
 
-  await test.step("should show the Integrated Terminal", async () => {
-    await codeServer.focusTerminal()
-    await expect(page.locator("#terminal")).toBeVisible()
+  test('wait for welcome screen to load', async ({codeServer, page}, testInfo) => {
+    await page.goto(codeServer.url);
+
+    await codeServer.isEditorVisible()
+    page.on("console", (msg) => log.info(msg.text()))
+
+    await codeServer.isEditorVisible()
+    await utils.waitForStableDOM(page, "div.monaco-workbench", 1000, 10000)
+    await utils.waitForNextRender(page)
+
+    await utils.takeScreenshot(page, testInfo, "welcome.png")
   })
 
-  await test.step("should execute Terminal command successfully", async () => {
-    await page.keyboard.type('echo The answer is $(( 6 * 7 )). > answer.txt', {delay: 100})
-    await page.keyboard.press('Enter', {delay: 100})
-  })
+  test('use the terminal to run command', async ({codeServer, page}, _testInfo) => {
+    await page.goto(codeServer.url);
 
-  await test.step("should open the file", async() => {
-    const file = path.join('/opt/app-root/src', 'answer.txt')
-    await codeServer.openFile(file)
-    await expect(page.getByText("The answer is 42.")).toBeVisible()
-  })
+    await test.step("Should always see the code-server editor", async () => {
+      expect(await codeServer.isEditorVisible()).toBe(true)
+    })
 
-})
+    await test.step("should show the Integrated Terminal", async () => {
+      await codeServer.focusTerminal()
+      await expect(page.locator("#terminal")).toBeVisible()
+    })
+
+    await test.step("should execute Terminal command successfully", async () => {
+      await page.keyboard.type('echo The answer is $(( 6 * 7 )). > answer.txt', {delay: 100})
+      await page.keyboard.press('Enter', {delay: 100})
+    })
+
+    await test.step("should open the file", async() => {
+      const file = path.join('/opt/app-root/src', 'answer.txt')
+      await codeServer.openFile(file)
+      await expect(page.getByText("The answer is 42.")).toBeVisible()
+    })
+
+  })
+});

--- a/tests/browser/tests/openshift_console.spec.ts
+++ b/tests/browser/tests/openshift_console.spec.ts
@@ -27,15 +27,17 @@ async function getConsoleUrl(): Promise<string> {
 // Resolved in beforeAll so a hung K8s API call fails fast with a clear message.
 let consoleUrl: string;
 
-test.beforeAll("fetch consoleUrl", async () => {
-  test.setTimeout(30_000);
-  consoleUrl = await getConsoleUrl();
-});
+test.describe('OpenShift console', { tag: '@openshift' }, () => {
+  test.beforeAll('fetch consoleUrl', async () => {
+    test.setTimeout(30_000);
+    consoleUrl = await getConsoleUrl();
+  });
 
-test.use({ ignoreHTTPSErrors: true });
+  test.use({ ignoreHTTPSErrors: true });
 
-test('@smoke @openshift OCP console loads', async ({ page }) => {
-  await page.goto(consoleUrl, { waitUntil: 'load' });
-  // Console shows login page or redirects to OAuth — either counts
-  await expect(page).toHaveTitle(/Log in|OpenShift|Red Hat/i);
+  test('OCP console loads', { tag: ['@smoke', '@stage1', '@stage2', '@stage3'] }, async ({ page }) => {
+    await page.goto(consoleUrl, { waitUntil: 'load' });
+    // Console shows login page or redirects to OAuth — either counts
+    await expect(page).toHaveTitle(/Log in|OpenShift|Red Hat/i);
+  });
 });


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4347

## Summary

- Use Playwright’s native `tag` / `test.describe` tagging instead of embedding `@tags` in test titles.
- **code-server**: `test.describe('code-server', { tag: '@codeserver' })` wraps existing specs; CI `--grep @codeserver` is unchanged.
- **OpenShift console**: `@openshift` stays on the suite; `@smoke` and `@stage1`–`@stage3` apply only to the “OCP console loads” test.

## Verification

- `pnpm typecheck` / `pnpm lint` in `tests/browser`
- `pnpm exec playwright test --list --grep @codeserver` / `@smoke` / `@stage2` / `@openshift`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test suites for code-server and OpenShift console with improved grouping and scoped setup.
  * Enhanced test suite structure for better maintainability and clearer test organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->