### PR TITLE
[RHAIENG-372] fix(tests/containers): remove the libodbc.so.2 allowlisting as it is no longer necessary

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -142,9 +142,6 @@ class TestBaseImage:
                         continue  # this is some kind of self test or what
                     if re.search(r"^/lib64/systemd/libsystemd-core-\d+.so", dlib) is not None:
                         continue  # this is expected and we don't use systemd anyway
-                    if deps.startswith("libodbc.so.2"):
-                        continue  # todo(jdanek): known issue RHOAIENG-18904
-
                     # NVIDIA Container Toolkit (CTK), Container Device Interface (CDI)
                     if deps.startswith("libcuda.so.1"):
                         continue  # cuda magic will mount this into /usr/lib64/libcuda.so.1 and it will be found


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://github.com/mtchoum1/notebooks/actions/runs/24795626813

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
