### PR TITLE
Update ODH ROCm to ROCM to 7.1

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v6.4
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR updates ROCm based images to 7.1 

Also related to: https://redhat.atlassian.net/browse/RHAIENG-4618

## Description
<!--- Describe your changes in detail -->

actually is a follow up PR for:  https://github.com/opendatahub-io/notebooks/pull/3417/changes#diff-4c56affc0525065bbc385a4c6038a1987eb68ebefc0b033c7cd9ee73c97d8781 to fix that missaligment as ROCm 7.1 wasn't developed yet at that day

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


ODH builds for ROCm based images tests and builds: https://github.com/opendatahub-io/notebooks/actions/runs/24991305144/job/73177424177?pr=3438


Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ROCm-based container base images to version 7.1 from version 6.4 across all Jupyter and runtime build environments. Affected configurations include minimal, PyTorch, and TensorFlow variants for Python 3.12. This upgrade provides access to the latest stable container image releases for ROCm-enabled workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->