### PR TITLE
fix(ci): add trivy.yaml config, update trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -23,11 +23,10 @@ jobs:
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
+          trivy-config: trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'MEDIUM,HIGH,CRITICAL'
           exit-code: '0'
-          ignore-unfixed: false
 
       - name: Update Security tab
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,28 @@
+---
+scan:
+  # Teach Trivy to recognize our non-standard Python requirements filenames:
+  #   requirements.cpu.txt, requirements.cuda.txt, requirements.rocm.txt
+  #   requirements-elyra.txt
+  # By default Trivy only matches "requirements.txt" exactly.
+  file-patterns:
+    - "pip:requirements.*\\.txt"
+
+  scanners:
+    - vuln
+
+  # Skip vendored code-server VS Code sources. These package-lock.json files are
+  # upstream dependencies that cannot be patched independently — only by upgrading
+  # code-server itself. The directory is copied into the build for hermetic Konflux
+  # builds (offline npm install). Scanning it produces ~31 non-actionable alerts
+  # from VS Code extension host internals that obscure real findings.
+  # Re-evaluate after code-server upgrades.
+  skip-dirs:
+    - codeserver/ubi9-python-3.12/prefetch-input/patches
+
+severity:
+  - MEDIUM
+  - HIGH
+  - CRITICAL
+
+vulnerability:
+  ignore-unfixed: false


### PR DESCRIPTION
## Summary

Add `trivy.yaml` configuration file and update the Trivy GHA workflow.

### What trivy.yaml does

- **Enables Python CVE scanning**: Adds `file-patterns` for our non-standard requirements filenames (`requirements.cpu.txt`, `requirements.cuda.txt`, `requirements.rocm.txt`, `requirements-elyra.txt`). Previously Trivy silently skipped all of these, resulting in zero Python vulnerability coverage.
- **Skips vendored code-server lockfiles**: The `codeserver/ubi9-python-3.12/prefetch-input/patches` directory contains upstream VS Code `package-lock.json` files that can only be fixed by upgrading code-server itself. These generated 31 open alerts that are not actionable.
- **Sets severity and scanner defaults**: Only vulnerability scanning (no misconfig/secret/license), MEDIUM and above.

### What the workflow change does

- Updates `trivy-action` from broken v0.33.1 to v0.35.0 (the old version's install script fails to download current Trivy releases, causing every PR's Security check to fail)
- References `trivy.yaml` via `trivy-config` input
- Keeps SARIF format/output in the workflow (GHA-specific) so local `trivy fs .` gives human-readable table output

### Note on superseded PR

This supersedes PR #3384 which only updated the trivy-action version. This PR adds the config file on top.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Trivy configuration to include additional Python dependency file patterns for scanning.
  * Configured scans to run vulnerability checks only and report MEDIUM/HIGH/CRITICAL severities.
  * Ensured unfixed vulnerabilities are reported and excluded a specific vendored directory from scans.
  * Updated CI workflow to reference the new Trivy configuration and move severity/ignore-unfixed settings out of the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->