### PR TITLE
fix(ci): update trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
           format: 'sarif'


### PR DESCRIPTION
## Summary

The pinned `trivy-action` v0.33.1 install script fails to download current Trivy releases, causing the `Security / Trivy scan (fs)` check to fail on every PR with exit code 1.

Update to v0.35.0 (latest, 2026-03-20, includes Trivy v0.69.3). Pin verified with `pinact run --verify`.

## Evidence

Trivy scan fails on every recent PR (checked #2130, #2126, #2125, #2124 on rhds — all FAILURE).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning tool for improved vulnerability detection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->