### PR TITLE
fix(manifests): rename py311 placeholders to match actual Python version

### DIFF
--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -163,10 +163,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/codeserver
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-codeserver-datascience-cpu-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-codeserver-datascience-cpu-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -176,10 +176,10 @@ spec:
         opendatahub.io/notebook-python-dependencies: '[{"name":"code-server","version":"4.16"}]'
         openshift.io/imported-from: quay.io/modh/codeserver
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-codeserver-datascience-cpu-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-codeserver-datascience-cpu-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/commit.env
+++ b/manifests/rhoai/base/commit.env
@@ -12,49 +12,49 @@ odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-2025-2=a2a3d8
 
 odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2025-1=32f22d3
 odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2023-2=76a016f
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2023-1=07015ec
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-1-2=3e71410
+odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2023-2=76a016f
+odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2023-1=07015ec
+odh-workbench-jupyter-minimal-cpu-py38-ubi9-commit-1-2=3e71410
 
 odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2025-1=aa5127f
 odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2023-2=76a016f
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2023-1=07015ec
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-1-2=3e71410
+odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2023-2=76a016f
+odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2023-1=07015ec
+odh-workbench-jupyter-minimal-cuda-py38-ubi9-commit-1-2=3e71410
 
 odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2025-1=aa5127f
 odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2023-2=76a016f
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2023-1=07015ec
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-1-2=3e71410
+odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2023-2=76a016f
+odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2023-1=07015ec
+odh-workbench-jupyter-pytorch-cuda-py38-ubi9-commit-1-2=3e71410
 
 odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2025-1=aa5127f
 odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2023-2=76a016f
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2023-1=07015ec
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-1-2=3e71410
+odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2023-2=76a016f
+odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2023-1=07015ec
+odh-workbench-jupyter-datascience-cpu-py38-ubi9-commit-1-2=3e71410
 
 odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2025-1=32f22d3
 odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2023-2=76a016f
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2023-1=07015ec
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-1-2=3e71410
+odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2023-2=76a016f
+odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2023-1=07015ec
+odh-workbench-jupyter-tensorflow-cuda-py38-ubi9-commit-1-2=3e71410
 
 odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2025-1=3914819
 odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2023-2=76a016f
-odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2023-1=07015ec
+odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2023-2=76a016f
+odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2023-1=07015ec
 
 odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2025-1=32f22d3
 odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2024-2=be38cca
-odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2024-1=b42b86c
-odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2023-2=76a016f
+odh-workbench-codeserver-datascience-cpu-py39-ubi9-commit-2024-1=b42b86c
+odh-workbench-codeserver-datascience-cpu-py39-ubi9-commit-2023-2=76a016f
 
 odh-workbench-jupyter-minimal-rocm-py311-ubi9-commit-2025-1=32f22d3
 odh-workbench-jupyter-minimal-rocm-py311-ubi9-commit-2024-2=be38cca

--- a/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
@@ -193,10 +193,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-datascience-cpu-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-jupyter-datascience-cpu-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -228,10 +228,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-datascience-cpu-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-jupyter-datascience-cpu-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source
@@ -257,10 +257,10 @@ spec:
             ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2023-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2023-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-datascience-cpu-py311-ubi9-2023-1_PLACEHOLDER
+        name: odh-workbench-jupyter-datascience-cpu-py39-ubi9-2023-1_PLACEHOLDER
       name: "2023.1"
       referencePolicy:
         type: Source
@@ -284,10 +284,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-1-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py38-ubi9-commit-1-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-datascience-cpu-py311-ubi9-1-2_PLACEHOLDER
+        name: odh-workbench-jupyter-datascience-cpu-py38-ubi9-1-2_PLACEHOLDER
       name: "1.2"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -119,10 +119,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cuda-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cuda-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -142,10 +142,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cuda-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cuda-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source
@@ -165,10 +165,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2023-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2023-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cuda-py311-ubi9-2023-1_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cuda-py39-ubi9-2023-1_PLACEHOLDER
       name: "2023.1"
       referencePolicy:
         type: Source
@@ -188,10 +188,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-1-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py38-ubi9-commit-1-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cuda-py311-ubi9-1-2_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cuda-py38-ubi9-1-2_PLACEHOLDER
       name: "1.2"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
@@ -114,10 +114,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cpu-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cpu-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -136,10 +136,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cpu-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cpu-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source
@@ -158,10 +158,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2023-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2023-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cpu-py311-ubi9-2023-1_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cpu-py39-ubi9-2023-1_PLACEHOLDER
       name: "2023.1"
       referencePolicy:
         type: Source
@@ -180,10 +180,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-1-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py38-ubi9-commit-1-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-minimal-cpu-py311-ubi9-1-2_PLACEHOLDER
+        name: odh-workbench-jupyter-minimal-cpu-py38-ubi9-1-2_PLACEHOLDER
       name: "1.2"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -215,10 +215,10 @@ spec:
 
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -254,10 +254,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source
@@ -287,10 +287,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2023-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2023-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2023-1_PLACEHOLDER
+        name: odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2023-1_PLACEHOLDER
       name: "2023.1"
       referencePolicy:
         type: Source
@@ -318,10 +318,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-1-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py38-ubi9-commit-1-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-pytorch-cuda-py311-ubi9-1-2_PLACEHOLDER
+        name: odh-workbench-jupyter-pytorch-cuda-py38-ubi9-1-2_PLACEHOLDER
       name: "1.2"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -213,10 +213,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -252,10 +252,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source
@@ -285,10 +285,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2023-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2023-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2023-1_PLACEHOLDER
+        name: odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2023-1_PLACEHOLDER
       name: "2023.1"
       referencePolicy:
         type: Source
@@ -313,10 +313,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: 'true'
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-1-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py38-ubi9-commit-1-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-1-2_PLACEHOLDER
+        name: odh-workbench-jupyter-tensorflow-cuda-py38-ubi9-1-2_PLACEHOLDER
       name: "1.2"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -212,10 +212,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2024-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2024-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2024-1_PLACEHOLDER
+        name: odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2024-1_PLACEHOLDER
       name: "2024.1"
       referencePolicy:
         type: Source
@@ -248,10 +248,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2023-2_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2023-2_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2023-2_PLACEHOLDER
+        name: odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2023-2_PLACEHOLDER
       name: "2023.2"
       referencePolicy:
         type: Source
@@ -278,10 +278,10 @@ spec:
           ]
         openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
         opendatahub.io/image-tag-outdated: "true"
-        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2023-1_PLACEHOLDER
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2023-1_PLACEHOLDER
       from:
         kind: DockerImage
-        name: odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2023-1_PLACEHOLDER
+        name: odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2023-1_PLACEHOLDER
       name: "2023.1"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -94,7 +94,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -107,7 +107,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -120,7 +120,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-2023-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py39-ubi9-2023-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -133,7 +133,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-1-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py38-ubi9-1-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -198,7 +198,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -211,7 +211,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -224,7 +224,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-2023-1
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py39-ubi9-2023-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -237,7 +237,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-1-2
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py38-ubi9-1-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -302,7 +302,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -315,7 +315,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -328,7 +328,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-2023-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py39-ubi9-2023-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -341,7 +341,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-1-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py38-ubi9-1-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -406,7 +406,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -419,7 +419,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -432,7 +432,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2023-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2023-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -445,7 +445,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-1-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py38-ubi9-1-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -510,7 +510,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -523,7 +523,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -536,7 +536,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2023-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2023-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -549,7 +549,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-1-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py38-ubi9-1-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -614,7 +614,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -627,7 +627,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -640,7 +640,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2023-1
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2023-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -705,7 +705,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-2024-1
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py39-ubi9-2024-1
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -718,7 +718,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-2023-2
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py39-ubi9-2023-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -965,7 +965,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -978,7 +978,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -991,7 +991,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2023-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py39-ubi9-commit-2023-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1004,7 +1004,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-1-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py38-ubi9-commit-1-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1069,7 +1069,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1082,7 +1082,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1095,7 +1095,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2023-1
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py39-ubi9-commit-2023-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1108,7 +1108,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-1-2
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py38-ubi9-commit-1-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1173,7 +1173,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1186,7 +1186,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1199,7 +1199,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2023-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py39-ubi9-commit-2023-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1212,7 +1212,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-1-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py38-ubi9-commit-1-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1277,7 +1277,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1290,7 +1290,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1303,7 +1303,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2023-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py39-ubi9-commit-2023-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1316,7 +1316,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-1-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py38-ubi9-commit-1-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1381,7 +1381,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1394,7 +1394,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1407,7 +1407,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2023-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-commit-2023-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1420,7 +1420,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-1-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py38-ubi9-commit-1-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1485,7 +1485,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1498,7 +1498,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1511,7 +1511,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2023-1
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py39-ubi9-commit-2023-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1576,7 +1576,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2024-1
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py39-ubi9-commit-2024-1
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -1589,7 +1589,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2023-2
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py39-ubi9-commit-2023-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1

--- a/manifests/rhoai/base/params.env
+++ b/manifests/rhoai/base/params.env
@@ -12,49 +12,49 @@ odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-2025-2=registry.redh
 
 odh-workbench-jupyter-minimal-cpu-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py311-rhel9@sha256:2b00a5b676b07d4fd6ab894d5dcaeb5bf88ef35bde76cbf3b4c0951987e5aad6
 odh-workbench-jupyter-minimal-cpu-py311-ubi9-2024-2=quay.io/modh/odh-minimal-notebook-container@sha256:2217d8a9cbf84c2bd3e6c6dc09089559e8a3905687ca3739e897c4b45e2b00b3
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-2024-1=quay.io/modh/odh-minimal-notebook-container@sha256:e2296a1386e4d9756c386b4c7dc44bac6f61b99b3b894a10c9ff2d8d5602ca4e
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-2023-2=quay.io/modh/odh-minimal-notebook-container@sha256:4ba72ae7f367a36030470fa4ac22eca0aab285c7c3f1c4cdcc33dc07aa522143
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-2023-1=quay.io/modh/odh-minimal-notebook-container@sha256:eec50e5518176d5a31da739596a7ddae032d73851f9107846a587442ebd10a82
-odh-workbench-jupyter-minimal-cpu-py311-ubi9-1-2=quay.io/modh/odh-minimal-notebook-container@sha256:39068767eebdf3a127fe8857fbdaca0832cdfef69eed6ec3ff6ed1858029420f
+odh-workbench-jupyter-minimal-cpu-py39-ubi9-2024-1=quay.io/modh/odh-minimal-notebook-container@sha256:e2296a1386e4d9756c386b4c7dc44bac6f61b99b3b894a10c9ff2d8d5602ca4e
+odh-workbench-jupyter-minimal-cpu-py39-ubi9-2023-2=quay.io/modh/odh-minimal-notebook-container@sha256:4ba72ae7f367a36030470fa4ac22eca0aab285c7c3f1c4cdcc33dc07aa522143
+odh-workbench-jupyter-minimal-cpu-py39-ubi9-2023-1=quay.io/modh/odh-minimal-notebook-container@sha256:eec50e5518176d5a31da739596a7ddae032d73851f9107846a587442ebd10a82
+odh-workbench-jupyter-minimal-cpu-py38-ubi9-1-2=quay.io/modh/odh-minimal-notebook-container@sha256:39068767eebdf3a127fe8857fbdaca0832cdfef69eed6ec3ff6ed1858029420f
 
 odh-workbench-jupyter-minimal-cuda-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py311-rhel9@sha256:481c5f3749efb85300ed6076a5b05ca5be1ceda17518791db3a67c7b1fa24941
 odh-workbench-jupyter-minimal-cuda-py311-ubi9-2024-2=quay.io/modh/cuda-notebooks@sha256:55598c7de919afc6390cf59595549dc4554102481617ec42beaa3c47ef26d5e4
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-2024-1=quay.io/modh/cuda-notebooks@sha256:81484fafe7012792ecdda28fef89287219c21b99c4e79a504aff0b265d94b429
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-2023-2=quay.io/modh/cuda-notebooks@sha256:a484d344f6feab25e025ea75575d837f5725f819b50a6e3476cef1f9925c07a5
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-2023-1=quay.io/modh/cuda-notebooks@sha256:f6cdc993b4d493ffaec876abb724ce44b3c6fc37560af974072b346e45ac1a3b
-odh-workbench-jupyter-minimal-cuda-py311-ubi9-1-2=quay.io/modh/cuda-notebooks@sha256:00c53599f5085beedd0debb062652a1856b19921ccf59bd76134471d24c3fa7d
+odh-workbench-jupyter-minimal-cuda-py39-ubi9-2024-1=quay.io/modh/cuda-notebooks@sha256:81484fafe7012792ecdda28fef89287219c21b99c4e79a504aff0b265d94b429
+odh-workbench-jupyter-minimal-cuda-py39-ubi9-2023-2=quay.io/modh/cuda-notebooks@sha256:a484d344f6feab25e025ea75575d837f5725f819b50a6e3476cef1f9925c07a5
+odh-workbench-jupyter-minimal-cuda-py39-ubi9-2023-1=quay.io/modh/cuda-notebooks@sha256:f6cdc993b4d493ffaec876abb724ce44b3c6fc37560af974072b346e45ac1a3b
+odh-workbench-jupyter-minimal-cuda-py38-ubi9-1-2=quay.io/modh/cuda-notebooks@sha256:00c53599f5085beedd0debb062652a1856b19921ccf59bd76134471d24c3fa7d
 
 odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py311-rhel9@sha256:384f2ea2df8ccf1978ba633a0b32332e12a4c8d026967ff93e7b8fb0928c8265
 odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2024-2=quay.io/modh/odh-pytorch-notebook@sha256:20f7ab8e7954106ea5e22f3ee0ba8bc7b03975e5735049a765e021aa7eb06861
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2024-1=quay.io/modh/odh-pytorch-notebook@sha256:2403b3dccc3daf5b45a973c49331fdac4ec66e2e020597975fcd9cb4a625099b
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2023-2=quay.io/modh/odh-pytorch-notebook@sha256:806e6524cb46bcbd228e37a92191c936bb4c117100fc731604e19df80286b19d
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2023-1=quay.io/modh/odh-pytorch-notebook@sha256:97b346197e6fc568c2eb52cb82e13a206277f27c21e299d1c211997f140f638b
-odh-workbench-jupyter-pytorch-cuda-py311-ubi9-1-2=quay.io/modh/odh-pytorch-notebook@sha256:b68e0192abf7d46c8c6876d0819b66c6a2d4a1e674f8893f8a71ffdcba96866c
+odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2024-1=quay.io/modh/odh-pytorch-notebook@sha256:2403b3dccc3daf5b45a973c49331fdac4ec66e2e020597975fcd9cb4a625099b
+odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2023-2=quay.io/modh/odh-pytorch-notebook@sha256:806e6524cb46bcbd228e37a92191c936bb4c117100fc731604e19df80286b19d
+odh-workbench-jupyter-pytorch-cuda-py39-ubi9-2023-1=quay.io/modh/odh-pytorch-notebook@sha256:97b346197e6fc568c2eb52cb82e13a206277f27c21e299d1c211997f140f638b
+odh-workbench-jupyter-pytorch-cuda-py38-ubi9-1-2=quay.io/modh/odh-pytorch-notebook@sha256:b68e0192abf7d46c8c6876d0819b66c6a2d4a1e674f8893f8a71ffdcba96866c
 
 odh-workbench-jupyter-datascience-cpu-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py311-rhel9@sha256:bd6528eddad7106704c9f78bd25d47bd5a556ecc0e35db317a0e95428be6d025
 odh-workbench-jupyter-datascience-cpu-py311-ubi9-2024-2=quay.io/modh/odh-generic-data-science-notebook@sha256:d0ba5fc23e2b3846763f60e8ade8a0f561cdcd2bf6717df6e732f6f8b68b89c4
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-2024-1=quay.io/modh/odh-generic-data-science-notebook@sha256:3e51c462fc03b5ccb080f006ced86d36480da036fa04b8685a3e4d6d51a817ba
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-2023-2=quay.io/modh/odh-generic-data-science-notebook@sha256:39853fd63555ebba097483c5ac6a375d6039e5522c7294684efb7966ba4bc693
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-2023-1=quay.io/modh/odh-generic-data-science-notebook@sha256:e2cab24ebe935d87f7596418772f5a97ce6a2e747ba0c1fd4cec08a728e99403
-odh-workbench-jupyter-datascience-cpu-py311-ubi9-1-2=quay.io/modh/odh-generic-data-science-notebook@sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1
+odh-workbench-jupyter-datascience-cpu-py39-ubi9-2024-1=quay.io/modh/odh-generic-data-science-notebook@sha256:3e51c462fc03b5ccb080f006ced86d36480da036fa04b8685a3e4d6d51a817ba
+odh-workbench-jupyter-datascience-cpu-py39-ubi9-2023-2=quay.io/modh/odh-generic-data-science-notebook@sha256:39853fd63555ebba097483c5ac6a375d6039e5522c7294684efb7966ba4bc693
+odh-workbench-jupyter-datascience-cpu-py39-ubi9-2023-1=quay.io/modh/odh-generic-data-science-notebook@sha256:e2cab24ebe935d87f7596418772f5a97ce6a2e747ba0c1fd4cec08a728e99403
+odh-workbench-jupyter-datascience-cpu-py38-ubi9-1-2=quay.io/modh/odh-generic-data-science-notebook@sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1
 
 odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py311-rhel9@sha256:a2f863e8df080b683f52453b3a3b8c1f70a50c9bbe9480d7a55da8f0d54fbee2
 odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2024-2=quay.io/modh/cuda-notebooks@sha256:99d3fb964e635873214de4676c259a96c2ea25f3f79cc4bead5bc9f39aba34c0
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2024-1=quay.io/modh/cuda-notebooks@sha256:0e57a0b756872636489ccd713dc9f00ad69d0c481a66ee0de97860f13b4fedcd
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2023-2=quay.io/modh/cuda-notebooks@sha256:3da74d732d158b92eaada0a27fb7067fa18c8bde5033c672e23caed0f21d6481
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2023-1=quay.io/modh/cuda-notebooks@sha256:88d80821ff8c5d53526794261d519125d0763b621d824f8c3222127dab7b6cc8
-odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-1-2=quay.io/modh/cuda-notebooks@sha256:6fadedc5a10f5a914bb7b27cd41bc644392e5757ceaf07d930db884112054265
+odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2024-1=quay.io/modh/cuda-notebooks@sha256:0e57a0b756872636489ccd713dc9f00ad69d0c481a66ee0de97860f13b4fedcd
+odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2023-2=quay.io/modh/cuda-notebooks@sha256:3da74d732d158b92eaada0a27fb7067fa18c8bde5033c672e23caed0f21d6481
+odh-workbench-jupyter-tensorflow-cuda-py39-ubi9-2023-1=quay.io/modh/cuda-notebooks@sha256:88d80821ff8c5d53526794261d519125d0763b621d824f8c3222127dab7b6cc8
+odh-workbench-jupyter-tensorflow-cuda-py38-ubi9-1-2=quay.io/modh/cuda-notebooks@sha256:6fadedc5a10f5a914bb7b27cd41bc644392e5757ceaf07d930db884112054265
 
 odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py311-rhel9@sha256:4331bd07ffb9676a3d9f387b56148e679e0bc50a05dbcc5e693df5aafb097bc0
 odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2024-2=quay.io/modh/odh-trustyai-notebook@sha256:a1b863c2787ba2bca292e381561ed1d92cf5bc25705edfb1ded5e0720a12d102
-odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2024-1=quay.io/modh/odh-trustyai-notebook@sha256:70fe49cee6d5a231ddea7f94d7e21aefd3d8da71b69321f51c406a92173d3334
-odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2023-2=quay.io/modh/odh-trustyai-notebook@sha256:fe883d8513c5d133af1ee3f7bb0b7b37d3bada8ae73fc7209052591d4be681c0
-odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2023-1=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
+odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2024-1=quay.io/modh/odh-trustyai-notebook@sha256:70fe49cee6d5a231ddea7f94d7e21aefd3d8da71b69321f51c406a92173d3334
+odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2023-2=quay.io/modh/odh-trustyai-notebook@sha256:fe883d8513c5d133af1ee3f7bb0b7b37d3bada8ae73fc7209052591d4be681c0
+odh-workbench-jupyter-trustyai-cpu-py39-ubi9-2023-1=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
 
 odh-workbench-codeserver-datascience-cpu-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py311-rhel9@sha256:755f8dacf495f6abb29233edb422ca473ba82cc23370d4fcbaa4f938e90a9c25
 odh-workbench-codeserver-datascience-cpu-py311-ubi9-2024-2=quay.io/modh/codeserver@sha256:92f2a10dde5c96b29324426b4325401e8f4a0d257e439927172d5fe909289c44
-odh-workbench-codeserver-datascience-cpu-py311-ubi9-2024-1=quay.io/modh/codeserver@sha256:1fd51b0e8a14995f1f7273a4b0b40f6e7e27e225ab179959747846e54079d61e
-odh-workbench-codeserver-datascience-cpu-py311-ubi9-2023-2=quay.io/modh/codeserver@sha256:b1a048f3711149e36a89e0eda1a5601130fb536ecc0aabae42ab6e4d26977354
+odh-workbench-codeserver-datascience-cpu-py39-ubi9-2024-1=quay.io/modh/codeserver@sha256:1fd51b0e8a14995f1f7273a4b0b40f6e7e27e225ab179959747846e54079d61e
+odh-workbench-codeserver-datascience-cpu-py39-ubi9-2023-2=quay.io/modh/codeserver@sha256:b1a048f3711149e36a89e0eda1a5601130fb536ecc0aabae42ab6e4d26977354
 
 odh-workbench-jupyter-minimal-rocm-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py311-rhel9@sha256:4cc172aab8be2ba278a9525ef0878c68d76963beb9506c8526c07d5b90b1eb58
 odh-workbench-jupyter-minimal-rocm-py311-ubi9-2024-2=quay.io/modh/rocm-notebooks@sha256:199367d2946fc8427611b4b96071cb411433ffbb5f0988279b10150020af22db


### PR DESCRIPTION
## Summary
- Rename `py311` in placeholder names to `py39` (or `py38` for tag 1.2) across params.env, commit.env, kustomization.yaml, and 7 imagestream YAML files
- These old tags (2024.1, 2023.x, 1.2) actually run Python 3.9/3.8 but had `py311` in their placeholder names, causing confusion and metadata drift
- 150 line changes (all renames, no logic changes)
- Verified with `manifests/tools/generate_kustomization.py` and `manifests/tools/commit_env_refs.py` — both produce identical output after the rename

## Test plan
- [x] `generate_kustomization.py` produces zero diff
- [x] `commit_env_refs.py` produces zero diff
- [x] `test_old_tag_annotations_match_quay` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Retargeted notebook and code-server image references to use Python 3.9 (and Python 3.8 for legacy 1.2) variants for multiple minimal, data‑science, GPU (PyTorch/TensorFlow), TrustyAI and code‑server builds.
  * Updated image commit/hash and parameter mappings so deployments reference the aligned Python runtime image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->