### PR TITLE
NO-JIRA: chore(ci): update Trivy scanner to v0.70.0

### DIFF
--- a/.github/actions/trivy-scan-action/action.yml
+++ b/.github/actions/trivy-scan-action/action.yml
@@ -26,7 +26,7 @@ inputs:
   trivy-version:
     description: 'Version of Trivy to use'
     required: false
-    default: '0.68.2'
+    default: '0.70.0'
   podman-socket:
     description: 'Path to Podman socket (required for image scans)'
     required: false

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -63,7 +63,7 @@ jobs:
       # GitHub image registry used for storing $(CONTAINER_ENGINE)'s cache
       CACHE: "ghcr.io/${{ github.repository }}/workbench-images/build-cache"
       # https://github.com/aquasecurity/trivy
-      TRIVY_VERSION: 0.68.2
+      TRIVY_VERSION: 0.70.0
       # Targets (and their folder) that should be scanned using FS instead of IMAGE scan due to resource constraints
       TRIVY_SCAN_FS_JSON: '{}'
       # Makefile variables

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Trivy scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
+          version: 'v0.70.0'
           scan-type: 'fs'
           trivy-config: trivy.yaml
           format: 'sarif'


### PR DESCRIPTION
## Summary
- Update Trivy vulnerability scanner from v0.68.2 to v0.70.0 in the custom scan action default and build template env var
- Pin `aquasecurity/trivy-action` in the security workflow to use Trivy v0.70.0 explicitly

## Test plan
- [ ] Verify `test-trivy-scan-action` workflow passes (uses the updated default)
- [x] Verify `security` workflow passes with explicit `version: v0.70.0`
- [x] Spot-check a build workflow run to confirm Trivy version in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Trivy vulnerability scanner from 0.68.2 to 0.70.0 across CI/CD workflows and action configurations, ensuring the pipeline uses a newer scanner version for filesystem and repository scans and keeping security scanning outputs and behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->