### PR TITLE
Security: Fix CVE-2026-27489 CVE-2026-28500 CVE-2026-34445 (onnx>=1.21.0)

### DIFF
--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -15,3 +15,7 @@ urllib3>=2.6.0
 keras>=3.13.1
 # RHAIENG-3210: CVE-2026-25990 Pillow: Out-of-bounds Write via Specially Crafted PSD Image
 pillow>=12.1.1
+# RHOAIENG-56503 RHOAIENG-54213 RHOAIENG-56499: CVE-2026-27489 CVE-2026-28500 CVE-2026-34445
+# ONNX: Information Disclosure via Path Traversal, Untrusted Model Repository Warnings Suppressed,
+# and Denial of Service via malicious model metadata
+onnx>=1.21.0


### PR DESCRIPTION
## Summary

This PR adds a minimum version constraint for ONNX to fix three related CVEs:

- **CVE-2026-27489**: ONNX Information Disclosure via Path Traversal Vulnerability (HIGH)
- **CVE-2026-28500**: ONNX Untrusted Model Repository Warnings Suppressed (HIGH)
- **CVE-2026-34445**: ONNX Denial of Service and potential information disclosure via malicious model metadata (HIGH)

### Change

Adds `onnx>=1.21.0` to `dependencies/cve-constraints.txt`.

### CVE Details

| CVE ID | Severity | Affected | Fixed In |
|--------|----------|----------|----------|
| CVE-2026-27489 | HIGH | onnx <=1.20.0 | 1.21.0 |
| CVE-2026-28500 | HIGH | onnx <=1.20.0 | 1.21.0 |
| CVE-2026-34445 | HIGH | onnx <=1.20.0 | 1.21.0 |

**Current version**: onnx==1.20.0 (confirmed present in datascience, pytorch, pytorch+llmcompressor, codeserver, rocm workbench images)

**Fix version**: onnx>=1.21.0 (available on PyPI)

### Test Results

**Status**: ⚠️ COULD NOT RUN — pytest not installed in CI environment

**Note**: The primary validation is CI/CD running `make refresh-lock-files` which will:
1. Attempt to resolve onnx>=1.21.0
2. Generate updated lock files for all image variants

**Important**: Lock file regeneration requires the RHOAI package team to first publish `onnx-1.21.0` to the RHOAI custom registry (currently only onnx-1.20.0 is available). CI may fail until the registry is updated.

### Registry Availability

| Registry | onnx-1.20.0 | onnx-1.21.0 |
|----------|-------------|-------------|
| PyPI | ✅ | ✅ |
| RHOAI CPU (3.4-EA2) | ✅ | ❌ Not yet |
| RHOAI CUDA (3.4-EA2) | ✅ | ❌ Not yet |
| RHOAI ROCm (3.4-EA2) | ✅ | ❌ Not yet |

### Breaking Changes

onnx 1.20.0 → 1.21.0 is a minor version bump. No breaking API changes expected. ONNX model files remain backward compatible.

### Verification Steps

- [ ] RHOAI team publishes onnx-1.21.0 to custom registry
- [ ] CI runs `make refresh-lock-files` successfully
- [ ] All image lock files updated to onnx-1.21.0
- [ ] Images build and pass tests with onnx-1.21.0

### Risk Assessment

**Risk Level**: LOW
- Minor version bump with no breaking API changes
- ONNX model format backward compatible
- Only affects Python workbench images; no service disruption expected

### Jira Issues

Resolves: RHOAIENG-56503, RHOAIENG-54213, [RHOAIENG-56499](https://redhat.atlassian.net/browse/RHOAIENG-56499)

And all associated per-image issues for these CVEs across rhoai-2.25 and rhoai-3.3 variants.

---
🤖 Generated by CVE Fixer Workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ONNX package dependency requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->