### PR TITLE
RHAIENG-4442: Fix NumPy version test failure for derived images

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -1,5 +1,7 @@
 ARG TARGETARCH
 
+# CI trigger for RHAIENG-4442 test validation - to be reverted
+
 #########################
 # configuration args    #
 #########################

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -1,7 +1,5 @@
 ARG TARGETARCH
 
-# CI trigger for RHAIENG-4442 test validation - to be reverted
-
 #########################
 # configuration args    #
 #########################

--- a/scripts/test_jupyter_with_papermill.sh
+++ b/scripts/test_jupyter_with_papermill.sh
@@ -308,20 +308,14 @@ function _create_test_versions_source_of_truth()
 }
 
 # Description:
-#   Main "test runner" function that copies the relevant test_notebook.ipynb file for the notebook under test into
-#	the running pod and then invokes papermill within the pod to actually execute test suite.
-#
-#	Script will return non-zero exit code in the event all unit tests were not successfully executed.  Diagnostic messages
-#	are printed in the event of a failure.
+#   Internal function that runs test notebooks WITHOUT creating expected_versions.json.
+#   Used by _test_datascience_notebook to run parent tests using the derived image's manifest.
 #
 # Arguments:
-#   $1 : Name of the notebook identifier
-function _run_test()
+#   $1 : Name of the notebook identifier (for locating test files)
+function _run_test_notebooks_only()
 {
     local notebook_id="${1:-}"
-
-    # Create expected_versions.json from the correct imagestream for THIS test
-    _create_test_versions_source_of_truth "${notebook_id}"
 
     local test_notebook_file='test_notebook.ipynb'
     local repo_test_directory=
@@ -360,6 +354,26 @@ function _run_test()
 }
 
 # Description:
+#   Main "test runner" function that copies the relevant test_notebook.ipynb file for the notebook under test into
+#	the running pod and then invokes papermill within the pod to actually execute test suite.
+#
+#	Script will return non-zero exit code in the event all unit tests were not successfully executed.  Diagnostic messages
+#	are printed in the event of a failure.
+#
+# Arguments:
+#   $1 : Name of the notebook identifier
+function _run_test()
+{
+    local notebook_id="${1:-}"
+
+    # Create expected_versions.json from the correct imagestream for THIS test
+    _create_test_versions_source_of_truth "${notebook_id}"
+
+    # Run the test notebooks
+    _run_test_notebooks_only "${notebook_id}"
+}
+
+# Description:
 #	Checks if the notebook under test is derived from the datasciences notebook.  This determination is subsequently used to know whether or not
 #	additional papermill tests should be invoked against the running notebook resource.
 #
@@ -381,10 +395,22 @@ function _image_derived_from_datascience()
 
 # Description:
 #	Convenience function that will invoke the minimal and datascience papermill tests against the running notebook workload
+#
+# Arguments:
+#   $1 : [optional] The actual image's notebook_id to use for expected_versions.json
+#        If not provided, uses datascience manifest (original behavior)
 function _test_datascience_notebook()
 {
-    _run_test "${jupyter_minimal_notebook_id}"
-    _run_test "${jupyter_datascience_notebook_id}"
+    local actual_image_id="${1:-${jupyter_datascience_notebook_id}}"
+
+    # Create expected_versions.json once from the ACTUAL image being tested
+    # This ensures derived images (pytorch+llmcompressor, trustyai, etc.) use their own
+    # manifest versions, not the parent datascience manifest
+    _create_test_versions_source_of_truth "${actual_image_id}"
+
+    # Run minimal and datascience tests without recreating expected_versions.json
+    _run_test_notebooks_only "${jupyter_minimal_notebook_id}"
+    _run_test_notebooks_only "${jupyter_datascience_notebook_id}"
 }
 
 function _get_notebook_id() {
@@ -437,7 +463,9 @@ function _handle_test()
     "${kbin}" exec "${notebook_workload_name}" -- /bin/sh -c "python3 -m pip install papermill"
 
     if _image_derived_from_datascience "${notebook_id}" ; then
-        _test_datascience_notebook
+        # Pass the actual notebook_id so derived images use their own manifest
+        # for expected_versions.json, not the parent datascience manifest
+        _test_datascience_notebook "${notebook_id}"
     fi
 
     if [ -n "${notebook_id}" ] && ! [ "${notebook_id}" = "${jupyter_datascience_notebook_id}" ]; then


### PR DESCRIPTION
## Summary

- Fixes CI test failure where `TestNumpy.test_version` expects NumPy 2.4 but pytorch-llmcompressor image has NumPy 2.3
- Root cause: When running datascience test notebooks on derived images, the test was using the datascience manifest for `expected_versions.json` instead of the actual image's manifest
- This affects all derived images (pytorch-llmcompressor, trustyai, tensorflow, pytorch) when their package versions differ from datascience

## Changes

- Added `_run_test_notebooks_only()` function to run test notebooks without recreating `expected_versions.json`
- Updated `_test_datascience_notebook()` to accept the actual image ID and create `expected_versions.json` once from that image's manifest
- Updated `_handle_test()` to pass the actual `notebook_id` to `_test_datascience_notebook()`

## How it works

Before this fix:
1. Test script detects pytorch-llmcompressor is derived from datascience
2. Runs `_test_datascience_notebook()` which calls `_run_test("datascience")`
3. `_run_test("datascience")` creates `expected_versions.json` from **datascience** manifest (NumPy 2.4)
4. Test fails because actual image has NumPy 2.3

After this fix:
1. Test script detects pytorch-llmcompressor is derived from datascience
2. Runs `_test_datascience_notebook("pytorch+llmcompressor")`
3. Creates `expected_versions.json` once from **pytorch-llmcompressor** manifest (NumPy 2.3)
4. Runs minimal and datascience tests using this `expected_versions.json`
5. Tests pass because expected version matches actual version

## Test plan

- [ ] CI tests pass for pytorch-llmcompressor image
- [ ] CI tests pass for other derived images (trustyai, tensorflow, pytorch)
- [ ] CI tests still pass for datascience image itself

Fixes: https://redhat.atlassian.net/browse/RHAIENG-4442

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored notebook testing to separate notebook execution from version-file generation: expected-version data is now created once per image and notebooks are executed independently, reducing redundant regeneration and allowing derived images to use their own manifest versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->