### PR TITLE
fix: Update commit-latest.env workflow to create PRs instead of direct push

### DIFF
--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: main
+          ref: ${{ github.ref }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -1,47 +1,95 @@
 ---
-name: Update commit-latest.env on params-latest.env change
+name: Update commit-latest.env with image vcs-ref labels
 
 "on":
   workflow_dispatch:
   schedule:
-    - cron: '0 11 * * *'  # Daily at midnight UTC
+    - cron: '0 11 * * *'  # Daily at 11am UTC
   push:
     branches:
       - main
-      - rhoai-*
     paths:
-      - 'manifests/base/params-latest.env'
+      - 'manifests/odh/base/params-latest.env'
+      - 'manifests/rhoai/base/params-latest.env'
+      - '**/Dockerfile*'
+      - '**/pyproject.toml'
+      - '**/pylock*.toml'
 
 jobs:
-  sync-commit:
+  update-commit-hashes:
     runs-on: ubuntu-latest
     concurrency:
       group: update-commit-latest-env-${{ github.ref }}
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read  # checkout only; push and PR creation use the PAT
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: true
+          ref: main
+          persist-credentials: false
+          fetch-depth: 0
 
-      - name: Update manifests/base/commit-latest.env
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install structlog
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Update commit-latest.env files
         id: update_env
         run: |
-          python3 scripts/update-commit-latest-env.py
+          python3 scripts/update-commit-latest-env.py --variant odh
+          python3 scripts/update-commit-latest-env.py --variant rhoai
 
-      - name: Commit and push changes
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          # Check for any changes
+          git add manifests/odh/base/commit-latest.env manifests/rhoai/base/commit-latest.env 2>/dev/null || true
 
-          # Check for changes before committing
-          if ! git diff --quiet manifests/base/commit-latest.env; then
-            git add manifests/base/commit-latest.env
-            git commit -m "ci: update commit SHAs for image digests changes"
-            git push
-          else
-            echo "No effective changes in manifests/base/commit-latest.env, skipping commit."
+          if git diff --cached --quiet; then
+            echo "No changes to commit-latest.env files, skipping PR creation."
+            exit 0
           fi
+
+          BRANCH_NAME="commit-hash-update-$(date +%Y%m%d-%H%M)"
+          git checkout -b "$BRANCH_NAME"
+          git commit -m "ci: update commit SHAs from image vcs-ref labels"
+
+          # Push using PAT for branch protection bypass
+          git push -u "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH_NAME"
+
+          gh pr create \
+            --title "ci: Update commit-latest.env with latest image commit hashes" \
+            --head "$BRANCH_NAME" \
+            --body "$(cat <<'EOF'
+          Automated update of commit hashes in `commit-latest.env` files.
+
+          This PR updates the `opendatahub.io/notebook-build-commit` annotation values
+          by reading the `vcs-ref` label from each built image using `skopeo inspect`.
+
+          **Files updated:**
+          - `manifests/odh/base/commit-latest.env` (ODH)
+          - `manifests/rhoai/base/commit-latest.env` (RHOAI)
+
+          **Auto-merge:** This PR can be merged once CI passes.
+          EOF
+          )" \
+            --label "automated-commit-hash-update" \
+            --base main

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -91,5 +91,4 @@ jobs:
           **Auto-merge:** This PR can be merged once CI passes.
           EOF
           )" \
-            --label "automated-commit-hash-update" \
             --base main

--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
+"""
+Update commit-latest.env files with vcs-ref labels from container images.
+
+This script reads params-latest.env to get image digests, then uses skopeo
+to inspect each image and extract the vcs-ref label (git commit hash).
+The results are written to commit-latest.env.
+
+Usage:
+    python3 scripts/update-commit-latest-env.py --variant odh
+    python3 scripts/update-commit-latest-env.py --variant rhoai
+"""
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import pathlib
@@ -10,11 +22,28 @@ import typing
 
 import structlog
 
-from ci.logging_config import configure_logging
+try:
+    from ci.logging_config import configure_logging
+except ImportError:
+    def configure_logging():
+        import logging
+        logging.basicConfig(level=logging.INFO)
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent
 
 log = structlog.get_logger()
+
+# Mapping of variant to paths
+VARIANT_PATHS = {
+    "odh": {
+        "params": PROJECT_ROOT / "manifests/odh/base/params-latest.env",
+        "commit": PROJECT_ROOT / "manifests/odh/base/commit-latest.env",
+    },
+    "rhoai": {
+        "params": PROJECT_ROOT / "manifests/rhoai/base/params-latest.env",
+        "commit": PROJECT_ROOT / "manifests/rhoai/base/commit-latest.env",
+    },
+}
 
 
 async def get_image_vcs_ref(image_url: str, semaphore: asyncio.Semaphore) -> tuple[str, str | None]:
@@ -100,25 +129,92 @@ async def inspect(images_to_inspect: typing.Iterable[str]) -> list[tuple[str, st
     return await asyncio.gather(*tasks)
 
 
-async def main():
-    with open(PROJECT_ROOT / "manifests/base/params-latest.env", "rt") as file:
-        images_to_inspect: list[list[str]] = [line.strip().split('=', 1) for line in file.readlines()
-                                              if line.strip() and not line.strip().startswith("#")]
+async def update_commit_env(variant: str) -> bool:
+    """
+    Update commit-latest.env for the specified variant (odh or rhoai).
+    
+    Returns True if successful, False otherwise.
+    """
+    paths = VARIANT_PATHS.get(variant)
+    if not paths:
+        log.error(f"Unknown variant: {variant}. Must be one of: {list(VARIANT_PATHS.keys())}")
+        return False
+
+    params_file = paths["params"]
+    commit_file = paths["commit"]
+
+    if not params_file.exists():
+        log.warning(f"Params file not found: {params_file}. Skipping {variant}.")
+        return True  # Not an error, just skip
+
+    log.info(f"Processing {variant} variant")
+    log.info(f"Reading params from: {params_file}")
+    log.info(f"Will write commits to: {commit_file}")
+
+    with open(params_file, "rt") as file:
+        images_to_inspect: list[list[str]] = [
+            line.strip().split('=', 1) for line in file.readlines()
+            if line.strip() and not line.strip().startswith("#") and '=' in line
+        ]
+
+    if not images_to_inspect:
+        log.warning(f"No images found in {params_file}")
+        return True
+
+    log.info(f"Found {len(images_to_inspect)} images to inspect")
 
     results = await inspect(value for _, value in images_to_inspect)
-    if any(commit_hash is None for variable, commit_hash in results):
-        log.error("Failed to get commit hash for some images. Quitting, please try again to try again, like.")
-        sys.exit(1)
+    
+    # Check for failures but don't fail completely - just log warnings
+    failed_count = sum(1 for _, commit_hash in results if commit_hash is None)
+    if failed_count > 0:
+        log.warning(f"Failed to get commit hash for {failed_count}/{len(results)} images")
 
     output = []
     for image, result in zip(images_to_inspect, results, strict=True):
         variable, image_digest = image
         _, commit_hash = result
-        output.append((re.sub(r'-n$', "-commit-n", variable), commit_hash[:7]))
+        if commit_hash:
+            # Convert variable name: remove trailing -n and add -commit-n
+            commit_var = re.sub(r'-n$', "-commit-n", variable)
+            output.append((commit_var, commit_hash[:7]))
 
-    with open(PROJECT_ROOT / "manifests/base/commit-latest.env", "wt") as file:
-        for line in sorted(output):
-            print(*line, file=file, sep="=", end="\n")
+    if output:
+        # Ensure parent directory exists
+        commit_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        with open(commit_file, "wt") as file:
+            for line in sorted(output):
+                print(*line, file=file, sep="=", end="\n")
+        
+        log.info(f"Successfully wrote {len(output)} entries to {commit_file}")
+    else:
+        log.warning(f"No commit hashes to write for {variant}")
+
+    return True
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Update commit-latest.env with vcs-ref labels from container images"
+    )
+    parser.add_argument(
+        "--variant",
+        choices=["odh", "rhoai", "all"],
+        default="all",
+        help="Which variant to update (default: all)"
+    )
+    args = parser.parse_args()
+
+    variants = list(VARIANT_PATHS.keys()) if args.variant == "all" else [args.variant]
+    
+    success = True
+    for variant in variants:
+        if not await update_commit_env(variant):
+            success = False
+
+    if not success:
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes [RHAIENG-3124](https://redhat.atlassian.net/browse/RHAIENG-3124): Incorrect workbench commit hashes on ImageStreams

The existing workflow fails silently due to branch protection rules when trying to push directly to `main`. This causes the `commit-latest.env` files to become stale, and the RHOAI Dashboard displays incorrect commit hashes.

### Changes

**Workflow (`update-commit-latest-env.yaml`):**
- Create PRs instead of direct push (following the pattern in `piplock-renewal.yaml`)
- Use `GH_ACCESS_TOKEN` secret for branch protection bypass
- Add triggers for Dockerfile, pyproject.toml, and pylock changes
- Update both ODH and RHOAI `commit-latest.env` files

**Script (`update-commit-latest-env.py`):**
- Add `--variant` argument to specify `odh`, `rhoai`, or `all`
- Fix paths to use `manifests/odh/base/` (not `manifests/base/`)
- Add graceful handling when params file doesn't exist
- Don't fail completely if some images fail inspection

## Test plan
- [ ] Manually trigger workflow via `workflow_dispatch` to verify it creates a PR
- [ ] Verify the PR contains correct commit hashes from image `vcs-ref` labels
- [ ] Merge and verify Dashboard shows updated commit hashes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation workflow to support multiple product variants with separate configuration tracking
  * Enhanced error handling to be more resilient when processing variant data
  * Modified update process to use pull request review workflow instead of direct commits
  * Expanded trigger conditions to monitor additional file types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHAIENG-3124]: https://redhat.atlassian.net/browse/RHAIENG-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ