### PR TITLE
fix: bump Feast to 0.62 in manifests and runtime pylocks

### DIFF
--- a/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
             {"name": "Codeflare-SDK", "version": "0.36"},
-            {"name": "Feast", "version": "0.61"},
+            {"name": "Feast", "version": "0.62"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},

--- a/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -40,7 +40,7 @@ spec:
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
             {"name": "Codeflare-SDK", "version": "0.36"},
-            {"name": "Feast", "version": "0.61"},
+            {"name": "Feast", "version": "0.62"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},

--- a/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
             {"name": "Codeflare-SDK", "version": "0.36"},
-            {"name": "Feast", "version": "0.61"},
+            {"name": "Feast", "version": "0.62"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},

--- a/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
@@ -88,7 +88,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.2"}
+            {"name": "JupyterLab", "version": "4.2"}
           ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: "true"

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
             {"name": "Codeflare-SDK", "version": "0.36"},
-            {"name": "Feast", "version": "0.61"},
+            {"name": "Feast", "version": "0.62"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
@@ -153,7 +153,7 @@ spec:
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
-            {"name": "JupyterLab","version": "4.2"},
+            {"name": "JupyterLab", "version": "4.2"},
             {"name": "PyTorch", "version": "2.4"},
             {"name": "Tensorboard", "version": "2.17"},
             {"name": "Boto3", "version": "1.35"},

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -40,7 +40,7 @@ spec:
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
             {"name": "Codeflare-SDK", "version": "0.36"},
-            {"name": "Feast", "version": "0.61"},
+            {"name": "Feast", "version": "0.62"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -42,7 +42,7 @@ spec:
             {"name": "PyMongo", "version": "4.16"},
             {"name": "Pyodbc", "version": "5.3"},
             {"name": "Codeflare-SDK", "version": "0.36"},
-            {"name": "Feast", "version": "0.61"},
+            {"name": "Feast", "version": "0.62"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -309,9 +309,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "feast"
-version = "0.61.0"
+version = "0.62.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9/feast-0.61.0-8-py3-none-any.whl", upload-time = 2026-03-11T00:36:53Z, size = 8205930, hashes = { sha256 = "c6907a53d48ac99a954c1e98a0a975d83bf499ffb02b060716c39adf14a2870e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9/feast-0.62.0-8-py3-none-any.whl", upload-time = 2026-04-09T02:41:36Z, size = 7993841, hashes = { sha256 = "073651e85cb1dc515331e041dff9e5eb2bd453004c49d7a22420a8d14c30e585" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -288,9 +288,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "feast"
-version = "0.61.0"
+version = "0.62.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9/feast-0.61.0-12-py3-none-any.whl", upload-time = 2026-03-11T00:37:21Z, size = 8205934, hashes = { sha256 = "f0c36edacd29273a0bbf28aaec7b971d823158a78ea1ee0eff37417e0a52a7e7" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/rocm6.4-ubi9/feast-0.62.0-12-py3-none-any.whl", upload-time = 2026-04-09T01:28:59Z, size = 7993843, hashes = { sha256 = "71004070a9e20f77c3a3e097948b7aa5896a178693fa1b30f7184b6f30d6cda5" } }]
 
 [[packages]]
 name = "filelock"

--- a/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -315,9 +315,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "feast"
-version = "0.61.0"
+version = "0.62.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9/feast-0.61.0-8-py3-none-any.whl", upload-time = 2026-03-11T00:36:53Z, size = 8205930, hashes = { sha256 = "c6907a53d48ac99a954c1e98a0a975d83bf499ffb02b060716c39adf14a2870e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4/cuda12.9-ubi9/feast-0.62.0-8-py3-none-any.whl", upload-time = 2026-04-09T02:41:36Z, size = 7993841, hashes = { sha256 = "073651e85cb1dc515331e041dff9e5eb2bd453004c49d7a22420a8d14c30e585" } }]
 
 [[packages]]
 name = "filelock"


### PR DESCRIPTION
## Summary
- Update ODH manifest annotations for pytorch, rocm-pytorch, and tensorflow to declare Feast 0.62 (missed by c44d687e2)
- Update runtime pylock files (pytorch, tensorflow, rocm-pytorch) from feast 0.61.0 to 0.62.0 using wheels already available on the RH registry
- Regenerate RHOAI manifest annotations via `update_imagestream_annotations_from_pylock.py`

## Test plan
- [ ] `make test` passes (specifically `test_image_pyprojects` no longer fails on Feast version mismatch)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated Feast library from version 0.61 to 0.62 across PyTorch, TensorFlow, and ROCm notebook image variants for both OpenDataHub and RHOAI deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->