### PR TITLE
[RHAIENG-4591] ci(piplock-renewal) updates piplock-renewal to skip pr it changes are only timestamps

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -112,6 +112,12 @@ jobs:
             exit 0
           fi
 
+          # Skip PR creation if only timestamp changes
+          if git diff --cached -I '^#.*--exclude-newer' --quiet; then
+            echo "Only timestamp changes. Skipping PR creation."
+            exit 0
+          fi
+
           BRANCH_NAME="lockfile-update-$(date +%Y%m%d-%H%M)"
           git checkout -b "$BRANCH_NAME"
           git commit -m "Update lock files and ImageStream dependency annotations"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- piplock-renewal workflow 1: After make test, detect when the working tree differs from HEAD only because of ephemeral UV/pylock metadata (e.g. --exclude-newer=… timestamps). If so, restore the worktree and do not open a PR, avoiding noisy multi-file renewals and rebase friction when package pins are unchanged.
- scripts/ci/lockfile_renewal_diff_is_metadata_only.py (+ unit tests): Implements that normalization/compare logic and documents exit codes for shell use.
- manifests/tools/update_imagestream_annotations_from_pylock.py: Expand abbreviated commit SHAs to full OIDs via the GitHub REST API when fetching from github.com, so git fetch <url> <short-sha> does not fail treating short hex as a ref name; wire GITHUB_TOKEN into the ImageStream refresh step for API auth/rate limits. Documentation updated for fork CI and RHDS-only commits.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

./uv run pytest tests/unit/scripts/ci/test_lockfile_renewal_diff_is_metadata_only.py (unit coverage for metadata-only detection)

GitHub Actions: Ran Lock Files Renewal Action on the fork; job refresh-lock-files completed successfully — [run log](https://github.com/mtchoum1/notebooks/actions/runs/24741226422/job/72381155884).

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation to detect and skip non-substantive timestamp/metadata-only updates, preventing creation of unnecessary pull requests and reducing noise in the project workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->