### PR TITLE
docs: add RH index availability check to Python CVE workflow

### DIFF
--- a/docs/cves/python.md
+++ b/docs/cves/python.md
@@ -97,6 +97,44 @@ uv tree --invert tornado
 
 Example: Tornado is typically pulled in by `jupyter-server`.
 
+### Step 4.5: Verify Package Availability on the RH Index
+
+Before attempting to fix the CVE, check that the fixed version is actually available
+on the RH index. A version may exist on PyPI but not on the RH index — this is a
+common blocker for downstream (RHOAI) images.
+
+```bash
+# Check which versions are on the production RH index
+curl -sL "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/<package>/?format=json" \
+  | python3 -c "
+import json,sys
+data = json.load(sys.stdin)
+versions = sorted({f['filename'].split('-')[1] for f in data.get('files',[])})
+print('\n'.join(versions))
+"
+```
+
+There are **three layers** that can block a CVE fix from resolving:
+
+1. **RH index**: The fixed version may not have been built by AIPCC yet.
+   If missing, request it via the [AIPCC dashboard](https://dashboard.aipcc.redhat.com/package-request).
+
+2. **Builder constraints**: The `wheels/builder` project may pin an older version
+   in `collections/torch-*/constraints.txt`. For example, `onnx==1.20.0` was pinned
+   with `# AIPCC-7623 - Constraining onnx while we carry patches`, preventing
+   1.21.0 from appearing on the index even after the onboarding pipeline ran.
+   Check with: `glab api --hostname gitlab.com "projects/58339326/search?scope=blobs&search=<package>%3D%3D"`
+
+3. **Upstream SDK exact pins**: Packages like `codeflare-sdk` may exact-pin the
+   vulnerable version (e.g., `cryptography==46.0.6`, `ray[data]==2.53.0`). These
+   conflicts surface during `make refresh-lock-files` as "unsatisfiable" errors.
+   Coordinate with the owning team per the
+   [component-team-owned packages](https://gitlab.cee.redhat.com/data-hub/guide/-/blob/main/docs/notebooks/cves/python.md)
+   procedure.
+
+If the fixed version is not on the RH index, **do not proceed to Step 5** — the
+lock refresh will fail. Instead, request the build and revisit once it is available.
+
 ### Step 5: Resolve the CVE
 
 #### Option A: Upgrade the Direct Dependency


### PR DESCRIPTION
## Summary

Adds a new **Step 4.5: Verify Package Availability on the RH Index** to the Python CVE resolution workflow in `docs/cves/python.md`.

This step was missing from the workflow and caused us to hit dead ends when attempting to fix CVEs. During a security sweep of the 258 open Dependabot alerts, we discovered that `make refresh-lock-files` fails silently when a required package version doesn't exist on the Red Hat AIPCC index -- even though the version exists on PyPI.

### What the new step documents

Three layers that can block a CVE fix from resolving in downstream (RHOAI) images:

1. **RH index**: the fixed version may not have been built by AIPCC yet (check with `curl` + `?format=json`)
2. **Builder constraints**: `wheels/builder` may pin an older version in `collections/torch-*/constraints.txt` (check with `glab api`)
3. **Upstream SDK exact pins**: packages like `codeflare-sdk` may exact-pin the vulnerable version (surfaces as "unsatisfiable" during lock refresh)

Includes concrete commands for each check and a link to the [AIPCC dashboard](https://dashboard.aipcc.redhat.com/package-request) for requesting missing package builds.

### Based on real investigation

- **onnx >= 1.21.0** (5 HIGH CVEs): RH index only has 1.19.1 and 1.20.0. Builder pins `onnx==1.20.0` with `# AIPCC-7623`. Filed [AIPCC-14368](https://issues.redhat.com/browse/AIPCC-14368) to request the build.
- **cryptography >= 46.0.7** and **ray >= 2.54.0**: blocked by `codeflare-sdk` exact pins. Contacted distributed workloads team in `#forum-openshift-ai-distributed-workloads`.

## Test plan

- [x] Documentation-only change, no code impact


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CVE resolution workflow with verification steps for package availability on the Red Hat index.
  * Added guidance on identifying and resolving common blockers in the CVE process.
  * Updated workflow instructions for improved clarity and proper sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->