### PR TITLE
fix: remove prefetch-input symlinks to unblock Konflux Hermeto prefetch

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -391,8 +391,12 @@ jobs:
           # Works for both Dockerfile.<flavor> and Dockerfile.konflux.<flavor> (extract last dot-separated segment).
           FLAVOR=$(echo "$DOCKERFILE" | sed -n 's/.*\.\([^.]*\)$/\1/p')
           FLAVOR=${FLAVOR:-cpu}
-          if [ -d "$COMPONENT_DIR/prefetch-input" ]; then
-            echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR (flavor=$FLAVOR)"
+          if [ -d "$COMPONENT_DIR/prefetch-input" ] || { grep -q 'prefetch-input/' "$DOCKERFILE" 2>/dev/null && [ -d prefetch-input ]; }; then
+            PREFETCH_ROOT="$COMPONENT_DIR/prefetch-input"
+            if [[ ! -d "$PREFETCH_ROOT" ]]; then
+              PREFETCH_ROOT="prefetch-input"
+            fi
+            echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR (prefetch root $PREFETCH_ROOT, flavor=$FLAVOR)"
             pip3 install --quiet --break-system-packages pyyaml
             command -v uv &>/dev/null || pip3 install --quiet --break-system-packages uv
 
@@ -401,8 +405,8 @@ jobs:
             # variant to avoid RPM conflicts (e.g. openssl-fips-provider vs
             # openssl-fips-provider-so).
             if [ "${{ inputs.subscription }}" = "true" ]; then
-              if [ ! -d "$COMPONENT_DIR/prefetch-input/rhds" ]; then
-                echo "Subscription build requires $COMPONENT_DIR/prefetch-input/rhds" >&2
+              if [ ! -d "$PREFETCH_ROOT/rhds" ]; then
+                echo "Subscription build requires $PREFETCH_ROOT/rhds" >&2
                 exit 1
               fi
               echo "Subscription build with rhds variant detected"

--- a/Makefile
+++ b/Makefile
@@ -91,23 +91,29 @@ define build_image
 			awk -F= '!/^#/ && NF {gsub(/^[ \t]+|[ \t]+$$/, "", $$1); gsub(/^[ \t]+|[ \t]+$$/, "", $$2); printf "--build-arg %s=%s ", $$1, $$2}' $(CONF_FILE); \
 		fi))
 
-# Hermetic local build: when cachi2/output/ exists AND this target has a
-# prefetch-input/ directory, mount pre-downloaded deps into the build.
+# Hermetic local build: when cachi2/output/ exists AND this target uses a
+# prefetch-input tree, mount pre-downloaded deps into the build.
+# Some images (e.g. jupyter/minimal, datascience, pytorch+llmcompressor)
+# reference repo-root prefetch-input/ in their Dockerfiles without having
+# a local prefetch-input/ directory (symlinks were removed to work around
+# Konflux Hermeto rejecting symlink segments in git submodule paths).
 # The repos.d mount overlays /etc/yum.repos.d/ with hermeto-generated repos,
 # making local builds behave like Konflux (repos already in place when the
 # Dockerfile runs). The mount hides the base image's default repos.
 # Konflux buildah-oci-ta task mounts YUM_REPOS_D_FETCHED at YUM_REPOS_D_TARGET (/etc/yum.repos.d).
 # See https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/
-$(eval CACHI2_VOLUME := $(if $(and $(wildcard cachi2/output),$(wildcard $(BUILD_DIR)prefetch-input)),\
+$(eval _DOCKERFILE_USES_PREFETCH := $(shell grep -q 'prefetch-input/' $(2) 2>/dev/null && echo yes))
+$(eval PREFETCH_INPUT_DIR := $(or $(wildcard $(BUILD_DIR)prefetch-input),$(if $(_DOCKERFILE_USES_PREFETCH),$(wildcard $(ROOT_DIR)prefetch-input),)))
+$(eval CACHI2_VOLUME := $(if $(and $(wildcard cachi2/output),$(PREFETCH_INPUT_DIR)),\
 	--volume $(ROOT_DIR)cachi2/output:/cachi2/output:Z \
 	--volume $(ROOT_DIR)cachi2/output/deps/rpm/$(RPM_ARCH)/repos.d/:/etc/yum.repos.d/:Z,))
 	$(info # Building $(IMAGE_NAME) using $(DOCKERFILE_NAME) with $(CONF_FILE) and $(BUILD_ARGS)...)
 
-	@if [ -d '$(BUILD_DIR)prefetch-input' ] && [ ! -d cachi2/output ]; then \
+	@if [ -n '$(PREFETCH_INPUT_DIR)' ] && [ ! -d cachi2/output ]; then \
 	  echo "Prefetch required for hermetic build. Run: scripts/lockfile-generators/prefetch-all.sh --component-dir $(patsubst %/,%,$(BUILD_DIR)) -- see scripts/lockfile-generators/README.md"; \
 	  exit 1; \
 	fi
-	@if [ -d cachi2/output ] && [ -d '$(BUILD_DIR)prefetch-input' ] && [ ! -d 'cachi2/output/deps/rpm/$(RPM_ARCH)/repos.d' ]; then \
+	@if [ -d cachi2/output ] && [ -n '$(PREFETCH_INPUT_DIR)' ] && [ ! -d 'cachi2/output/deps/rpm/$(RPM_ARCH)/repos.d' ]; then \
 	  echo "Missing RPM repos for $(RPM_ARCH). Re-run: scripts/lockfile-generators/prefetch-all.sh --component-dir $(patsubst %/,%,$(BUILD_DIR))"; \
 	  exit 1; \
 	fi

--- a/jupyter/datascience/ubi9-python-3.12/prefetch-input
+++ b/jupyter/datascience/ubi9-python-3.12/prefetch-input
@@ -1,1 +1,0 @@
-../../../prefetch-input

--- a/jupyter/minimal/ubi9-python-3.12/prefetch-input
+++ b/jupyter/minimal/ubi9-python-3.12/prefetch-input
@@ -1,1 +1,0 @@
-../../../prefetch-input

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input
@@ -1,1 +1,0 @@
-../../../prefetch-input

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -159,16 +159,27 @@ if [[ -n "$ACTIVATION_KEY" ]]; then
 fi
 
 # --- Variant selection ---
-# Each component uses COMPONENT_DIR/prefetch-input (often a symlink to the
-# repo-root prefetch-input/ for Jupyter hermetic images). Under that: odh/
-# (upstream, CentOS Stream packages) and optionally rhds/ (downstream, RHEL).
-# The variant determines which lockfiles are used for all four steps.
+# Each component uses COMPONENT_DIR/prefetch-input when present; Jupyter
+# notebook dirs that share upstream RPM/generic locks use repo-root
+# prefetch-input/ (no symlink — Konflux Hermeto rejects symlink path segments
+# for git submodule resolution). Under that: odh/ (upstream, CentOS Stream
+# packages) and optionally rhds/ (downstream, RHEL). The variant determines
+# which lockfiles are used for all four steps.
 #
 # In GHA CI, the template passes --rhds explicitly for subscription builds;
 # secrets are globally available so auto-detection would wrongly switch ODH
 # builds to RHDS, contaminating the layer cache (see #3256).
 # For standalone/local use, auto-detect from credentials when not in CI.
 PREFETCH_DIR="$COMPONENT_DIR/prefetch-input"
+if [[ ! -d "$PREFETCH_DIR" ]] && [[ -d prefetch-input ]]; then
+  # Check if any Dockerfile in the component dir references repo-root prefetch-input/.
+  # This catches components whose symlinks were removed (Konflux Hermeto rejects
+  # symlink segments in git submodule paths) but whose Dockerfiles still use
+  # COPY prefetch-input/... relative to the repo-root build context.
+  if grep -rq 'prefetch-input/' "$COMPONENT_DIR"/Dockerfile* 2>/dev/null; then
+    PREFETCH_DIR="prefetch-input"
+  fi
+fi
 if [[ -z "${CI:-}" ]] && [[ "$VARIANT" == "odh" ]] && [[ -n "$ACTIVATION_KEY" ]] && [[ -d "$PREFETCH_DIR/rhds" ]]; then
   echo "Subscription credentials provided — switching to RHDS variant"
   VARIANT="rhds"


### PR DESCRIPTION
## Problem

All hermetic Konflux builds with gomod `prefetch-input` fail on same-repo PRs:

```
error: expected 'jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input'
in submodule path '.../prefetch-input/mongocli' not to be a symbolic link
```

The `prefetch-dependencies` task (Hermeto) runs `git fetch --tags` on the shallow-cloned source.
Git's post-fetch submodule path validation (CVE-2022-39253, Git 2.39+) walks the fetched commit
graph, encounters `.gitmodules` entries for `prefetch-input/mongocli`, and rejects the path because
a component (`prefetch-input`) resolves through a symlink in the Jupyter image directories.

### Root cause details

- The failure only occurs when **new tag objects are actually fetched** (not "up to date")
- Once tags exist locally, subsequent fetches skip validation — this is why SSH-host reproductions pass
  (the source artifact already contains fetched tags in its packfiles)
- The specific tags matter: a fork with 5 tags passes; the same fork with all 50 upstream tags pushed
  to it fails identically
- Hermeto calls `git fetch --tags` **before** its `shutil.copytree` source copy (which would resolve
  symlinks), so the symlinks are still present when Git validates

Reproduced and confirmed via `batch/v1 Job` on the Konflux cluster using the same Hermeto image.

### References

- Upstream Hermeto issue: hermetoproject/hermeto#1503
- Internal tracker: [STONEBLD-4595](https://redhat.atlassian.net/browse/STONEBLD-4595)
- GHA workaround (fetch-depth: 0): #3300
- Layout origin (centralized prefetch-input): #3232

## Changes

1. **Remove three component-local `prefetch-input` symlinks:**
   - `jupyter/minimal/ubi9-python-3.12/prefetch-input`
   - `jupyter/datascience/ubi9-python-3.12/prefetch-input`
   - `jupyter/pytorch+llmcompressor/ubi9-python-3.12/prefetch-input`

2. **Makefile:** For hermetic/cachi2 mounts, detect repo-root `prefetch-input/` as fallback
   when no per-component `prefetch-input/` exists for Jupyter build dirs.

3. **GHA template (`build-notebooks-TEMPLATE.yaml`):** Same fallback logic for the prefetch step
   and the RHDS variant directory check.

4. **`scripts/lockfile-generators/prefetch-all.sh`:** Fall back to repo-root `prefetch-input/`
   for Jupyter components that lack a local copy.

Dockerfiles are unchanged — they already use build context `.` and `COPY prefetch-input/...`,
so the repo-root `prefetch-input/` directory is accessible without symlinks.

## Experiment results

Validated on the Konflux cluster with both fork and same-repo PRs:

| PR | Source | Konflux prefetch-dependencies |
|----|--------|-------------------------------|
| #3374 (closed) | fork | Passed |
| #3375 (closed) | same-repo | Passed |

## Self-checklist

- [x] `make test` passes locally (static tests, no container runtime needed)
- [x] Verified local `make` hermetic build still detects `prefetch-input/`
- [x] Konflux `prefetch-dependencies` confirmed passing for both fork and same-repo PRs
- [x] No Dockerfile changes needed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved build prefetch detection to handle either component-local or repo-root prefetch inputs, with clearer reporting of the resolved prefetch location.
  * Removed redundant component-level indirection files that previously pointed to shared prefetch inputs.

* **Chores**
  * Updated build and helper scripts to mount and validate prefetch resources only when the resolved prefetch directory is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->