### PR TITLE
[exp4-same-repo] fix: remove prefetch-input symlinks (same-repo test)

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -391,8 +391,12 @@ jobs:
           # Works for both Dockerfile.<flavor> and Dockerfile.konflux.<flavor> (extract last dot-separated segment).
           FLAVOR=$(echo "$DOCKERFILE" | sed -n 's/.*\.\([^.]*\)$/\1/p')
           FLAVOR=${FLAVOR:-cpu}
-          if [ -d "$COMPONENT_DIR/prefetch-input" ]; then
-            echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR (flavor=$FLAVOR)"
+          if [ -d "$COMPONENT_DIR/prefetch-input" ] || { [[ "$COMPONENT_DIR" == jupyter/* ]] && [ -d prefetch-input ]; }; then
+            PREFETCH_ROOT="$COMPONENT_DIR/prefetch-input"
+            if [[ ! -d "$PREFETCH_ROOT" ]]; then
+              PREFETCH_ROOT="prefetch-input"
+            fi
+            echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR (prefetch root $PREFETCH_ROOT, flavor=$FLAVOR)"
             pip3 install --quiet --break-system-packages pyyaml
             command -v uv &>/dev/null || pip3 install --quiet --break-system-packages uv
 
@@ -401,8 +405,8 @@ jobs:
             # variant to avoid RPM conflicts (e.g. openssl-fips-provider vs
             # openssl-fips-provider-so).
             if [ "${{ inputs.subscription }}" = "true" ]; then
-              if [ ! -d "$COMPONENT_DIR/prefetch-input/rhds" ]; then
-                echo "Subscription build requires $COMPONENT_DIR/prefetch-input/rhds" >&2
+              if [ ! -d "$PREFETCH_ROOT/rhds" ]; then
+                echo "Subscription build requires $PREFETCH_ROOT/rhds" >&2
                 exit 1
               fi
               echo "Subscription build with rhds variant detected"

--- a/Makefile
+++ b/Makefile
@@ -91,23 +91,26 @@ define build_image
 			awk -F= '!/^#/ && NF {gsub(/^[ \t]+|[ \t]+$$/, "", $$1); gsub(/^[ \t]+|[ \t]+$$/, "", $$2); printf "--build-arg %s=%s ", $$1, $$2}' $(CONF_FILE); \
 		fi))
 
-# Hermetic local build: when cachi2/output/ exists AND this target has a
-# prefetch-input/ directory, mount pre-downloaded deps into the build.
+# Hermetic local build: when cachi2/output/ exists AND this target uses a
+# prefetch-input tree, mount pre-downloaded deps into the build.
+# Jupyter images share repo-root prefetch-input/ (no per-component symlink:
+# Konflux Hermeto rejects symlink segments in paths to git submodules).
 # The repos.d mount overlays /etc/yum.repos.d/ with hermeto-generated repos,
 # making local builds behave like Konflux (repos already in place when the
 # Dockerfile runs). The mount hides the base image's default repos.
 # Konflux buildah-oci-ta task mounts YUM_REPOS_D_FETCHED at YUM_REPOS_D_TARGET (/etc/yum.repos.d).
 # See https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/
-$(eval CACHI2_VOLUME := $(if $(and $(wildcard cachi2/output),$(wildcard $(BUILD_DIR)prefetch-input)),\
+$(eval PREFETCH_INPUT_DIR := $(or $(wildcard $(BUILD_DIR)prefetch-input),$(if $(findstring jupyter/,$(BUILD_DIR)),$(wildcard $(ROOT_DIR)prefetch-input),)))
+$(eval CACHI2_VOLUME := $(if $(and $(wildcard cachi2/output),$(PREFETCH_INPUT_DIR)),\
 	--volume $(ROOT_DIR)cachi2/output:/cachi2/output:Z \
 	--volume $(ROOT_DIR)cachi2/output/deps/rpm/$(RPM_ARCH)/repos.d/:/etc/yum.repos.d/:Z,))
 	$(info # Building $(IMAGE_NAME) using $(DOCKERFILE_NAME) with $(CONF_FILE) and $(BUILD_ARGS)...)
 
-	@if [ -d '$(BUILD_DIR)prefetch-input' ] && [ ! -d cachi2/output ]; then \
+	@if [ -n '$(PREFETCH_INPUT_DIR)' ] && [ ! -d cachi2/output ]; then \
 	  echo "Prefetch required for hermetic build. Run: scripts/lockfile-generators/prefetch-all.sh --component-dir $(patsubst %/,%,$(BUILD_DIR)) -- see scripts/lockfile-generators/README.md"; \
 	  exit 1; \
 	fi
-	@if [ -d cachi2/output ] && [ -d '$(BUILD_DIR)prefetch-input' ] && [ ! -d 'cachi2/output/deps/rpm/$(RPM_ARCH)/repos.d' ]; then \
+	@if [ -d cachi2/output ] && [ -n '$(PREFETCH_INPUT_DIR)' ] && [ ! -d 'cachi2/output/deps/rpm/$(RPM_ARCH)/repos.d' ]; then \
 	  echo "Missing RPM repos for $(RPM_ARCH). Re-run: scripts/lockfile-generators/prefetch-all.sh --component-dir $(patsubst %/,%,$(BUILD_DIR))"; \
 	  exit 1; \
 	fi

--- a/jupyter/datascience/ubi9-python-3.12/prefetch-input
+++ b/jupyter/datascience/ubi9-python-3.12/prefetch-input
@@ -1,1 +1,0 @@
-../../../prefetch-input

--- a/jupyter/minimal/ubi9-python-3.12/prefetch-input
+++ b/jupyter/minimal/ubi9-python-3.12/prefetch-input
@@ -1,1 +1,0 @@
-../../../prefetch-input

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input
@@ -1,1 +1,0 @@
-../../../prefetch-input

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -159,16 +159,21 @@ if [[ -n "$ACTIVATION_KEY" ]]; then
 fi
 
 # --- Variant selection ---
-# Each component uses COMPONENT_DIR/prefetch-input (often a symlink to the
-# repo-root prefetch-input/ for Jupyter hermetic images). Under that: odh/
-# (upstream, CentOS Stream packages) and optionally rhds/ (downstream, RHEL).
-# The variant determines which lockfiles are used for all four steps.
+# Each component uses COMPONENT_DIR/prefetch-input when present; Jupyter
+# notebook dirs that share upstream RPM/generic locks use repo-root
+# prefetch-input/ (no symlink — Konflux Hermeto rejects symlink path segments
+# for git submodule resolution). Under that: odh/ (upstream, CentOS Stream
+# packages) and optionally rhds/ (downstream, RHEL). The variant determines
+# which lockfiles are used for all four steps.
 #
 # In GHA CI, the template passes --rhds explicitly for subscription builds;
 # secrets are globally available so auto-detection would wrongly switch ODH
 # builds to RHDS, contaminating the layer cache (see #3256).
 # For standalone/local use, auto-detect from credentials when not in CI.
 PREFETCH_DIR="$COMPONENT_DIR/prefetch-input"
+if [[ ! -d "$PREFETCH_DIR" ]] && [[ "$COMPONENT_DIR" == jupyter/* ]] && [[ -d prefetch-input ]]; then
+  PREFETCH_DIR="prefetch-input"
+fi
 if [[ -z "${CI:-}" ]] && [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
   echo "Subscription credentials provided — switching to RHDS variant"
   VARIANT="rhds"


### PR DESCRIPTION
## Summary

Same-repo variant of #3374 (experiment 4 from the Konflux prefetch symlink investigation).

Tests whether removing `prefetch-input` symlinks fixes the Hermeto `git fetch --tags` failure
when the PR branch comes from the **same repo** (not a fork).

The fork-based #3374 is already passing `prefetch-dependencies`. This PR tests
whether the fix also works for same-repo PRs, which is where the original
failure in #3372 occurred.

## Test plan

- [ ] Observe whether Konflux `prefetch-dependencies` passes for `odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored build system to support a shared prefetch input directory at the repository root for Jupyter components, eliminating the need for component-specific prefetch configuration files.
  * Improved hermetic build detection to enable Jupyter components to leverage centralized dependency caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->