### PR TITLE
refactor: reuse shared env-file parser and canonicalize_name

### DIFF
--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -24,6 +24,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from manifests.tools.commit_env_refs import parse_env_file
 from ntb.strings import process_template_with_indents
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -92,16 +93,7 @@ _PARAM_KEY_RE = re.compile(
 
 def _parse_env_keys(env_path: Path) -> set[str]:
     """Read an .env file and return the set of keys (left side of '=')."""
-    keys: set[str] = set()
-    if not env_path.exists():
-        return keys
-    for line in env_path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        key, _, _ = line.partition("=")
-        keys.add(key.strip())
-    return keys
+    return set(parse_env_file(env_path).keys())
 
 
 def _parse_imagestream_name(yaml_path: Path) -> str | None:

--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -91,11 +91,6 @@ _PARAM_KEY_RE = re.compile(
 )
 
 
-def _parse_env_keys(env_path: Path) -> set[str]:
-    """Read an .env file and return the set of keys (left side of '=')."""
-    return set(parse_env_file(env_path).keys())
-
-
 def _parse_imagestream_name(yaml_path: Path) -> str | None:
     """Extract ``metadata.name`` from an ImageStream YAML file.
 
@@ -131,7 +126,7 @@ def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[st
     imagestream_to_resource = _build_imagestream_to_resource(base_dir, all_resources)
 
     # 2) Collect all param keys from .env files
-    param_keys = _parse_env_keys(base_dir / "params.env") | _parse_env_keys(base_dir / "params-latest.env")
+    param_keys = set(parse_env_file(base_dir / "params.env").keys()) | set(parse_env_file(base_dir / "params-latest.env").keys())
 
     # 3) Parse param keys into (base_key, suffix) pairs.
     #    e.g. "odh-workbench-...-ubi9-n"      -> ("odh-workbench-...-ubi9", "-n")

--- a/scripts/fix_package_naming.py
+++ b/scripts/fix_package_naming.py
@@ -10,6 +10,7 @@ import argparse
 import re
 from pathlib import Path
 
+import packaging.utils
 import requests
 import structlog
 
@@ -26,11 +27,10 @@ def get_canonical_name(name):
     try:
         resp = requests.get(url, timeout=5)
         if resp.ok:
-            pypi_name = resp.json()['info']['name']
-            return re.sub(r"[-_.]+", "-", name).lower() 
+            return packaging.utils.canonicalize_name(name)
     except Exception:
         pass
-    return name 
+    return name
 
 def normalize_pipfile_packages(pipfile_path):
     with open(pipfile_path, 'r', encoding='utf-8') as f:

--- a/scripts/lockfile-generators/helpers/download-pip-packages.py
+++ b/scripts/lockfile-generators/helpers/download-pip-packages.py
@@ -37,6 +37,8 @@ import sys
 import urllib.request
 from pathlib import Path
 
+import packaging.utils
+
 OUT_DIR = Path("cachi2/output/deps/pip")
 PYPI_JSON = "https://pypi.org/pypi/{name}/{version}/json"
 
@@ -132,7 +134,7 @@ def fetch_simple_index_urls(index_url: str, name: str, version: str, wanted_hash
     Used for RHOAI and other custom indexes that don't provide a JSON API.
     """
     # Normalize name for URL: PEP 503 uses lowercase with hyphens
-    normalized = re.sub(r"[-_.]+", "-", name).lower()
+    normalized = packaging.utils.canonicalize_name(name)
     page_url = f"{index_url.rstrip('/')}/{normalized}/"
     try:
         req = urllib.request.Request(page_url, headers={"Accept": "text/html"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,7 @@ import packaging.version
 import pytest
 import yaml
 
+from manifests.tools.commit_env_refs import parse_env_file
 from manifests.tools.package_names import manifest_name_to_pip
 from tests import PROJECT_ROOT, manifests
 
@@ -521,16 +522,7 @@ _PLACEHOLDER_RE = re.compile(
 
 
 def _parse_env_keys(env_path: pathlib.Path) -> set[str]:
-    keys: set[str] = set()
-    if not env_path.exists():
-        return keys
-    for line in env_path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        key, _, _ = line.partition("=")
-        keys.add(key.strip())
-    return keys
+    return set(parse_env_file(env_path).keys())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -191,8 +191,7 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                     req = packaging.requirements.Requirement(dep_str)
                     canonical = packaging.utils.canonicalize_name(req.name)
                     assert req.name == canonical, (
-                        f"pyproject.toml dependency {req.name!r} is not canonical; "
-                        f"should be {canonical!r}"
+                        f"pyproject.toml dependency {req.name!r} is not canonical; should be {canonical!r}"
                     )
 
             if (f := file.parent / "uv.lock.d").is_dir():
@@ -521,10 +520,6 @@ _PLACEHOLDER_RE = re.compile(
 )
 
 
-def _parse_env_keys(env_path: pathlib.Path) -> set[str]:
-    return set(parse_env_file(env_path).keys())
-
-
 @pytest.mark.parametrize(
     "base_dir", [PROJECT_ROOT / "manifests" / "odh" / "base", PROJECT_ROOT / "manifests" / "rhoai" / "base"]
 )
@@ -558,8 +553,12 @@ def test_imagestream_kustomization_consistency(subtests: pytest_subtests.plugin.
                     )
                     commit_replacements[key] = field_path_key
 
-    param_env_keys = _parse_env_keys(base_dir / "params.env") | _parse_env_keys(base_dir / "params-latest.env")
-    commit_env_keys = _parse_env_keys(base_dir / "commit.env") | _parse_env_keys(base_dir / "commit-latest.env")
+    param_env_keys = set(parse_env_file(base_dir / "params.env").keys()) | set(
+        parse_env_file(base_dir / "params-latest.env").keys()
+    )
+    commit_env_keys = set(parse_env_file(base_dir / "commit.env").keys()) | set(
+        parse_env_file(base_dir / "commit-latest.env").keys()
+    )
 
     for is_file in sorted(base_dir.glob("*-imagestream.yaml")):
         is_data = yaml.safe_load(is_file.read_text())


### PR DESCRIPTION
## Summary

* Replace duplicated `_parse_env_keys` implementations in `generate_kustomization.py` and `test_main.py` with `parse_env_file().keys()` from the shared helper in `manifests/tools/commit_env_refs.py`
* Replace manual `re.sub(r"[-_.]+", "-", ...).lower()` PEP 503 normalization with `packaging.utils.canonicalize_name()` in `fix_package_naming.py` and `download-pip-packages.py`

Follow-up to #3342.

## Test plan

* `test_image_pyprojects` passes (55 subtests)
* `test_imagestream_kustomization_consistency` passes
* `generate_kustomization.py --check` passes (both ODH and RHOAI)
* Unit tests pass (26 tests)

🤖 Generated with Claude Code

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized environment-file parsing and package name normalization into shared utilities for consistent behavior across tooling.
* **Tests**
  * Updated test cases to use the centralized parsing utilities, aligning test behavior with the refactor and improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->