### PR TITLE
RHAIENG-4728: Regenerate rpms.lock.yaml to update s390x

### DIFF
--- a/prefetch-input/rhds/rpms.lock.yaml
+++ b/prefetch-input/rhds/rpms.lock.yaml
@@ -11,6 +11,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhelai/3.4/os/Packages/l/libsndfile-1.2.2-6.el9ai.aarch64.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-rpms
+    size: 216967
+    checksum: sha256:27aef40759c128486cef4e0ce1d18d6f4a4123194d08863254aa1fdadb1a964e
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+    sourcerpm: libsndfile-1.2.2-6.el9ai.src.rpm
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.aarch64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
     size: 100637
@@ -179,13 +186,6 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1437140
-    checksum: sha256:4d62a8fe879ba1da792cc23451678608e37b7a5107c6063a8a18c0dd98b0c5b5
-    name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_6.1
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 57636
@@ -221,13 +221,6 @@ arches:
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/c/crun-1.23.1-2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 234252
-    checksum: sha256:75ae137f0fa28ada6d53664da56f578ef610281475e5b9d8934a450d90b1e79b
-    name: crun
-    evr: 1.23.1-2.el9_6
-    sourcerpm: crun-1.23.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/d/dconf-0.40.0-6.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 116887
@@ -375,20 +368,6 @@ arches:
     name: gcc-plugin-annobin
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 500725
-    checksum: sha256:2a0d7efe3d55ee215b954d9958ad78889750565b927af763aa27f094248339cf
-    name: gdk-pixbuf2
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 88451
-    checksum: sha256:b24c89528a82b1c95f1579e99e80ae43f294e4991793711a4f578f1c42b74a2d
-    name: gdk-pixbuf2-modules
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/geoclue2-2.6.0-8.el9_6.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 127197
@@ -424,13 +403,6 @@ arches:
     name: ghostscript-tools-printing
     evr: 9.54.0-19.el9_6
     sourcerpm: ghostscript-9.54.0-19.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/giflib-5.2.1-9.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 52392
-    checksum: sha256:39339d27f6f69951fce475c228d266ee3182c5a3783b5bd3baf0d4a85e4bc758
-    name: giflib
-    evr: 5.2.1-9.el9
-    sourcerpm: giflib-5.2.1-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 5036453
@@ -438,13 +410,6 @@ arches:
     name: git-core
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4257334
-    checksum: sha256:b383d009910d65b7ff22b42a1a8e798a2fd67a570775df789de959328e17e15d
-    name: git-lfs
-    evr: 3.6.1-2.el9_6
-    sourcerpm: git-lfs-3.6.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.24.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 561564
@@ -452,13 +417,6 @@ arches:
     name: glibc-devel
     evr: 2.34-168.el9_6.24
     sourcerpm: glibc-2.34-168.el9_6.24.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/go-srpm-macros-3.6.0-10.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 28143
-    checksum: sha256:c1cbc05c812994c77b7f7bf80e76039c94d6ba887c9169228833e7e702aa095a
-    name: go-srpm-macros
-    evr: 3.6.0-10.el9_6
-    sourcerpm: go-rpm-macros-3.6.0-10.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/google-droid-sans-fonts-20200215-11.el9.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2836183
@@ -487,13 +445,6 @@ arches:
     name: gstreamer1
     evr: 1.22.12-3.el9
     sourcerpm: gstreamer1-1.22.12-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-4.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2230704
-    checksum: sha256:5a8659cf5abadfebf7b133f7f8610f5351436825545323ad598b6ecf7c9d6859
-    name: gstreamer1-plugins-base
-    evr: 1.22.12-4.el9
-    sourcerpm: gstreamer1-plugins-base-1.22.12-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/gtk-update-icon-cache-3.24.31-5.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 35312
@@ -522,20 +473,6 @@ arches:
     name: iso-codes
     evr: 4.6.0-3.el9
     sourcerpm: iso-codes-4.6.0-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 461925
-    checksum: sha256:872774921f3394bf16223cd7cee1417a6bd598630fbbe4a538505cc328173968
-    name: java-17-openjdk
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 46534192
-    checksum: sha256:fee661c0f32259ed2e45a2756eaf9708bcdc330541ee81085fcfbcc44950aaea
-    name: java-17-openjdk-headless
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/j/javapackages-filesystem-6.4.0-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17320
@@ -557,13 +494,6 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.62.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3705537
-    checksum: sha256:5028c463f66ad29ac525c73cfca06e513fb89e2936144204dbc7917d193cc6f8
-    name: kernel-headers
-    evr: 5.14.0-570.62.1.el9_6
-    sourcerpm: kernel-5.14.0-570.62.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17792
@@ -571,6 +501,13 @@ arches:
     name: kernel-srpm-macros
     evr: 1.0-13.el9
     sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/lame-libs-3.100-12.el9.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 343543
+    checksum: sha256:120ce9db5f08ff54b5c5c66b9ad83a19f00604259292d09a36b633e155a54d98
+    name: lame-libs
+    evr: 3.100-12.el9
+    sourcerpm: lame-3.100-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/langpacks-core-font-en-3.0-16.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 10986
@@ -921,20 +858,6 @@ arches:
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libsndfile-1.0.31-9.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 215056
-    checksum: sha256:a14084ba261306046c7ed9011a22ef47b993d3d6bd87678ce5d360673ad9c8e3
-    name: libsndfile
-    evr: 1.0.31-9.el9
-    sourcerpm: libsndfile-1.0.31-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.3.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 406322
-    checksum: sha256:b02e5a27246d6e38ec1d1da5023d23112f610910854c2743579b90f5563ba1e8
-    name: libsoup
-    evr: 2.72.0-10.el9_6.3
-    sourcerpm: libsoup-2.72.0-10.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-5.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2526795
@@ -963,13 +886,6 @@ arches:
     name: libtheora
     evr: 1:1.1.1-31.el9
     sourcerpm: libtheora-1.1.1-31.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 195076
-    checksum: sha256:d6aceb1b3f2902bb40fdf3f6aae858bbd66ba06db8c01ad9a01c4acda3cd2894
-    name: libtiff
-    evr: 4.4.0-13.el9_6.2
-    sourcerpm: libtiff-4.4.0-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libtool-2.4.6-46.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 598835
@@ -1082,13 +998,6 @@ arches:
     name: libxshmfence
     evr: 1.3-10.el9
     sourcerpm: libxshmfence-1.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 248330
-    checksum: sha256:973e5e7144917cb7c9e0552a444159004b330346dc5212d744312304dfdd4610
-    name: libxslt
-    evr: 1.1.34-13.el9_6
-    sourcerpm: libxslt-1.1.34-13.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/llvm-libs-19.1.7-2.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 28302267
@@ -1131,48 +1040,6 @@ arches:
     name: m4
     evr: 1.4.19-1.el9
     sourcerpm: m4-1.4.19-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 8367815
-    checksum: sha256:93d250977348d599d70c7275bd0965afa1d5b4cc460bdbf5164858797ecab306
-    name: mesa-dri-drivers
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-filesystem-24.2.8-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 10747
-    checksum: sha256:d03131b9eb918fd1cccef051ff55c06fdca89233936b43a375832a75efd841e1
-    name: mesa-filesystem
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libEGL-24.2.8-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 139919
-    checksum: sha256:3a7897cd7c532aa105dd6a36165048b35f011e4c5ad62f8fca953657e5f992ae
-    name: mesa-libEGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libGL-24.2.8-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 178555
-    checksum: sha256:2da38e9cf36c16e71cd75ac7916caec12f24eaff531efad5c5e17c66e28a8dd2
-    name: mesa-libGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libgbm-24.2.8-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 36006
-    checksum: sha256:b6fe9b9517dd8b2121398310b6fd16c8069f310b6a59da66de0f30a1a3ceab0d
-    name: mesa-libgbm
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libglapi-24.2.8-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 62162
-    checksum: sha256:77ae33e2a80d80e192669a53c394ba07f9feb48f077730d3876b6ba26fafd996
-    name: mesa-libglapi
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mkfontscale-1.2.1-3.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34837
@@ -1180,48 +1047,13 @@ arches:
     name: mkfontscale
     evr: 1.2.1-3.el9
     sourcerpm: mkfontscale-1.2.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/m/mpg123-libs-1.32.9-1.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 132948
-    checksum: sha256:17124daa5425a70b9573ff2ac479043d42174f9197f656c549307d31843c75c1
-    name: nspr
-    evr: 4.36.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-3.112.0-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 716093
-    checksum: sha256:b604959ea1defcc76f55b2fd7a2299300dec998108b0c1cb80be0efa845e8572
-    name: nss
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 399692
-    checksum: sha256:35197e3cac43476bf14b17b89c95be12209af7fa193ae3807ec73ed88a0f4d5a
-    name: nss-softokn
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 424604
-    checksum: sha256:131a636b10bdb8f94f7918e461ec18d37d81e7f5bf97b307c60c482db4d31034
-    name: nss-softokn-freebl
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 18002
-    checksum: sha256:89d455cb36e1b3b059eabc502f94c21161219f0570668068efba70d5df2c0719
-    name: nss-sysinit
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 88331
-    checksum: sha256:f15db365cf300f60b6ae9e0730c01015bd70d217ea656161daa63f1a75d4ea1e
-    name: nss-util
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+    size: 361512
+    checksum: sha256:aefb5a88a723e922382a7e5f906b8b19c7ea8347b7034f44647cc776729c778d
+    name: mpg123-libs
+    evr: 1.32.9-1.el9_5
+    sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 9270
@@ -1271,13 +1103,6 @@ arches:
     name: openjpeg2
     evr: 2.4.0-8.el9
     sourcerpm: openjpeg2-2.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4649968
-    checksum: sha256:ef8529d34eaadf43c95be9afda9e3d98a48d66fa184b246fe549b2dfd8d80483
-    name: openssl-devel
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/o/opus-1.3.1-10.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 200236
@@ -1306,13 +1131,6 @@ arches:
     name: osinfo-db-tools
     evr: 1.10.0-1.el9
     sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/o/ostree-libs-2025.2-2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 434185
-    checksum: sha256:e72088acb0c4476d4060b84756b0ac6e31d4d0854aafadb8dd8b91b2162a00a2
-    name: ostree-libs
-    evr: 2025.2-2.el9_6
-    sourcerpm: ostree-2025.2-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/p11-kit-server-0.25.3-3.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 239346
@@ -2608,13 +2426,6 @@ arches:
     name: perl-User-pwent
     evr: 1.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 245142
-    checksum: sha256:d8a3978dcdb846468fd92b3ce200742f45992c8b88c4f4dca4365a7322664724
-    name: perl-XML-Parser
-    evr: 2.46-9.el9
-    sourcerpm: perl-XML-Parser-2.46-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-XML-XPath-1.44-11.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94037
@@ -2993,13 +2804,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/poppler-21.01.0-21.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1024993
-    checksum: sha256:fb05eb19e424916853664496460f8ec58127a33ff2502e5302b5ba259c817a62
-    name: poppler
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/poppler-data-0.4.9-9.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1971104
@@ -3007,34 +2811,6 @@ arches:
     name: poppler-data
     evr: 0.4.9-9.el9
     sourcerpm: poppler-data-0.4.9-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/poppler-glib-21.01.0-21.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 149167
-    checksum: sha256:959e991c86b67dcd444fdd1faf5c5cfee67a2e11e20de04e811bc3451d2d698c
-    name: poppler-glib
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/postgresql-13.22-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1678580
-    checksum: sha256:1fccb1429b76f9ff8a75c0563870433f40eac04f53db8600e5027afbddec305b
-    name: postgresql
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/postgresql-private-libs-13.22-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 137104
-    checksum: sha256:01530188de07aab7ee3830f026f507e3acf8744c75581147b9dfcbfbb4cb1bd4
-    name: postgresql-private-libs
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/protobuf-3.14.0-16.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 960397
-    checksum: sha256:ddbd84ae82a2c25adeb4d4b13de30976de56e4245a0f6bf2e6a8bb55159d1bd5
-    name: protobuf
-    evr: 3.14.0-16.el9
-    sourcerpm: protobuf-3.14.0-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/pulseaudio-libs-15.0-3.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 662752
@@ -3056,20 +2832,6 @@ arches:
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.2.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9102
-    checksum: sha256:7aec11632e430e2d0ee4a4a4e60336ce36ebdd023e6a5645175654e3e339e688
-    name: python-unversioned-command
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 249899
-    checksum: sha256:398029540fbebd62e3b20a3b66d120fdffb3cc84d47dafb12750b62dc1a9e1d3
-    name: python3-devel
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2133958
@@ -3105,13 +2867,6 @@ arches:
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 8690432
-    checksum: sha256:fe2365bf0f27bcf3682e2accce4703dcf8be26ce0918bb16e200bd407e8aa12c
-    name: skopeo
-    evr: 2:1.18.1-2.el9_6
-    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 50394
@@ -3133,13 +2888,6 @@ arches:
     name: sound-theme-freedesktop
     evr: 0.8-17.el9
     sourcerpm: sound-theme-freedesktop-0.8-17.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/s/systemtap-sdt-devel-5.2-2.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 79108
-    checksum: sha256:2fb90e5f9bb0eaf80d4b59d4de2adf53de68500a3b4478867af4b0c66bdea6da
-    name: systemtap-sdt-devel
-    evr: 5.2-2.el9
-    sourcerpm: systemtap-5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/t/teckit-2.5.9-8.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 444027
@@ -4351,13 +4099,6 @@ arches:
     name: ttmkfdir
     evr: 3.0.9-65.el9
     sourcerpm: ttmkfdir-3.0.9-65.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/t/tzdata-java-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 233483
-    checksum: sha256:952b215f1e04b08ddfbf4bf19f6285d23f5a9d0dead6a64b4b9a6e1492fb2da0
-    name: tzdata-java
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/u/unixODBC-2.3.9-4.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 486298
@@ -4456,13 +4197,6 @@ arches:
     name: urw-base35-z003-fonts
     evr: 20200910-6.el9
     sourcerpm: urw-base35-fonts-20200910-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/w/webkit2gtk3-jsc-2.50.1-0.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4482779
-    checksum: sha256:ccb71e25608b6e75abe945511ef4c71b422a95714338e01c49c7c640fc03eb74
-    name: webkit2gtk3-jsc
-    evr: 2.50.1-0.el9_6
-    sourcerpm: webkit2gtk3-2.50.1-0.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/w/webrtc-audio-processing-0.3.1-8.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 304870
@@ -4589,20 +4323,6 @@ arches:
     name: bash-completion
     evr: 1:2.11-5.el9
     sourcerpm: bash-completion-2.11-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-2.35.2-63.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 5023899
-    checksum: sha256:c0daaed62bf2dc4ff0f3a30e3f0c538170c998c2b805acf931b7e8b77accf087
-    name: binutils
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 903496
-    checksum: sha256:71c324de618542f894eb113644b2082d2f0e8d648d31a32f8a5fe14a78a5d295
-    name: binutils-gold
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/bluez-libs-5.72-4.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 89503
@@ -4694,13 +4414,6 @@ arches:
     name: cups-libs
     evr: 1:2.3.3op2-33.el9_6.1
     sourcerpm: cups-2.3.3op2-33.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 297441
-    checksum: sha256:2309ea0f7d0419cce848392be9189383a8081e0d8bc2b20a9c6ab1c5b95c4812
-    name: curl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-21.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 779811
@@ -4785,13 +4498,6 @@ arches:
     name: elfutils-libs
     evr: 0.192-6.el9_6
     sourcerpm: elfutils-0.192-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 116016
-    checksum: sha256:fd3234795b06ce0a45bfdec417be51a88296c0da0ea5b0d156aa327839e33052
-    name: expat
-    evr: 2.5.0-5.el9_6
-    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/f/file-5.39-16.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 53149
@@ -4876,13 +4582,6 @@ arches:
     name: glib-networking
     evr: 2.68.3-3.el9
     sourcerpm: glib-networking-2.68.3-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.3.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2736665
-    checksum: sha256:772cd553d795798d1950f2da9e97f9eb80a0f6620cf3a3e17f7796cdbf9e6e86
-    name: glib2
-    evr: 2.68.4-16.el9_6.3
-    sourcerpm: glib2-2.68.4-16.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/glibc-2.34-168.el9_6.24.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1786734
@@ -4918,20 +4617,6 @@ arches:
     name: gmp
     evr: 1:6.2.0-13.el9
     sourcerpm: gmp-6.2.0-13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/gnupg2-2.3.3-4.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2614559
-    checksum: sha256:b8d86ab0a1db75c456ea1afd3cfb6412b30665e55ef6c3a5aa9fdcb9a5c7d972
-    name: gnupg2
-    evr: 2.3.3-4.el9
-    sourcerpm: gnupg2-2.3.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1048254
-    checksum: sha256:682fcb2e56dc07258afad84a1a4b2b143b7e95d67deb0d8c81ca5c3447227bb7
-    name: gnutls
-    evr: 3.8.3-6.el9_6.2
-    sourcerpm: gnutls-3.8.3-6.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/gobject-introspection-1.68.0-11.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 258397
@@ -5058,13 +4743,6 @@ arches:
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 787033
-    checksum: sha256:4682a9785422acb29457e95042974d342e45a12008ea8070b95ceb58cd717667
-    name: krb5-libs
-    evr: 1.21.1-8.el9_6
-    sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/less-590-5.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 169771
@@ -5079,13 +4757,6 @@ arches:
     name: libacl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libarchive-3.5.3-6.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 393863
-    checksum: sha256:df450146cd73d948038aa4bc707fc5e1f8a763089de91d06d3bd77b9d64002e1
-    name: libarchive
-    evr: 3.5.3-6.el9_6
-    sourcerpm: libarchive-3.5.3-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libassuan-2.5.5-3.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 71019
@@ -5114,13 +4785,6 @@ arches:
     name: libblkid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 322936
-    checksum: sha256:d0b95c3894f7cfe2be53d79923c14608f6d18d30b5cdddbd4d4c48e75fcbe74a
-    name: libbrotli
-    evr: 1.0.9-7.el9_5
-    sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libcap-2.48-9.el9_2.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 75490
@@ -5149,13 +4813,6 @@ arches:
     name: libcom_err
     evr: 1.46.5-7.el9
     sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 285965
-    checksum: sha256:bc17ae139d3a3284c6fdc2e5626baca87126de61045ab3a06dfcd6223dce7c5e
-    name: libcurl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 727417
@@ -5282,13 +4939,6 @@ arches:
     name: libmount
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 75928
-    checksum: sha256:049f00edc1895a2091d81a0dfb9c55c586d8f3f658bf8d19a834a20860c9edb1
-    name: libnghttp2
-    evr: 1.43.0-6.el9
-    sourcerpm: nghttp2-1.43.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 363241
@@ -5303,13 +4953,6 @@ arches:
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libpng-1.6.37-12.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 119529
-    checksum: sha256:4b5c5f328eb641047d857fbcc026dcdd9db65cd670df15e6bf0f0010990ddd6f
-    name: libpng
-    evr: 2:1.6.37-12.el9
-    sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libproxy-0.4.15-35.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 75974
@@ -5373,20 +5016,6 @@ arches:
     name: libsmartcols
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 214850
-    checksum: sha256:f0fd6f451b3673ea9cb4fe5e1561ccb0325a2bad7119d8f1ea783af2951026f3
-    name: libssh
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 7991
-    checksum: sha256:845c662af1f78eee4a1f67977a805b551edc939e21d3b201cb332682b18443fb
-    name: libssh-config
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-5.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 719222
@@ -5450,13 +5079,6 @@ arches:
     name: libxcrypt
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 747188
-    checksum: sha256:b7c97cd53466ce5b08f2958320012c4b083c31303a0da5be40b54ac66ac76c90
-    name: libxml2
-    evr: 2.9.13-12.el9_6
-    sourcerpm: libxml2-2.9.13-12.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 283159
@@ -5506,13 +5128,6 @@ arches:
     name: mpfr
     evr: 4.1.0-7.el9
     sourcerpm: mpfr-4.1.0-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-9.el9_6.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1941901
-    checksum: sha256:592454a4039e3dc801f1eac3c2077cfeed527dbb58278364714d719c9399c388
-    name: NetworkManager-libnm
-    evr: 1:1.52.0-9.el9_6
-    sourcerpm: NetworkManager-1.52.0-9.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9_6.2.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 414358
@@ -5562,27 +5177,6 @@ arches:
     name: openldap
     evr: 2.6.8-4.el9
     sourcerpm: openldap-2.6.8-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-8.7p1-45.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 463778
-    checksum: sha256:61e5df0df8802317203a9f4d4a2e928521905fe5a7f527130ab1f1dedfde2ef0
-    name: openssh
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 705047
-    checksum: sha256:c8588d3934dd98ad635e0cafade53b522a9f0984f0d22cfa438b10742f345e22
-    name: openssh-clients
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1398689
-    checksum: sha256:f914250a9ef52968e27af0f0e2520745df4443dc354367bec54dd06b4a2da60b
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 9593
@@ -5597,13 +5191,6 @@ arches:
     name: openssl-fips-provider-so
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2085943
-    checksum: sha256:fb9062e4635959a929f278002c5ff1bf35323987538c71fa86442c980eab4a44
-    name: openssl-libs
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 523171
@@ -5709,20 +5296,6 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 26147
-    checksum: sha256:3851bc964d444f1f6c3541dbee7925c306697eef2d12dd9e8c47b12637f8fbc4
-    name: python3
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8462232
-    checksum: sha256:4191303aa2093eae9020efdb77485b356e00f5e8470885a742267142d16d59e9
-    name: python3-libs
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1193706
@@ -5821,48 +5394,6 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-8.el9_6
     sourcerpm: sqlite-3.34.1-8.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-252-51.el9_6.3.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4153356
-    checksum: sha256:4bc7c421e87dd7b2f01808ed8866d0a029d28c8ed79cdeefa3bd81ec89e3d8be
-    name: systemd
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-libs-252-51.el9_6.3.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 650479
-    checksum: sha256:fe741c8d98688712e46d6f9cc15f6f31fe44af189fd1f3ee4a27e9f468923da9
-    name: systemd-libs
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-pam-252-51.el9_6.3.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 270149
-    checksum: sha256:14b9afdc8f071f0f1f8aa582700da1a18ad0db880f272ce6bf5ab5f0ad5c887c
-    name: systemd-pam
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.3.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 63512
-    checksum: sha256:0735a7ac27891726d56502705f25d14ad243d49bf1f097c9dcf3ce0bd5ca7a97
-    name: systemd-rpm-macros
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-udev-252-51.el9_6.3.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2051865
-    checksum: sha256:12068d82de83bec270c921c6e7d5d5fcef633972acf1d7bdedc893101fb9059e
-    name: systemd-udev
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/t/tar-1.34-7.el9.aarch64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 900197
-    checksum: sha256:44552dea889d350403c3074a33d7cb274b3f57553e47db998745df13f931b458
-    name: tar
-    evr: 2:1.34-7.el9
-    sourcerpm: tar-1.34-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 572170
@@ -5870,13 +5401,6 @@ arches:
     name: tpm2-tss
     evr: 3.2.3-1.el9
     sourcerpm: tpm2-tss-3.2.3-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/t/tzdata-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 862160
-    checksum: sha256:0687e5a1115ba679137404c8d37a45141a31968ffd01677455530d24c126a0d2
-    name: tzdata
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/u/unzip-6.0-58.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 186875
@@ -5898,13 +5422,6 @@ arches:
     name: util-linux-core
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 13249
-    checksum: sha256:9298e32061a3bce9b94f8c1bd1ac3ee0bfa67a68863cc3a0cd97c5432b6e89ed
-    name: vim-filesystem
-    evr: 2:8.2.2637-22.el9_6.1
-    sourcerpm: vim-8.2.2637-22.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/w/which-2.21-30.el9_6.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 41522
@@ -5996,7 +5513,3192 @@ arches:
     name: unixODBC-devel
     evr: 2.3.9-4.el9
     sourcerpm: unixODBC-2.3.9-4.el9.src.rpm
-  source: []
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1436772
+    checksum: sha256:00c4066bca9d20f93f38d2a59fef8c82abcea36aa9dc4a62b72e8027bff873e5
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/crun-1.26-1.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 242042
+    checksum: sha256:0a3d9f02540dd07366787661c4a252be88da3f217c6b618fb6107c5bd92ae92c
+    name: crun
+    evr: 1.26-1.el9_6
+    sourcerpm: crun-1.26-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 500815
+    checksum: sha256:28bbcf2f64c1d75f8cb333b882f4eb7fb67eb0c90e84d1d9eedeb99e41f96cff
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 87957
+    checksum: sha256:bf86456195a207150a9f04c7082efb9650219915681c1c7945377451fb2874ab
+    name: gdk-pixbuf2-modules
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/giflib-5.2.1-9.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 47772
+    checksum: sha256:b9fba782fd18ec9b29a3fa8084b30732c40b998437d48d1a60a4b31f60131b9e
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+    sourcerpm: giflib-5.2.1-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.3.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4438597
+    checksum: sha256:e7ea6ab91c2e40a912ad9d6d2b0dd621048ea6812bb1f711b3b61db4c44b2b53
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+    sourcerpm: git-lfs-3.6.1-2.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 27174
+    checksum: sha256:d045b514c2b217509ffa931e4647a613bd49f8aea31e42a030320cd6ab1f9b26
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_6
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 2221812
+    checksum: sha256:9f6f9ff87d912ec32cc3fbc84a620667674f06affdffea13514eba351774a7dd
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+    sourcerpm: gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 462726
+    checksum: sha256:c9ced87c982304d0815d10d8f0d88f877347ee752256608a4828961ab462d345
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.19.0.10-1.el9.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 46696780
+    checksum: sha256:2383eff65fc7abdf5886eb96b98f28e345d61674849d9a207eedb0c9b030a5cb
+    name: java-17-openjdk-headless
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.110.1.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 3787937
+    checksum: sha256:edcc1e144c9e1bfb4bccceccc318a39e0b599e5e100525c0993e41fcc2c668fb
+    name: kernel-headers
+    evr: 5.14.0-570.110.1.el9_6
+    sourcerpm: kernel-5.14.0-570.110.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 406012
+    checksum: sha256:9574d38a8286ff77bb068b39f49df9c7b6a1c675eaccca95a2ded8c308a4cc97
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+    sourcerpm: libsoup-2.72.0-10.el9_6.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.3.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 195170
+    checksum: sha256:b67843685407a0fb46a5ff34ad0124cd4a038fdbf2c837d2e17898e3dd982b80
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+    sourcerpm: libtiff-4.4.0-13.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 244463
+    checksum: sha256:5c2b240916b054dd00e8add4fe43479816f2b214ea8be3461de6a710bc5e39d1
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+    sourcerpm: libxslt-1.1.34-13.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 8368902
+    checksum: sha256:063f3e1b6f05b8f308496e24bf9d415152ea665ca15a55ed0816bac7ee810983
+    name: mesa-dri-drivers
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-filesystem-24.2.8-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 10522
+    checksum: sha256:0e43b84222f51636a1625df3d57bd17bc95762710b9979434a7394c992553090
+    name: mesa-filesystem
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libEGL-24.2.8-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 139703
+    checksum: sha256:a9089cb244eabd29fbb70b9b52c7af5ff143dc9eef95007551a65702375a46b4
+    name: mesa-libEGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libGL-24.2.8-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 178409
+    checksum: sha256:31379af880d6bf2ae751866c0ebc2fed8f65f629b08c0579b90d7d01c0d20f41
+    name: mesa-libGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libgbm-24.2.8-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 35787
+    checksum: sha256:647cad0c2a971e18def2b77b052ecad14c03deb2be045d796296e7825efb0c21
+    name: mesa-libgbm
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/m/mesa-libglapi-24.2.8-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 62005
+    checksum: sha256:9e83e299ea04bdd574f26eacc53eb136e43c2f4e4efd5f4b3aed28dff79238ae
+    name: mesa-libglapi
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/n/nspr-4.36.0-8.el9_4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 133009
+    checksum: sha256:62c1b2f3c3449398c9e26260fd5ffef5b2a98c46021f0500997acf300dd73c8c
+    name: nspr
+    evr: 4.36.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-3.112.0-8.el9_4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 716665
+    checksum: sha256:0ef932c6db313eaa521bf06bfb9f4db64fde4c7ebd0d7c1a52d83d47681c3835
+    name: nss
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-softokn-3.112.0-8.el9_4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 401904
+    checksum: sha256:b29a815c51c277a643d6be562b5adada99b176a5ba88ef70846857dd5a7afae3
+    name: nss-softokn
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-8.el9_4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 426649
+    checksum: sha256:bf4b311a50db968ea7b6792d4bc65abd76c69e175c1f98c93ab58b15ace50867
+    name: nss-softokn-freebl
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-sysinit-3.112.0-8.el9_4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 18107
+    checksum: sha256:94fece74db2641d00a59c645854b095079ceba5229ff865ed7f4c02b668a94f6
+    name: nss-sysinit
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/n/nss-util-3.112.0-8.el9_4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 88444
+    checksum: sha256:231995ed0e7855c83a0ce2ff70d435c430b32f347573cc4969734438715b313c
+    name: nss-util
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/o/openssl-devel-3.2.2-7.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4627737
+    checksum: sha256:e13aee56bab18df29daf00c6b8a72dc66d1863c3ad6e71045d752729dbfeb828
+    name: openssl-devel
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/o/ostree-libs-2025.2-4.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 434036
+    checksum: sha256:9ad0cc79c88cc6d5f4bc4005f5d18c2ddae724f8ba9ac5f432cbb130e0e52508
+    name: ostree-libs
+    evr: 2025.2-4.el9_6
+    sourcerpm: ostree-2025.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 243635
+    checksum: sha256:84f32d5af040a4fa70fd595b1cb7f04acc75a7262355bc6aa3c003be0a46ca2e
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+    sourcerpm: perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/poppler-21.01.0-22.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1026553
+    checksum: sha256:f1c46a6a97a77bfc2303ad0cda4c7d6f7ac4f216b38ed49b20d03a7885b8ec26
+    name: poppler
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/poppler-glib-21.01.0-22.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 146390
+    checksum: sha256:e258048d6b871d40f5d18a9898bedc50b0933bb54f6398039ca00e9dd475d49c
+    name: poppler-glib
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/postgresql-13.23-1.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1691630
+    checksum: sha256:2b460a2169e50f9399ed730160d46248af75369bef717bf7d0bfe4e99b97a2d5
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/postgresql-private-libs-13.23-1.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 138239
+    checksum: sha256:8eb3a0b5e70bd385bdb7617f42219ae887d4d865f35d6bc0ac46aaae890011f1
+    name: postgresql-private-libs
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/protobuf-3.14.0-16.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 957285
+    checksum: sha256:21eae886d36e74ab57c5856e1fe75f0b6f6f6cb355fe15e4845552429bb30878
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+    sourcerpm: protobuf-3.14.0-16.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.5.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9159
+    checksum: sha256:589d36caea67e6e33607045cb1614aa0070de792fcca10a24d50d06280204496
+    name: python-unversioned-command
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.5.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 249960
+    checksum: sha256:73e4d65ad07c0f983e08336b740770d718114e151c4c7c716d26b2ad1b1c2ca0
+    name: python3-devel
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 8858898
+    checksum: sha256:bbcbc8bf94bd6646502ef1c55996766d27073fe90c860d90826998fe01385d57
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+    sourcerpm: skopeo-1.18.1-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/systemtap-sdt-devel-5.2-4.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 74915
+    checksum: sha256:1fe7a745555611f3d4939ff16e52cf8d37d91fa0b91f4a797394681647a3a3cd
+    name: systemtap-sdt-devel
+    evr: 5.2-4.el9_6
+    sourcerpm: systemtap-5.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/t/tzdata-java-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 228444
+    checksum: sha256:6278f74c2029794cc7eea4a9bb298bda81e9ef165c689cb8e0a09584e0b7104c
+    name: tzdata-java
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.3-1.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4592158
+    checksum: sha256:d51b7a0a7a689d19e3f906cd4cb5819d5e625e629c45b09cb83a6cd12ae2dd51
+    name: webkit2gtk3-jsc
+    evr: 2.52.3-1.el9_6
+    sourcerpm: webkit2gtk3-2.52.3-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-2.35.2-63.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 5018051
+    checksum: sha256:20efd1dc9369ac73f70517add633750f642de16def4bb0c9ca1ec41fdcd1ba38
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 901490
+    checksum: sha256:2578225a6e1c7e4f245fa10c6782c7c62baba7069eda90d1010a07217fb60814
+    name: binutils-gold
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/c/curl-7.76.1-31.el9_6.3.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 295564
+    checksum: sha256:77dfbb21055047acd9e7dafc66940f0aef3679c06d96a74af19c247e4f5ee61d
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 114276
+    checksum: sha256:e8d6aa4fe8b26b09a06b2f99f91ec91cc8c6733e564f0a57fd43167b95a7a9ca
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+    sourcerpm: expat-2.5.0-5.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2736323
+    checksum: sha256:4c04aff96ae3c0c9c4c5cd8900cb4450b8dbc0a5b0a6a71c1012167bc9d63f32
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+    sourcerpm: glib2-2.68.4-16.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/g/gnupg2-2.3.3-4.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2606840
+    checksum: sha256:11c2dd18a341fae0e62f76fb9c1916ffdcba4a7acabf641743601328dc1be8c2
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+    sourcerpm: gnupg2-2.3.3-4.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.3.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1050181
+    checksum: sha256:1559989ce1dbfab84515dabe77e73190162f1ea9c5ed700d0386dff3afdf1592
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+    sourcerpm: gnutls-3.8.3-6.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 785550
+    checksum: sha256:ee02be20f133ff7cc8a1e3744aa2e452390e0427109395cb0b43236b370de109
+    name: krb5-libs
+    evr: 1.21.1-8.el9_6.1
+    sourcerpm: krb5-1.21.1-8.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libarchive-3.5.3-7.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 394025
+    checksum: sha256:8c1f5f7ff517776b06cd35b6a1a4ff2f037f45cb7d47ab13a73dbf08072c7e5f
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+    sourcerpm: libarchive-3.5.3-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 318088
+    checksum: sha256:c32e50ccada28e7641d7dbbd95aa891aaa7579165f9a071409883bc5485e45c4
+    name: libbrotli
+    evr: 1.0.9-7.el9_6.1
+    sourcerpm: brotli-1.0.9-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.3.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 283927
+    checksum: sha256:0ce34bffa2f5fd9d18956ccbb4510bb653a813120caaf2a180042681a73da9cb
+    name: libcurl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 72988
+    checksum: sha256:626a3b9d03caf15b3d12f90d362f2928e156ec5da047ae757ddbb58de9147a2b
+    name: libnghttp2
+    evr: 1.43.0-6.el9_6.1
+    sourcerpm: nghttp2-1.43.0-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libpng-1.6.37-12.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 116280
+    checksum: sha256:9ab43979b2379b70c04a994cff8cb4c905726a817d7dccc9bc5b56ece41878eb
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+    sourcerpm: libpng-1.6.37-12.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 214937
+    checksum: sha256:4e1a0d8a120047d99ba30c0511b1b441d069edc28eb44ae6057f5a4e1eed61db
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8157
+    checksum: sha256:cb0bf985f9cbb43161d848b6849234c95fed7acdd0aeb1f8113ac17ba23a7ce2
+    name: libssh-config
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 747293
+    checksum: sha256:73583dc39fe165586789691ce503dc6df9957bbd2f3503642102e14634fd1a0b
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+    sourcerpm: libxml2-2.9.13-12.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-10.el9_6.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1940394
+    checksum: sha256:d94d90ea1c66f1c48723da7a433f8ed0d4fa3b6cb8ed8e41786b7e0b958f5211
+    name: NetworkManager-libnm
+    evr: 1:1.52.0-10.el9_6
+    sourcerpm: NetworkManager-1.52.0-10.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-8.7p1-45.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 456820
+    checksum: sha256:8a8eed20672cdd7dfa7cabb3a6d0db93a45e0f78d60f8194c8723cc96fb28cdc
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 698879
+    checksum: sha256:60e1843ee481b3a1a29dd84fb1b83af57748fd31146a132f70ba238134f12b98
+    name: openssh-clients
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-3.2.2-7.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1384462
+    checksum: sha256:aa1bdeabfb4d466325cca4197372d1bb44b935ce301cc45929ebb6dda9810eaa
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-libs-3.2.2-7.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2073917
+    checksum: sha256:b8d003d64cd7f838e18a85c9fbae4d0d5dd98ce21bc0558015b37b1bad6b3351
+    name: openssl-libs
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.5.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 26184
+    checksum: sha256:020ac473241dd2724c20916b23a1eed9d5457d00b8f788dab3fb930cba16959a
+    name: python3
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.5.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8461044
+    checksum: sha256:a4e98c429761c256b6924cc9ce6ffb068db53cced45af2e6177d09a2f6c7167e
+    name: python3-libs
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-252-51.el9_6.4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 4153453
+    checksum: sha256:b5aea886e072ba7cc1c575c99117ccc777e616d0731406f61e7cb0efd50c3daf
+    name: systemd
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-libs-252-51.el9_6.4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 649917
+    checksum: sha256:1a2cee9ae4f07cc17c78095ef2476206e21755951981743965e45526ffa3065a
+    name: systemd-libs
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-pam-252-51.el9_6.4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 269426
+    checksum: sha256:18637605d736e22b70341b2baa8d578d56a92301eee2d237dd898278f8ea1d05
+    name: systemd-pam
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.4.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 62787
+    checksum: sha256:96fa8cf07e84e172156c7229a95cb74de5f1980389730d8fa5c4ef4113fe4ded
+    name: systemd-rpm-macros
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-udev-252-51.el9_6.4.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2049547
+    checksum: sha256:7191b1fb46a0834590ccfe434f3a789a60f05f5aa87540f516b21aba8e412c39
+    name: systemd-udev
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/t/tar-1.34-7.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 897893
+    checksum: sha256:15e888c97b5d59cfd48b813b7dec65f73b9ca8f06154ec56b500fefcf6447aef
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+    sourcerpm: tar-1.34-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/t/tzdata-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 926162
+    checksum: sha256:ae429e8acbacad17e1b65a4571fcbf85122925cabeb97d25a9699774c1c38bbd
+    name: tzdata
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.2.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 13634
+    checksum: sha256:c5bdcda9be95aa6c7467bd64fb32f6a9cf2fee9421a728901889e850e83a4b29
+    name: vim-filesystem
+    evr: 2:8.2.2637-22.el9_6.2
+    sourcerpm: vim-8.2.2637-22.el9_6.2.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhelai/3.4/source/SRPMS/Packages/l/libsndfile-1.2.2-6.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 750483
+    checksum: sha256:2ed7a90be00fa333f0274d17dd68bb11366f4543434f2b63b398fbd29416b9d7
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhelai/3.4/source/SRPMS/Packages/t/texlive-tcolorbox-20200406-1.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 4964524
+    checksum: sha256:1bc9bb50498a035797cbe8cf8e2499f5d6e6f87ef6a97d5c682d3e98c41b7c2b
+    name: texlive-tcolorbox
+    evr: 20200406-1.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/source/SRPMS/Packages/c/containers-common-1-78.rhaos4.16.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 98665
+    checksum: sha256:7f31f05fa1f959849a1aead06559015cfbdcec919b7b5027e0c8c97785b636e3
+    name: containers-common
+    evr: 3:1-78.rhaos4.16.el9
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/source/SRPMS/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 16183933
+    checksum: sha256:0d3a9996f6287020460e6e91cfb22c636a047a5488d27a09ac6bbfce22d17810
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/abattis-cantarell-fonts-0.301-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 582900
+    checksum: sha256:ce11dc78d92b207947633e00a792a3c8c3b7b4f23c2b7912eaba587dc7893f4c
+    name: abattis-cantarell-fonts
+    evr: 0.301-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/adobe-mappings-cmap-20171205-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4127058
+    checksum: sha256:7c2f5be26bd8cee4e6a5b37a399484c9b230dd3fa8e93e45636d96c914d2504f
+    name: adobe-mappings-cmap
+    evr: 20171205-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/adobe-mappings-pdf-20180407-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1445392
+    checksum: sha256:84f5b00a6bf51f6b77ef54e7672da8dfb5aac1e55e88111dc8ef3384f6376d1c
+    name: adobe-mappings-pdf
+    evr: 20180407-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/adwaita-icon-theme-40.1.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17249062
+    checksum: sha256:0a59369173dca9368ed6b14bd4d068768ea45b4dab9a73cb8fa578990e8e53af
+    name: adwaita-icon-theme
+    evr: 40.1.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/alsa-lib-1.2.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1215277
+    checksum: sha256:1b9db2aa1e09cb40372bdcd1dfe6f613d20b7eaed88028687c96c934379e7d6f
+    name: alsa-lib
+    evr: 1.2.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/annobin-12.92-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 998524
+    checksum: sha256:65ee4ea686dfa6a8da136896ff590fb476248e998a14c38b28713a34a23cf1b9
+    name: annobin
+    evr: 12.92-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/at-spi2-atk-2.38.0-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111112
+    checksum: sha256:5713e30db407b1debad820ea89e57f3db5fe9c4e222ce44ab45d9e38ce52fe5a
+    name: at-spi2-atk
+    evr: 2.38.0-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/at-spi2-core-2.40.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 213364
+    checksum: sha256:3a5717b63603264a184a1ef26f606898c7f0ecc4b57ebd996d05b73a77bb8336
+    name: at-spi2-core
+    evr: 2.40.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/atk-2.36.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313725
+    checksum: sha256:171734f6cf9638497ccaccb73ab79b49d37085930e0c03d4c954aac2eaddbdc9
+    name: atk
+    evr: 2.36.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/autoconf-2.69-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1239007
+    checksum: sha256:946149054ebac72d6e6694d2525bca703c5faaa414f1f74ee7e12b0754c01cbd
+    name: autoconf
+    evr: 2.69-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/a/automake-1.16.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1598281
+    checksum: sha256:ac46e755161516f951c497c2794f344716a271ba68531883edb17bbbbab8958a
+    name: automake
+    evr: 1.16.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/cairo-1.17.4-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41864767
+    checksum: sha256:0185c51c6c00b3a238e9038addfa1be86fee1b3cc3933efdd4f05f8c5db775d6
+    name: cairo
+    evr: 1.17.4-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/cmake-3.26.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10671338
+    checksum: sha256:2f86bb96562eaf679969c2716738fbdfcc8a3966ecc3bb6317596fe2e214ea2b
+    name: cmake
+    evr: 3.26.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/colord-1.4.5-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1889181
+    checksum: sha256:e84bbbfb02504405637c022bb2cf90f2e278bbe1e136915a93b9f6e4d8402754
+    name: colord
+    evr: 1.4.5-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/composefs-1.0.8-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 8969650
+    checksum: sha256:13901e1b50ee0021eb56092859869125ea6ac9f2eafb2a880d758e87a18825e8
+    name: composefs
+    evr: 1.0.8-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/copy-jdk-configs-4.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17565
+    checksum: sha256:df1244121141d62420480aa1e07486bd0fa548360c2062c1ef138716dd7d68e8
+    name: copy-jdk-configs
+    evr: 4.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/criu-3.19-1.2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1397633
+    checksum: sha256:b055915dd2fd04c16c79a36775e1647f7c4f020cd341e94cda3a59898c3d6502
+    name: criu
+    evr: 3.19-1.2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/d/dconf-0.40.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133768
+    checksum: sha256:bbf4109630c6b65ff78bd4332c9a3b31c44776ff089361f0586cea1e758bbe25
+    name: dconf
+    evr: 0.40.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/d/dwz-0.14-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 159459
+    checksum: sha256:7565e0aed6cfb90c2c4be4ae2b33536fc4cf9b1b05a6a07da940ec564475580f
+    name: dwz
+    evr: 0.14-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 44824139
+    checksum: sha256:50a3faee5df3fd8d39609d97a62ef1297f668733105f4871d41a9257840269a3
+    name: emacs
+    evr: 1:27.2-14.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/e/exempi-2.6.0-0.2.20211007gite23c213.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19993045
+    checksum: sha256:2913c28e8198b0f722c4b16eebe6a102fdb4e33d934ad863aaf3fd25af4ff4aa
+    name: exempi
+    evr: 2.6.0-0.2.20211007gite23c213.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/e/exiv2-0.27.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32725837
+    checksum: sha256:65335824ab2515880092f0d0557882669e95f8c064aa4a18f2d36a3a3725913d
+    name: exiv2
+    evr: 0.27.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/f/fdk-aac-free-2.0.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2184629
+    checksum: sha256:2ccc9e447d4d1aa5ee0eccc9f06064bbb3f8c170c24f769a5dd7b580bf72537e
+    name: fdk-aac-free
+    evr: 2.0.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/f/flac-1.3.3-10.el9_2.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1063337
+    checksum: sha256:c9a340cb3e679da5f281425dcf1e785a2e882e733631638b45e76d3aa1f2e68f
+    name: flac
+    evr: 1.3.3-10.el9_2.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/f/flatpak-1.12.9-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1595419
+    checksum: sha256:5c870a95bee4384b536f3f53423e4e313dd5ebe0493ca12cfb71b09f84750ce2
+    name: flatpak
+    evr: 1.12.9-4.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/f/fontconfig-2.14.0-2.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1460194
+    checksum: sha256:623ac6b43061ad2f2b5d07861dfeb9b83ef70ead8df02319d375e71bc0110b67
+    name: fontconfig
+    evr: 2.14.0-2.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/f/fribidi-1.0.10-6.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1177189
+    checksum: sha256:d5e12deb110f7a5a8776435efa8f6c5e42ecf990e0ed27f95293020b65891254
+    name: fribidi
+    evr: 1.0.10-6.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 114235
+    checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/geoclue2-2.6.0-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108381
+    checksum: sha256:4ce03414616b5a8af25be3a451576b938b10c2c50a1ae9eab64627837f3f3ca8
+    name: geoclue2
+    evr: 2.6.0-8.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/ghc-srpm-macros-1.5.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10180
+    checksum: sha256:2d980af2311afd353583b200783cb39a5da7e89b6dbb9e67aa7d77a2c53e0cab
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/ghostscript-9.54.0-19.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 56071528
+    checksum: sha256:b2d608294cabab2b30197fa1ad90bff391840d5bfed4455081f627119c3cec87
+    name: ghostscript
+    evr: 9.54.0-19.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7707656
+    checksum: sha256:815c2ae9574006ecb596000492929264de785444736ee3968d5ee34cb6e75159
+    name: git
+    evr: 2.47.3-1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/google-droid-fonts-20200215-11.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3288061
+    checksum: sha256:b58b720be2c7a22d8a3c25731bfacaffc11f4d805f15a05022382cb456ec9f96
+    name: google-droid-fonts
+    evr: 20200215-11.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/graphene-1.10.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 345896
+    checksum: sha256:80bb7aed95ed969225d7b3b9d36103511b52b554c01f90c44681d18a861e2031
+    name: graphene
+    evr: 1.10.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/gsm-1.0.19-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80557
+    checksum: sha256:1a6ba3deaab6b12d3bcd23126c69340795d353e6b2eea36bf3696064db1be11c
+    name: gsm
+    evr: 1.0.19-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/gstreamer1-1.22.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1824267
+    checksum: sha256:cc25d402dff67470712a6032acc99f393898df78cdf30a2e346550db5a8ec091
+    name: gstreamer1
+    evr: 1.22.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/gtk3-3.24.31-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22491893
+    checksum: sha256:a6d0d395b3f0c64c10b8ccea931b318eee6ae36015b9852631c76d68283f0a68
+    name: gtk3
+    evr: 3.24.31-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/h/hicolor-icon-theme-0.17-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65737
+    checksum: sha256:8e62b8cf7aa5c7ef7a9ce6d1f1b159eeba7bc24519fbbb012e8a573ac072bcc6
+    name: hicolor-icon-theme
+    evr: 0.17-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/i/iso-codes-4.6.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14096241
+    checksum: sha256:3b17af011d4074e0fac62f3cf699090889892a45cf317df37942ebd2b39bc934
+    name: iso-codes
+    evr: 4.6.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/j/javapackages-tools-6.4.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 210942
+    checksum: sha256:7915590da093f42d4cfccb6196e1e3f22dce8d36f850ed2d46d0f41f238de01f
+    name: javapackages-tools
+    evr: 6.4.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/j/jbig2dec-0.19-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 584264
+    checksum: sha256:ac2fcfa2e65095617b1b9efef5ae8bf52e69e0f4b3b152ddd3c3c2fb7da0b3f7
+    name: jbig2dec
+    evr: 0.19-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/j/jbigkit-2.1-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 456145
+    checksum: sha256:7761a61c9cdaa019287d8daa7639d47e76f9ec1b177a50e94b46ceadf0c2cbfa
+    name: jbigkit
+    evr: 2.1-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/k/kernel-srpm-macros-1.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28536
+    checksum: sha256:6607ae4cf2e0ee6971a740ef64937853e4e636179822de40e709e8e3e0c7853b
+    name: kernel-srpm-macros
+    evr: 1.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/lame-3.100-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1537232
+    checksum: sha256:6e17b1767f6a8949f7ae4f549fbc4f93d4074072f3499a2346a2ce5f2b248d83
+    name: lame
+    evr: 3.100-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/langpacks-3.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28929
+    checksum: sha256:59d393e1505dc39e15cad9e0f0f54d5392f230aeaafadf4af09b31391ca573f4
+    name: langpacks
+    evr: 3.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/lcms2-2.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7428658
+    checksum: sha256:d0605c68533c1656eabe3d6d5a41b97513a9264030a28c46baad2cdcf57ec09c
+    name: lcms2
+    evr: 2.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libX11-1.7.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2436722
+    checksum: sha256:8720840bc38af119d62734144a5e8c95c1400ba42bd877e4279a786120d878d7
+    name: libX11
+    evr: 1.7.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXau-1.0.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335512
+    checksum: sha256:3a52f0d37183b84a7f8d37d6ca314ec17a32c1d4167c9131cf4000285d82c59a
+    name: libXau
+    evr: 1.0.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXcomposite-0.4.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 329141
+    checksum: sha256:10f74555246a4a992de429bf1139b762ca6b8d754d092a5eb85f0c55f576a9db
+    name: libXcomposite
+    evr: 0.4.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXcursor-1.2.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 347960
+    checksum: sha256:80bedd1206fa645654fbb6fd05fed788700ca3bf2cc0ade2408abc0a5802a801
+    name: libXcursor
+    evr: 1.2.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXdamage-1.1.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 315892
+    checksum: sha256:15c2c0d99190985a2a7d376b0cbb2d9f6172ebdcb1a3305ac0bbd7a394942e8c
+    name: libXdamage
+    evr: 1.1.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXext-1.3.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 401955
+    checksum: sha256:7f50b5d07f8e1782c4ad2c485416f210004db0477588465167c257aa62fd0b6c
+    name: libXext
+    evr: 1.3.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXfixes-5.0.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306511
+    checksum: sha256:3c8feb2710a52fe119d58369895cb2a17a10097a0a6b3a2bf469f0e34cf58db6
+    name: libXfixes
+    evr: 5.0.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXft-2.3.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 365800
+    checksum: sha256:b1ef5a942e759207022bf9bff3d122bc9596914d8dd7ab92ea56ebcad96ee9a6
+    name: libXft
+    evr: 2.3.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXi-1.7.10-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 498271
+    checksum: sha256:1de8a31cbe5edf8d10fe85fd96c1ebd1d0525c08a3ec75599ef12bad2945545c
+    name: libXi
+    evr: 1.7.10-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXinerama-1.1.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 297833
+    checksum: sha256:c9f68ea2938d52730688d24fc8b50f583193ab20ae158746e7751d8e092e92ed
+    name: libXinerama
+    evr: 1.1.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXrandr-1.5.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 343241
+    checksum: sha256:a565d64c7ff4b9c46cfc916097b1c8c9d886c006a7c18eac085f4ca6b4e8d310
+    name: libXrandr
+    evr: 1.5.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXrender-0.9.10-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:5fc0f3794b08cc71d89bf24c19a4a02c2d15c63850225327af9f20b45e1250e8
+    name: libXrender
+    evr: 0.9.10-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXtst-1.2.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 332563
+    checksum: sha256:59a99e7e1af8762969b9212aa5375be77a7bdafce73f416be82694b16ec388d5
+    name: libXtst
+    evr: 1.2.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXv-1.0.11-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 328666
+    checksum: sha256:fac6cc1bff31576443af0c71b3ffb1fbcd6e53b8fef38241ec0093cfba739c85
+    name: libXv
+    evr: 1.0.11-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libXxf86vm-1.1.4-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 305757
+    checksum: sha256:1e6c5a2d734c54d881523b50f1307ece5815574512fd7dedb10ee38282608532
+    name: libXxf86vm
+    evr: 1.1.4-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libappstream-glib-0.7.18-5.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2332780
+    checksum: sha256:a00834a072ed97371d8ffbccdbf5747d0d8e64ec2ae4e17f90d5c5e8bbdd22d8
+    name: libappstream-glib
+    evr: 0.7.18-5.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libasyncns-0.8-22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 351816
+    checksum: sha256:93c66acfdc39c88c4cced4056c53d2c637e667da2b09a8e9004f7c05bccb490e
+    name: libasyncns
+    evr: 0.8-22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libcanberra-0.30-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 336225
+    checksum: sha256:101d6e863d2b367a2d00cf29e75670c8190acfb8f19c0f31db66d4c5914f6ad6
+    name: libcanberra
+    evr: 0.30-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libdatrie-0.2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 325692
+    checksum: sha256:c9a3acd383ebb5f8d5d2c069dca717f147fddc461155cc12f07572972a82e7fe
+    name: libdatrie
+    evr: 0.2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libdrm-2.4.123-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 500530
+    checksum: sha256:8fd4b075f14ade405808c1ae309270aad50709f615bcd24d93aa39ae65e3a977
+    name: libdrm
+    evr: 2.4.123-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libepoxy-1.5.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 235419
+    checksum: sha256:53500b6a43fdf7e1a5083491d3ccdc808d2bec45a5559ff3eb9a14be798f8423
+    name: libepoxy
+    evr: 1.5.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libexif-0.6.22-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1123325
+    checksum: sha256:cbc3a148928165b570202330b52dd1baef75ff0b7479a0de16d7da0c252af8e3
+    name: libexif
+    evr: 0.6.22-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libfontenc-1.1.3-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313939
+    checksum: sha256:d169ca46af1a05f9f96805cb39acc44e794688b240e835c400353fb8f9e6302b
+    name: libfontenc
+    evr: 1.1.3-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libgexiv2-0.12.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 393822
+    checksum: sha256:5cba4e86ba7149ed6b9d90bd53fda20a17227218563b0ffc08b6ef0efc953914
+    name: libgexiv2
+    evr: 0.12.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libglvnd-1.3.4-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1046031
+    checksum: sha256:dbb82468e248c1dcb455f14b6c03b2a2772233f0c6b9e542c703bb3e4b96cb90
+    name: libglvnd
+    evr: 1:1.3.4-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libgsf-1.14.47-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 705600
+    checksum: sha256:393825b1ac768befa5cf2d1678c872231ebb77ceabb8eca8934d44eacf4ff0ea
+    name: libgsf
+    evr: 1.14.47-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libgxps-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91543
+    checksum: sha256:8a21727bce320f7736ce43cc5ffeeff3d6babc299b23b665df6b8fd1b450c770
+    name: libgxps
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libijs-0.35-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 423495
+    checksum: sha256:50aa92a3658366bf48452eb29154886da20761e885d7f52c3770c0e36aa6c562
+    name: libijs
+    evr: 0.35-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libiptcdata-1.0.5-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 604357
+    checksum: sha256:182950ba5b02a71634571889e11e70b94b4c91da56fa1836cb77bc85e44b3720
+    name: libiptcdata
+    evr: 1.0.5-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libjpeg-turbo-2.0.90-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2271766
+    checksum: sha256:6766d34e67f5bbfd82c5d543596b46790a2d98c97c2a33b67781829cac86c705
+    name: libjpeg-turbo
+    evr: 2.0.90-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libldac-2.0.2.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 86540
+    checksum: sha256:28903f22a062d976f8ff02786c4006fea01c0de6b5702a511351a9180e82d68b
+    name: libldac
+    evr: 2.0.2.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 846236
+    checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
+    name: libmpc
+    evr: 1.2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 611553
+    checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
+    name: libnet
+    evr: 1.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libnotify-0.7.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 115322
+    checksum: sha256:ea8f8a235fb2feb6bf876c44024551e92c770f0d78b1f879485a5bcf5a6e964e
+    name: libnotify
+    evr: 0.7.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libogg-1.3.4-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 441193
+    checksum: sha256:5e218f83debe3dafbbe5795b0696d7ecb00b88b4c1c78bc4acb6e83b9cf9d56b
+    name: libogg
+    evr: 2:1.3.4-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libosinfo-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306786
+    checksum: sha256:2efb475aa7815e6f24efaa0ca26276785935ec611d9a13ff3ded1dcda59b5fae
+    name: libosinfo
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libpaper-1.1.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57233
+    checksum: sha256:1648c52d0e1f0e8e10101106eb7d95a4f069176846fee76b1f6c0a1904b0750f
+    name: libpaper
+    evr: 1.1.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/librsvg2-2.50.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22252235
+    checksum: sha256:5c0fdc6b36b2bb071c73d1181bd76ec6252b20b2ace475e86f0a69b27733f3a0
+    name: librsvg2
+    evr: 2.50.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libstemmer-0-18.585svn.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 142242
+    checksum: sha256:c21d9668bbfba8bcff8be8442c0dee31190efbcc362bd29e7e5e128869cb64f1
+    name: libstemmer
+    evr: 0-18.585svn.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libthai-0.1.28-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 426287
+    checksum: sha256:1bff93f9076778b16fea27d75a7434caf8e9fb5e9bcabbf2cf8f7f0069302d73
+    name: libthai
+    evr: 0.1.28-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libtheora-1.1.1-31.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1451614
+    checksum: sha256:c43318355a6c960e0685d789887cddf450fdfd7908ba1a02d375e1ff290b3483
+    name: libtheora
+    evr: 1:1.1.1-31.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libuv-1.42.0-2.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1300269
+    checksum: sha256:f9dfa0dc965675730184604570c6a2aa95ddc2dfa6a7cb209514b1e744a4e3d7
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libvorbis-1.3.7-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1216523
+    checksum: sha256:2c9f1a80c9f1b7c2d6872ef82bd385a68abb37be3ab8d3bfc26dcb6c7c5ef477
+    name: libvorbis
+    evr: 1:1.3.7-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libwebp-1.2.0-8.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4112860
+    checksum: sha256:34b9ace12d22dffba4277247a539bce83ccf6a517fd2ac3f603bd092a90e23fa
+    name: libwebp
+    evr: 1.2.0-8.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libxcb-1.13.1-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 519787
+    checksum: sha256:6e79beeac5762cb0f4eca5a4e09aaf9f607b8d54a8154e68a672c4d42e5a617b
+    name: libxcb
+    evr: 1.13.1-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libxkbcommon-1.0.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 446799
+    checksum: sha256:47b1254e062547a0e553b4e072498a91bf3c7364c8499c15a2762858197c50de
+    name: libxkbcommon
+    evr: 1.0.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libxshmfence-1.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 319069
+    checksum: sha256:9a36c33eafdf600040cb41cc1d8ca40395a3e00f2fd6a41a28ad66644d90edaa
+    name: libxshmfence
+    evr: 1.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/llvm-19.1.7-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141371853
+    checksum: sha256:2da62e4083e0f9ff5ca3d5ffc794682ff16004b2f0b38b4a103e34d18dbd322e
+    name: llvm
+    evr: 19.1.7-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/low-memory-monitor-2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34855
+    checksum: sha256:ddbf37a31d785971549ab83b2f554c112bf1cefc10ca2b36326e8367e04a68c2
+    name: low-memory-monitor
+    evr: 2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/lua-posix-35.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 193080
+    checksum: sha256:dba43478e632a56d95cdbbda1fba2e4c1e626126902cfe5ae9985f088928e431
+    name: lua-posix
+    evr: 35.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/lua-rpm-macros-1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12116
+    checksum: sha256:19fdee3aa469d583a7f48dce71513da47c5046018bc35bfbe57c818b7aae21d0
+    name: lua-rpm-macros
+    evr: 1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/m/m4-1.4.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1669463
+    checksum: sha256:c4098a14fdf286cce1c9981dcfbc9d2eefac08e2e80f68ac28b478e0d52ff837
+    name: m4
+    evr: 1.4.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/m/mkfontscale-1.2.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 161434
+    checksum: sha256:c517dd47af14b3a01e0abd6865252f0ed12f9f7041c909de43b37969d5a9e328
+    name: mkfontscale
+    evr: 1.2.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/m/mpg123-1.32.9-1.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1128174
+    checksum: sha256:b337b1eefaaa639a90ec349daa719d1c49222a31410eb1329299de16d1f37d4b
+    name: mpg123
+    evr: 1.32.9-1.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/ocaml-srpm-macros-6-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10233
+    checksum: sha256:198f33946c3b1c1e104109073449ac03fd59035e6c3f646ad847626aa646e336
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/openblas-0.3.26-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23507999
+    checksum: sha256:152ab881d01425b6b7e2b2ebecf419498b5c1ae4c673f450e1d63439ec8f923f
+    name: openblas
+    evr: 0.3.26-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/openblas-srpm-macros-2-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 9345
+    checksum: sha256:fe7a59edc21a63ddabfc48585a536d7c97dbcf27d46fa1e8b723df87a3c76bb3
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/openjpeg2-2.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2248257
+    checksum: sha256:d139d8a3730303ad1189b8a6949f43e2bde066d39c2d6e4ddce752c728c6a379
+    name: openjpeg2
+    evr: 2.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/opus-1.3.1-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1538330
+    checksum: sha256:f2f586f32a461d05e0c09a496a4b1cbf29e330967a68641deba1f7f9d4767962
+    name: opus
+    evr: 1.3.1-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/orc-0.4.31-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 192280
+    checksum: sha256:349e1f558859f7733899de6b5c43a975c730853869689914bd518153094c56bb
+    name: orc
+    evr: 0.4.31-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/osinfo-db-20250124-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 176763
+    checksum: sha256:8dee9b4e27b489e6808635f6fb9edaaea6900e4e09e3b4cfb6ef20e7f98e6937
+    name: osinfo-db
+    evr: 20250124-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/osinfo-db-tools-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 71184
+    checksum: sha256:2bd22032e8b549b1009783e61381ae8700f26556934ef93200cf441f717902fc
+    name: osinfo-db-tools
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/pango-1.48.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2073489
+    checksum: sha256:4efddadb4bf304a47e2cce96d6d63d1643f5bdcb06dace3c04f8d37410f8bc22
+    name: pango
+    evr: 1.48.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12786537
+    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43626
+    checksum: sha256:5bdfea020bfb4ee04c5fd3a5552724f21af7df49d8bf9b774060f1dd47c6b972
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Archive-Tar-2.38-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 79758
+    checksum: sha256:c543a9be1a2e718e3fa282b16fc058a4e3e3c21d75513591ed170a63c9944e37
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Archive-Zip-1.68-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 177506
+    checksum: sha256:0bc6505ab7fe87129f423e887a65153d015c38ddc68115ccf2149ebff5db92e1
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-CPAN-2.29-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 913914
+    checksum: sha256:ce91adec7194b6d7b65079f712418469db4b4d657251ddcf6643299b232644a1
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26900
+    checksum: sha256:2dde7ae0e396bf60d579f1c711a0ce6845c5a6dc8a3069fc125e64709c03e764
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-2.150010-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 129946
+    checksum: sha256:b93a6beedf64a4270dc4281fd9ea6fc5fabc08511bfd7ec95582bdcd5a3f50f3
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45057
+    checksum: sha256:cae76684fe68e4ef068523036a12aa65aa9ff697908aa448af0b5842507c8f11
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 63081
+    checksum: sha256:b0ae0d2859a6dbf7cd77de0e547370f85489f617319d8f55eb3b3533c22ea943
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Compress-Bzip2-2.28-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 908406
+    checksum: sha256:fd5ed562b1231e74f8dd6856e8b4494872a1afc84a11dc4b26eb3f59193cf78f
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 154607
+    checksum: sha256:06e2c818ae4ac7823ae67869037edb071cedb745bce8e010a268d1850999ac38
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133511
+    checksum: sha256:e73434426813ed9db9b82bdd301f4d0717b613fc8db3ff48e2e198d3b1e20fad
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 271620
+    checksum: sha256:f815738f7e64cb1912a188a57f32b9e3416192bdc2c80a61308cf668a0cb6ba9
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Config-Perl-V-0.33-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35359
+    checksum: sha256:77f7dbd94351b5cbe86859d557eb08525cb50bad76a344c7e4f5b16decb97be1
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-DB_File-1.855-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 158812
+    checksum: sha256:b0db40023b1387c9e1cb5f4a28914e4e7426e112132fd9e03a21a78c08a91bd9
+    name: perl-DB_File
+    evr: 1.855-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Data-OptList-0.110-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 31802
+    checksum: sha256:e2b75b4859a73491af1aa145027a54aeda204f31508f98c264ec719f0759fef0
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Data-Section-0.200007-14.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35026
+    checksum: sha256:29b50e2e9fcfd3ef490fde575e5651dd185d7bc10f62c97b2d7b6b525ecdd746
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Devel-PPPort-3.62-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 469970
+    checksum: sha256:1c4181c874720056a80d1ee015196f36ceef296709fe93d5d2b5282d6b90f80f
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Devel-Size-0.83-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 88128
+    checksum: sha256:5d65648105f4b21ba27f516113c995f25d19df091820d1fe6e99d72a6e89783c
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Digest-SHA-6.02-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60965
+    checksum: sha256:6223e7b6ee3e168987685a0432eb30908b88a4e33503c4f71ffd1f4202be64d5
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Digest-SHA1-2.13-34.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51532
+    checksum: sha256:24cb3be49a88473ca75fb773cca161a32a081afb243cd8b737aa7d3b6399a7f0
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Encode-Locale-1.05-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19941
+    checksum: sha256:4c7446c8690a0dc5a7e80a703ab32be8d7f8819493aec5e15a9468e5972f9070
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Env-1.04-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22963
+    checksum: sha256:f7872c1ec5309090bab03ab984ef49e7ab108f6e7f7a7acddc718e67847f2489
+    name: perl-Env
+    evr: 1.04-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54700
+    checksum: sha256:c4825f03bd2f125d4a7b9c361fdbae58e3eb888b40792d6ca740d4c9796529a3
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Install-2.20-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52908
+    checksum: sha256:a5a00213a6c11ebfe564f890525323981c10bb990ce06a1ad05163ccce239a54
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 504754
+    checksum: sha256:8f17335d16783c182512dfc1af5cd8a762b41944f024f456849f2dd475ad2648
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51571
+    checksum: sha256:db9319ce19481088c58205d252bc03fc816711399ac54b9cb90a0f12cc7a24c4
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 138437
+    checksum: sha256:aaa28538e07c7df4eb6e0d3ca1aa6d2806f7977116839c0605bf49962332e16b
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-File-Fetch-1.00-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32628
+    checksum: sha256:ee5ddafaff74bc4cbaafb81de847a4e5fcafe7d55ea39a3aad8acce1d3cfd9a2
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-File-HomeDir-1.006-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 48314
+    checksum: sha256:9324fc77f0cae4a487865f7168e58fefaf2a45dd44d5acb0c0ffd607bc79e972
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-File-Which-1.23-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35149
+    checksum: sha256:fd089f060aea15adcd7fe380a388fa8feb40daa0820b3d50dd20616c56bd6c68
+    name: perl-File-Which
+    evr: 1.23-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Filter-1.60-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108315
+    checksum: sha256:a9b8bb8bef551453366fab1f66883904c8ba996926d906fd32b759880a588dad
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Filter-Simple-0.96-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32804
+    checksum: sha256:a070b22cd4c09d06fa4078588f0a2a8735490defc6a93ebea7599ae5ee1ee557
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IO-Compress-2.102-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 311395
+    checksum: sha256:6a4d183d03c58572ad99c44427d4f80174a74e88f82e815ef9b68ee367949414
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 117388
+    checksum: sha256:b98fc6c2bba6a5310eeea99c39c4eb4b4c9c5f6f115c1ca391ff9f983b3603b6
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IO-Zlib-1.11-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22007
+    checksum: sha256:e83d2fcd26cbbac178ae8a77d75bb1e35ae697a0a1ebd9838787b0e7355b476f
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IPC-Cmd-1.04-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45145
+    checksum: sha256:d36b285269c9f8f186899296e922527b0d5efedae08d8ecef5e928369f344f04
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IPC-SysV-2.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80187
+    checksum: sha256:f3d99435bdc3bb3066a79ccf7e0e15b91ce2503a7ef2ef8a228238e03fd41b09
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-IPC-System-Simple-1.30-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46334
+    checksum: sha256:13c06559e1d68b47019a9e4ae4387d5962f0dd85a6ee77f2ed23ebcea92a7990
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Importer-0.026-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52799
+    checksum: sha256:52f89eb0a2d5f0a6a668679aa2d9adb4fb92e35fdd06e87d0b9d169d43d2e7ce
+    name: perl-Importer
+    evr: 0.026-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-JSON-PP-4.06-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 66646
+    checksum: sha256:25990b7a748140b948e4ad9a6aad236f7c82dc7a5c6eab6c2fb370de45d582d5
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Locale-Maketext-1.29-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68578
+    checksum: sha256:eb34611f4a8b295e9ba09f63b102db48b152e4915f90d9a9c33dba6e3331b3ed
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-MIME-Charset-1.012.2-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68860
+    checksum: sha256:375a66d8aadbde800a204d0681df4b0146dbd2cbcca577762162708d772095f4
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-MRO-Compat-0.13-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 21684
+    checksum: sha256:145780b93fce797e44ceb5911d79d150830ef976551d2a2dea4a64368002cd59
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3013100
+    checksum: sha256:6dc7b0f22726602de1368de52d7f4eae6c5144971ba6bf9dd6fe17a293f8da6d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2419116
+    checksum: sha256:b1221f5ccb5a07e8f87ba1397e17eea89ae9d9e152a724feb666985e76738e45
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Math-BigRat-0.2614-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62659
+    checksum: sha256:9e90c3abafc7b3b556ba1e1054834d95c79b698d4d72d31ad0d846ce9f8ba166
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Module-Build-0.42.31-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 321930
+    checksum: sha256:203f542dbb18437a7d0f30cfc819eb2b719f191b3a4e2b0456f20a291f68a0da
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Module-CoreList-5.20240609-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 139931
+    checksum: sha256:f40d3b1814a4a9d35a071732892b188cfe5ca7546f477944fb54b8ddc19676a5
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Module-Load-0.36-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 20494
+    checksum: sha256:d48889d7e5f4606b8de8d7886988274da466b047cb2434dc91bfe4d4339d1e24
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26054
+    checksum: sha256:69741f661710264f9aa8d97cdbde828b80323503bfa7da5c91330987a00d89ba
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Module-Metadata-1.000037-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65016
+    checksum: sha256:f3816981e19fb56a34bf13f1e288c01ef18613693bae505aa5ee0dc372d7aad1
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Module-Signature-0.88-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 113588
+    checksum: sha256:2777705793dd0cf55ac736f06632c02a93c47e5ef38c5eb0cd7603c3f2c76ec1
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Net-Ping-2.74-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 70563
+    checksum: sha256:e4a27ae525d6bf274e4f1612f3c5dc81e4557467bda40bd63ce8e5723e00a8cb
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Object-HashBase-0.009-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32480
+    checksum: sha256:5e8e5fb82b0a685c85f86490924ea1e0e3ac6364b07f43e087175d3f587c0e64
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Package-Generator-1.106-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 29367
+    checksum: sha256:6a5be4bb4322abe97c45c84cb26368b594b9d90a7e66d4841b74d179ecd72c9a
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Params-Check-0.38-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23416
+    checksum: sha256:aa052e7b8c96f6c4610ab34686928f0f7adbb41044e29378620e3d5e827cce76
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Params-Util-1.102-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 207956
+    checksum: sha256:a7eb296be9dc11401756128d84ae57a6e2e98fd0231cb5a52d7e86d42153ee56
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Perl-OSType-1.010-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32465
+    checksum: sha256:dd1ff7c7ef5ad251b1af9029f0555b4d21f3d96dd589ebb0d5989bd185f9abed
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24579
+    checksum: sha256:d06492c280011cd128a3e84fe071584470de288053375da173a6304ebafc0e87
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Pod-Checker-1.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35413
+    checksum: sha256:ce262ff36c0f737cd181b4e8974ded778cffcc6a6ca949b98b716e2a822b41fe
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Software-License-0.103014-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 135074
+    checksum: sha256:27c65fae4f13a24c6e3634b70f39b439bf5b90b8892b2987d4498dbb4ba2780f
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Sub-Exporter-0.987-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 59528
+    checksum: sha256:a552bfe187044ae29d0dc667e6e0a29c6340bf308d32d4b0c902f19d124e2c39
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Sub-Install-0.928-28.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30662
+    checksum: sha256:224662bdabe9c803615622a3adcb891165ddcdc3eb58aedfed1789576f9048f1
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Sys-Syslog-0.36-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 97885
+    checksum: sha256:8f3db804c924748fc7f7f3a10e093bd1195661657a404ab102a9c1fbb8fe5cb4
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Term-Size-Any-0.002-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 15436
+    checksum: sha256:f9aa001a28f500b09632dc321a4b46780f0cd02aa02ac8de8529684960fea05f
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Term-Size-Perl-0.031-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24324
+    checksum: sha256:c0283217d4d0998f3c2b24f42d956de7bc0c0c41478f40bdf6ef868748e003ec
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Term-Table-0.015-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 42326
+    checksum: sha256:a51423376f857f9720d3ad0e706db782758ac19bc3a28a0feaba80442ea7bd81
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 98184
+    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Test-Harness-3.42-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 226770
+    checksum: sha256:9c62f68a4bb3b0c1e6fbdfbbf2a840e50d93e1f6e0f8936931153725e0593c53
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Test-Simple-1.302183-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 355537
+    checksum: sha256:9b4b7c9a1a8723a1d4c1c353060ddb7f57e48343552506af10066d9ebaed37e6
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-Balanced-2.04-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52612
+    checksum: sha256:41dca789e663140111944d257574c4eaa74b66d6169f256a9ffe407fa8070d27
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-Diff-1.45-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41875
+    checksum: sha256:df1478044a0c7fb575b1324c0e9311a51e883ca61ff39952d0042ee1b2eb5fd1
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-Glob-0.11-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 16200
+    checksum: sha256:9aa6c8502f05a42e5048063c2aff09e15cf8a44f6d00b3f8f154e58f051ff4cc
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-Template-1.59-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62651
+    checksum: sha256:71bd67c547eec1d910a9c549be0ed7959a0f8e52a09e37d000a76bab1fd73cd3
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Text-Unidecode-1.30-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 146381
+    checksum: sha256:8aa240add109758d1549e9fda86ea601bdde3a2f3b0afdc62f097859648145e6
+    name: perl-Text-Unidecode
+    evr: 1.30-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Thread-Queue-3.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 27710
+    checksum: sha256:d844642772b9a505fc9bd5aaf94b597f1cf66ba2a890462f33f0fa226ccde79b
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Tie-RefHash-1.40-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43611
+    checksum: sha256:d21a4a6ac093c7622f28c5ac2bd6aa7fae86c5b4c150249d9ca696b5461f3f6a
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Time-HiRes-1.9764-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 124567
+    checksum: sha256:c9e00767aec7da2661ca2785530bc7f35c120e7411cfcd6889437c20add7ade1
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Unicode-Collate-1.29-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 915935
+    checksum: sha256:9f5cd2c294c8f4383e9d6d8ea9b7e2c2a1e913c5a27d39e041885548a570dff4
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:52d4dd85581dfa68c432cab3bde847ee4f62285bbc18ee04fdd5fc5e87dd9a2d
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-Unicode-Normalize-1.27-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55458
+    checksum: sha256:514286df911a40dad2269810466a25279f07d2efab97db7479de337cfcedd971
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-XML-XPath-1.44-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68741
+    checksum: sha256:3484e0703eb0b88f31533dcc9f0f4ce2c4d1c0fd827f206de4c44038db541680
+    name: perl-XML-XPath
+    evr: 1.44-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-autodie-2.34-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 106197
+    checksum: sha256:82f0f75aaf2ac269983fc0c5a4a8c436e0382963ea15dd3e6b1b983865a6ae9b
+    name: perl-autodie
+    evr: 2.34-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-bignum-0.51-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 40019
+    checksum: sha256:065483710b985ef93e23a0a9d69826d777ac3b3580429b011ecc1db4b03f6f8d
+    name: perl-bignum
+    evr: 0.51-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-experimental-0.022-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24159
+    checksum: sha256:72d8e178ae3d2c2607e9ac4875957f841af9511398ddf07279b5e02a0e38034c
+    name: perl-experimental
+    evr: 0.022-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-inc-latest-0.500-20.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28925
+    checksum: sha256:3ac7d9dbcf90cfa75334d84853688e714b67a2982e4c9a33afac0ea4f79b1fb4
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-local-lib-2.000024-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 78260
+    checksum: sha256:4f60f5abc65be4e926262251a0a8d6ed0a86ac650dba678411b148c6a4ea34fd
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-perlfaq-5.20210520-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 212379
+    checksum: sha256:9d33eccd67de62a9793105ef005f4865af5d931471697c9aaf4fd6e2f3da3a16
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-srpm-macros-1-41.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10651
+    checksum: sha256:05990bf148e58515223b0936ee7b621e5d39bb875e2481a4d84522bd4b57d4e3
+    name: perl-srpm-macros
+    evr: 1-41.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-threads-2.25-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130514
+    checksum: sha256:92008f60b397b2e4380eddfe58aa788f78245a8fc44352d68bfa324fbec46655
+    name: perl-threads
+    evr: 1:2.25-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-threads-shared-1.61-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 119822
+    checksum: sha256:1b348ea3a479412c1236b95dc2d5d651a42e1c144626c38b8c08ef190b0c137b
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-version-0.99.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 180220
+    checksum: sha256:123e4f54296116246dfd22b4c6628fab4537c62c8a95394194085e6f60b3763c
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/pipewire-1.0.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2262481
+    checksum: sha256:9f0d3774bea6361293c6f949dca5e45ffae541e4dc24e5f2dac78d2d246008a5
+    name: pipewire
+    evr: 1.0.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/pixman-0.40.0-6.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 647633
+    checksum: sha256:0bd62940984b88bfd5914463d948999e29665450e6850ad5c9c4fbc129f3c3d0
+    name: pixman
+    evr: 0.40.0-6.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/poppler-data-0.4.9-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4130057
+    checksum: sha256:10a56ad2ab5d77157377805fc1481f40f5ccfb069fd34ec4bcf14e2a8ac309fe
+    name: poppler-data
+    evr: 0.4.9-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/pulseaudio-15.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1546014
+    checksum: sha256:01a1e060c7b753b68277a6274f0e16e438c75efd7add7d7aeb759721dde58f3a
+    name: pulseaudio
+    evr: 15.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 289973
+    checksum: sha256:cb7775937762f5ab13165854b5fab8d1e1ea8003451ccb02faaf60b4590c1949
+    name: pyproject-rpm-macros
+    evr: 1.16.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/python-rpm-macros-3.9-54.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32761
+    checksum: sha256:b48fc9a942da394ad4cefd19dd2ebf4c5839d0267a41c797fb04dc6173b5f296
+    name: python-rpm-macros
+    evr: 3.9-54.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/q/qt5-5.15.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 13771
+    checksum: sha256:149c54e64307cb3da96287a068f09c4ea5d3968bf2ba088383069f294695cc6d
+    name: qt5
+    evr: 5.15.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/r/redhat-rpm-config-209-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 96708
+    checksum: sha256:a6f4aa2f37f5c6205cca36ea99c640c6509587aa29732a3e145d7c3af304868f
+    name: redhat-rpm-config
+    evr: 209-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/r/rtkit-0.11-29.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 152904
+    checksum: sha256:c726c0b22b16017bf014107a15f313b18cdc0f09d9257822b027d1adc5bd47a8
+    name: rtkit
+    evr: 0.11-29.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/r/rust-srpm-macros-17-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35132
+    checksum: sha256:dfb94bc23f8c1be02f7d94e4b6d6dc05e98c7d4a162f5ef64f407bf6af738d42
+    name: rust-srpm-macros
+    evr: 17-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/sbc-1.4-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 261568
+    checksum: sha256:b4dbb3348492acf470f5d483cac09ec790c83270176a4d370e9ee6f40d785746
+    name: sbc
+    evr: 1.4-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/sgml-common-0.6.3-58.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111961
+    checksum: sha256:ca6fe92503402d24ebc976123288ec2169e75632bd63dd1c146e8d310eb5ee01
+    name: sgml-common
+    evr: 0.6.3-58.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 76240
+    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/sombok-2.4.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318398
+    checksum: sha256:5f192b4d26bb9550982e644248f675017ec3d85af2fc721c6509c329c6e1c2bc
+    name: sombok
+    evr: 2.4.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/sound-theme-freedesktop-0.8-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 488981
+    checksum: sha256:de474e09a97c0b6cbb54262b9d02f889ba350be1298285d732b06814375a068c
+    name: sound-theme-freedesktop
+    evr: 0.8-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/t/teckit-2.5.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1956688
+    checksum: sha256:57dab9e5aa55d6b2b558e4ef6efda7638176df62ee309d50ef979baa3a8efa3a
+    name: teckit
+    evr: 2.5.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/t/texlive-20200406-26.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 572348942
+    checksum: sha256:fc8a1cd1b58bfaf6f01d981027490920718905a722c7c988be4be28faf2b78fb
+    name: texlive
+    evr: 9:20200406-26.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/t/totem-pl-parser-3.26.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1517364
+    checksum: sha256:3fb99db442bf7988c725139716f102830efb05d559343b387d53fd98af029c9b
+    name: totem-pl-parser
+    evr: 3.26.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/t/tracker-3.1.2-3.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1474282
+    checksum: sha256:ae1dcc262f916002818ec6f6a54413e18ac570c536e299496aed99fd997fae74
+    name: tracker
+    evr: 3.1.2-3.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/t/tracker-miners-3.1.2-4.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4117590
+    checksum: sha256:80cad05049d22e5b7083be12d098f4add783886eff898c84547f89b1149ebff1
+    name: tracker-miners
+    evr: 3.1.2-4.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/t/ttmkfdir-3.0.9-65.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46879
+    checksum: sha256:e4d67a93e5605b5e8b4d0e0c8e5242b9137230b95ba5045c97815c216cfe1d71
+    name: ttmkfdir
+    evr: 3.0.9-65.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/u/unixODBC-2.3.9-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1693729
+    checksum: sha256:0f7bb1708709236922246be96a3cba788d404fbc3a58d4e2a4df8ddc8fc55313
+    name: unixODBC
+    evr: 2.3.9-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/u/upower-0.99.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 464654
+    checksum: sha256:6612bb4ed90e1d08b549615bdee8b36e5e7f46bf7e96d68c2af521a3f30097da
+    name: upower
+    evr: 0.99.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/u/urw-base35-fonts-20200910-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14393016
+    checksum: sha256:e47a39ecac5571addb3b1fc5c57c2cea8d999977eb3f8c29e9921ac29528a9c8
+    name: urw-base35-fonts
+    evr: 20200910-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/w/wayland-1.21.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 239785
+    checksum: sha256:f26f7fc3c60e1c5fe67abd6b6a0c26bb435e869f8451f092805eafe440b23172
+    name: wayland
+    evr: 1.21.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/w/webrtc-audio-processing-0.3.1-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 710526
+    checksum: sha256:70255f0b9784ad78d52f1f25e6e3bf683a1be9727a884760b7d6d9e6ac18b4ea
+    name: webrtc-audio-processing
+    evr: 0.3.1-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/w/wireplumber-0.4.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335147
+    checksum: sha256:efe9ba84e0851cf8cb2e2bf7b75d83b490182f0c55c6268923bc227e81c1bf67
+    name: wireplumber
+    evr: 0.4.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/x/xdg-dbus-proxy-0.1.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130185
+    checksum: sha256:18118ab2f72bb339fd444fceb08acd571a92ef478e8a0417c01aa080b4867c54
+    name: xdg-dbus-proxy
+    evr: 0.1.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-1.12.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 508933
+    checksum: sha256:2d5826de57e8bd5da82557abfd69d274f006c7055b32058a7d2d6cf64405964c
+    name: xdg-desktop-portal
+    evr: 1.12.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-gtk-1.12.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 388924
+    checksum: sha256:5779bc5047853ae2f09723fb92994841f7f54608bf734abecae20b68dbb650da
+    name: xdg-desktop-portal-gtk
+    evr: 1.12.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/x/xkeyboard-config-2.33-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1768610
+    checksum: sha256:fc472164cec4c2e4794081a476f00448bc8defadb7a863d079d4a782ba1f23c7
+    name: xkeyboard-config
+    evr: 2.33-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/x/xorg-x11-fonts-7.5-33.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 11582295
+    checksum: sha256:a9b2eceddc29f02bf49d3d4dee6d564d6b5a4b0f397190090f41a8426b1402ad
+    name: xorg-x11-fonts
+    evr: 7.5-33.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 101373
+    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
+    name: yajl
+    evr: 2.1.0-25.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/z/zziplib-0.13.71-11.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1157547
+    checksum: sha256:2ffa5b060b58d204e6686c07461c594d2f1cf1bdaf8e4a7d9309f9aa982484e3
+    name: zziplib
+    evr: 0.13.71-11.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/a/acl-2.3.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 535332
+    checksum: sha256:cb449bc6c85e0b50fa0bb98c969ff8481fee40517d8ebec5e28b72e5360fbe1e
+    name: acl
+    evr: 2.3.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8251850
+    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 482234
+    checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
+    name: attr
+    evr: 2.5.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1262288
+    checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
+    name: audit
+    evr: 3.1.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/a/avahi-0.8-22.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1629705
+    checksum: sha256:8e0cd07caf638b2d935ecc76fecc8d77adf5e399dbfb48958eacacb395b013d9
+    name: avahi
+    evr: 0.8-22.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/basesystem-11-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9884
+    checksum: sha256:5a4ed0779fc06f08115d6e06aa95486f1e1e251f8f9ddb6c7e14e811bb2e24ef
+    name: basesystem
+    evr: 11-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/bash-5.1.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 10512850
+    checksum: sha256:5d7bbbf2538361be1a11846602862c3a56809b3ea43b69b86bcf407538e9e260
+    name: bash
+    evr: 5.1.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/bash-completion-2.11-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 323037
+    checksum: sha256:e1da4ec276292a64279e9a62ae93a98295fb7be131618cc6ca48b053d0da8ca9
+    name: bash-completion
+    evr: 1:2.11-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/bluez-5.72-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2416940
+    checksum: sha256:5283227c6c84280f4956d9092d71d82f78176ff599adcf4be7d106387858a47b
+    name: bluez
+    evr: 5.72-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/bubblewrap-0.4.1-8.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 230660
+    checksum: sha256:0766cbd8405dd66aa93e316760405c0cdfb8b64f2a0e406fef915d3f51262a50
+    name: bubblewrap
+    evr: 0.4.1-8.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 824335
+    checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 711648
+    checksum: sha256:d3193e155ddd297042a944729fe54c1b90c17bdbd1876fc68e4f66d7857f9e81
+    name: ca-certificates
+    evr: 2025.2.80_v9.0.305-91.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/chkconfig-1.24-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 214658
+    checksum: sha256:b2618b278f5c8d6dacfae790c8c73b1fc1578b8f64011f325ced5a4a2e3b58bc
+    name: chkconfig
+    evr: 1.24-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/coreutils-8.32-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5692590
+    checksum: sha256:f042749974d210ad9049ffcb68172e4eaf91e3c0c249b33620e1f94effe82e6d
+    name: coreutils
+    evr: 8.32-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/cpio-2.13-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1395694
+    checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
+    name: cpio
+    evr: 2.13-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6414228
+    checksum: sha256:56a815a100d75c1d42c07090b632f05e51ea6d17df097d2936ab25d9aca49310
+    name: cracklib
+    evr: 2.9.6-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/crypto-policies-20250128-1.git5269e22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 102787
+    checksum: sha256:0f6081ad96e9d7cb80aa18736e3a06bbf7d2c19bdc0f95a707a4f3ed0926b878
+    name: crypto-policies
+    evr: 20250128-1.git5269e22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11657571
+    checksum: sha256:0a8b07dac531288c2fb1987106664a4e762e1b985c8851d577aa8aac60636a06
+    name: cryptsetup
+    evr: 2.7.2-3.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/cups-2.3.3op2-33.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8125712
+    checksum: sha256:d47b1ed7a8374a9881475617f7d1779e73960fbdc5a1402fd1327a144de06136
+    name: cups
+    evr: 1:2.3.3op2-33.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4030574
+    checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
+    name: cyrus-sasl
+    evr: 2.1.27-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/d/dbus-1.12.20-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2143916
+    checksum: sha256:3fe74a2b4fb4485c93e974010d9376e30a63dfcc628bfd6c01837c27b4953912
+    name: dbus
+    evr: 1:1.12.20-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/d/dbus-broker-28-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 254475
+    checksum: sha256:aced3097fbb8a424ca1816b8cb3e79960a9ccf7ba139538282886e692c317b29
+    name: dbus-broker
+    evr: 28-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/d/dejavu-fonts-2.37-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 13631421
+    checksum: sha256:4a325b197556c40187c2785302ede62d3e4cf300984ad6b8cf57e7a4974246aa
+    name: dejavu-fonts
+    evr: 2.37-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7418303
+    checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/e/efi-rpm-macros-6-2.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 26255
+    checksum: sha256:a8fc8e505e79f9a3f2cead3e4705f08469195659f4761889e6011ecac6c75610
+    name: efi-rpm-macros
+    evr: 6-2.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/e/elfutils-0.192-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11944670
+    checksum: sha256:afe7c9bef952ed086637fe83ac77bfafa70bf2ba28c1d7aaa51a18c9a75146b6
+    name: elfutils
+    evr: 0.192-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1003666
+    checksum: sha256:e8261cbcd55b85efdcd12ce1a2c6e63a72c64c872d618de4ba24557a1fda63c0
+    name: file
+    evr: 5.39-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/filesystem-3.16-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 20486
+    checksum: sha256:c795690df30c46e521372e2f649c995a2abc159b76c8ef6cd5da8a713ea17937
+    name: filesystem
+    evr: 3.16-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/findutils-4.8.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2010585
+    checksum: sha256:48bd4d4dd081120bcc6ab772b930a150f30b2fc89a4a14a24220383d24a30b3f
+    name: findutils
+    evr: 1:4.8.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 50762
+    checksum: sha256:6da7d722d419e6e9ce5abb4f6adcb82613d0629261011ec42134cfe092078e83
+    name: fonts-rpm-macros
+    evr: 1:2.0.5-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/freetype-2.10.4-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4767581
+    checksum: sha256:b5f1bbbd25b22e01fc2508188b49a97fdf5f72d069039358cb5837dffcf9f2c1
+    name: freetype
+    evr: 2.10.4-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/fuse-2.9.9-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1832743
+    checksum: sha256:9a11b340f925ae501331459e5d8d2edb819b947406d26cb565cf46a9f1b27f97
+    name: fuse
+    evr: 2.9.9-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gawk-5.1.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3190934
+    checksum: sha256:37571947707e835d36ceb5641b187aba13ef8f5f605a6762ce72aeea3e745b8d
+    name: gawk
+    evr: 5.1.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 81877102
+    checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
+    name: gcc
+    evr: 11.5.0-5.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gdbm-1.23-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130147
+    checksum: sha256:ad42264274c2a792220395a4dbe736a1de6100c4e14611707ec1dd447583271f
+    name: gdbm
+    evr: 1:1.23-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/glib-networking-2.68.3-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 256221
+    checksum: sha256:08f2d7a3c389bd63fb7ff6f8ac4a5a1fbb088451ca40f4fbe8ed70d2e820e897
+    name: glib-networking
+    evr: 2.68.3-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.24.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19844004
+    checksum: sha256:7c3dc8448748d98fb9af6f1ec0115ea61b0618135f5eb0104298bc1f9927eea3
+    name: glibc
+    evr: 2.34-168.el9_6.24
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gmp-6.2.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2503825
+    checksum: sha256:d0d8a795eea9ae555da63fbcfc3575425e86bb7e96d117b9ae2785b4f5e82f7c
+    name: gmp
+    evr: 1:6.2.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gobject-introspection-1.68.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1041521
+    checksum: sha256:cc54e6b0e1c09dd0ac59df81e8670434134ccc6adfd390a69fa11963be209231
+    name: gobject-introspection
+    evr: 1.68.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gpgme-1.15.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1737968
+    checksum: sha256:ceeb7d42bc8ddf6f09013439bfed4e591411b81293fe3db5e4edb06cbe1879fb
+    name: gpgme
+    evr: 1.15.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/graphite2-1.3.14-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6312801
+    checksum: sha256:5e2022500d0c9129817bb77916e6b55375344ed2737e05cc82e0f53f295cf2d6
+    name: graphite2
+    evr: 1.3.14-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/grep-3.6-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1620891
+    checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
+    name: grep
+    evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gsettings-desktop-schemas-40.0-7.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 714013
+    checksum: sha256:6ad3eec701e251c7b04018c0148173961474f33477f7a68eaad4779c3d2aed62
+    name: gsettings-desktop-schemas
+    evr: 40.0-7.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/h/harfbuzz-2.7.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9551851
+    checksum: sha256:d0ea2d865c05da90d7a32c6ad835bc3ba2067e759aaec2b0ca94a148735e43f8
+    name: harfbuzz
+    evr: 2.7.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/h/hwdata-0.348-9.18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2508307
+    checksum: sha256:af6cdae99470d14fa48057ac70a01cc8ab8567577eb74fc8c8be32ac080ad0ba
+    name: hwdata
+    evr: 0.348-9.18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/i/icu-67.1-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 23181317
+    checksum: sha256:3abe8dc1abc22213826dd6ffb214cdd88705def93dcb234ffc87c792909b0879
+    name: icu
+    evr: 67.1-10.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1505374
+    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
+    name: jq
+    evr: 1.6-17.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/j/json-c-0.14-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 341227
+    checksum: sha256:c4c76ebfd66ba6d00edf672797d7f077b29d279b7866a04e05258a257a5bc306
+    name: json-c
+    evr: 0.14-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/j/json-glib-1.6.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1319256
+    checksum: sha256:7ed60df640cc4c3cd08af33325b6ca4925a8b30c984e866a5abc1f66407634e9
+    name: json-glib
+    evr: 1.6.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/k/kbd-2.4.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1167414
+    checksum: sha256:8d50e573c7beff06b0167dd7d6bccfe542bc393aaf652bbecb205277af293231
+    name: kbd
+    evr: 2.4.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 150790
+    checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
+    name: keyutils
+    evr: 1.6.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libassuan-2.5.5-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 586136
+    checksum: sha256:dcc858194f9497ec86960651fa76413a9c731f94423d67298e8e3c0c7a5e7806
+    name: libassuan
+    evr: 2.5.5-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libcap-2.48-9.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 202341
+    checksum: sha256:cf258d269e2690617bbace76ec328e55c6f1431ddb47b67bcd4841472870d483
+    name: libcap
+    evr: 2.48-9.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 470599
+    checksum: sha256:48bb098662e2f3e1dbb94e27e4e612bc6794fbb62708e1f1a431cc2480fcdb00
+    name: libcap-ng
+    evr: 0.8.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libdb-5.3.28-57.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 35290920
+    checksum: sha256:6a74a3d96bd4657659524050945e2a47e93779addf2de374a13e1baf32b4ab8d
+    name: libdb
+    evr: 5.3.28-57.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libeconf-0.4.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 201501
+    checksum: sha256:4541a0915eca1e6fd1440253cf6bdfc5482c7b6dd3d3c7310a77faf852b7671a
+    name: libeconf
+    evr: 0.4.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libevent-2.1.12-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1123179
+    checksum: sha256:8c00dc837b8685fc660cc0bcdfd4f533888facaa8c83655c26d2fb068cb7b135
+    name: libevent
+    evr: 2.1.12-8.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libffi-3.4.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1367398
+    checksum: sha256:2b384204cc70c8f23d3a86e5cc9f736306a7a91a72e282044e3b23f3fd831647
+    name: libffi
+    evr: 3.4.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libgudev-237-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 40294
+    checksum: sha256:3ae56503c2508bfcba274b4bdaa169ee0a54294682edba202890f999d07b300a
+    name: libgudev
+    evr: 237-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libgusb-0.3.8-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 57034
+    checksum: sha256:18f50c2b798110da109d5d0b429948c762d5b98ba5d37705b6d1b4d327200847
+    name: libgusb
+    evr: 0.3.8-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libidn2-2.3.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2214169
+    checksum: sha256:c27f21437a76f07b0ee9f4f7e61d621cbb9c483c14563b31e55e320d19df99a6
+    name: libidn2
+    evr: 2.3.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libksba-1.5.1-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 677223
+    checksum: sha256:6d334a90bcbc270ee691183624e5664fdbe7dbf2d4a47319e6c75860e16abd43
+    name: libksba
+    evr: 1.5.1-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libproxy-0.4.15-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 123932
+    checksum: sha256:7b2cdc89e0020245af06c0b12f3e077c457cf3947d60c53b9303a0fe36d84002
+    name: libproxy
+    evr: 0.4.15-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9160109
+    checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
+    name: libpsl
+    evr: 0.21.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447225
+    checksum: sha256:14fbf335e2c6f22b441a9750a69b7c41e197c4dd21adac701fd81f17660ee0b4
+    name: libpwquality
+    evr: 1.4.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 653169
+    checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
+    name: libseccomp
+    evr: 2.5.2-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 271153
+    checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
+    name: libselinux
+    evr: 3.6-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 223978
+    checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
+    name: libsemanage
+    evr: 3.6-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libsepol-3.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 538074
+    checksum: sha256:2e02ff0ce3c6767962d1e7a3fbe657ea2a241bcd1c0182d9c552321ba4f8404b
+    name: libsepol
+    evr: 3.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libsigsegv-2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 473267
+    checksum: sha256:734651070d0113de033da80114b416931c4c0be21ce51f6b1c1641b1185c34f3
+    name: libsigsegv
+    evr: 2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libtasn1-4.16.0-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1895591
+    checksum: sha256:a3d9612fc631100fa0a528d7721bdee96acc33e35befb6a96544526eae169936
+    name: libtasn1
+    evr: 4.16.0-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libtdb-1.4.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 762833
+    checksum: sha256:d402a0c800081eb75cd81f27f632638e204fc210f24f911766f0484bc0a95313
+    name: libtdb
+    evr: 1.4.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libtool-2.4.6-46.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1002417
+    checksum: sha256:1130b15333736ad40a18b5924959a8b0c6c151305bc252c0cbd5276432e10002
+    name: libtool
+    evr: 2.4.6-46.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libunistring-0.9.10-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2065802
+    checksum: sha256:f6c329a60743d0d4955e070c5104407e47795b1ef617e7e59d052298961aec2b
+    name: libunistring
+    evr: 0.9.10-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libusbx-1.0.26-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 643959
+    checksum: sha256:e9359c9ad4fedd8d880f23c2c6a248fd0e17d657ee4ef5d17d572844dfe5f016
+    name: libusbx
+    evr: 1.0.26-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libutempter-1.2.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 30093
+    checksum: sha256:e48843d2734fefad084a86165860ea9575bdc53f63bb5845d8807ce9ccb4f914
+    name: libutempter
+    evr: 1.2.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 396005
+    checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
+    name: libverto
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543970
+    checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/lksctp-tools-1.0.19-3.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 594235
+    checksum: sha256:7f3e4ff54446b4e015958dc5bbe342cfb64151e4b6b886889921b116c373d640
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/lua-5.4.4-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 521629
+    checksum: sha256:18feaae23ff1b674acccf0f081f0d3c36ca482df0c468e9368d4f4432dff820c
+    name: lua
+    evr: 5.4.4-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/lvm2-2.03.28-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2992347
+    checksum: sha256:5361a813c7d6ea933fba20b461c5e3af5528b8876724460f8526f82564e0a063
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/lz4-1.9.3-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 333421
+    checksum: sha256:44e9e079f0f30476a0d8d9849ef1cd940fcc37abee11f481d6043b184bd0cf14
+    name: lz4
+    evr: 1.9.3-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/m/ModemManager-1.20.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1480103
+    checksum: sha256:81e6ab62ffedbf646500c284da42c11609b77c7ba57e1eb561cc95ca0ffe3a30
+    name: ModemManager
+    evr: 1.20.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2335546
+    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
+    name: make
+    evr: 1:4.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/m/mpfr-4.1.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1556195
+    checksum: sha256:1a6f60487d5ebb8998718c8246a49baf182e27318aa16e6a80b1ba7600b74e13
+    name: mpfr
+    evr: 4.1.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3587058
+    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
+    name: ncurses
+    evr: 6.2-10.20210508.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/n/nettle-3.10.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4331292
+    checksum: sha256:1f3587f2d59896bc3f427e4b5b9395095189dfb04237c242daa5cc536c7e02a9
+    name: nettle
+    evr: 3.10.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/n/npth-1.6-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 314570
+    checksum: sha256:3d0685cc559f0af453b6b3ace61944dec9b9cb090695e4de5f5579da7b35b750
+    name: npth
+    evr: 1.6-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/o/openldap-2.6.8-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6548889
+    checksum: sha256:0d21c12c55d40d1fc2f006c8ec187b5fcc799b794cfd31ed2d98434189c62800
+    name: openldap
+    evr: 2.6.8-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 89980613
+    checksum: sha256:4c7cd5a5b7095fcaa5850322ef1f1a7f42e69eacb0386d32fd6ced3dd7a9e7f5
+    name: openssl-fips-provider
+    evr: 3.0.7-6.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/p11-kit-0.25.3-3.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1027881
+    checksum: sha256:de598a2e1ca170df85cd69d6cc406402407a244988506f53f8736a7546135260
+    name: p11-kit
+    evr: 0.25.3-3.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/pam-1.5.1-26.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130406
+    checksum: sha256:9a351f0455da788ff63026af9a8ee30e744017941c82283f970d1ed066000bb6
+    name: pam
+    evr: 1.5.1-26.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/pcre-8.44-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1624356
+    checksum: sha256:7edbd87b866a3f6e3df1426d660b902e063193d6186027bf99f6d77626a43817
+    name: pcre
+    evr: 8.44-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/pcre2-10.40-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1789790
+    checksum: sha256:a570f7192be555222aa3704882b9199fb013a84ad4d7dcf40a93d8de2ecf6e0a
+    name: pcre2
+    evr: 10.40-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/polkit-0.117-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 336356709
+    checksum: sha256:29fafdd944809b56c0c2e9fe65c2f777e18e5d53473c95e14f6365af4287b131
+    name: polkit
+    evr: 0.117-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/polkit-pkla-compat-0.1-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 302278
+    checksum: sha256:8e4af06bc58994064b55ef7cdac31d48f9797f874fa82e011ad75b6233940636
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/popt-1.18-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 595630
+    checksum: sha256:1c5d47907a884ec21001c4965013fa70bea3f770d385fdc897cb7afc1cf62fe6
+    name: popt
+    evr: 1.18-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 93646
+    checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
+    name: publicsuffix-list
+    evr: 20210518-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/python-pip-21.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8984717
+    checksum: sha256:cb9e0cca3bd8dc24798cf1fb333d574774ce8288598331d44994d768f33648d3
+    name: python-pip
+    evr: 21.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/python-setuptools-53.0.0-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2080099
+    checksum: sha256:9cd7d11ed9e7fe2fa274de10d803f6fecd53cc1101bd0cbae386dbb66ce03824
+    name: python-setuptools
+    evr: 53.0.0-13.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/r/readline-8.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3009702
+    checksum: sha256:bc7a168b7275d1f9bd0f16b47029dd857ddce83fa80c3cb32eac63cb55f591f3
+    name: readline
+    evr: 8.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/r/redhat-release-9.6-0.1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 62469
+    checksum: sha256:6720f3d5c6675bbf8d79ce5424f891a34303e0c5c39be0e52ca51f70107f585b
+    name: redhat-release
+    evr: 9.6-0.1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4490587
+    checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
+    name: rpm
+    evr: 4.16.1.3-37.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/s/sed-4.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1424192
+    checksum: sha256:0590550f0cbdce0a26f98a73c756f663a7f220486d10f9c16d1ce0c8c4d14378
+    name: sed
+    evr: 4.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/s/setup-2.13.7-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 195940
+    checksum: sha256:3acdbbd63bd77dd8b18210b9d597bd59ddf455ff728067638c54194ac3a8a32b
+    name: setup
+    evr: 2.13.7-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1715281
+    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
+    name: shadow-utils
+    evr: 2:4.9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/s/shared-mime-info-2.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5257989
+    checksum: sha256:93b45d557d2958d316a6ee4645a9fdccb824cad2133c451ba22221fc933e6f9f
+    name: shared-mime-info
+    evr: 2.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/s/sqlite-3.34.1-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 25109243
+    checksum: sha256:ca9c26565fc4cdfdd8b813a116bb6bba1b36db634bb4b38602cc02f008db064c
+    name: sqlite
+    evr: 3.34.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/t/tpm2-tss-3.2.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1660943
+    checksum: sha256:11c9b6951d6823d120d310243f500f78ce13f9e206134309692e4a761294f3b9
+    name: tpm2-tss
+    evr: 3.2.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6281028
+    checksum: sha256:cde2d6a98345d49de9d225fc3acf7542fb35fde32832f1361415486a7839c222
+    name: util-linux
+    evr: 2.37.4-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/w/which-2.21-30.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 163429
+    checksum: sha256:3ab75392900a7b7d5b7e869c0d5beba9e184e970946e328f995f79f2e35397ff
+    name: which
+    evr: 2.21-30.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1168293
+    checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
+    name: xz
+    evr: 5.2.5-8.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/z/zip-3.0-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1137410
+    checksum: sha256:416b6957a4365204cfb2ba9e5b9b9f21075b615114c6afe46c83166de258bb5d
+    name: zip
+    evr: 3.0-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/z/zlib-1.2.11-40.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 561153
+    checksum: sha256:e47b884c132983fd0cc40c761de72e1a34ada9ee395cfe50997f9fb9257669d8
+    name: zlib
+    evr: 1.2.11-40.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2378112
+    checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
+    name: zstd
+    evr: 1.5.5-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7626843
+    checksum: sha256:9dbaca23d62c0bcb1f25ba74c73e3488a5878362bf35e302a64981befc3b7f3f
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/c/crun-1.26-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 896467
+    checksum: sha256:728c9ee33f9c4c2a8b9718c9b6b8e86be57897bf80b5bf1cc2fb195e824bb681
+    name: crun
+    evr: 1.26-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7737493
+    checksum: sha256:93923e9e509be34b01501dbc898e47ed8e5984110b424d12387cac9928372574
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/giflib-5.2.1-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 454644
+    checksum: sha256:7190afe993e439540a36a564f62c09dbd455f477a9e2b4223943b35c4ddf407d
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/git-lfs-3.6.1-2.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3704183
+    checksum: sha256:da9df4e5a770589c8d3a72ea5b7dde9860d5cf4869a3198009cafdad05beb10a
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/go-rpm-macros-3.6.0-13.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 134217
+    checksum: sha256:2b01ccb1ff201351069d5e7faed2b638bfabd63a58fe5dbac54c4fa77020efeb
+    name: go-rpm-macros
+    evr: 3.6.0-13.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2402853
+    checksum: sha256:b708fd816f9269983034eb5a4af7431a4d640885668e61020c18f21cc858b2b2
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 67369706
+    checksum: sha256:ccdf6f1911dbc397143a302aff66c575c035222a97fdfbc15dc4e18b4cbdec47
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libsoup-2.72.0-10.el9_6.6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 1524773
+    checksum: sha256:e09ab5c0baa53fd164dec50e512ec341aa7005fe4881df7fa7e008de5d7b1a5b
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libtiff-4.4.0-13.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2894616
+    checksum: sha256:fe00b8631ff587d510f42b10e15d9eeb0e248d559a8940029077c1846a79e81f
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/l/libxslt-1.1.34-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3560934
+    checksum: sha256:b3947676add0f33392769160c17de031191fd4af0caaddb009903b2f981cdd0f
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/m/mesa-24.2.8-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 33254288
+    checksum: sha256:0a6183042f15cad55922f1262d1df8d3836e950a4c2a4a92aa4655c5869772cb
+    name: mesa
+    evr: 24.2.8-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/n/nss-3.112.0-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 81985898
+    checksum: sha256:03e1f0c080506262cf5cf8198eedc16dbcab50f7ff3ab75eeec20bb6dffbf65a
+    name: nss
+    evr: 3.112.0-8.el9_4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/o/ostree-2025.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2151401
+    checksum: sha256:9be705455801c8632ce93ebe7d2d3f1ca1ca66ac20c6e0801a39b0626bd4fde5
+    name: ostree
+    evr: 2025.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 269666
+    checksum: sha256:712a5069cc5e3863ce0c84dacb69850ed20ce354d992a3f8773f577d6aa6801e
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/poppler-21.01.0-22.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 4696462
+    checksum: sha256:db66bfc8235cf25007f20d0b9c1422e577660cb6d1441b3de07e18cea988c738
+    name: poppler
+    evr: 21.01.0-22.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/postgresql-13.23-1.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 51333145
+    checksum: sha256:ad1a81d99d970d228aca114b49db118c692da06d5b5c9d43b3ece667730b50e1
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-16.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6493619
+    checksum: sha256:16c2aaa5191a3e816c32aa0543b5106f4042577e0336930ab22c5775606605c8
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 10642816
+    checksum: sha256:9d266472087f840a668e6eb2855a4021e054a48b0b7c9f7ad1fe5acb42e93b95
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/s/systemtap-5.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6602276
+    checksum: sha256:9f86d158ac1db2e0ed479f194ec9b9113a19f678b6d4a83ab1a42877ba9b779b
+    name: systemtap
+    evr: 5.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS/Packages/w/webkit2gtk3-2.52.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 65133497
+    checksum: sha256:bdd945c48a7e40a7daec8f6b2291fda7e3584a6e59f2d0a6b3ab7adecd12fc7d
+    name: webkit2gtk3
+    evr: 2.52.3-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 22423248
+    checksum: sha256:bd25b72280f9648cf99327b74dc03713a200a30068834bbca48a8ad7f7cfcd79
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 510894
+    checksum: sha256:299496cf3aafff9c162da9ec0cb6eaa65ee0d8dc8b8594998968959282e0b536
+    name: brotli
+    evr: 1.0.9-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2549990
+    checksum: sha256:9945d643a0ded5725b7fd4eaebc2f7350324c782ee7857e3a72d1e7fd1aa243b
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/e/expat-2.5.0-5.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8380127
+    checksum: sha256:207d7440755167a1049b86dafd99052a0162107167dfad2405386ab8452e6e76
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/glib2-2.68.4-16.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 5078743
+    checksum: sha256:452f757e564781db4e489cfabc4ab6062375e9f580da4dbd1fa7157f41fb8f39
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gnupg2-2.3.3-4.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7615913
+    checksum: sha256:cd27551144e10f730f613ade3c9f3c201c912941a8abfce2c3fc770f6845b9ab
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-6.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8612613
+    checksum: sha256:dc677685c729543c50bb6c99ae875ef7f83b36f2c25b74f55269c49f160409a9
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.110.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 149742415
+    checksum: sha256:95170092b5c7994be8941bf5b6ae3660a876a6691b3f06fdf46af7124de14a89
+    name: kernel
+    evr: 5.14.0-570.110.1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/k/krb5-1.21.1-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8943275
+    checksum: sha256:0e9b010a294e5358b4bd1e28b7cd1f1eb15256d4040f68814b0659f92f5a1ec2
+    name: krb5
+    evr: 1.21.1-8.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libarchive-3.5.3-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7054617
+    checksum: sha256:a590c3f706fbc8932245513fca3328d68708a0b11565da86eed8002399f80c65
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libpng-1.6.37-12.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 1530809
+    checksum: sha256:4ad341aec16d15a0b68009e84704662aebb9238f8ca98b521083de05b0dcc861
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libssh-0.10.4-15.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 665493
+    checksum: sha256:dbe0318bea854b3a1f8af8f6aceab24d0beac8172d0afd30779afdf0b62d96f5
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/l/libxml2-2.9.13-12.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3287566
+    checksum: sha256:2bc2fd257740e6baa0555a9e98ae5731a5e18d98332afa10e2e6e8bd92b1880a
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/n/NetworkManager-1.52.0-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 6295554
+    checksum: sha256:fc995af619a89f8184e3d19b975e653615e6f1687c36de40b0ec63ff0df580d8
+    name: NetworkManager
+    evr: 1:1.52.0-10.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/n/nghttp2-1.43.0-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3997194
+    checksum: sha256:25c2a8aaef5b90676fe217d732db026441e110951ed66b00e7327b79886a7a72
+    name: nghttp2
+    evr: 1.43.0-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2410966
+    checksum: sha256:1ddf2a92b05dd9431ce5b6b884b449c7f855806a7586114f9034c2602172163f
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 17980237
+    checksum: sha256:2010e981778502acfddd21095efbb7bbe407e8d85ddf6185563f6a41508591a0
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/p/python3.9-3.9.21-2.el9_6.5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 20305745
+    checksum: sha256:28b422b6eddc8c6531629680290fbcfd4539ff4bbb199fb0fbf6e9a8262e8b1a
+    name: python3.9
+    evr: 3.9.21-2.el9_6.5
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/s/systemd-252-51.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 43231152
+    checksum: sha256:c7324d32266c9b398924b5495019101abb46013f2d4f348b19b5fe156c6140ff
+    name: systemd
+    evr: 252-51.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2282353
+    checksum: sha256:8845bf368f2fcda2e27130cf4ef8301fed4ac310c0b1ef048542bd85261bf21c
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 919356
+    checksum: sha256:eb238075d8e20f9b5bee4666e55572ec2762203a0040e1d1fc350b390e412c99
+    name: tzdata
+    evr: 2026a-1.el9_0
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS/Packages/v/vim-8.2.2637-22.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 12824612
+    checksum: sha256:7fec61a8292d8ed5cf71f95d47ae8b594967391eef07fe306899359735eda157
+    name: vim
+    evr: 2:8.2.2637-22.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/source/SRPMS/Packages/p/pybind11-2.10.4-2.el9.src.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-eus-source-rpms
+    size: 753907
+    checksum: sha256:7b09202a3413bd4d9b0ec480bc7135c5baa7951bac0044891ddaa64999af4f31
+    name: pybind11
+    evr: 2.10.4-2.el9
   module_metadata: []
 - arch: ppc64le
   packages:
@@ -6007,6 +8709,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.4/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-rpms
+    size: 246716
+    checksum: sha256:2c1b20c3cfe2b72bfc4cc319edd37a8027564db2ea0429f1592cbe515c0a7dfc
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+    sourcerpm: libsndfile-1.2.2-6.el9ai.src.rpm
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.ppc64le.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
     size: 100652
@@ -6175,13 +8884,6 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1592980
-    checksum: sha256:cc4e307266401ba58b33127e54459d7384b4f6f143204f1e9688a14db94d273f
-    name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_6.1
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 62898
@@ -6217,13 +8919,6 @@ arches:
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/c/crun-1.23.1-2.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 272868
-    checksum: sha256:99d43e3988182607d03b49afa323bf43a86e5793dd4880a576b5ae84edd376d3
-    name: crun
-    evr: 1.23.1-2.el9_6
-    sourcerpm: crun-1.23.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/d/dconf-0.40.0-6.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 124428
@@ -6371,20 +9066,6 @@ arches:
     name: gcc-plugin-annobin
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 510183
-    checksum: sha256:650ffcc930f4b66208a8e49624bac8f2d3b664ffd78edc9111e8abd8cf6ac30e
-    name: gdk-pixbuf2
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 95933
-    checksum: sha256:10e36c36276df1c61673ad862a24e680717702e7665787091896c8b1fe6bd008
-    name: gdk-pixbuf2-modules
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/geoclue2-2.6.0-8.el9_6.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 135343
@@ -6420,13 +9101,6 @@ arches:
     name: ghostscript-tools-printing
     evr: 9.54.0-19.el9_6
     sourcerpm: ghostscript-9.54.0-19.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/giflib-5.2.1-9.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 56114
-    checksum: sha256:d6755daa9e5460403032515c8a37d43a725c7e47dc0a5317463442342ede9064
-    name: giflib
-    evr: 5.2.1-9.el9
-    sourcerpm: giflib-5.2.1-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 5417950
@@ -6434,13 +9108,6 @@ arches:
     name: git-core
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4248467
-    checksum: sha256:d32777a700432c078acebc0632a350ed7f704110cfc6ccfbb96675c12f327c4b
-    name: git-lfs
-    evr: 3.6.1-2.el9_6
-    sourcerpm: git-lfs-3.6.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.24.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 572653
@@ -6448,13 +9115,6 @@ arches:
     name: glibc-devel
     evr: 2.34-168.el9_6.24
     sourcerpm: glibc-2.34-168.el9_6.24.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/go-srpm-macros-3.6.0-10.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 28143
-    checksum: sha256:c1cbc05c812994c77b7f7bf80e76039c94d6ba887c9169228833e7e702aa095a
-    name: go-srpm-macros
-    evr: 3.6.0-10.el9_6
-    sourcerpm: go-rpm-macros-3.6.0-10.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/google-droid-sans-fonts-20200215-11.el9.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2836183
@@ -6483,13 +9143,6 @@ arches:
     name: gstreamer1
     evr: 1.22.12-3.el9
     sourcerpm: gstreamer1-1.22.12-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-4.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2387436
-    checksum: sha256:f04cf31f8bee24a5c7e7f3d53714b749155466022fb4d6c5333f78a55a4b7c55
-    name: gstreamer1-plugins-base
-    evr: 1.22.12-4.el9
-    sourcerpm: gstreamer1-plugins-base-1.22.12-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/g/gtk-update-icon-cache-3.24.31-5.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 36711
@@ -6518,20 +9171,6 @@ arches:
     name: iso-codes
     evr: 4.6.0-3.el9
     sourcerpm: iso-codes-4.6.0-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 515296
-    checksum: sha256:ff1f08a9ca8e1ac20bc8e9e0a70b1eb8e41db678ee72259c80d3c046f912dce4
-    name: java-17-openjdk
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 46557407
-    checksum: sha256:86bfba857a74e51cffc6c6761cf1358a611398878a27a0ca1bc7430375e5f0be
-    name: java-17-openjdk-headless
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/j/javapackages-filesystem-6.4.0-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17320
@@ -6553,13 +9192,6 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.62.1.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3727257
-    checksum: sha256:207b46e45414f02e5b1e2d1d710927ba1a7a23cd69ee2b46bf9d63b8f07697cf
-    name: kernel-headers
-    evr: 5.14.0-570.62.1.el9_6
-    sourcerpm: kernel-5.14.0-570.62.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17792
@@ -6567,6 +9199,13 @@ arches:
     name: kernel-srpm-macros
     evr: 1.0-13.el9
     sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/lame-libs-3.100-12.el9.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 362946
+    checksum: sha256:de0c727b8538ad811caf525ebf33cd8c57768a22986a4e1cf72c698bdd1080ee
+    name: lame-libs
+    evr: 3.100-12.el9
+    sourcerpm: lame-3.100-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/langpacks-core-font-en-3.0-16.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 10986
@@ -6917,20 +9556,6 @@ arches:
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/libsndfile-1.0.31-9.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 244011
-    checksum: sha256:12d231be484b1722147933803f80c761d6c15aac2d239ef1e3a4c6cf1d234a01
-    name: libsndfile
-    evr: 1.0.31-9.el9
-    sourcerpm: libsndfile-1.0.31-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.3.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 434396
-    checksum: sha256:27d379d426bb3e0c25efbe1c12904ab86136793b29900460cde64d382323ccc3
-    name: libsoup
-    evr: 2.72.0-10.el9_6.3
-    sourcerpm: libsoup-2.72.0-10.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/libstdc++-devel-11.5.0-5.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2532640
@@ -6959,13 +9584,6 @@ arches:
     name: libtheora
     evr: 1:1.1.1-31.el9
     sourcerpm: libtheora-1.1.1-31.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.2.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 218361
-    checksum: sha256:593da31e8af7ba188bd866bfb9c2a7ce8394629096027f96c051f6c0601ad526
-    name: libtiff
-    evr: 4.4.0-13.el9_6.2
-    sourcerpm: libtiff-4.4.0-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/libtool-2.4.6-46.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 598794
@@ -7078,13 +9696,6 @@ arches:
     name: libxshmfence
     evr: 1.3-10.el9
     sourcerpm: libxshmfence-1.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 268687
-    checksum: sha256:59218c6016f5f208dffe832833a193c330fb7853237c8435662fbc00e0327276
-    name: libxslt
-    evr: 1.1.34-13.el9_6
-    sourcerpm: libxslt-1.1.34-13.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/l/llvm-libs-19.1.7-2.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30302255
@@ -7127,48 +9738,6 @@ arches:
     name: m4
     evr: 1.4.19-1.el9
     sourcerpm: m4-1.4.19-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-3.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 7788738
-    checksum: sha256:6ccf0e8ad61eb0dcd0c5a3df71a31107d6c153aaa8ff20a936bda6795c534880
-    name: mesa-dri-drivers
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-filesystem-24.2.8-3.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 10769
-    checksum: sha256:af26b2a01cf3aa852d4c0dd9bddb56a86ae732f4c029a66a1dad0bddb7925fd4
-    name: mesa-filesystem
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libEGL-24.2.8-3.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 157853
-    checksum: sha256:2966c3e173593557d63ef87115a597a67e44e35cf5e4bdf5f4bc6120f4ffc92e
-    name: mesa-libEGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libGL-24.2.8-3.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 191480
-    checksum: sha256:95e3e3ba75fce5f3212f4de48cd788508fc53eb60f7c0f7f35b620176694aca8
-    name: mesa-libGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libgbm-24.2.8-3.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 41800
-    checksum: sha256:37f2065c372d33e38ae37a02b58b592cfd03dac47d8876ac22d305f41085d123
-    name: mesa-libgbm
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libglapi-24.2.8-3.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 44692
-    checksum: sha256:e0b80a471039bcbbc25aad852fbbc9ba96bb7a4cfc2642e0a809d1f883ea0873
-    name: mesa-libglapi
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mkfontscale-1.2.1-3.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 37595
@@ -7176,48 +9745,13 @@ arches:
     name: mkfontscale
     evr: 1.2.1-3.el9
     sourcerpm: mkfontscale-1.2.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/m/mpg123-libs-1.32.9-1.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 150220
-    checksum: sha256:6ad5f74f984e17b979be64da32a08550c42a31832c2a5ecc7087b7549348b26f
-    name: nspr
-    evr: 4.36.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-3.112.0-4.el9_4.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 814623
-    checksum: sha256:bc50567f2da110dd183b6ba5a168032bb221c432060c78f6858de63a261c9edb
-    name: nss
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 441512
-    checksum: sha256:caba5d54d0e4208aa8f7a2ecb5520290eb60de185207da3bd86ee70e0ac2365e
-    name: nss-softokn
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 458672
-    checksum: sha256:871d95d48c439e62d60c611bafb75313219a449bf8044e20da715c4c137abd1a
-    name: nss-softokn-freebl
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 18141
-    checksum: sha256:6f1e9e49ef3f5569a5a065f4d5d643a0d37ad8904a948ed28a4a960b3ddaa0fc
-    name: nss-sysinit
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 100927
-    checksum: sha256:955c1018068279390c185971f58a29ba31091779fdd826c113dd688ee34861ec
-    name: nss-util
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+    size: 392218
+    checksum: sha256:932d2e2cff48ef3d31cfdb0fb08fe2357320b8d267c51000e113a951908cce11
+    name: mpg123-libs
+    evr: 1.32.9-1.el9_5
+    sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 9270
@@ -7267,13 +9801,6 @@ arches:
     name: openjpeg2
     evr: 2.4.0-8.el9
     sourcerpm: openjpeg2-2.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4649573
-    checksum: sha256:ccae65d7caa28b81158b799a434263aaa92fd693119f7145a73b7490633eacf1
-    name: openssl-devel
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/o/opus-1.3.1-10.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 227789
@@ -7302,13 +9829,6 @@ arches:
     name: osinfo-db-tools
     evr: 1.10.0-1.el9
     sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/o/ostree-libs-2025.2-2.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 479115
-    checksum: sha256:e341cbd17271dfa00e8e7b658be7b38c885c486af015983c2e837831204c44f5
-    name: ostree-libs
-    evr: 2025.2-2.el9_6
-    sourcerpm: ostree-2025.2-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/p11-kit-server-0.25.3-3.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 249446
@@ -8604,13 +11124,6 @@ arches:
     name: perl-User-pwent
     evr: 1.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 246595
-    checksum: sha256:d34fa1a3365592b4cd146050d054cbf3ed2f526c2dfe3afa72b02d6a43161fb2
-    name: perl-XML-Parser
-    evr: 2.46-9.el9
-    sourcerpm: perl-XML-Parser-2.46-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/perl-XML-XPath-1.44-11.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94037
@@ -8989,13 +11502,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/poppler-21.01.0-21.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1153815
-    checksum: sha256:2b1ddc58c06bdbcaa0c90339474180982f84b76e56af2126d5fdf28be565b6ae
-    name: poppler
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/poppler-data-0.4.9-9.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1971104
@@ -9003,34 +11509,6 @@ arches:
     name: poppler-data
     evr: 0.4.9-9.el9
     sourcerpm: poppler-data-0.4.9-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/poppler-glib-21.01.0-21.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 163941
-    checksum: sha256:dcd10507e7d146df02f522857d22fc1401e77a991a4b6bbbacb697fbc42ac728
-    name: poppler-glib
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/postgresql-13.22-1.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1735685
-    checksum: sha256:85f1d710d22118c4e563e01ef32951d479ff47037bc7ad15f0308590171397cc
-    name: postgresql
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/postgresql-private-libs-13.22-1.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 156651
-    checksum: sha256:61229b5d9e70a706a453aa9851710cd26c0c13a6d45b4e8bbf34889213d28c45
-    name: postgresql-private-libs
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/protobuf-3.14.0-16.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1058375
-    checksum: sha256:e814cda469c39b6068d3d254ba92ebb1e8b4c6e0dd0e8e81109e286055e8f412
-    name: protobuf
-    evr: 3.14.0-16.el9
-    sourcerpm: protobuf-3.14.0-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/pulseaudio-libs-15.0-3.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 704915
@@ -9052,20 +11530,6 @@ arches:
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.2.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9102
-    checksum: sha256:7aec11632e430e2d0ee4a4a4e60336ce36ebdd023e6a5645175654e3e339e688
-    name: python-unversioned-command
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.2.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 250084
-    checksum: sha256:083834475beb1de995222ea2f74862c153c773369161b5b6d41918d4d1e5939a
-    name: python3-devel
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2133958
@@ -9101,13 +11565,6 @@ arches:
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 8780483
-    checksum: sha256:ea9a4277afb3ea0937a367930f2762db48e453d46b03c936a675609b75077a47
-    name: skopeo
-    evr: 2:1.18.1-2.el9_6
-    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 52666
@@ -9129,13 +11586,6 @@ arches:
     name: sound-theme-freedesktop
     evr: 0.8-17.el9
     sourcerpm: sound-theme-freedesktop-0.8-17.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/s/systemtap-sdt-devel-5.2-2.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 79147
-    checksum: sha256:b529ee239376f02f6d40da44c3e54d5e50455819889cb580f257391f694f5668
-    name: systemtap-sdt-devel
-    evr: 5.2-2.el9
-    sourcerpm: systemtap-5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/t/teckit-2.5.9-8.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 447268
@@ -10347,13 +12797,6 @@ arches:
     name: ttmkfdir
     evr: 3.0.9-65.el9
     sourcerpm: ttmkfdir-3.0.9-65.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/t/tzdata-java-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 233483
-    checksum: sha256:952b215f1e04b08ddfbf4bf19f6285d23f5a9d0dead6a64b4b9a6e1492fb2da0
-    name: tzdata-java
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/u/unixODBC-2.3.9-4.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 512086
@@ -10452,13 +12895,6 @@ arches:
     name: urw-base35-z003-fonts
     evr: 20200910-6.el9
     sourcerpm: urw-base35-fonts-20200910-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/w/webkit2gtk3-jsc-2.50.1-0.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4209874
-    checksum: sha256:a462e2bc0befa57e847cdba9538ee5a077f2d2f193e909137f486ea0bcc7cb6c
-    name: webkit2gtk3-jsc
-    evr: 2.50.1-0.el9_6
-    sourcerpm: webkit2gtk3-2.50.1-0.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/w/webrtc-audio-processing-0.3.1-8.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 336651
@@ -10585,20 +13021,6 @@ arches:
     name: bash-completion
     evr: 1:2.11-5.el9
     sourcerpm: bash-completion-2.11-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/b/binutils-2.35.2-63.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 5199630
-    checksum: sha256:ff0fe53687a6e04f7e6283215300bae116d4a372976354dab0feadae5ce51175
-    name: binutils
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1068913
-    checksum: sha256:d5b6d1537be6d6c2828476c21eccac5352f6a730831ee6206f39d42b6990fdc9
-    name: binutils-gold
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/b/bluez-libs-5.72-4.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 92901
@@ -10690,13 +13112,6 @@ arches:
     name: cups-libs
     evr: 1:2.3.3op2-33.el9_6.1
     sourcerpm: cups-2.3.3op2-33.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 304213
-    checksum: sha256:2c1031addfbe3a8eb272104d5c93a269fccdfe93ce1cfb8f78cd2c2b48f87509
-    name: curl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-21.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 887955
@@ -10781,13 +13196,6 @@ arches:
     name: elfutils-libs
     evr: 0.192-6.el9_6
     sourcerpm: elfutils-0.192-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/e/expat-2.5.0-5.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 127290
-    checksum: sha256:d2b0e91d162cedf8e6b68c82795eec1553ab15618862b2717139fedc27586953
-    name: expat
-    evr: 2.5.0-5.el9_6
-    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/f/file-5.39-16.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 53426
@@ -10872,13 +13280,6 @@ arches:
     name: glib-networking
     evr: 2.68.3-3.el9
     sourcerpm: glib-networking-2.68.3-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.3.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2883173
-    checksum: sha256:845b70278aa82b55ccd5ec6f0115db0666e83b4989f9d0f89d03db8c67ec26d6
-    name: glib2
-    evr: 2.68.4-16.el9_6.3
-    sourcerpm: glib2-2.68.4-16.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/g/glibc-2.34-168.el9_6.24.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 2847060
@@ -10914,20 +13315,6 @@ arches:
     name: gmp
     evr: 1:6.2.0-13.el9
     sourcerpm: gmp-6.2.0-13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/g/gnupg2-2.3.3-4.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2800058
-    checksum: sha256:3c7fdbebe26262ac5b6aad3c1b573c5baa0c50ae7140cca437d79d917c9a4769
-    name: gnupg2
-    evr: 2.3.3-4.el9
-    sourcerpm: gnupg2-2.3.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.2.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1118572
-    checksum: sha256:b9d5d8df9887c34aa9dca912a82daaee112ad853efe3cace295896d1422dfc09
-    name: gnutls
-    evr: 3.8.3-6.el9_6.2
-    sourcerpm: gnutls-3.8.3-6.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/g/gobject-introspection-1.68.0-11.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 265545
@@ -11054,13 +13441,6 @@ arches:
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 866052
-    checksum: sha256:9c6267e1a0f91003624557e23515f267d9044ae9f95f9f5ae5bdc75844e196f1
-    name: krb5-libs
-    evr: 1.21.1-8.el9_6
-    sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/less-590-5.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 182590
@@ -11075,13 +13455,6 @@ arches:
     name: libacl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libarchive-3.5.3-6.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 465166
-    checksum: sha256:3eebeadc8751000732cda54b376c08d825fd156e1df6cb0339d0f70366ca62c3
-    name: libarchive
-    evr: 3.5.3-6.el9_6
-    sourcerpm: libarchive-3.5.3-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libassuan-2.5.5-3.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 75672
@@ -11110,13 +13483,6 @@ arches:
     name: libblkid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 347425
-    checksum: sha256:7f1571cb99807f3d06d2d1cf9b9c804a7d3e773f1ac6828871aeddcb8900c12b
-    name: libbrotli
-    evr: 1.0.9-7.el9_5
-    sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libcap-2.48-9.el9_2.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 80588
@@ -11145,13 +13511,6 @@ arches:
     name: libcom_err
     evr: 1.46.5-7.el9
     sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.1.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 322930
-    checksum: sha256:58dd7209a97a836a921c2681fa5b23bc8f03ba1cb8924e6c48a476acda4420e6
-    name: libcurl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 837087
@@ -11278,13 +13637,6 @@ arches:
     name: libmount
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 85990
-    checksum: sha256:6f9c2190323d33ec5d9355965971a6d5423fb233d152f95b91a6e7b3b80ab584
-    name: libnghttp2
-    evr: 1.43.0-6.el9
-    sourcerpm: nghttp2-1.43.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libnl3-3.11.0-1.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 393979
@@ -11299,13 +13651,6 @@ arches:
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libpng-1.6.37-12.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 143255
-    checksum: sha256:8b2608fe679c8665c9b7c76c90197bcae4e09e4b94e1a587d255236a164b6613
-    name: libpng
-    evr: 2:1.6.37-12.el9
-    sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libproxy-0.4.15-35.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 82192
@@ -11383,20 +13728,6 @@ arches:
     name: libsmartcols
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 243230
-    checksum: sha256:413de40355daaf14a563ba5bb9438ab02790ef14312f410db72647d6ce3a82a2
-    name: libssh
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 7991
-    checksum: sha256:845c662af1f78eee4a1f67977a805b551edc939e21d3b201cb332682b18443fb
-    name: libssh-config
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libstdc++-11.5.0-5.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 855950
@@ -11460,13 +13791,6 @@ arches:
     name: libxcrypt
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 841440
-    checksum: sha256:029f6f9ed4f08c4396e47eb9043eccbbee6e91b347f9b39c552dc297aa725e23
-    name: libxml2
-    evr: 2.9.13-12.el9_6
-    sourcerpm: libxml2-2.9.13-12.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/l/libzstd-1.5.5-1.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 329280
@@ -11516,13 +13840,6 @@ arches:
     name: mpfr
     evr: 4.1.0-7.el9
     sourcerpm: mpfr-4.1.0-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-9.el9_6.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2015664
-    checksum: sha256:e40d573232706739be5812d589f1c9e34d518191c84f05f55a70bc6ffd41fd93
-    name: NetworkManager-libnm
-    evr: 1:1.52.0-9.el9_6
-    sourcerpm: NetworkManager-1.52.0-9.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9_6.2.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 422671
@@ -11572,27 +13889,6 @@ arches:
     name: openldap
     evr: 2.6.8-4.el9
     sourcerpm: openldap-2.6.8-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssh-8.7p1-45.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 487150
-    checksum: sha256:eb10234c2205c71a0faaa5d26c01d89f67a006993d3f0514ea8f0e380cec263a
-    name: openssh
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 760795
-    checksum: sha256:2ccc6cf89b038d32c7117903bcc1e5b4040b9cca4ad755f5b0a225efb4f2417f
-    name: openssh-clients
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1422952
-    checksum: sha256:56283cbf84234ec9256fb68e2d2669bc5799862eb2ee40521b8ac59044567835
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 9614
@@ -11607,13 +13903,6 @@ arches:
     name: openssl-fips-provider-so
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2320865
-    checksum: sha256:8e9f1ff32873b3531cd38d9583fe20526c790066785312301ea87ebbf980d8ce
-    name: openssl-libs
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 547598
@@ -11719,20 +14008,6 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/p/python3-3.9.21-2.el9_6.2.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 26184
-    checksum: sha256:c6761178efcc5132313aca7427fe0e220dfc78595c7a12d590453df3c11d64f5
-    name: python3
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.2.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8438812
-    checksum: sha256:b6ecae6aa9996e918e543e30bc23368fb61908bf1da5cd2260711efcb52a34fc
-    name: python3-libs
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1193706
@@ -11831,48 +14106,6 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-8.el9_6
     sourcerpm: sqlite-3.34.1-8.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-252-51.el9_6.3.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4432292
-    checksum: sha256:4d78555927fa841ad3d7affd6834b74e83bfa372829e5dc66f6b1f84f05320c7
-    name: systemd
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-libs-252-51.el9_6.3.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 716028
-    checksum: sha256:3fba5993cc762a1859908307fb5659d73c45224c7870f7cde68d62ae9f9fc2a3
-    name: systemd-libs
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-pam-252-51.el9_6.3.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 298399
-    checksum: sha256:a87d0b9445029862428b1df7e0c3c053397fd940fc2edb76413747741772801d
-    name: systemd-pam
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.3.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 63512
-    checksum: sha256:0735a7ac27891726d56502705f25d14ad243d49bf1f097c9dcf3ce0bd5ca7a97
-    name: systemd-rpm-macros
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-udev-252-51.el9_6.3.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1989346
-    checksum: sha256:b99b4bc944ece38bb934d17927c22b6d73974c92814f81264e252f214cc6d4b8
-    name: systemd-udev
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/t/tar-1.34-7.el9.ppc64le.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 937724
-    checksum: sha256:f2cc206dfacc9981fad6cf33600ad28bcd1c573f16d8c18523dc9df52ca90660
-    name: tar
-    evr: 2:1.34-7.el9
-    sourcerpm: tar-1.34-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 548711
@@ -11880,13 +14113,6 @@ arches:
     name: tpm2-tss
     evr: 3.2.3-1.el9
     sourcerpm: tpm2-tss-3.2.3-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/t/tzdata-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 862160
-    checksum: sha256:0687e5a1115ba679137404c8d37a45141a31968ffd01677455530d24c126a0d2
-    name: tzdata
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/u/unzip-6.0-58.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 195024
@@ -11908,13 +14134,6 @@ arches:
     name: util-linux-core
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 13249
-    checksum: sha256:9298e32061a3bce9b94f8c1bd1ac3ee0bfa67a68863cc3a0cd97c5432b6e89ed
-    name: vim-filesystem
-    evr: 2:8.2.2637-22.el9_6.1
-    sourcerpm: vim-8.2.2637-22.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/w/which-2.21-30.el9_6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 43161
@@ -12006,7 +14225,3192 @@ arches:
     name: unixODBC-devel
     evr: 2.3.9-4.el9
     sourcerpm: unixODBC-2.3.9-4.el9.src.rpm
-  source: []
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1592333
+    checksum: sha256:880b31a0d3cda21e76d5bd0b53df3f7b1c31d644cdfddcabc9900c6eae0fa45d
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/c/crun-1.26-1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 283472
+    checksum: sha256:3f0da12576cf1f2190bffb16bf6c2e28d278ccf24af496587b1305b03fd2608a
+    name: crun
+    evr: 1.26-1.el9_6
+    sourcerpm: crun-1.26-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 509637
+    checksum: sha256:0e71af4762a03682767b1979bc36584c94b96ca9892231758fdf1fdc038bbddb
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 96105
+    checksum: sha256:be0a5ce09122073992d9f2424301c5b70803d895ab3a9647440496b95fe6e60f
+    name: gdk-pixbuf2-modules
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/g/giflib-5.2.1-9.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 51403
+    checksum: sha256:72f06a9ac5d47832a9b306f31f40234ab261dcd0030bf62f1d45962b6c44d12c
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+    sourcerpm: giflib-5.2.1-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.3.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4490473
+    checksum: sha256:89d90711b26f25b3518d9c1c8f75548ae7f2e31dfb9c80df7b6c59533fc8e2d8
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+    sourcerpm: git-lfs-3.6.1-2.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 27174
+    checksum: sha256:d045b514c2b217509ffa931e4647a613bd49f8aea31e42a030320cd6ab1f9b26
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_6
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 2376269
+    checksum: sha256:fd58689880a5e485bbb0043efadffbaffff2697e465deb5f7fd93cb4996531c5
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+    sourcerpm: gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 517052
+    checksum: sha256:07e5bbd940c0ba9a80295114ba1bb4850799d6bb477da5e428f85cb7a188a22d
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/j/java-17-openjdk-headless-17.0.19.0.10-1.el9.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 46725467
+    checksum: sha256:d4353fe4a5d26df9d4bac6c437c19ca283215314247a108d50a9394fa1249179
+    name: java-17-openjdk-headless
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.110.1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 3809661
+    checksum: sha256:513ae67eba6d2173e6f809947911f4d58fe880157e8c2609976f47923dc10a64
+    name: kernel-headers
+    evr: 5.14.0-570.110.1.el9_6
+    sourcerpm: kernel-5.14.0-570.110.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 434714
+    checksum: sha256:1ee6dba8c45738d8b87a10d734314a13303e3b739c7772f8ec2c69e577444f5e
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+    sourcerpm: libsoup-2.72.0-10.el9_6.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.3.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 218211
+    checksum: sha256:88cd6a730e0c0ccbdcfd18c246a008889eb072ac6e06ea3508bb70ead22fa1c1
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+    sourcerpm: libtiff-4.4.0-13.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 264883
+    checksum: sha256:54e326b246f30c6c11a49476944cc90bb31b8b050be65a8733d79a40d79b73aa
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+    sourcerpm: libxslt-1.1.34-13.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 7789716
+    checksum: sha256:2c18d3bb55d7037bcfb42947b671cfa72ce2cee62f7bf9646179ad757c74c5e8
+    name: mesa-dri-drivers
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-filesystem-24.2.8-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 10542
+    checksum: sha256:cff858212234424dbc1572678e9f2c2cb523fa4e71520df183b2387432d9bf64
+    name: mesa-filesystem
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libEGL-24.2.8-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 157796
+    checksum: sha256:9061260e74a577de05d6e89bfefc21fe965e49ee35042bb226db84fbe4cd3ef3
+    name: mesa-libEGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libGL-24.2.8-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 191317
+    checksum: sha256:73be2283dd79387e9250ba71c78c5df3c572178ba9d1fa58c2aa389fc6a728a1
+    name: mesa-libGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libgbm-24.2.8-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 41558
+    checksum: sha256:c6c83bad57c986eea3acf80096c9efccd5ea4b8f1a0f02df34a517d74da9481c
+    name: mesa-libgbm
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/m/mesa-libglapi-24.2.8-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 44670
+    checksum: sha256:ffc9e107d284ccf8cf1264fbc90cbd7461275990a14fa2dd191ad05eee7d7540
+    name: mesa-libglapi
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/n/nspr-4.36.0-8.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 150610
+    checksum: sha256:99a7a001327b95375a1803bcd569cd67f669cc6c825f34047a2aae43de86ac6f
+    name: nspr
+    evr: 4.36.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-3.112.0-8.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 815124
+    checksum: sha256:b11739b55dee3f18881bf6205039e0d1045038bc0736117f7d0968427e7eb824
+    name: nss
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-softokn-3.112.0-8.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 443304
+    checksum: sha256:cbc4ba3eaf83c5efbab8357835c7f4d99cae0623ee2045b9323c68d3d80f7d31
+    name: nss-softokn
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-8.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 461129
+    checksum: sha256:a5c357701fbbdafe6b6c76ead7613bbb088d53a2f8b8255a19130f165aff1f67
+    name: nss-softokn-freebl
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-sysinit-3.112.0-8.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 18333
+    checksum: sha256:b593da50424027dd16ebd290b438d9b6e3e632cb3169ec149d456cd8921dbcde
+    name: nss-sysinit
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/n/nss-util-3.112.0-8.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 101062
+    checksum: sha256:5f35939db9815f64e2e47c223c6a512a7a6d55f48bb128addab643970c1639f7
+    name: nss-util
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/o/openssl-devel-3.2.2-7.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4627592
+    checksum: sha256:8909897689e8c9d040af950e7c5ba0e0e2201d987a4483f8621e41e89f9a03d8
+    name: openssl-devel
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/o/ostree-libs-2025.2-4.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 479115
+    checksum: sha256:dd2f281d2d67f2503186ffbb0dee8cd720d2ad3569f05327afab729f4c188faa
+    name: ostree-libs
+    evr: 2025.2-4.el9_6
+    sourcerpm: ostree-2025.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 244882
+    checksum: sha256:9aad05c3111ca90fe72d175d88cc4dfbc8f8d64b4786bde458254beea40d301d
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+    sourcerpm: perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/poppler-21.01.0-22.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1149497
+    checksum: sha256:1ed1bc0cb3442f6622d1c6968c4179862693d58b4795a57100fc241496d2d069
+    name: poppler
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/poppler-glib-21.01.0-22.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 160640
+    checksum: sha256:f86e1839354b6aed1934ba4be3b62e5804069728f0ed09998ad1416c6b73c035
+    name: poppler-glib
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/postgresql-13.23-1.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1746741
+    checksum: sha256:a6ae2c9b72b9372f883431ab80e8235025ed3c57626a517a67016fc508d59958
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/postgresql-private-libs-13.23-1.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 157621
+    checksum: sha256:274fd2acc8f993b111efea4ce113528f49c7a10273d7fda27a44c6e3b1658f9f
+    name: postgresql-private-libs
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/protobuf-3.14.0-16.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1052890
+    checksum: sha256:f311fb5ebfc3da6244580f093b1bac11909328a2b9037ae36609377d97cd3e0d
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+    sourcerpm: protobuf-3.14.0-16.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.5.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9159
+    checksum: sha256:589d36caea67e6e33607045cb1614aa0070de792fcca10a24d50d06280204496
+    name: python-unversioned-command
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.5.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 250049
+    checksum: sha256:00e523c78a161264eea34dc82f7832fc0efb897edee86882948585a7c0109646
+    name: python3-devel
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9003852
+    checksum: sha256:106a35da2e60cdb44358cf697f486737fb5d3b16da9a9a7b389f6bb56307ae74
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+    sourcerpm: skopeo-1.18.1-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/s/systemtap-sdt-devel-5.2-4.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 74928
+    checksum: sha256:cf49d54b6fed1c66155cd1e1cfb227aab7c91b10a2ef1e9ef56d98c69c3fafa0
+    name: systemtap-sdt-devel
+    evr: 5.2-4.el9_6
+    sourcerpm: systemtap-5.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/t/tzdata-java-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 228444
+    checksum: sha256:6278f74c2029794cc7eea4a9bb298bda81e9ef165c689cb8e0a09584e0b7104c
+    name: tzdata-java
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.3-1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4413264
+    checksum: sha256:ae1aeca8835f669fbca94fb045b71557e463754d096eb7b975bae3b1cbb8cb54
+    name: webkit2gtk3-jsc
+    evr: 2.52.3-1.el9_6
+    sourcerpm: webkit2gtk3-2.52.3-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/b/binutils-2.35.2-63.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 5194932
+    checksum: sha256:605d7c07497330271289cc02957345db460ca41601582ae821b95e7c3566e629
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1063654
+    checksum: sha256:82b37af0cc179f44f3e6ef1f266495f486a3725a0204140be84dcdf070937f83
+    name: binutils-gold
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/c/curl-7.76.1-31.el9_6.3.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 302357
+    checksum: sha256:c2634bf62f4f1f7fb517db188c7087227af10cbca797aa6cbc2ac6ccbb06d90c
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/e/expat-2.5.0-5.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 125399
+    checksum: sha256:ff21486dd4a95c31d5eea61f1dc030e34186ea356a20a5540e2e6f68e79cc80d
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+    sourcerpm: expat-2.5.0-5.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2882998
+    checksum: sha256:e89cc8c1bb87874dac9424b6bf325031fea0251ede71daf90968c992597e2e67
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+    sourcerpm: glib2-2.68.4-16.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/g/gnupg2-2.3.3-4.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2794134
+    checksum: sha256:006e5f9acb61fe8ca5fce49aecbe94cb4f0289eaf100902b498616a0c3ddd6e6
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+    sourcerpm: gnupg2-2.3.3-4.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.3.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1119975
+    checksum: sha256:56a88276c615ceb7473179e60eb91539a085e8dcfc34626a64f9918e2ff081db
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+    sourcerpm: gnutls-3.8.3-6.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 864883
+    checksum: sha256:5f6977aa52c580c388f426bf6e42d7070ee3f7da2873ba3d689527f1877f2e9b
+    name: krb5-libs
+    evr: 1.21.1-8.el9_6.1
+    sourcerpm: krb5-1.21.1-8.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libarchive-3.5.3-7.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 464748
+    checksum: sha256:6884b5718216c7d378571497807c0f7127f9870f4bb24de21782fce4c7edab17
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+    sourcerpm: libarchive-3.5.3-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 342352
+    checksum: sha256:fd79b46190ced55f146745116ee4979538badba8c9f9b867995bd469a3f87446
+    name: libbrotli
+    evr: 1.0.9-7.el9_6.1
+    sourcerpm: brotli-1.0.9-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.3.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 320951
+    checksum: sha256:9db56afcb66ce79c363d1648541c568b318b107e94d67f04b5f76ef292dfb8a9
+    name: libcurl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 82942
+    checksum: sha256:9b1953fd5523191a8417984c7c4faebfa92eda657ce6a827001ea30673b37ec5
+    name: libnghttp2
+    evr: 1.43.0-6.el9_6.1
+    sourcerpm: nghttp2-1.43.0-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libpng-1.6.37-12.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 138704
+    checksum: sha256:7b32c3315250b2205f9131cdc0c3a5a3d1f234e1805556f359bae75dbfe2e20e
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+    sourcerpm: libpng-1.6.37-12.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 243439
+    checksum: sha256:2c8778a443e59e3d400b383f2627ce879ce492c47700006d0453515c8898c078
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8157
+    checksum: sha256:cb0bf985f9cbb43161d848b6849234c95fed7acdd0aeb1f8113ac17ba23a7ce2
+    name: libssh-config
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 841987
+    checksum: sha256:99dd3f772004c29cc138e14bec3d6f88d73e9dbea39dd9b6d9f5bb3c379ef0ad
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+    sourcerpm: libxml2-2.9.13-12.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-10.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2013268
+    checksum: sha256:ad9e0938c2d8f3179c3c612b2a030038df822faac0979fc941ce03fa11e81692
+    name: NetworkManager-libnm
+    evr: 1:1.52.0-10.el9_6
+    sourcerpm: NetworkManager-1.52.0-10.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssh-8.7p1-45.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 480219
+    checksum: sha256:fc217c2ec048b8f74ad5c21f3eca3aac8a1d25c3248cb6a6a580a9a72191b55f
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 754018
+    checksum: sha256:3d9fb96ed9264844533a56dd7861fef484d3c97dc0dc034dba96ab690d8bc221
+    name: openssh-clients
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssl-3.2.2-7.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1408694
+    checksum: sha256:ac32e6c1aa16f8e1601a63fcb0002468615a86c7efbd25895db848598579a01d
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/o/openssl-libs-3.2.2-7.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2307234
+    checksum: sha256:7f5953957123a86adebef8bbff438023f5f5a3e3ef7888cd9f9335263c1fc377
+    name: openssl-libs
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/p/python3-3.9.21-2.el9_6.5.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 26235
+    checksum: sha256:a7b6102b4fee2fc1fa73aa31b427df7e169e3bf64bdaa1c0b06d262bfa4fc5b3
+    name: python3
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.5.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8438437
+    checksum: sha256:8772ddd92f0637d788ac0e3c72b718731eae47d30d7962093bef94ae6271a4c4
+    name: python3-libs
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-252-51.el9_6.4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 4429408
+    checksum: sha256:d2641f8e8c2a7007246d4ccdd2dd3fa8b20e0e3f8d3e8473477215a7ffaffd49
+    name: systemd
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-libs-252-51.el9_6.4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 715428
+    checksum: sha256:1277ce45a2063211f1942867a6b2f8fea288ed542b2b21f681b4f35988949d6f
+    name: systemd-libs
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-pam-252-51.el9_6.4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 297610
+    checksum: sha256:9c3da032b5c9a8b99121f81c202dc3397d14d083bcc1875f63ac3456257e04bc
+    name: systemd-pam
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.4.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 62787
+    checksum: sha256:96fa8cf07e84e172156c7229a95cb74de5f1980389730d8fa5c4ef4113fe4ded
+    name: systemd-rpm-macros
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/s/systemd-udev-252-51.el9_6.4.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1988384
+    checksum: sha256:e7a3afdbfe4f787b63e22509720554be61e00e5bfd4754311ffb2958b4486c14
+    name: systemd-udev
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/t/tar-1.34-7.el9_6.2.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 937441
+    checksum: sha256:849d24f91962732fae8dd82d6107f582ebfa6ed51e834e1b64e32c3a15f6b347
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+    sourcerpm: tar-1.34-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/t/tzdata-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 926162
+    checksum: sha256:ae429e8acbacad17e1b65a4571fcbf85122925cabeb97d25a9699774c1c38bbd
+    name: tzdata
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.2.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 13634
+    checksum: sha256:c5bdcda9be95aa6c7467bd64fb32f6a9cf2fee9421a728901889e850e83a4b29
+    name: vim-filesystem
+    evr: 2:8.2.2637-22.el9_6.2
+    sourcerpm: vim-8.2.2637-22.el9_6.2.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.4/source/SRPMS/Packages/l/libsndfile-1.2.2-6.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 750483
+    checksum: sha256:2ed7a90be00fa333f0274d17dd68bb11366f4543434f2b63b398fbd29416b9d7
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.4/source/SRPMS/Packages/t/texlive-tcolorbox-20200406-1.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 4964524
+    checksum: sha256:1bc9bb50498a035797cbe8cf8e2499f5d6e6f87ef6a97d5c682d3e98c41b7c2b
+    name: texlive-tcolorbox
+    evr: 20200406-1.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/source/SRPMS/Packages/c/containers-common-1-78.rhaos4.16.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 98665
+    checksum: sha256:7f31f05fa1f959849a1aead06559015cfbdcec919b7b5027e0c8c97785b636e3
+    name: containers-common
+    evr: 3:1-78.rhaos4.16.el9
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/source/SRPMS/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 16183933
+    checksum: sha256:0d3a9996f6287020460e6e91cfb22c636a047a5488d27a09ac6bbfce22d17810
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/abattis-cantarell-fonts-0.301-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 582900
+    checksum: sha256:ce11dc78d92b207947633e00a792a3c8c3b7b4f23c2b7912eaba587dc7893f4c
+    name: abattis-cantarell-fonts
+    evr: 0.301-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/adobe-mappings-cmap-20171205-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4127058
+    checksum: sha256:7c2f5be26bd8cee4e6a5b37a399484c9b230dd3fa8e93e45636d96c914d2504f
+    name: adobe-mappings-cmap
+    evr: 20171205-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/adobe-mappings-pdf-20180407-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1445392
+    checksum: sha256:84f5b00a6bf51f6b77ef54e7672da8dfb5aac1e55e88111dc8ef3384f6376d1c
+    name: adobe-mappings-pdf
+    evr: 20180407-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/adwaita-icon-theme-40.1.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17249062
+    checksum: sha256:0a59369173dca9368ed6b14bd4d068768ea45b4dab9a73cb8fa578990e8e53af
+    name: adwaita-icon-theme
+    evr: 40.1.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/alsa-lib-1.2.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1215277
+    checksum: sha256:1b9db2aa1e09cb40372bdcd1dfe6f613d20b7eaed88028687c96c934379e7d6f
+    name: alsa-lib
+    evr: 1.2.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/annobin-12.92-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 998524
+    checksum: sha256:65ee4ea686dfa6a8da136896ff590fb476248e998a14c38b28713a34a23cf1b9
+    name: annobin
+    evr: 12.92-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/at-spi2-atk-2.38.0-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111112
+    checksum: sha256:5713e30db407b1debad820ea89e57f3db5fe9c4e222ce44ab45d9e38ce52fe5a
+    name: at-spi2-atk
+    evr: 2.38.0-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/at-spi2-core-2.40.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 213364
+    checksum: sha256:3a5717b63603264a184a1ef26f606898c7f0ecc4b57ebd996d05b73a77bb8336
+    name: at-spi2-core
+    evr: 2.40.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/atk-2.36.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313725
+    checksum: sha256:171734f6cf9638497ccaccb73ab79b49d37085930e0c03d4c954aac2eaddbdc9
+    name: atk
+    evr: 2.36.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/autoconf-2.69-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1239007
+    checksum: sha256:946149054ebac72d6e6694d2525bca703c5faaa414f1f74ee7e12b0754c01cbd
+    name: autoconf
+    evr: 2.69-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/a/automake-1.16.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1598281
+    checksum: sha256:ac46e755161516f951c497c2794f344716a271ba68531883edb17bbbbab8958a
+    name: automake
+    evr: 1.16.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/cairo-1.17.4-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41864767
+    checksum: sha256:0185c51c6c00b3a238e9038addfa1be86fee1b3cc3933efdd4f05f8c5db775d6
+    name: cairo
+    evr: 1.17.4-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/cmake-3.26.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10671338
+    checksum: sha256:2f86bb96562eaf679969c2716738fbdfcc8a3966ecc3bb6317596fe2e214ea2b
+    name: cmake
+    evr: 3.26.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/colord-1.4.5-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1889181
+    checksum: sha256:e84bbbfb02504405637c022bb2cf90f2e278bbe1e136915a93b9f6e4d8402754
+    name: colord
+    evr: 1.4.5-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/composefs-1.0.8-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 8969650
+    checksum: sha256:13901e1b50ee0021eb56092859869125ea6ac9f2eafb2a880d758e87a18825e8
+    name: composefs
+    evr: 1.0.8-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/copy-jdk-configs-4.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17565
+    checksum: sha256:df1244121141d62420480aa1e07486bd0fa548360c2062c1ef138716dd7d68e8
+    name: copy-jdk-configs
+    evr: 4.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/criu-3.19-1.2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1397633
+    checksum: sha256:b055915dd2fd04c16c79a36775e1647f7c4f020cd341e94cda3a59898c3d6502
+    name: criu
+    evr: 3.19-1.2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/d/dconf-0.40.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133768
+    checksum: sha256:bbf4109630c6b65ff78bd4332c9a3b31c44776ff089361f0586cea1e758bbe25
+    name: dconf
+    evr: 0.40.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/d/dwz-0.14-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 159459
+    checksum: sha256:7565e0aed6cfb90c2c4be4ae2b33536fc4cf9b1b05a6a07da940ec564475580f
+    name: dwz
+    evr: 0.14-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 44824139
+    checksum: sha256:50a3faee5df3fd8d39609d97a62ef1297f668733105f4871d41a9257840269a3
+    name: emacs
+    evr: 1:27.2-14.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/e/exempi-2.6.0-0.2.20211007gite23c213.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19993045
+    checksum: sha256:2913c28e8198b0f722c4b16eebe6a102fdb4e33d934ad863aaf3fd25af4ff4aa
+    name: exempi
+    evr: 2.6.0-0.2.20211007gite23c213.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/e/exiv2-0.27.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32725837
+    checksum: sha256:65335824ab2515880092f0d0557882669e95f8c064aa4a18f2d36a3a3725913d
+    name: exiv2
+    evr: 0.27.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/f/fdk-aac-free-2.0.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2184629
+    checksum: sha256:2ccc9e447d4d1aa5ee0eccc9f06064bbb3f8c170c24f769a5dd7b580bf72537e
+    name: fdk-aac-free
+    evr: 2.0.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/f/flac-1.3.3-10.el9_2.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1063337
+    checksum: sha256:c9a340cb3e679da5f281425dcf1e785a2e882e733631638b45e76d3aa1f2e68f
+    name: flac
+    evr: 1.3.3-10.el9_2.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/f/flatpak-1.12.9-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1595419
+    checksum: sha256:5c870a95bee4384b536f3f53423e4e313dd5ebe0493ca12cfb71b09f84750ce2
+    name: flatpak
+    evr: 1.12.9-4.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/f/fontconfig-2.14.0-2.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1460194
+    checksum: sha256:623ac6b43061ad2f2b5d07861dfeb9b83ef70ead8df02319d375e71bc0110b67
+    name: fontconfig
+    evr: 2.14.0-2.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/f/fribidi-1.0.10-6.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1177189
+    checksum: sha256:d5e12deb110f7a5a8776435efa8f6c5e42ecf990e0ed27f95293020b65891254
+    name: fribidi
+    evr: 1.0.10-6.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 114235
+    checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/geoclue2-2.6.0-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108381
+    checksum: sha256:4ce03414616b5a8af25be3a451576b938b10c2c50a1ae9eab64627837f3f3ca8
+    name: geoclue2
+    evr: 2.6.0-8.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/ghc-srpm-macros-1.5.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10180
+    checksum: sha256:2d980af2311afd353583b200783cb39a5da7e89b6dbb9e67aa7d77a2c53e0cab
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/ghostscript-9.54.0-19.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 56071528
+    checksum: sha256:b2d608294cabab2b30197fa1ad90bff391840d5bfed4455081f627119c3cec87
+    name: ghostscript
+    evr: 9.54.0-19.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7707656
+    checksum: sha256:815c2ae9574006ecb596000492929264de785444736ee3968d5ee34cb6e75159
+    name: git
+    evr: 2.47.3-1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/google-droid-fonts-20200215-11.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3288061
+    checksum: sha256:b58b720be2c7a22d8a3c25731bfacaffc11f4d805f15a05022382cb456ec9f96
+    name: google-droid-fonts
+    evr: 20200215-11.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/graphene-1.10.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 345896
+    checksum: sha256:80bb7aed95ed969225d7b3b9d36103511b52b554c01f90c44681d18a861e2031
+    name: graphene
+    evr: 1.10.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/gsm-1.0.19-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80557
+    checksum: sha256:1a6ba3deaab6b12d3bcd23126c69340795d353e6b2eea36bf3696064db1be11c
+    name: gsm
+    evr: 1.0.19-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/gstreamer1-1.22.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1824267
+    checksum: sha256:cc25d402dff67470712a6032acc99f393898df78cdf30a2e346550db5a8ec091
+    name: gstreamer1
+    evr: 1.22.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/gtk3-3.24.31-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22491893
+    checksum: sha256:a6d0d395b3f0c64c10b8ccea931b318eee6ae36015b9852631c76d68283f0a68
+    name: gtk3
+    evr: 3.24.31-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/h/hicolor-icon-theme-0.17-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65737
+    checksum: sha256:8e62b8cf7aa5c7ef7a9ce6d1f1b159eeba7bc24519fbbb012e8a573ac072bcc6
+    name: hicolor-icon-theme
+    evr: 0.17-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/i/iso-codes-4.6.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14096241
+    checksum: sha256:3b17af011d4074e0fac62f3cf699090889892a45cf317df37942ebd2b39bc934
+    name: iso-codes
+    evr: 4.6.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/j/javapackages-tools-6.4.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 210942
+    checksum: sha256:7915590da093f42d4cfccb6196e1e3f22dce8d36f850ed2d46d0f41f238de01f
+    name: javapackages-tools
+    evr: 6.4.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/j/jbig2dec-0.19-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 584264
+    checksum: sha256:ac2fcfa2e65095617b1b9efef5ae8bf52e69e0f4b3b152ddd3c3c2fb7da0b3f7
+    name: jbig2dec
+    evr: 0.19-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/j/jbigkit-2.1-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 456145
+    checksum: sha256:7761a61c9cdaa019287d8daa7639d47e76f9ec1b177a50e94b46ceadf0c2cbfa
+    name: jbigkit
+    evr: 2.1-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/k/kernel-srpm-macros-1.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28536
+    checksum: sha256:6607ae4cf2e0ee6971a740ef64937853e4e636179822de40e709e8e3e0c7853b
+    name: kernel-srpm-macros
+    evr: 1.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/lame-3.100-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1537232
+    checksum: sha256:6e17b1767f6a8949f7ae4f549fbc4f93d4074072f3499a2346a2ce5f2b248d83
+    name: lame
+    evr: 3.100-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/langpacks-3.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28929
+    checksum: sha256:59d393e1505dc39e15cad9e0f0f54d5392f230aeaafadf4af09b31391ca573f4
+    name: langpacks
+    evr: 3.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/lcms2-2.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7428658
+    checksum: sha256:d0605c68533c1656eabe3d6d5a41b97513a9264030a28c46baad2cdcf57ec09c
+    name: lcms2
+    evr: 2.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libX11-1.7.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2436722
+    checksum: sha256:8720840bc38af119d62734144a5e8c95c1400ba42bd877e4279a786120d878d7
+    name: libX11
+    evr: 1.7.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXau-1.0.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335512
+    checksum: sha256:3a52f0d37183b84a7f8d37d6ca314ec17a32c1d4167c9131cf4000285d82c59a
+    name: libXau
+    evr: 1.0.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXcomposite-0.4.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 329141
+    checksum: sha256:10f74555246a4a992de429bf1139b762ca6b8d754d092a5eb85f0c55f576a9db
+    name: libXcomposite
+    evr: 0.4.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXcursor-1.2.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 347960
+    checksum: sha256:80bedd1206fa645654fbb6fd05fed788700ca3bf2cc0ade2408abc0a5802a801
+    name: libXcursor
+    evr: 1.2.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXdamage-1.1.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 315892
+    checksum: sha256:15c2c0d99190985a2a7d376b0cbb2d9f6172ebdcb1a3305ac0bbd7a394942e8c
+    name: libXdamage
+    evr: 1.1.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXext-1.3.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 401955
+    checksum: sha256:7f50b5d07f8e1782c4ad2c485416f210004db0477588465167c257aa62fd0b6c
+    name: libXext
+    evr: 1.3.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXfixes-5.0.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306511
+    checksum: sha256:3c8feb2710a52fe119d58369895cb2a17a10097a0a6b3a2bf469f0e34cf58db6
+    name: libXfixes
+    evr: 5.0.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXft-2.3.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 365800
+    checksum: sha256:b1ef5a942e759207022bf9bff3d122bc9596914d8dd7ab92ea56ebcad96ee9a6
+    name: libXft
+    evr: 2.3.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXi-1.7.10-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 498271
+    checksum: sha256:1de8a31cbe5edf8d10fe85fd96c1ebd1d0525c08a3ec75599ef12bad2945545c
+    name: libXi
+    evr: 1.7.10-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXinerama-1.1.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 297833
+    checksum: sha256:c9f68ea2938d52730688d24fc8b50f583193ab20ae158746e7751d8e092e92ed
+    name: libXinerama
+    evr: 1.1.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXrandr-1.5.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 343241
+    checksum: sha256:a565d64c7ff4b9c46cfc916097b1c8c9d886c006a7c18eac085f4ca6b4e8d310
+    name: libXrandr
+    evr: 1.5.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXrender-0.9.10-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:5fc0f3794b08cc71d89bf24c19a4a02c2d15c63850225327af9f20b45e1250e8
+    name: libXrender
+    evr: 0.9.10-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXtst-1.2.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 332563
+    checksum: sha256:59a99e7e1af8762969b9212aa5375be77a7bdafce73f416be82694b16ec388d5
+    name: libXtst
+    evr: 1.2.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXv-1.0.11-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 328666
+    checksum: sha256:fac6cc1bff31576443af0c71b3ffb1fbcd6e53b8fef38241ec0093cfba739c85
+    name: libXv
+    evr: 1.0.11-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libXxf86vm-1.1.4-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 305757
+    checksum: sha256:1e6c5a2d734c54d881523b50f1307ece5815574512fd7dedb10ee38282608532
+    name: libXxf86vm
+    evr: 1.1.4-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libappstream-glib-0.7.18-5.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2332780
+    checksum: sha256:a00834a072ed97371d8ffbccdbf5747d0d8e64ec2ae4e17f90d5c5e8bbdd22d8
+    name: libappstream-glib
+    evr: 0.7.18-5.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libasyncns-0.8-22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 351816
+    checksum: sha256:93c66acfdc39c88c4cced4056c53d2c637e667da2b09a8e9004f7c05bccb490e
+    name: libasyncns
+    evr: 0.8-22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libcanberra-0.30-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 336225
+    checksum: sha256:101d6e863d2b367a2d00cf29e75670c8190acfb8f19c0f31db66d4c5914f6ad6
+    name: libcanberra
+    evr: 0.30-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libdatrie-0.2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 325692
+    checksum: sha256:c9a3acd383ebb5f8d5d2c069dca717f147fddc461155cc12f07572972a82e7fe
+    name: libdatrie
+    evr: 0.2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libdrm-2.4.123-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 500530
+    checksum: sha256:8fd4b075f14ade405808c1ae309270aad50709f615bcd24d93aa39ae65e3a977
+    name: libdrm
+    evr: 2.4.123-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libepoxy-1.5.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 235419
+    checksum: sha256:53500b6a43fdf7e1a5083491d3ccdc808d2bec45a5559ff3eb9a14be798f8423
+    name: libepoxy
+    evr: 1.5.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libexif-0.6.22-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1123325
+    checksum: sha256:cbc3a148928165b570202330b52dd1baef75ff0b7479a0de16d7da0c252af8e3
+    name: libexif
+    evr: 0.6.22-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libfontenc-1.1.3-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313939
+    checksum: sha256:d169ca46af1a05f9f96805cb39acc44e794688b240e835c400353fb8f9e6302b
+    name: libfontenc
+    evr: 1.1.3-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libgexiv2-0.12.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 393822
+    checksum: sha256:5cba4e86ba7149ed6b9d90bd53fda20a17227218563b0ffc08b6ef0efc953914
+    name: libgexiv2
+    evr: 0.12.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libglvnd-1.3.4-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1046031
+    checksum: sha256:dbb82468e248c1dcb455f14b6c03b2a2772233f0c6b9e542c703bb3e4b96cb90
+    name: libglvnd
+    evr: 1:1.3.4-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libgsf-1.14.47-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 705600
+    checksum: sha256:393825b1ac768befa5cf2d1678c872231ebb77ceabb8eca8934d44eacf4ff0ea
+    name: libgsf
+    evr: 1.14.47-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libgxps-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91543
+    checksum: sha256:8a21727bce320f7736ce43cc5ffeeff3d6babc299b23b665df6b8fd1b450c770
+    name: libgxps
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libijs-0.35-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 423495
+    checksum: sha256:50aa92a3658366bf48452eb29154886da20761e885d7f52c3770c0e36aa6c562
+    name: libijs
+    evr: 0.35-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libiptcdata-1.0.5-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 604357
+    checksum: sha256:182950ba5b02a71634571889e11e70b94b4c91da56fa1836cb77bc85e44b3720
+    name: libiptcdata
+    evr: 1.0.5-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libjpeg-turbo-2.0.90-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2271766
+    checksum: sha256:6766d34e67f5bbfd82c5d543596b46790a2d98c97c2a33b67781829cac86c705
+    name: libjpeg-turbo
+    evr: 2.0.90-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libldac-2.0.2.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 86540
+    checksum: sha256:28903f22a062d976f8ff02786c4006fea01c0de6b5702a511351a9180e82d68b
+    name: libldac
+    evr: 2.0.2.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 846236
+    checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
+    name: libmpc
+    evr: 1.2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 611553
+    checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
+    name: libnet
+    evr: 1.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libnotify-0.7.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 115322
+    checksum: sha256:ea8f8a235fb2feb6bf876c44024551e92c770f0d78b1f879485a5bcf5a6e964e
+    name: libnotify
+    evr: 0.7.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libogg-1.3.4-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 441193
+    checksum: sha256:5e218f83debe3dafbbe5795b0696d7ecb00b88b4c1c78bc4acb6e83b9cf9d56b
+    name: libogg
+    evr: 2:1.3.4-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libosinfo-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306786
+    checksum: sha256:2efb475aa7815e6f24efaa0ca26276785935ec611d9a13ff3ded1dcda59b5fae
+    name: libosinfo
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libpaper-1.1.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57233
+    checksum: sha256:1648c52d0e1f0e8e10101106eb7d95a4f069176846fee76b1f6c0a1904b0750f
+    name: libpaper
+    evr: 1.1.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/librsvg2-2.50.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22252235
+    checksum: sha256:5c0fdc6b36b2bb071c73d1181bd76ec6252b20b2ace475e86f0a69b27733f3a0
+    name: librsvg2
+    evr: 2.50.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libstemmer-0-18.585svn.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 142242
+    checksum: sha256:c21d9668bbfba8bcff8be8442c0dee31190efbcc362bd29e7e5e128869cb64f1
+    name: libstemmer
+    evr: 0-18.585svn.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libthai-0.1.28-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 426287
+    checksum: sha256:1bff93f9076778b16fea27d75a7434caf8e9fb5e9bcabbf2cf8f7f0069302d73
+    name: libthai
+    evr: 0.1.28-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libtheora-1.1.1-31.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1451614
+    checksum: sha256:c43318355a6c960e0685d789887cddf450fdfd7908ba1a02d375e1ff290b3483
+    name: libtheora
+    evr: 1:1.1.1-31.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libuv-1.42.0-2.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1300269
+    checksum: sha256:f9dfa0dc965675730184604570c6a2aa95ddc2dfa6a7cb209514b1e744a4e3d7
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libvorbis-1.3.7-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1216523
+    checksum: sha256:2c9f1a80c9f1b7c2d6872ef82bd385a68abb37be3ab8d3bfc26dcb6c7c5ef477
+    name: libvorbis
+    evr: 1:1.3.7-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libwebp-1.2.0-8.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4112860
+    checksum: sha256:34b9ace12d22dffba4277247a539bce83ccf6a517fd2ac3f603bd092a90e23fa
+    name: libwebp
+    evr: 1.2.0-8.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libxcb-1.13.1-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 519787
+    checksum: sha256:6e79beeac5762cb0f4eca5a4e09aaf9f607b8d54a8154e68a672c4d42e5a617b
+    name: libxcb
+    evr: 1.13.1-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libxkbcommon-1.0.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 446799
+    checksum: sha256:47b1254e062547a0e553b4e072498a91bf3c7364c8499c15a2762858197c50de
+    name: libxkbcommon
+    evr: 1.0.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libxshmfence-1.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 319069
+    checksum: sha256:9a36c33eafdf600040cb41cc1d8ca40395a3e00f2fd6a41a28ad66644d90edaa
+    name: libxshmfence
+    evr: 1.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/llvm-19.1.7-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141371853
+    checksum: sha256:2da62e4083e0f9ff5ca3d5ffc794682ff16004b2f0b38b4a103e34d18dbd322e
+    name: llvm
+    evr: 19.1.7-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/low-memory-monitor-2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34855
+    checksum: sha256:ddbf37a31d785971549ab83b2f554c112bf1cefc10ca2b36326e8367e04a68c2
+    name: low-memory-monitor
+    evr: 2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/lua-posix-35.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 193080
+    checksum: sha256:dba43478e632a56d95cdbbda1fba2e4c1e626126902cfe5ae9985f088928e431
+    name: lua-posix
+    evr: 35.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/lua-rpm-macros-1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12116
+    checksum: sha256:19fdee3aa469d583a7f48dce71513da47c5046018bc35bfbe57c818b7aae21d0
+    name: lua-rpm-macros
+    evr: 1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/m/m4-1.4.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1669463
+    checksum: sha256:c4098a14fdf286cce1c9981dcfbc9d2eefac08e2e80f68ac28b478e0d52ff837
+    name: m4
+    evr: 1.4.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/m/mkfontscale-1.2.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 161434
+    checksum: sha256:c517dd47af14b3a01e0abd6865252f0ed12f9f7041c909de43b37969d5a9e328
+    name: mkfontscale
+    evr: 1.2.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/m/mpg123-1.32.9-1.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1128174
+    checksum: sha256:b337b1eefaaa639a90ec349daa719d1c49222a31410eb1329299de16d1f37d4b
+    name: mpg123
+    evr: 1.32.9-1.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/ocaml-srpm-macros-6-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10233
+    checksum: sha256:198f33946c3b1c1e104109073449ac03fd59035e6c3f646ad847626aa646e336
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/openblas-0.3.26-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23507999
+    checksum: sha256:152ab881d01425b6b7e2b2ebecf419498b5c1ae4c673f450e1d63439ec8f923f
+    name: openblas
+    evr: 0.3.26-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/openblas-srpm-macros-2-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 9345
+    checksum: sha256:fe7a59edc21a63ddabfc48585a536d7c97dbcf27d46fa1e8b723df87a3c76bb3
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/openjpeg2-2.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2248257
+    checksum: sha256:d139d8a3730303ad1189b8a6949f43e2bde066d39c2d6e4ddce752c728c6a379
+    name: openjpeg2
+    evr: 2.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/opus-1.3.1-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1538330
+    checksum: sha256:f2f586f32a461d05e0c09a496a4b1cbf29e330967a68641deba1f7f9d4767962
+    name: opus
+    evr: 1.3.1-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/orc-0.4.31-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 192280
+    checksum: sha256:349e1f558859f7733899de6b5c43a975c730853869689914bd518153094c56bb
+    name: orc
+    evr: 0.4.31-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/osinfo-db-20250124-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 176763
+    checksum: sha256:8dee9b4e27b489e6808635f6fb9edaaea6900e4e09e3b4cfb6ef20e7f98e6937
+    name: osinfo-db
+    evr: 20250124-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/osinfo-db-tools-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 71184
+    checksum: sha256:2bd22032e8b549b1009783e61381ae8700f26556934ef93200cf441f717902fc
+    name: osinfo-db-tools
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/pango-1.48.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2073489
+    checksum: sha256:4efddadb4bf304a47e2cce96d6d63d1643f5bdcb06dace3c04f8d37410f8bc22
+    name: pango
+    evr: 1.48.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12786537
+    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43626
+    checksum: sha256:5bdfea020bfb4ee04c5fd3a5552724f21af7df49d8bf9b774060f1dd47c6b972
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Archive-Tar-2.38-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 79758
+    checksum: sha256:c543a9be1a2e718e3fa282b16fc058a4e3e3c21d75513591ed170a63c9944e37
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Archive-Zip-1.68-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 177506
+    checksum: sha256:0bc6505ab7fe87129f423e887a65153d015c38ddc68115ccf2149ebff5db92e1
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-CPAN-2.29-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 913914
+    checksum: sha256:ce91adec7194b6d7b65079f712418469db4b4d657251ddcf6643299b232644a1
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26900
+    checksum: sha256:2dde7ae0e396bf60d579f1c711a0ce6845c5a6dc8a3069fc125e64709c03e764
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-2.150010-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 129946
+    checksum: sha256:b93a6beedf64a4270dc4281fd9ea6fc5fabc08511bfd7ec95582bdcd5a3f50f3
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45057
+    checksum: sha256:cae76684fe68e4ef068523036a12aa65aa9ff697908aa448af0b5842507c8f11
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 63081
+    checksum: sha256:b0ae0d2859a6dbf7cd77de0e547370f85489f617319d8f55eb3b3533c22ea943
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Compress-Bzip2-2.28-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 908406
+    checksum: sha256:fd5ed562b1231e74f8dd6856e8b4494872a1afc84a11dc4b26eb3f59193cf78f
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 154607
+    checksum: sha256:06e2c818ae4ac7823ae67869037edb071cedb745bce8e010a268d1850999ac38
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133511
+    checksum: sha256:e73434426813ed9db9b82bdd301f4d0717b613fc8db3ff48e2e198d3b1e20fad
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 271620
+    checksum: sha256:f815738f7e64cb1912a188a57f32b9e3416192bdc2c80a61308cf668a0cb6ba9
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Config-Perl-V-0.33-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35359
+    checksum: sha256:77f7dbd94351b5cbe86859d557eb08525cb50bad76a344c7e4f5b16decb97be1
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-DB_File-1.855-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 158812
+    checksum: sha256:b0db40023b1387c9e1cb5f4a28914e4e7426e112132fd9e03a21a78c08a91bd9
+    name: perl-DB_File
+    evr: 1.855-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Data-OptList-0.110-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 31802
+    checksum: sha256:e2b75b4859a73491af1aa145027a54aeda204f31508f98c264ec719f0759fef0
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Data-Section-0.200007-14.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35026
+    checksum: sha256:29b50e2e9fcfd3ef490fde575e5651dd185d7bc10f62c97b2d7b6b525ecdd746
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Devel-PPPort-3.62-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 469970
+    checksum: sha256:1c4181c874720056a80d1ee015196f36ceef296709fe93d5d2b5282d6b90f80f
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Devel-Size-0.83-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 88128
+    checksum: sha256:5d65648105f4b21ba27f516113c995f25d19df091820d1fe6e99d72a6e89783c
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Digest-SHA-6.02-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60965
+    checksum: sha256:6223e7b6ee3e168987685a0432eb30908b88a4e33503c4f71ffd1f4202be64d5
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Digest-SHA1-2.13-34.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51532
+    checksum: sha256:24cb3be49a88473ca75fb773cca161a32a081afb243cd8b737aa7d3b6399a7f0
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Encode-Locale-1.05-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19941
+    checksum: sha256:4c7446c8690a0dc5a7e80a703ab32be8d7f8819493aec5e15a9468e5972f9070
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Env-1.04-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22963
+    checksum: sha256:f7872c1ec5309090bab03ab984ef49e7ab108f6e7f7a7acddc718e67847f2489
+    name: perl-Env
+    evr: 1.04-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54700
+    checksum: sha256:c4825f03bd2f125d4a7b9c361fdbae58e3eb888b40792d6ca740d4c9796529a3
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Install-2.20-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52908
+    checksum: sha256:a5a00213a6c11ebfe564f890525323981c10bb990ce06a1ad05163ccce239a54
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 504754
+    checksum: sha256:8f17335d16783c182512dfc1af5cd8a762b41944f024f456849f2dd475ad2648
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51571
+    checksum: sha256:db9319ce19481088c58205d252bc03fc816711399ac54b9cb90a0f12cc7a24c4
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 138437
+    checksum: sha256:aaa28538e07c7df4eb6e0d3ca1aa6d2806f7977116839c0605bf49962332e16b
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-Fetch-1.00-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32628
+    checksum: sha256:ee5ddafaff74bc4cbaafb81de847a4e5fcafe7d55ea39a3aad8acce1d3cfd9a2
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-HomeDir-1.006-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 48314
+    checksum: sha256:9324fc77f0cae4a487865f7168e58fefaf2a45dd44d5acb0c0ffd607bc79e972
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-Which-1.23-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35149
+    checksum: sha256:fd089f060aea15adcd7fe380a388fa8feb40daa0820b3d50dd20616c56bd6c68
+    name: perl-File-Which
+    evr: 1.23-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Filter-1.60-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108315
+    checksum: sha256:a9b8bb8bef551453366fab1f66883904c8ba996926d906fd32b759880a588dad
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Filter-Simple-0.96-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32804
+    checksum: sha256:a070b22cd4c09d06fa4078588f0a2a8735490defc6a93ebea7599ae5ee1ee557
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Compress-2.102-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 311395
+    checksum: sha256:6a4d183d03c58572ad99c44427d4f80174a74e88f82e815ef9b68ee367949414
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 117388
+    checksum: sha256:b98fc6c2bba6a5310eeea99c39c4eb4b4c9c5f6f115c1ca391ff9f983b3603b6
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Zlib-1.11-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22007
+    checksum: sha256:e83d2fcd26cbbac178ae8a77d75bb1e35ae697a0a1ebd9838787b0e7355b476f
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IPC-Cmd-1.04-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45145
+    checksum: sha256:d36b285269c9f8f186899296e922527b0d5efedae08d8ecef5e928369f344f04
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IPC-SysV-2.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80187
+    checksum: sha256:f3d99435bdc3bb3066a79ccf7e0e15b91ce2503a7ef2ef8a228238e03fd41b09
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-IPC-System-Simple-1.30-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46334
+    checksum: sha256:13c06559e1d68b47019a9e4ae4387d5962f0dd85a6ee77f2ed23ebcea92a7990
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Importer-0.026-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52799
+    checksum: sha256:52f89eb0a2d5f0a6a668679aa2d9adb4fb92e35fdd06e87d0b9d169d43d2e7ce
+    name: perl-Importer
+    evr: 0.026-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-JSON-PP-4.06-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 66646
+    checksum: sha256:25990b7a748140b948e4ad9a6aad236f7c82dc7a5c6eab6c2fb370de45d582d5
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Locale-Maketext-1.29-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68578
+    checksum: sha256:eb34611f4a8b295e9ba09f63b102db48b152e4915f90d9a9c33dba6e3331b3ed
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-MIME-Charset-1.012.2-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68860
+    checksum: sha256:375a66d8aadbde800a204d0681df4b0146dbd2cbcca577762162708d772095f4
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-MRO-Compat-0.13-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 21684
+    checksum: sha256:145780b93fce797e44ceb5911d79d150830ef976551d2a2dea4a64368002cd59
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3013100
+    checksum: sha256:6dc7b0f22726602de1368de52d7f4eae6c5144971ba6bf9dd6fe17a293f8da6d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2419116
+    checksum: sha256:b1221f5ccb5a07e8f87ba1397e17eea89ae9d9e152a724feb666985e76738e45
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Math-BigRat-0.2614-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62659
+    checksum: sha256:9e90c3abafc7b3b556ba1e1054834d95c79b698d4d72d31ad0d846ce9f8ba166
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Module-Build-0.42.31-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 321930
+    checksum: sha256:203f542dbb18437a7d0f30cfc819eb2b719f191b3a4e2b0456f20a291f68a0da
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Module-CoreList-5.20240609-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 139931
+    checksum: sha256:f40d3b1814a4a9d35a071732892b188cfe5ca7546f477944fb54b8ddc19676a5
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Module-Load-0.36-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 20494
+    checksum: sha256:d48889d7e5f4606b8de8d7886988274da466b047cb2434dc91bfe4d4339d1e24
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26054
+    checksum: sha256:69741f661710264f9aa8d97cdbde828b80323503bfa7da5c91330987a00d89ba
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Module-Metadata-1.000037-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65016
+    checksum: sha256:f3816981e19fb56a34bf13f1e288c01ef18613693bae505aa5ee0dc372d7aad1
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Module-Signature-0.88-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 113588
+    checksum: sha256:2777705793dd0cf55ac736f06632c02a93c47e5ef38c5eb0cd7603c3f2c76ec1
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Net-Ping-2.74-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 70563
+    checksum: sha256:e4a27ae525d6bf274e4f1612f3c5dc81e4557467bda40bd63ce8e5723e00a8cb
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Object-HashBase-0.009-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32480
+    checksum: sha256:5e8e5fb82b0a685c85f86490924ea1e0e3ac6364b07f43e087175d3f587c0e64
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Package-Generator-1.106-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 29367
+    checksum: sha256:6a5be4bb4322abe97c45c84cb26368b594b9d90a7e66d4841b74d179ecd72c9a
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Params-Check-0.38-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23416
+    checksum: sha256:aa052e7b8c96f6c4610ab34686928f0f7adbb41044e29378620e3d5e827cce76
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Params-Util-1.102-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 207956
+    checksum: sha256:a7eb296be9dc11401756128d84ae57a6e2e98fd0231cb5a52d7e86d42153ee56
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Perl-OSType-1.010-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32465
+    checksum: sha256:dd1ff7c7ef5ad251b1af9029f0555b4d21f3d96dd589ebb0d5989bd185f9abed
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24579
+    checksum: sha256:d06492c280011cd128a3e84fe071584470de288053375da173a6304ebafc0e87
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Checker-1.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35413
+    checksum: sha256:ce262ff36c0f737cd181b4e8974ded778cffcc6a6ca949b98b716e2a822b41fe
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Software-License-0.103014-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 135074
+    checksum: sha256:27c65fae4f13a24c6e3634b70f39b439bf5b90b8892b2987d4498dbb4ba2780f
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Sub-Exporter-0.987-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 59528
+    checksum: sha256:a552bfe187044ae29d0dc667e6e0a29c6340bf308d32d4b0c902f19d124e2c39
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Sub-Install-0.928-28.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30662
+    checksum: sha256:224662bdabe9c803615622a3adcb891165ddcdc3eb58aedfed1789576f9048f1
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Sys-Syslog-0.36-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 97885
+    checksum: sha256:8f3db804c924748fc7f7f3a10e093bd1195661657a404ab102a9c1fbb8fe5cb4
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-Size-Any-0.002-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 15436
+    checksum: sha256:f9aa001a28f500b09632dc321a4b46780f0cd02aa02ac8de8529684960fea05f
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-Size-Perl-0.031-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24324
+    checksum: sha256:c0283217d4d0998f3c2b24f42d956de7bc0c0c41478f40bdf6ef868748e003ec
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-Table-0.015-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 42326
+    checksum: sha256:a51423376f857f9720d3ad0e706db782758ac19bc3a28a0feaba80442ea7bd81
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 98184
+    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Test-Harness-3.42-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 226770
+    checksum: sha256:9c62f68a4bb3b0c1e6fbdfbbf2a840e50d93e1f6e0f8936931153725e0593c53
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Test-Simple-1.302183-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 355537
+    checksum: sha256:9b4b7c9a1a8723a1d4c1c353060ddb7f57e48343552506af10066d9ebaed37e6
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Balanced-2.04-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52612
+    checksum: sha256:41dca789e663140111944d257574c4eaa74b66d6169f256a9ffe407fa8070d27
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Diff-1.45-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41875
+    checksum: sha256:df1478044a0c7fb575b1324c0e9311a51e883ca61ff39952d0042ee1b2eb5fd1
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Glob-0.11-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 16200
+    checksum: sha256:9aa6c8502f05a42e5048063c2aff09e15cf8a44f6d00b3f8f154e58f051ff4cc
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Template-1.59-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62651
+    checksum: sha256:71bd67c547eec1d910a9c549be0ed7959a0f8e52a09e37d000a76bab1fd73cd3
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Unidecode-1.30-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 146381
+    checksum: sha256:8aa240add109758d1549e9fda86ea601bdde3a2f3b0afdc62f097859648145e6
+    name: perl-Text-Unidecode
+    evr: 1.30-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Thread-Queue-3.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 27710
+    checksum: sha256:d844642772b9a505fc9bd5aaf94b597f1cf66ba2a890462f33f0fa226ccde79b
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Tie-RefHash-1.40-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43611
+    checksum: sha256:d21a4a6ac093c7622f28c5ac2bd6aa7fae86c5b4c150249d9ca696b5461f3f6a
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Time-HiRes-1.9764-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 124567
+    checksum: sha256:c9e00767aec7da2661ca2785530bc7f35c120e7411cfcd6889437c20add7ade1
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Unicode-Collate-1.29-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 915935
+    checksum: sha256:9f5cd2c294c8f4383e9d6d8ea9b7e2c2a1e913c5a27d39e041885548a570dff4
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:52d4dd85581dfa68c432cab3bde847ee4f62285bbc18ee04fdd5fc5e87dd9a2d
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-Unicode-Normalize-1.27-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55458
+    checksum: sha256:514286df911a40dad2269810466a25279f07d2efab97db7479de337cfcedd971
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-XML-XPath-1.44-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68741
+    checksum: sha256:3484e0703eb0b88f31533dcc9f0f4ce2c4d1c0fd827f206de4c44038db541680
+    name: perl-XML-XPath
+    evr: 1.44-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-autodie-2.34-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 106197
+    checksum: sha256:82f0f75aaf2ac269983fc0c5a4a8c436e0382963ea15dd3e6b1b983865a6ae9b
+    name: perl-autodie
+    evr: 2.34-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-bignum-0.51-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 40019
+    checksum: sha256:065483710b985ef93e23a0a9d69826d777ac3b3580429b011ecc1db4b03f6f8d
+    name: perl-bignum
+    evr: 0.51-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-experimental-0.022-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24159
+    checksum: sha256:72d8e178ae3d2c2607e9ac4875957f841af9511398ddf07279b5e02a0e38034c
+    name: perl-experimental
+    evr: 0.022-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-inc-latest-0.500-20.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28925
+    checksum: sha256:3ac7d9dbcf90cfa75334d84853688e714b67a2982e4c9a33afac0ea4f79b1fb4
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-local-lib-2.000024-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 78260
+    checksum: sha256:4f60f5abc65be4e926262251a0a8d6ed0a86ac650dba678411b148c6a4ea34fd
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-perlfaq-5.20210520-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 212379
+    checksum: sha256:9d33eccd67de62a9793105ef005f4865af5d931471697c9aaf4fd6e2f3da3a16
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-srpm-macros-1-41.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10651
+    checksum: sha256:05990bf148e58515223b0936ee7b621e5d39bb875e2481a4d84522bd4b57d4e3
+    name: perl-srpm-macros
+    evr: 1-41.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-threads-2.25-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130514
+    checksum: sha256:92008f60b397b2e4380eddfe58aa788f78245a8fc44352d68bfa324fbec46655
+    name: perl-threads
+    evr: 1:2.25-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-threads-shared-1.61-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 119822
+    checksum: sha256:1b348ea3a479412c1236b95dc2d5d651a42e1c144626c38b8c08ef190b0c137b
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-version-0.99.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 180220
+    checksum: sha256:123e4f54296116246dfd22b4c6628fab4537c62c8a95394194085e6f60b3763c
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/pipewire-1.0.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2262481
+    checksum: sha256:9f0d3774bea6361293c6f949dca5e45ffae541e4dc24e5f2dac78d2d246008a5
+    name: pipewire
+    evr: 1.0.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/pixman-0.40.0-6.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 647633
+    checksum: sha256:0bd62940984b88bfd5914463d948999e29665450e6850ad5c9c4fbc129f3c3d0
+    name: pixman
+    evr: 0.40.0-6.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/poppler-data-0.4.9-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4130057
+    checksum: sha256:10a56ad2ab5d77157377805fc1481f40f5ccfb069fd34ec4bcf14e2a8ac309fe
+    name: poppler-data
+    evr: 0.4.9-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/pulseaudio-15.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1546014
+    checksum: sha256:01a1e060c7b753b68277a6274f0e16e438c75efd7add7d7aeb759721dde58f3a
+    name: pulseaudio
+    evr: 15.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 289973
+    checksum: sha256:cb7775937762f5ab13165854b5fab8d1e1ea8003451ccb02faaf60b4590c1949
+    name: pyproject-rpm-macros
+    evr: 1.16.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/python-rpm-macros-3.9-54.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32761
+    checksum: sha256:b48fc9a942da394ad4cefd19dd2ebf4c5839d0267a41c797fb04dc6173b5f296
+    name: python-rpm-macros
+    evr: 3.9-54.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/q/qt5-5.15.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 13771
+    checksum: sha256:149c54e64307cb3da96287a068f09c4ea5d3968bf2ba088383069f294695cc6d
+    name: qt5
+    evr: 5.15.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/r/redhat-rpm-config-209-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 96708
+    checksum: sha256:a6f4aa2f37f5c6205cca36ea99c640c6509587aa29732a3e145d7c3af304868f
+    name: redhat-rpm-config
+    evr: 209-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/r/rtkit-0.11-29.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 152904
+    checksum: sha256:c726c0b22b16017bf014107a15f313b18cdc0f09d9257822b027d1adc5bd47a8
+    name: rtkit
+    evr: 0.11-29.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/r/rust-srpm-macros-17-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35132
+    checksum: sha256:dfb94bc23f8c1be02f7d94e4b6d6dc05e98c7d4a162f5ef64f407bf6af738d42
+    name: rust-srpm-macros
+    evr: 17-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/sbc-1.4-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 261568
+    checksum: sha256:b4dbb3348492acf470f5d483cac09ec790c83270176a4d370e9ee6f40d785746
+    name: sbc
+    evr: 1.4-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/sgml-common-0.6.3-58.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111961
+    checksum: sha256:ca6fe92503402d24ebc976123288ec2169e75632bd63dd1c146e8d310eb5ee01
+    name: sgml-common
+    evr: 0.6.3-58.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 76240
+    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/sombok-2.4.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318398
+    checksum: sha256:5f192b4d26bb9550982e644248f675017ec3d85af2fc721c6509c329c6e1c2bc
+    name: sombok
+    evr: 2.4.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/sound-theme-freedesktop-0.8-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 488981
+    checksum: sha256:de474e09a97c0b6cbb54262b9d02f889ba350be1298285d732b06814375a068c
+    name: sound-theme-freedesktop
+    evr: 0.8-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/t/teckit-2.5.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1956688
+    checksum: sha256:57dab9e5aa55d6b2b558e4ef6efda7638176df62ee309d50ef979baa3a8efa3a
+    name: teckit
+    evr: 2.5.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/t/texlive-20200406-26.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 572348942
+    checksum: sha256:fc8a1cd1b58bfaf6f01d981027490920718905a722c7c988be4be28faf2b78fb
+    name: texlive
+    evr: 9:20200406-26.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/t/totem-pl-parser-3.26.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1517364
+    checksum: sha256:3fb99db442bf7988c725139716f102830efb05d559343b387d53fd98af029c9b
+    name: totem-pl-parser
+    evr: 3.26.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/t/tracker-3.1.2-3.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1474282
+    checksum: sha256:ae1dcc262f916002818ec6f6a54413e18ac570c536e299496aed99fd997fae74
+    name: tracker
+    evr: 3.1.2-3.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/t/tracker-miners-3.1.2-4.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4117590
+    checksum: sha256:80cad05049d22e5b7083be12d098f4add783886eff898c84547f89b1149ebff1
+    name: tracker-miners
+    evr: 3.1.2-4.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/t/ttmkfdir-3.0.9-65.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46879
+    checksum: sha256:e4d67a93e5605b5e8b4d0e0c8e5242b9137230b95ba5045c97815c216cfe1d71
+    name: ttmkfdir
+    evr: 3.0.9-65.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/u/unixODBC-2.3.9-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1693729
+    checksum: sha256:0f7bb1708709236922246be96a3cba788d404fbc3a58d4e2a4df8ddc8fc55313
+    name: unixODBC
+    evr: 2.3.9-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/u/upower-0.99.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 464654
+    checksum: sha256:6612bb4ed90e1d08b549615bdee8b36e5e7f46bf7e96d68c2af521a3f30097da
+    name: upower
+    evr: 0.99.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/u/urw-base35-fonts-20200910-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14393016
+    checksum: sha256:e47a39ecac5571addb3b1fc5c57c2cea8d999977eb3f8c29e9921ac29528a9c8
+    name: urw-base35-fonts
+    evr: 20200910-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/w/wayland-1.21.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 239785
+    checksum: sha256:f26f7fc3c60e1c5fe67abd6b6a0c26bb435e869f8451f092805eafe440b23172
+    name: wayland
+    evr: 1.21.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/w/webrtc-audio-processing-0.3.1-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 710526
+    checksum: sha256:70255f0b9784ad78d52f1f25e6e3bf683a1be9727a884760b7d6d9e6ac18b4ea
+    name: webrtc-audio-processing
+    evr: 0.3.1-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/w/wireplumber-0.4.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335147
+    checksum: sha256:efe9ba84e0851cf8cb2e2bf7b75d83b490182f0c55c6268923bc227e81c1bf67
+    name: wireplumber
+    evr: 0.4.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/x/xdg-dbus-proxy-0.1.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130185
+    checksum: sha256:18118ab2f72bb339fd444fceb08acd571a92ef478e8a0417c01aa080b4867c54
+    name: xdg-dbus-proxy
+    evr: 0.1.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-1.12.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 508933
+    checksum: sha256:2d5826de57e8bd5da82557abfd69d274f006c7055b32058a7d2d6cf64405964c
+    name: xdg-desktop-portal
+    evr: 1.12.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-gtk-1.12.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 388924
+    checksum: sha256:5779bc5047853ae2f09723fb92994841f7f54608bf734abecae20b68dbb650da
+    name: xdg-desktop-portal-gtk
+    evr: 1.12.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/x/xkeyboard-config-2.33-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1768610
+    checksum: sha256:fc472164cec4c2e4794081a476f00448bc8defadb7a863d079d4a782ba1f23c7
+    name: xkeyboard-config
+    evr: 2.33-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/x/xorg-x11-fonts-7.5-33.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 11582295
+    checksum: sha256:a9b2eceddc29f02bf49d3d4dee6d564d6b5a4b0f397190090f41a8426b1402ad
+    name: xorg-x11-fonts
+    evr: 7.5-33.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 101373
+    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
+    name: yajl
+    evr: 2.1.0-25.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/z/zziplib-0.13.71-11.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1157547
+    checksum: sha256:2ffa5b060b58d204e6686c07461c594d2f1cf1bdaf8e4a7d9309f9aa982484e3
+    name: zziplib
+    evr: 0.13.71-11.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/a/acl-2.3.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 535332
+    checksum: sha256:cb449bc6c85e0b50fa0bb98c969ff8481fee40517d8ebec5e28b72e5360fbe1e
+    name: acl
+    evr: 2.3.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8251850
+    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 482234
+    checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
+    name: attr
+    evr: 2.5.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1262288
+    checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
+    name: audit
+    evr: 3.1.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/a/avahi-0.8-22.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1629705
+    checksum: sha256:8e0cd07caf638b2d935ecc76fecc8d77adf5e399dbfb48958eacacb395b013d9
+    name: avahi
+    evr: 0.8-22.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/basesystem-11-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9884
+    checksum: sha256:5a4ed0779fc06f08115d6e06aa95486f1e1e251f8f9ddb6c7e14e811bb2e24ef
+    name: basesystem
+    evr: 11-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/bash-5.1.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 10512850
+    checksum: sha256:5d7bbbf2538361be1a11846602862c3a56809b3ea43b69b86bcf407538e9e260
+    name: bash
+    evr: 5.1.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/bash-completion-2.11-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 323037
+    checksum: sha256:e1da4ec276292a64279e9a62ae93a98295fb7be131618cc6ca48b053d0da8ca9
+    name: bash-completion
+    evr: 1:2.11-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/bluez-5.72-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2416940
+    checksum: sha256:5283227c6c84280f4956d9092d71d82f78176ff599adcf4be7d106387858a47b
+    name: bluez
+    evr: 5.72-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/bubblewrap-0.4.1-8.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 230660
+    checksum: sha256:0766cbd8405dd66aa93e316760405c0cdfb8b64f2a0e406fef915d3f51262a50
+    name: bubblewrap
+    evr: 0.4.1-8.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 824335
+    checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 711648
+    checksum: sha256:d3193e155ddd297042a944729fe54c1b90c17bdbd1876fc68e4f66d7857f9e81
+    name: ca-certificates
+    evr: 2025.2.80_v9.0.305-91.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/chkconfig-1.24-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 214658
+    checksum: sha256:b2618b278f5c8d6dacfae790c8c73b1fc1578b8f64011f325ced5a4a2e3b58bc
+    name: chkconfig
+    evr: 1.24-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/coreutils-8.32-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5692590
+    checksum: sha256:f042749974d210ad9049ffcb68172e4eaf91e3c0c249b33620e1f94effe82e6d
+    name: coreutils
+    evr: 8.32-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/cpio-2.13-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1395694
+    checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
+    name: cpio
+    evr: 2.13-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6414228
+    checksum: sha256:56a815a100d75c1d42c07090b632f05e51ea6d17df097d2936ab25d9aca49310
+    name: cracklib
+    evr: 2.9.6-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/crypto-policies-20250128-1.git5269e22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 102787
+    checksum: sha256:0f6081ad96e9d7cb80aa18736e3a06bbf7d2c19bdc0f95a707a4f3ed0926b878
+    name: crypto-policies
+    evr: 20250128-1.git5269e22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11657571
+    checksum: sha256:0a8b07dac531288c2fb1987106664a4e762e1b985c8851d577aa8aac60636a06
+    name: cryptsetup
+    evr: 2.7.2-3.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/cups-2.3.3op2-33.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8125712
+    checksum: sha256:d47b1ed7a8374a9881475617f7d1779e73960fbdc5a1402fd1327a144de06136
+    name: cups
+    evr: 1:2.3.3op2-33.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4030574
+    checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
+    name: cyrus-sasl
+    evr: 2.1.27-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/d/dbus-1.12.20-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2143916
+    checksum: sha256:3fe74a2b4fb4485c93e974010d9376e30a63dfcc628bfd6c01837c27b4953912
+    name: dbus
+    evr: 1:1.12.20-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/d/dbus-broker-28-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 254475
+    checksum: sha256:aced3097fbb8a424ca1816b8cb3e79960a9ccf7ba139538282886e692c317b29
+    name: dbus-broker
+    evr: 28-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/d/dejavu-fonts-2.37-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 13631421
+    checksum: sha256:4a325b197556c40187c2785302ede62d3e4cf300984ad6b8cf57e7a4974246aa
+    name: dejavu-fonts
+    evr: 2.37-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7418303
+    checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/e/elfutils-0.192-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11944670
+    checksum: sha256:afe7c9bef952ed086637fe83ac77bfafa70bf2ba28c1d7aaa51a18c9a75146b6
+    name: elfutils
+    evr: 0.192-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1003666
+    checksum: sha256:e8261cbcd55b85efdcd12ce1a2c6e63a72c64c872d618de4ba24557a1fda63c0
+    name: file
+    evr: 5.39-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/filesystem-3.16-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 20486
+    checksum: sha256:c795690df30c46e521372e2f649c995a2abc159b76c8ef6cd5da8a713ea17937
+    name: filesystem
+    evr: 3.16-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/findutils-4.8.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2010585
+    checksum: sha256:48bd4d4dd081120bcc6ab772b930a150f30b2fc89a4a14a24220383d24a30b3f
+    name: findutils
+    evr: 1:4.8.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 50762
+    checksum: sha256:6da7d722d419e6e9ce5abb4f6adcb82613d0629261011ec42134cfe092078e83
+    name: fonts-rpm-macros
+    evr: 1:2.0.5-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/freetype-2.10.4-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4767581
+    checksum: sha256:b5f1bbbd25b22e01fc2508188b49a97fdf5f72d069039358cb5837dffcf9f2c1
+    name: freetype
+    evr: 2.10.4-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/fuse-2.9.9-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1832743
+    checksum: sha256:9a11b340f925ae501331459e5d8d2edb819b947406d26cb565cf46a9f1b27f97
+    name: fuse
+    evr: 2.9.9-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gawk-5.1.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3190934
+    checksum: sha256:37571947707e835d36ceb5641b187aba13ef8f5f605a6762ce72aeea3e745b8d
+    name: gawk
+    evr: 5.1.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 81877102
+    checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
+    name: gcc
+    evr: 11.5.0-5.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gdbm-1.23-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130147
+    checksum: sha256:ad42264274c2a792220395a4dbe736a1de6100c4e14611707ec1dd447583271f
+    name: gdbm
+    evr: 1:1.23-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/glib-networking-2.68.3-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 256221
+    checksum: sha256:08f2d7a3c389bd63fb7ff6f8ac4a5a1fbb088451ca40f4fbe8ed70d2e820e897
+    name: glib-networking
+    evr: 2.68.3-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.24.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19844004
+    checksum: sha256:7c3dc8448748d98fb9af6f1ec0115ea61b0618135f5eb0104298bc1f9927eea3
+    name: glibc
+    evr: 2.34-168.el9_6.24
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gmp-6.2.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2503825
+    checksum: sha256:d0d8a795eea9ae555da63fbcfc3575425e86bb7e96d117b9ae2785b4f5e82f7c
+    name: gmp
+    evr: 1:6.2.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gobject-introspection-1.68.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1041521
+    checksum: sha256:cc54e6b0e1c09dd0ac59df81e8670434134ccc6adfd390a69fa11963be209231
+    name: gobject-introspection
+    evr: 1.68.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gpgme-1.15.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1737968
+    checksum: sha256:ceeb7d42bc8ddf6f09013439bfed4e591411b81293fe3db5e4edb06cbe1879fb
+    name: gpgme
+    evr: 1.15.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/graphite2-1.3.14-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6312801
+    checksum: sha256:5e2022500d0c9129817bb77916e6b55375344ed2737e05cc82e0f53f295cf2d6
+    name: graphite2
+    evr: 1.3.14-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/grep-3.6-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1620891
+    checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
+    name: grep
+    evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gsettings-desktop-schemas-40.0-7.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 714013
+    checksum: sha256:6ad3eec701e251c7b04018c0148173961474f33477f7a68eaad4779c3d2aed62
+    name: gsettings-desktop-schemas
+    evr: 40.0-7.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/h/harfbuzz-2.7.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9551851
+    checksum: sha256:d0ea2d865c05da90d7a32c6ad835bc3ba2067e759aaec2b0ca94a148735e43f8
+    name: harfbuzz
+    evr: 2.7.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/h/hwdata-0.348-9.18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2508307
+    checksum: sha256:af6cdae99470d14fa48057ac70a01cc8ab8567577eb74fc8c8be32ac080ad0ba
+    name: hwdata
+    evr: 0.348-9.18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/i/icu-67.1-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 23181317
+    checksum: sha256:3abe8dc1abc22213826dd6ffb214cdd88705def93dcb234ffc87c792909b0879
+    name: icu
+    evr: 67.1-10.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1505374
+    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
+    name: jq
+    evr: 1.6-17.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/j/json-c-0.14-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 341227
+    checksum: sha256:c4c76ebfd66ba6d00edf672797d7f077b29d279b7866a04e05258a257a5bc306
+    name: json-c
+    evr: 0.14-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/j/json-glib-1.6.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1319256
+    checksum: sha256:7ed60df640cc4c3cd08af33325b6ca4925a8b30c984e866a5abc1f66407634e9
+    name: json-glib
+    evr: 1.6.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/k/kbd-2.4.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1167414
+    checksum: sha256:8d50e573c7beff06b0167dd7d6bccfe542bc393aaf652bbecb205277af293231
+    name: kbd
+    evr: 2.4.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 150790
+    checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
+    name: keyutils
+    evr: 1.6.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libassuan-2.5.5-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 586136
+    checksum: sha256:dcc858194f9497ec86960651fa76413a9c731f94423d67298e8e3c0c7a5e7806
+    name: libassuan
+    evr: 2.5.5-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libcap-2.48-9.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 202341
+    checksum: sha256:cf258d269e2690617bbace76ec328e55c6f1431ddb47b67bcd4841472870d483
+    name: libcap
+    evr: 2.48-9.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 470599
+    checksum: sha256:48bb098662e2f3e1dbb94e27e4e612bc6794fbb62708e1f1a431cc2480fcdb00
+    name: libcap-ng
+    evr: 0.8.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libdb-5.3.28-57.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 35290920
+    checksum: sha256:6a74a3d96bd4657659524050945e2a47e93779addf2de374a13e1baf32b4ab8d
+    name: libdb
+    evr: 5.3.28-57.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libeconf-0.4.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 201501
+    checksum: sha256:4541a0915eca1e6fd1440253cf6bdfc5482c7b6dd3d3c7310a77faf852b7671a
+    name: libeconf
+    evr: 0.4.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libevent-2.1.12-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1123179
+    checksum: sha256:8c00dc837b8685fc660cc0bcdfd4f533888facaa8c83655c26d2fb068cb7b135
+    name: libevent
+    evr: 2.1.12-8.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libffi-3.4.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1367398
+    checksum: sha256:2b384204cc70c8f23d3a86e5cc9f736306a7a91a72e282044e3b23f3fd831647
+    name: libffi
+    evr: 3.4.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libgudev-237-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 40294
+    checksum: sha256:3ae56503c2508bfcba274b4bdaa169ee0a54294682edba202890f999d07b300a
+    name: libgudev
+    evr: 237-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libgusb-0.3.8-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 57034
+    checksum: sha256:18f50c2b798110da109d5d0b429948c762d5b98ba5d37705b6d1b4d327200847
+    name: libgusb
+    evr: 0.3.8-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libidn2-2.3.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2214169
+    checksum: sha256:c27f21437a76f07b0ee9f4f7e61d621cbb9c483c14563b31e55e320d19df99a6
+    name: libidn2
+    evr: 2.3.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libksba-1.5.1-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 677223
+    checksum: sha256:6d334a90bcbc270ee691183624e5664fdbe7dbf2d4a47319e6c75860e16abd43
+    name: libksba
+    evr: 1.5.1-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libproxy-0.4.15-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 123932
+    checksum: sha256:7b2cdc89e0020245af06c0b12f3e077c457cf3947d60c53b9303a0fe36d84002
+    name: libproxy
+    evr: 0.4.15-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9160109
+    checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
+    name: libpsl
+    evr: 0.21.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447225
+    checksum: sha256:14fbf335e2c6f22b441a9750a69b7c41e197c4dd21adac701fd81f17660ee0b4
+    name: libpwquality
+    evr: 1.4.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/librtas-2.0.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 162965
+    checksum: sha256:b87597d7d10c2031ef18cb2bbaf2a318ecd21c274855c49d57a9557df3292113
+    name: librtas
+    evr: 2.0.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 653169
+    checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
+    name: libseccomp
+    evr: 2.5.2-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 271153
+    checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
+    name: libselinux
+    evr: 3.6-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 223978
+    checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
+    name: libsemanage
+    evr: 3.6-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libsepol-3.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 538074
+    checksum: sha256:2e02ff0ce3c6767962d1e7a3fbe657ea2a241bcd1c0182d9c552321ba4f8404b
+    name: libsepol
+    evr: 3.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libsigsegv-2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 473267
+    checksum: sha256:734651070d0113de033da80114b416931c4c0be21ce51f6b1c1641b1185c34f3
+    name: libsigsegv
+    evr: 2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libtasn1-4.16.0-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1895591
+    checksum: sha256:a3d9612fc631100fa0a528d7721bdee96acc33e35befb6a96544526eae169936
+    name: libtasn1
+    evr: 4.16.0-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libtdb-1.4.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 762833
+    checksum: sha256:d402a0c800081eb75cd81f27f632638e204fc210f24f911766f0484bc0a95313
+    name: libtdb
+    evr: 1.4.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libtool-2.4.6-46.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1002417
+    checksum: sha256:1130b15333736ad40a18b5924959a8b0c6c151305bc252c0cbd5276432e10002
+    name: libtool
+    evr: 2.4.6-46.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libunistring-0.9.10-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2065802
+    checksum: sha256:f6c329a60743d0d4955e070c5104407e47795b1ef617e7e59d052298961aec2b
+    name: libunistring
+    evr: 0.9.10-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libusbx-1.0.26-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 643959
+    checksum: sha256:e9359c9ad4fedd8d880f23c2c6a248fd0e17d657ee4ef5d17d572844dfe5f016
+    name: libusbx
+    evr: 1.0.26-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libutempter-1.2.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 30093
+    checksum: sha256:e48843d2734fefad084a86165860ea9575bdc53f63bb5845d8807ce9ccb4f914
+    name: libutempter
+    evr: 1.2.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 396005
+    checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
+    name: libverto
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543970
+    checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/lksctp-tools-1.0.19-3.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 594235
+    checksum: sha256:7f3e4ff54446b4e015958dc5bbe342cfb64151e4b6b886889921b116c373d640
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/lua-5.4.4-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 521629
+    checksum: sha256:18feaae23ff1b674acccf0f081f0d3c36ca482df0c468e9368d4f4432dff820c
+    name: lua
+    evr: 5.4.4-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/lvm2-2.03.28-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2992347
+    checksum: sha256:5361a813c7d6ea933fba20b461c5e3af5528b8876724460f8526f82564e0a063
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/lz4-1.9.3-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 333421
+    checksum: sha256:44e9e079f0f30476a0d8d9849ef1cd940fcc37abee11f481d6043b184bd0cf14
+    name: lz4
+    evr: 1.9.3-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/m/ModemManager-1.20.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1480103
+    checksum: sha256:81e6ab62ffedbf646500c284da42c11609b77c7ba57e1eb561cc95ca0ffe3a30
+    name: ModemManager
+    evr: 1.20.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2335546
+    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
+    name: make
+    evr: 1:4.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/m/mpfr-4.1.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1556195
+    checksum: sha256:1a6f60487d5ebb8998718c8246a49baf182e27318aa16e6a80b1ba7600b74e13
+    name: mpfr
+    evr: 4.1.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3587058
+    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
+    name: ncurses
+    evr: 6.2-10.20210508.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/n/nettle-3.10.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4331292
+    checksum: sha256:1f3587f2d59896bc3f427e4b5b9395095189dfb04237c242daa5cc536c7e02a9
+    name: nettle
+    evr: 3.10.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/n/npth-1.6-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 314570
+    checksum: sha256:3d0685cc559f0af453b6b3ace61944dec9b9cb090695e4de5f5579da7b35b750
+    name: npth
+    evr: 1.6-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/o/openldap-2.6.8-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6548889
+    checksum: sha256:0d21c12c55d40d1fc2f006c8ec187b5fcc799b794cfd31ed2d98434189c62800
+    name: openldap
+    evr: 2.6.8-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 89980613
+    checksum: sha256:4c7cd5a5b7095fcaa5850322ef1f1a7f42e69eacb0386d32fd6ced3dd7a9e7f5
+    name: openssl-fips-provider
+    evr: 3.0.7-6.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/p11-kit-0.25.3-3.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1027881
+    checksum: sha256:de598a2e1ca170df85cd69d6cc406402407a244988506f53f8736a7546135260
+    name: p11-kit
+    evr: 0.25.3-3.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.5.1-26.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130406
+    checksum: sha256:9a351f0455da788ff63026af9a8ee30e744017941c82283f970d1ed066000bb6
+    name: pam
+    evr: 1.5.1-26.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/pcre-8.44-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1624356
+    checksum: sha256:7edbd87b866a3f6e3df1426d660b902e063193d6186027bf99f6d77626a43817
+    name: pcre
+    evr: 8.44-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/pcre2-10.40-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1789790
+    checksum: sha256:a570f7192be555222aa3704882b9199fb013a84ad4d7dcf40a93d8de2ecf6e0a
+    name: pcre2
+    evr: 10.40-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/polkit-0.117-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 336356709
+    checksum: sha256:29fafdd944809b56c0c2e9fe65c2f777e18e5d53473c95e14f6365af4287b131
+    name: polkit
+    evr: 0.117-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/polkit-pkla-compat-0.1-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 302278
+    checksum: sha256:8e4af06bc58994064b55ef7cdac31d48f9797f874fa82e011ad75b6233940636
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/popt-1.18-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 595630
+    checksum: sha256:1c5d47907a884ec21001c4965013fa70bea3f770d385fdc897cb7afc1cf62fe6
+    name: popt
+    evr: 1.18-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 93646
+    checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
+    name: publicsuffix-list
+    evr: 20210518-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/python-pip-21.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8984717
+    checksum: sha256:cb9e0cca3bd8dc24798cf1fb333d574774ce8288598331d44994d768f33648d3
+    name: python-pip
+    evr: 21.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/python-setuptools-53.0.0-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2080099
+    checksum: sha256:9cd7d11ed9e7fe2fa274de10d803f6fecd53cc1101bd0cbae386dbb66ce03824
+    name: python-setuptools
+    evr: 53.0.0-13.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/r/readline-8.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3009702
+    checksum: sha256:bc7a168b7275d1f9bd0f16b47029dd857ddce83fa80c3cb32eac63cb55f591f3
+    name: readline
+    evr: 8.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/r/redhat-release-9.6-0.1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 62469
+    checksum: sha256:6720f3d5c6675bbf8d79ce5424f891a34303e0c5c39be0e52ca51f70107f585b
+    name: redhat-release
+    evr: 9.6-0.1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4490587
+    checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
+    name: rpm
+    evr: 4.16.1.3-37.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/s/sed-4.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1424192
+    checksum: sha256:0590550f0cbdce0a26f98a73c756f663a7f220486d10f9c16d1ce0c8c4d14378
+    name: sed
+    evr: 4.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/s/setup-2.13.7-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 195940
+    checksum: sha256:3acdbbd63bd77dd8b18210b9d597bd59ddf455ff728067638c54194ac3a8a32b
+    name: setup
+    evr: 2.13.7-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1715281
+    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
+    name: shadow-utils
+    evr: 2:4.9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/s/shared-mime-info-2.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5257989
+    checksum: sha256:93b45d557d2958d316a6ee4645a9fdccb824cad2133c451ba22221fc933e6f9f
+    name: shared-mime-info
+    evr: 2.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/s/sqlite-3.34.1-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 25109243
+    checksum: sha256:ca9c26565fc4cdfdd8b813a116bb6bba1b36db634bb4b38602cc02f008db064c
+    name: sqlite
+    evr: 3.34.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/t/tpm2-tss-3.2.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1660943
+    checksum: sha256:11c9b6951d6823d120d310243f500f78ce13f9e206134309692e4a761294f3b9
+    name: tpm2-tss
+    evr: 3.2.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6281028
+    checksum: sha256:cde2d6a98345d49de9d225fc3acf7542fb35fde32832f1361415486a7839c222
+    name: util-linux
+    evr: 2.37.4-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/w/which-2.21-30.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 163429
+    checksum: sha256:3ab75392900a7b7d5b7e869c0d5beba9e184e970946e328f995f79f2e35397ff
+    name: which
+    evr: 2.21-30.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1168293
+    checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
+    name: xz
+    evr: 5.2.5-8.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/z/zip-3.0-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1137410
+    checksum: sha256:416b6957a4365204cfb2ba9e5b9b9f21075b615114c6afe46c83166de258bb5d
+    name: zip
+    evr: 3.0-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/z/zlib-1.2.11-40.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 561153
+    checksum: sha256:e47b884c132983fd0cc40c761de72e1a34ada9ee395cfe50997f9fb9257669d8
+    name: zlib
+    evr: 1.2.11-40.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2378112
+    checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
+    name: zstd
+    evr: 1.5.5-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7626843
+    checksum: sha256:9dbaca23d62c0bcb1f25ba74c73e3488a5878362bf35e302a64981befc3b7f3f
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/c/crun-1.26-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 896467
+    checksum: sha256:728c9ee33f9c4c2a8b9718c9b6b8e86be57897bf80b5bf1cc2fb195e824bb681
+    name: crun
+    evr: 1.26-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7737493
+    checksum: sha256:93923e9e509be34b01501dbc898e47ed8e5984110b424d12387cac9928372574
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/giflib-5.2.1-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 454644
+    checksum: sha256:7190afe993e439540a36a564f62c09dbd455f477a9e2b4223943b35c4ddf407d
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/git-lfs-3.6.1-2.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3704183
+    checksum: sha256:da9df4e5a770589c8d3a72ea5b7dde9860d5cf4869a3198009cafdad05beb10a
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/go-rpm-macros-3.6.0-13.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 134217
+    checksum: sha256:2b01ccb1ff201351069d5e7faed2b638bfabd63a58fe5dbac54c4fa77020efeb
+    name: go-rpm-macros
+    evr: 3.6.0-13.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2402853
+    checksum: sha256:b708fd816f9269983034eb5a4af7431a4d640885668e61020c18f21cc858b2b2
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 67369706
+    checksum: sha256:ccdf6f1911dbc397143a302aff66c575c035222a97fdfbc15dc4e18b4cbdec47
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libsoup-2.72.0-10.el9_6.6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 1524773
+    checksum: sha256:e09ab5c0baa53fd164dec50e512ec341aa7005fe4881df7fa7e008de5d7b1a5b
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libtiff-4.4.0-13.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2894616
+    checksum: sha256:fe00b8631ff587d510f42b10e15d9eeb0e248d559a8940029077c1846a79e81f
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/l/libxslt-1.1.34-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3560934
+    checksum: sha256:b3947676add0f33392769160c17de031191fd4af0caaddb009903b2f981cdd0f
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/m/mesa-24.2.8-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 33254288
+    checksum: sha256:0a6183042f15cad55922f1262d1df8d3836e950a4c2a4a92aa4655c5869772cb
+    name: mesa
+    evr: 24.2.8-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/n/nss-3.112.0-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 81985898
+    checksum: sha256:03e1f0c080506262cf5cf8198eedc16dbcab50f7ff3ab75eeec20bb6dffbf65a
+    name: nss
+    evr: 3.112.0-8.el9_4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/o/ostree-2025.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2151401
+    checksum: sha256:9be705455801c8632ce93ebe7d2d3f1ca1ca66ac20c6e0801a39b0626bd4fde5
+    name: ostree
+    evr: 2025.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 269666
+    checksum: sha256:712a5069cc5e3863ce0c84dacb69850ed20ce354d992a3f8773f577d6aa6801e
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/poppler-21.01.0-22.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 4696462
+    checksum: sha256:db66bfc8235cf25007f20d0b9c1422e577660cb6d1441b3de07e18cea988c738
+    name: poppler
+    evr: 21.01.0-22.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/postgresql-13.23-1.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 51333145
+    checksum: sha256:ad1a81d99d970d228aca114b49db118c692da06d5b5c9d43b3ece667730b50e1
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-16.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6493619
+    checksum: sha256:16c2aaa5191a3e816c32aa0543b5106f4042577e0336930ab22c5775606605c8
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 10642816
+    checksum: sha256:9d266472087f840a668e6eb2855a4021e054a48b0b7c9f7ad1fe5acb42e93b95
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/s/systemtap-5.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6602276
+    checksum: sha256:9f86d158ac1db2e0ed479f194ec9b9113a19f678b6d4a83ab1a42877ba9b779b
+    name: systemtap
+    evr: 5.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS/Packages/w/webkit2gtk3-2.52.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 65133497
+    checksum: sha256:bdd945c48a7e40a7daec8f6b2291fda7e3584a6e59f2d0a6b3ab7adecd12fc7d
+    name: webkit2gtk3
+    evr: 2.52.3-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 22423248
+    checksum: sha256:bd25b72280f9648cf99327b74dc03713a200a30068834bbca48a8ad7f7cfcd79
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 510894
+    checksum: sha256:299496cf3aafff9c162da9ec0cb6eaa65ee0d8dc8b8594998968959282e0b536
+    name: brotli
+    evr: 1.0.9-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2549990
+    checksum: sha256:9945d643a0ded5725b7fd4eaebc2f7350324c782ee7857e3a72d1e7fd1aa243b
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/e/expat-2.5.0-5.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8380127
+    checksum: sha256:207d7440755167a1049b86dafd99052a0162107167dfad2405386ab8452e6e76
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/glib2-2.68.4-16.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 5078743
+    checksum: sha256:452f757e564781db4e489cfabc4ab6062375e9f580da4dbd1fa7157f41fb8f39
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gnupg2-2.3.3-4.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7615913
+    checksum: sha256:cd27551144e10f730f613ade3c9f3c201c912941a8abfce2c3fc770f6845b9ab
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-6.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8612613
+    checksum: sha256:dc677685c729543c50bb6c99ae875ef7f83b36f2c25b74f55269c49f160409a9
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.110.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 149742415
+    checksum: sha256:95170092b5c7994be8941bf5b6ae3660a876a6691b3f06fdf46af7124de14a89
+    name: kernel
+    evr: 5.14.0-570.110.1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/k/krb5-1.21.1-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8943275
+    checksum: sha256:0e9b010a294e5358b4bd1e28b7cd1f1eb15256d4040f68814b0659f92f5a1ec2
+    name: krb5
+    evr: 1.21.1-8.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libarchive-3.5.3-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7054617
+    checksum: sha256:a590c3f706fbc8932245513fca3328d68708a0b11565da86eed8002399f80c65
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libpng-1.6.37-12.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 1530809
+    checksum: sha256:4ad341aec16d15a0b68009e84704662aebb9238f8ca98b521083de05b0dcc861
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libssh-0.10.4-15.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 665493
+    checksum: sha256:dbe0318bea854b3a1f8af8f6aceab24d0beac8172d0afd30779afdf0b62d96f5
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/l/libxml2-2.9.13-12.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3287566
+    checksum: sha256:2bc2fd257740e6baa0555a9e98ae5731a5e18d98332afa10e2e6e8bd92b1880a
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/n/NetworkManager-1.52.0-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 6295554
+    checksum: sha256:fc995af619a89f8184e3d19b975e653615e6f1687c36de40b0ec63ff0df580d8
+    name: NetworkManager
+    evr: 1:1.52.0-10.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/n/nghttp2-1.43.0-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3997194
+    checksum: sha256:25c2a8aaef5b90676fe217d732db026441e110951ed66b00e7327b79886a7a72
+    name: nghttp2
+    evr: 1.43.0-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2410966
+    checksum: sha256:1ddf2a92b05dd9431ce5b6b884b449c7f855806a7586114f9034c2602172163f
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 17980237
+    checksum: sha256:2010e981778502acfddd21095efbb7bbe407e8d85ddf6185563f6a41508591a0
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/p/python3.9-3.9.21-2.el9_6.5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 20305745
+    checksum: sha256:28b422b6eddc8c6531629680290fbcfd4539ff4bbb199fb0fbf6e9a8262e8b1a
+    name: python3.9
+    evr: 3.9.21-2.el9_6.5
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/s/systemd-252-51.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 43231152
+    checksum: sha256:c7324d32266c9b398924b5495019101abb46013f2d4f348b19b5fe156c6140ff
+    name: systemd
+    evr: 252-51.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2282353
+    checksum: sha256:8845bf368f2fcda2e27130cf4ef8301fed4ac310c0b1ef048542bd85261bf21c
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 919356
+    checksum: sha256:eb238075d8e20f9b5bee4666e55572ec2762203a0040e1d1fc350b390e412c99
+    name: tzdata
+    evr: 2026a-1.el9_0
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS/Packages/v/vim-8.2.2637-22.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 12824612
+    checksum: sha256:7fec61a8292d8ed5cf71f95d47ae8b594967391eef07fe306899359735eda157
+    name: vim
+    evr: 2:8.2.2637-22.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/source/SRPMS/Packages/p/pybind11-2.10.4-2.el9.src.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-eus-source-rpms
+    size: 753907
+    checksum: sha256:7b09202a3413bd4d9b0ec480bc7135c5baa7951bac0044891ddaa64999af4f31
+    name: pybind11
+    evr: 2.10.4-2.el9
   module_metadata: []
 - arch: s390x
   packages:
@@ -12017,6 +17421,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.4/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-rpms
+    size: 215170
+    checksum: sha256:c08f31e4dedac70227ac0798070f9dedcee0696afa34ac016e89b650c62dab8f
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+    sourcerpm: libsndfile-1.2.2-6.el9ai.src.rpm
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.s390x.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
     size: 100645
@@ -12185,13 +17596,6 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1215996
-    checksum: sha256:67e641c9a86b684e9e3ff85090c23b2a2654bb3287d544c1d7c89ab40ce6bd0a
-    name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_6.1
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 58254
@@ -12227,13 +17631,6 @@ arches:
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/c/crun-1.23.1-2.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 231679
-    checksum: sha256:09f8995e4ad877a3db891c0bcb3f8405cca630710fe8b5dd6fd2802835bb3cfc
-    name: crun
-    evr: 1.23.1-2.el9_6
-    sourcerpm: crun-1.23.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/d/dconf-0.40.0-6.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 115496
@@ -12388,20 +17785,6 @@ arches:
     name: gcc-plugin-annobin
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 499972
-    checksum: sha256:a154a4031e83e3e178d72d683c621e4431b9ae9c671766579e4d8a23ebc924c1
-    name: gdk-pixbuf2
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 88336
-    checksum: sha256:e4591103182bd57cad99f0c790aafd23ad3ea697722a031f0b33a7abe10643a5
-    name: gdk-pixbuf2-modules
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/geoclue2-2.6.0-8.el9_6.1.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 125463
@@ -12437,13 +17820,6 @@ arches:
     name: ghostscript-tools-printing
     evr: 9.54.0-19.el9_6
     sourcerpm: ghostscript-9.54.0-19.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/giflib-5.2.1-9.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 52380
-    checksum: sha256:22807611a3fc27aa37b4fe5fa17ade888b9654f1b07b436a6b42b60beb8e311f
-    name: giflib
-    evr: 5.2.1-9.el9
-    sourcerpm: giflib-5.2.1-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 4802290
@@ -12451,13 +17827,6 @@ arches:
     name: git-core
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4394872
-    checksum: sha256:efd6a11017703f2d435ce55fb8b013220c111eb23c33177a11e51719c86a5c07
-    name: git-lfs
-    evr: 3.6.1-2.el9_6
-    sourcerpm: git-lfs-3.6.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.24.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 40678
@@ -12472,13 +17841,6 @@ arches:
     name: glibc-headers
     evr: 2.34-168.el9_6.24
     sourcerpm: glibc-2.34-168.el9_6.24.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/go-srpm-macros-3.6.0-10.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 28143
-    checksum: sha256:c1cbc05c812994c77b7f7bf80e76039c94d6ba887c9169228833e7e702aa095a
-    name: go-srpm-macros
-    evr: 3.6.0-10.el9_6
-    sourcerpm: go-rpm-macros-3.6.0-10.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/google-droid-sans-fonts-20200215-11.el9.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2836183
@@ -12514,13 +17876,6 @@ arches:
     name: gstreamer1
     evr: 1.22.12-3.el9
     sourcerpm: gstreamer1-1.22.12-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-4.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2218912
-    checksum: sha256:4359c11439e26ce84c8981212f46c514ffc1da7ebb45117103584bfa3e2b9f19
-    name: gstreamer1-plugins-base
-    evr: 1.22.12-4.el9
-    sourcerpm: gstreamer1-plugins-base-1.22.12-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/g/gtk-update-icon-cache-3.24.31-5.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 35443
@@ -12556,20 +17911,6 @@ arches:
     name: iso-codes
     evr: 4.6.0-3.el9
     sourcerpm: iso-codes-4.6.0-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 380934
-    checksum: sha256:eaefc514fa6f006367edbd4245c4ae7ba77eabdd82b072c4b96988d306e29a4d
-    name: java-17-openjdk
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 43320185
-    checksum: sha256:46025d72d0f88f9606bf16a6b69a0350ae877b1397ef9e6236db490c928e8b2b
-    name: java-17-openjdk-headless
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/j/javapackages-filesystem-6.4.0-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17320
@@ -12591,13 +17932,6 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-570.62.1.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3735229
-    checksum: sha256:fcea3938faee6970ec7457d373339878ab88e63acace6cb096f23f67c6b0a8e0
-    name: kernel-headers
-    evr: 5.14.0-570.62.1.el9_6
-    sourcerpm: kernel-5.14.0-570.62.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17792
@@ -12605,6 +17939,13 @@ arches:
     name: kernel-srpm-macros
     evr: 1.0-13.el9
     sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/lame-libs-3.100-12.el9.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 341277
+    checksum: sha256:ec54e2dcc0278f166c79ede6c425d1f115089493e149e7206f875c41d82d8378
+    name: lame-libs
+    evr: 3.100-12.el9
+    sourcerpm: lame-3.100-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/langpacks-core-font-en-3.0-16.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 10986
@@ -12920,13 +18261,6 @@ arches:
     name: libpaper
     evr: 1.1.28-4.el9
     sourcerpm: libpaper-1.1.28-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libpng-1.6.37-12.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 120682
-    checksum: sha256:0f0b11489e0edbe86a145ea822661e1c8279ec9265e6ce2b789e4dbb66713e83
-    name: libpng
-    evr: 2:1.6.37-12.el9
-    sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libproxy-webkitgtk4-0.4.15-35.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22139
@@ -12955,20 +18289,6 @@ arches:
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libsndfile-1.0.31-9.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 213664
-    checksum: sha256:b69692ace2316b53c4a4155b8b9105c891a5345db0e36ccf254478da11b054e6
-    name: libsndfile
-    evr: 1.0.31-9.el9
-    sourcerpm: libsndfile-1.0.31-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.3.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 405069
-    checksum: sha256:50f2947d0d3fe43fa8b40b71c6262947b7bd38177437546e936264757d434035
-    name: libsoup
-    evr: 2.72.0-10.el9_6.3
-    sourcerpm: libsoup-2.72.0-10.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libstdc++-devel-11.5.0-5.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2518321
@@ -12997,13 +18317,6 @@ arches:
     name: libtheora
     evr: 1:1.1.1-31.el9
     sourcerpm: libtheora-1.1.1-31.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.2.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 196456
-    checksum: sha256:e8b1a0e78cc131ae0297cef8c5c7417a3ac02386d7d3675507b1ad459a6dda91
-    name: libtiff
-    evr: 4.4.0-13.el9_6.2
-    sourcerpm: libtiff-4.4.0-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libtool-2.4.6-46.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 598814
@@ -13116,13 +18429,6 @@ arches:
     name: libxshmfence
     evr: 1.3-10.el9
     sourcerpm: libxshmfence-1.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 243361
-    checksum: sha256:619e7668ac0470ad0330307bd083a9c36e59616c55c5173cf1a7898e589b37a3
-    name: libxslt
-    evr: 1.1.34-13.el9_6
-    sourcerpm: libxslt-1.1.34-13.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/l/llvm-libs-19.1.7-2.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 40096334
@@ -13165,48 +18471,6 @@ arches:
     name: m4
     evr: 1.4.19-1.el9
     sourcerpm: m4-1.4.19-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-3.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3557272
-    checksum: sha256:bc583ecbc6171cfec44d6530aee82316f22d96b0e7c8e7c4dabbd348332c1a0a
-    name: mesa-dri-drivers
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-filesystem-24.2.8-3.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 10754
-    checksum: sha256:6d6d583fda8fba55cf28520f241a1f0fb5496c8dbddc1b5eb0c63469dcb35d67
-    name: mesa-filesystem
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libEGL-24.2.8-3.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 139041
-    checksum: sha256:5a5d8c1920f502d0fd559a5b50e0cd0097871e95ffd3a53e2b00ec24396455c6
-    name: mesa-libEGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libGL-24.2.8-3.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 182300
-    checksum: sha256:a4e3f51ccab25c3fdd06e1b6c2beb22bbdf40ca1db4041368b9ff61ea36cc31b
-    name: mesa-libGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libgbm-24.2.8-3.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 36119
-    checksum: sha256:771336f03dff0cb4b838671b691d72309bd49ea064bc3a092ec4f3cb78989dd3
-    name: mesa-libgbm
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libglapi-24.2.8-3.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 71266
-    checksum: sha256:4821fd9036d9e13a41f5bd2c675915c7ba1b9bfc03a61172ba3287f44ac08024
-    name: mesa-libglapi
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mkfontscale-1.2.1-3.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34797
@@ -13214,48 +18478,13 @@ arches:
     name: mkfontscale
     evr: 1.2.1-3.el9
     sourcerpm: mkfontscale-1.2.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/m/mpg123-libs-1.32.9-1.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 135799
-    checksum: sha256:54fbd8f7a41548d165c2b3d6140e3175d3d48f8ee79301d9757cab0a8788d2d2
-    name: nspr
-    evr: 4.36.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/n/nss-3.112.0-4.el9_4.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 694219
-    checksum: sha256:963396fd7816a9c1b92ef17695046c35a626f556251397aa3351a386c3f6b137
-    name: nss
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 391378
-    checksum: sha256:1d3639c8fd1a8d9916ebe8c1f68bdd63c0b54d3c1eef9d844a44346659acb594
-    name: nss-softokn
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 417708
-    checksum: sha256:fc2c460ce088b06dae6f82998754868899c404c80b0cd574b7e935c0f303a5ed
-    name: nss-softokn-freebl
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 18087
-    checksum: sha256:69f2bb25e414bca1d2eac2786c3a915fc0ff50f8e3dd7dba7bb3fd06d4bd17d3
-    name: nss-sysinit
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 90586
-    checksum: sha256:3c3d6cca2c14c25144b46fa25e0ab7186db29612cb7117304174bbde18b347b2
-    name: nss-util
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+    size: 353050
+    checksum: sha256:ead66fe0453d2eab591c45c7b33dbad041871b75dd4fe213ee930dad0dc643de
+    name: mpg123-libs
+    evr: 1.32.9-1.el9_5
+    sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 9270
@@ -13305,13 +18534,6 @@ arches:
     name: openjpeg2
     evr: 2.4.0-8.el9
     sourcerpm: openjpeg2-2.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4650765
-    checksum: sha256:2e3029dbd402015ec123789ce24837a75cf603730f75cce0b5d955931bfe2a82
-    name: openssl-devel
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/o/opus-1.3.1-10.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 210872
@@ -13340,13 +18562,6 @@ arches:
     name: osinfo-db-tools
     evr: 1.10.0-1.el9
     sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/o/ostree-libs-2025.2-2.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 442975
-    checksum: sha256:173a244b0e784c7152852c57798d734297e3d1a5eaaf3bbea5d7ebd8f7d3fbe4
-    name: ostree-libs
-    evr: 2025.2-2.el9_6
-    sourcerpm: ostree-2025.2-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/p11-kit-server-0.25.3-3.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 277177
@@ -14642,13 +19857,6 @@ arches:
     name: perl-User-pwent
     evr: 1.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 244611
-    checksum: sha256:90450f0809e59cc6d1fd08ea935173d65dd20b672a25a1e8df101b466a8ef436
-    name: perl-XML-Parser
-    evr: 2.46-9.el9
-    sourcerpm: perl-XML-Parser-2.46-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/perl-XML-XPath-1.44-11.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94037
@@ -15027,13 +20235,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/poppler-21.01.0-21.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1040853
-    checksum: sha256:b32c293f6d27674dc4c27ff390427f633182955609c6a5d8eb980b5009436939
-    name: poppler
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/poppler-data-0.4.9-9.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1971104
@@ -15041,34 +20242,6 @@ arches:
     name: poppler-data
     evr: 0.4.9-9.el9
     sourcerpm: poppler-data-0.4.9-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/poppler-glib-21.01.0-21.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 150392
-    checksum: sha256:33acf6391c86ee26f68e11970aae79d04f5ceed760aefdbcfebb4bc23d5a1c51
-    name: poppler-glib
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/postgresql-13.22-1.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1700715
-    checksum: sha256:42f3ec154b938a375e87de50c09308a89d057bd759f5e4dd0d11ad5f8a62763e
-    name: postgresql
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/postgresql-private-libs-13.22-1.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 136630
-    checksum: sha256:b19663a941c6fe4300660e77930df1efbe9c6824b72bf69c62a135c5e97bc494
-    name: postgresql-private-libs
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/protobuf-3.14.0-16.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 988184
-    checksum: sha256:d0a40007e676d188faa8c3f51efece90c57273453979156422e3327e38b45cb9
-    name: protobuf
-    evr: 3.14.0-16.el9
-    sourcerpm: protobuf-3.14.0-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/pulseaudio-libs-15.0-3.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 682171
@@ -15090,20 +20263,6 @@ arches:
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.2.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9102
-    checksum: sha256:7aec11632e430e2d0ee4a4a4e60336ce36ebdd023e6a5645175654e3e339e688
-    name: python-unversioned-command
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.2.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 249843
-    checksum: sha256:b1cec1ef74a93620d8d121f5dd0a93ad41a7a0d97e6496a444f5bfdf433cf98b
-    name: python3-devel
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2133958
@@ -15139,13 +20298,6 @@ arches:
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9000980
-    checksum: sha256:7369b926ac4e07cd3bc25a5c546214bc67514996343c15145b0c38e08afeff85
-    name: skopeo
-    evr: 2:1.18.1-2.el9_6
-    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 50223
@@ -15167,13 +20319,6 @@ arches:
     name: sound-theme-freedesktop
     evr: 0.8-17.el9
     sourcerpm: sound-theme-freedesktop-0.8-17.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/s/systemtap-sdt-devel-5.2-2.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 79111
-    checksum: sha256:55a568bd100f7e693b0232ecf8225679af4ff7716f5319e392536a11f666fab6
-    name: systemtap-sdt-devel
-    evr: 5.2-2.el9
-    sourcerpm: systemtap-5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/t/teckit-2.5.9-8.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 494043
@@ -16385,13 +21530,6 @@ arches:
     name: ttmkfdir
     evr: 3.0.9-65.el9
     sourcerpm: ttmkfdir-3.0.9-65.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/t/tzdata-java-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 233483
-    checksum: sha256:952b215f1e04b08ddfbf4bf19f6285d23f5a9d0dead6a64b4b9a6e1492fb2da0
-    name: tzdata-java
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/u/unixODBC-2.3.9-4.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 481797
@@ -16490,13 +21628,6 @@ arches:
     name: urw-base35-z003-fonts
     evr: 20200910-6.el9
     sourcerpm: urw-base35-fonts-20200910-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/w/webkit2gtk3-jsc-2.50.1-0.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4841316
-    checksum: sha256:fc6d53e6c6309f6ea92a08e144871f74f08847fbb8a99ef307eccf5c4605fb46
-    name: webkit2gtk3-jsc
-    evr: 2.50.1-0.el9_6
-    sourcerpm: webkit2gtk3-2.50.1-0.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/w/webrtc-audio-processing-0.3.1-8.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 301470
@@ -16623,20 +21754,6 @@ arches:
     name: bash-completion
     evr: 1:2.11-5.el9
     sourcerpm: bash-completion-2.11-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/b/binutils-2.35.2-63.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4761844
-    checksum: sha256:ba70deb6c9b7003dc263aace0b80c1405528a34b6740d1dabae51bfc44eda6e2
-    name: binutils
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 845926
-    checksum: sha256:8f053eec2b5d8ee31a4e6d9ed8f951dc34547bc0367fd2e2f41a229c5d9b7fc7
-    name: binutils-gold
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/b/bluez-libs-5.72-4.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 82946
@@ -16728,13 +21845,6 @@ arches:
     name: cups-libs
     evr: 1:2.3.3op2-33.el9_6.1
     sourcerpm: cups-2.3.3op2-33.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 299232
-    checksum: sha256:1ca28d367cd8c8f366eb0e7f8c12615bee63017b8e4910278480d51c89131742
-    name: curl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-21.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 768894
@@ -16819,13 +21929,6 @@ arches:
     name: elfutils-libs
     evr: 0.192-6.el9_6
     sourcerpm: elfutils-0.192-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/e/expat-2.5.0-5.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 118327
-    checksum: sha256:b4c649297dc3b80d70769c0ab38229d1bb497e56d8a1dec514c2fd21eefa3851
-    name: expat
-    evr: 2.5.0-5.el9_6
-    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/f/file-5.39-16.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 52878
@@ -16903,13 +22006,6 @@ arches:
     name: glib-networking
     evr: 2.68.3-3.el9
     sourcerpm: glib-networking-2.68.3-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.3.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2716571
-    checksum: sha256:cf652931e67da1bbf4ce069be44c85f166ccdee22bca4a806bb07d5131ec36ba
-    name: glib2
-    evr: 2.68.4-16.el9_6.3
-    sourcerpm: glib2-2.68.4-16.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/g/glibc-2.34-168.el9_6.24.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1761635
@@ -16945,20 +22041,6 @@ arches:
     name: gmp
     evr: 1:6.2.0-13.el9
     sourcerpm: gmp-6.2.0-13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/g/gnupg2-2.3.3-4.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2581304
-    checksum: sha256:d8b5a4b121e008feb5e55342f19426547a253edef37b0c1d965754da92598338
-    name: gnupg2
-    evr: 2.3.3-4.el9
-    sourcerpm: gnupg2-2.3.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.2.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 988666
-    checksum: sha256:454c6e61dfce612ac5c34d9e6a4013ea9d464c1f5f450b4460b06c338953b750
-    name: gnutls
-    evr: 3.8.3-6.el9_6.2
-    sourcerpm: gnutls-3.8.3-6.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/g/gobject-introspection-1.68.0-11.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 256508
@@ -17071,13 +22153,6 @@ arches:
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 766219
-    checksum: sha256:7cdba78a9793788481f125c87f9de71daf6ddd79b70f4ab49709d9f28ec5835f
-    name: krb5-libs
-    evr: 1.21.1-8.el9_6
-    sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/less-590-5.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 171249
@@ -17092,13 +22167,6 @@ arches:
     name: libacl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libarchive-3.5.3-6.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 393968
-    checksum: sha256:6c328c72720bf2dac8d8a7288c136d6419028b739cc1328692e75f16f6dcd184
-    name: libarchive
-    evr: 3.5.3-6.el9_6
-    sourcerpm: libarchive-3.5.3-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libassuan-2.5.5-3.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 70075
@@ -17127,13 +22195,6 @@ arches:
     name: libblkid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 326862
-    checksum: sha256:0a0d4dc9c873727fbcf07f39edc0c20dd66e28402f24b5cd62022af1c58a6f51
-    name: libbrotli
-    evr: 1.0.9-7.el9_5
-    sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libcap-2.48-9.el9_2.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 75468
@@ -17162,13 +22223,6 @@ arches:
     name: libcom_err
     evr: 1.46.5-7.el9
     sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.1.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 285543
-    checksum: sha256:54aec68ae00dc30c40d5c8ebef83b1ae502271a573d466585154c2d0bd131ac7
-    name: libcurl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 721041
@@ -17295,13 +22349,6 @@ arches:
     name: libmount
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 74709
-    checksum: sha256:2e625ed22a873782f0a7bc21a71187e87b8b6d037cba455b1e3dcb3c95aecd4f
-    name: libnghttp2
-    evr: 1.43.0-6.el9
-    sourcerpm: nghttp2-1.43.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libnl3-3.11.0-1.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 361754
@@ -17379,20 +22426,6 @@ arches:
     name: libsmartcols
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 205467
-    checksum: sha256:19f9046b513e0f24e3ffe6cbd751704afb32ccedb54a6a4380c130dd3f244904
-    name: libssh
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 7991
-    checksum: sha256:845c662af1f78eee4a1f67977a805b551edc939e21d3b201cb332682b18443fb
-    name: libssh-config
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libstdc++-11.5.0-5.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 794076
@@ -17456,13 +22489,6 @@ arches:
     name: libxcrypt
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 726478
-    checksum: sha256:c086d1ec733477c747435cfc36b5c7fc46fabe3983b8fa4fe292eb75fae1a002
-    name: libxml2
-    evr: 2.9.13-12.el9_6
-    sourcerpm: libxml2-2.9.13-12.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/l/libzstd-1.5.5-1.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 283786
@@ -17512,13 +22538,6 @@ arches:
     name: mpfr
     evr: 4.1.0-7.el9
     sourcerpm: mpfr-4.1.0-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-9.el9_6.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1945664
-    checksum: sha256:852bfe7fa3cf8c02e7886d9679b8e7add586cce29ee35eba18f966d05190404d
-    name: NetworkManager-libnm
-    evr: 1:1.52.0-9.el9_6
-    sourcerpm: NetworkManager-1.52.0-9.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9_6.2.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 417296
@@ -17568,27 +22587,6 @@ arches:
     name: openldap
     evr: 2.6.8-4.el9
     sourcerpm: openldap-2.6.8-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/o/openssh-8.7p1-45.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 459208
-    checksum: sha256:dbcfc54c9b29ad55b4ea8407b3b38220f844e056e3c9eca63eacb2fce9824542
-    name: openssh
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 688262
-    checksum: sha256:f37e277368b22152ffff03720214161e911b4e5ff2c4c77fd7b394d15fd8d5bf
-    name: openssh-clients
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1407537
-    checksum: sha256:0a24289ee6324c2ecd6edad913f8ecfcfc6db43fbf6fed65458141e3ec0c104f
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 9601
@@ -17603,13 +22601,6 @@ arches:
     name: openssl-fips-provider-so
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1830531
-    checksum: sha256:3d58f9488bc2a5113d852d6c78df07e414f6d95bb75f1ff78b7530bafdf1eb02
-    name: openssl-libs
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 554452
@@ -17715,20 +22706,6 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/p/python3-3.9.21-2.el9_6.2.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 25980
-    checksum: sha256:9813f9e471dd406aaa60c8fcff9160918ccbadb001f003b98d52a9b7ac745391
-    name: python3
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.2.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8305642
-    checksum: sha256:0b7552ddca09d42227aa3eed6252c855b71207df304e3d9c77c1da7b984adb6b
-    name: python3-libs
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1193706
@@ -17827,48 +22804,6 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-8.el9_6
     sourcerpm: sqlite-3.34.1-8.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-252-51.el9_6.3.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4164163
-    checksum: sha256:a45b62a9e62316ae1640067f1a589a6ee62f1cf15bba94c8c39fd59c4595e588
-    name: systemd
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-libs-252-51.el9_6.3.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 644981
-    checksum: sha256:c2ebfc7d5fda43fcc9695d89bc721d60972652ff4a5ad6cff11ac1145075768a
-    name: systemd-libs
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-pam-252-51.el9_6.3.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 270145
-    checksum: sha256:cb803d534d94468a2bfe4b688685a8fbf5d15c571c6efca7ffc3a440f2ff12c3
-    name: systemd-pam
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.3.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 63512
-    checksum: sha256:0735a7ac27891726d56502705f25d14ad243d49bf1f097c9dcf3ce0bd5ca7a97
-    name: systemd-rpm-macros
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-udev-252-51.el9_6.3.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1954587
-    checksum: sha256:ea2635a9abbf12957a2ef6bc30db09eac4ed81b22fc70d4c70cecb5a5ea18079
-    name: systemd-udev
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/t/tar-1.34-7.el9.s390x.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 902370
-    checksum: sha256:fa8758bac6a56830de66ad1ab623c87768065bcc6f8242faa42ac4198260d456
-    name: tar
-    evr: 2:1.34-7.el9
-    sourcerpm: tar-1.34-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 557484
@@ -17876,13 +22811,6 @@ arches:
     name: tpm2-tss
     evr: 3.2.3-1.el9
     sourcerpm: tpm2-tss-3.2.3-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/t/tzdata-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 862160
-    checksum: sha256:0687e5a1115ba679137404c8d37a45141a31968ffd01677455530d24c126a0d2
-    name: tzdata
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/u/unzip-6.0-58.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 185386
@@ -17904,13 +22832,6 @@ arches:
     name: util-linux-core
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 13249
-    checksum: sha256:9298e32061a3bce9b94f8c1bd1ac3ee0bfa67a68863cc3a0cd97c5432b6e89ed
-    name: vim-filesystem
-    evr: 2:8.2.2637-22.el9_6.1
-    sourcerpm: vim-8.2.2637-22.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/w/which-2.21-30.el9_6.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 42656
@@ -18002,7 +22923,3156 @@ arches:
     name: unixODBC-devel
     evr: 2.3.9-4.el9
     sourcerpm: unixODBC-2.3.9-4.el9.src.rpm
-  source: []
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1215395
+    checksum: sha256:5edb2f6481bd2736913f58ebd13d3cedcac4dd35053b31de93fee83c404a6c4c
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/c/crun-1.26-1.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 239312
+    checksum: sha256:5cca9578ae417797cd13178ee78e2894185f38ea8accb85ec671a650f0f8c8ad
+    name: crun
+    evr: 1.26-1.el9_6
+    sourcerpm: crun-1.26-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 499942
+    checksum: sha256:e9a31a6a46be5c144686f51607e5f8cfa6df87864ac8a9f94907aa8685fd3346
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 87810
+    checksum: sha256:49b2c1813eeb07d44b6f42353a09d72d33bbbc95ec834c11c89e5c6ccf668368
+    name: gdk-pixbuf2-modules
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/g/giflib-5.2.1-9.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 47766
+    checksum: sha256:3b52c678f1319633aa53cb82ce5433794111cd8e69af7cb1301a96e388081110
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+    sourcerpm: giflib-5.2.1-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.3.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4622229
+    checksum: sha256:61651a72adf0834e8e4e3896fed65d418a997495dd11d1bc19f1732072ecb3fe
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+    sourcerpm: git-lfs-3.6.1-2.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 27174
+    checksum: sha256:d045b514c2b217509ffa931e4647a613bd49f8aea31e42a030320cd6ab1f9b26
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_6
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 2207912
+    checksum: sha256:f4dd339dab88fcfacf6265285921246068bace37062d312b77f7957293a4da04
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+    sourcerpm: gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 380306
+    checksum: sha256:c60d90791f9aaee9ef0060e497a890294eec0ddba38deeb90e963f823582e63b
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/j/java-17-openjdk-headless-17.0.19.0.10-1.el9.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 43414273
+    checksum: sha256:e7050a5d97a98dda49651b0ec483035c567e331ff645ae253b6fa5787a5d109f
+    name: java-17-openjdk-headless
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-570.110.1.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 3817641
+    checksum: sha256:5f781280d9d33ebef8b299d0414fd7f5fd5f7a7caeee97ca284390dc6e572465
+    name: kernel-headers
+    evr: 5.14.0-570.110.1.el9_6
+    sourcerpm: kernel-5.14.0-570.110.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/l/libpng-1.6.37-12.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 116776
+    checksum: sha256:ae7757ae3f7329862c89a5145fc5c4f5ec130c9902adb9b0da97ab28acd7d13a
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+    sourcerpm: libpng-1.6.37-12.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 405314
+    checksum: sha256:3f7cfa56266b5d6c76120734fc8b57393da2c8fbb90ab00a04cbb17eece22a64
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+    sourcerpm: libsoup-2.72.0-10.el9_6.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.3.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 196418
+    checksum: sha256:6e5769d59ccb5e894f11604ba345d18cdd1a853a5f0fabb2d318cba63323cb4c
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+    sourcerpm: libtiff-4.4.0-13.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 239815
+    checksum: sha256:505e8eeb1e7812335eb739b339b13d34fb20f39a486d8e25041aefb92ef64cc4
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+    sourcerpm: libxslt-1.1.34-13.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 3557043
+    checksum: sha256:738c214dd36cf082e85fa5391651e4a52311bc0df076eb4adf456366dc95be42
+    name: mesa-dri-drivers
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-filesystem-24.2.8-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 10528
+    checksum: sha256:7520cfe3896b161eb208474d3451b288b2980dfb3e16c4a096ce78085487591f
+    name: mesa-filesystem
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libEGL-24.2.8-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 138774
+    checksum: sha256:3001e342fb35f5aab462f6b049e63961b9933658f5ab701c17efcbfad02267e5
+    name: mesa-libEGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libGL-24.2.8-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 181915
+    checksum: sha256:60368601b021c6784e69aa6e8c78cc8b1cc406aa434b38d2353e61cdaa293bb9
+    name: mesa-libGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libgbm-24.2.8-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 35878
+    checksum: sha256:969886fa66c65290f4eb2e01ada1f13a38a06ebd23e40b1209ceb98a5ebc28e8
+    name: mesa-libgbm
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/m/mesa-libglapi-24.2.8-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 71983
+    checksum: sha256:71d5dbd3c90a6cdcf5e6f00ccc2c431f42c6543f8e7d1c1132be8e99313a5e49
+    name: mesa-libglapi
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/n/nspr-4.36.0-8.el9_4.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 135771
+    checksum: sha256:deff4a55c804bec418ce8f01dca3b0b3e8935643c83adceb2cb18b5293652dd8
+    name: nspr
+    evr: 4.36.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/n/nss-3.112.0-8.el9_4.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 695174
+    checksum: sha256:ee749fb762a63a7786c70d18cd1d6e6ca024aa35087fac90a7b44263f2565ccf
+    name: nss
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/n/nss-softokn-3.112.0-8.el9_4.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 394640
+    checksum: sha256:7773863ca2592520a17fcfc61a3f0001b5b37195c0b97049155e7714a516c094
+    name: nss-softokn
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-8.el9_4.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 419526
+    checksum: sha256:6ed17f2d27a71623739131340e4d951434681af06ca090320a7110573ac00f95
+    name: nss-softokn-freebl
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/n/nss-sysinit-3.112.0-8.el9_4.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 18198
+    checksum: sha256:41935da0c1fd8372386f0d6775f47ab2d6e0faecb8b4c8cc7e0961f7db077757
+    name: nss-sysinit
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/n/nss-util-3.112.0-8.el9_4.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 90500
+    checksum: sha256:9de26758ea9420e1c530e96f18ecf9bc2c30e9dbfc0dd48aafdf32c6cdcf0a9a
+    name: nss-util
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/o/openssl-devel-3.2.2-7.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4628464
+    checksum: sha256:40d5868ce7c34f4c8afbd0a9a04f7217d6eb7428fcdc7223ae9469fe8a20f482
+    name: openssl-devel
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/o/ostree-libs-2025.2-4.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 442983
+    checksum: sha256:8eedda29f1eeb86debee2ef52dbbcf32945e6e0646354eaa6ace201851975ed2
+    name: ostree-libs
+    evr: 2025.2-4.el9_6
+    sourcerpm: ostree-2025.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 243099
+    checksum: sha256:980047870d032f269deb36aaf1bb08ec748e62a6a12dafc6f691465e5be83944
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+    sourcerpm: perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/poppler-21.01.0-22.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1038195
+    checksum: sha256:925aa4824c88ecd478929f4407d93fba98b64d89ff02fd9cfa99b33d10a2f795
+    name: poppler
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/poppler-glib-21.01.0-22.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 147117
+    checksum: sha256:dc1d5fa664a2f2c42966a98fe24ac858d339d5b5032d26ccea718f0fe5ae4b59
+    name: poppler-glib
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/postgresql-13.23-1.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1709555
+    checksum: sha256:249ac9d2074f1fba7f15054cb6822bb2ff2ab0c187b0e5980cfe9e9cdbe67d71
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/postgresql-private-libs-13.23-1.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 137342
+    checksum: sha256:1269816a40a64bf233cddde2ed05191f7188c2af3d6cfcbfd848b8e97f847049
+    name: postgresql-private-libs
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/protobuf-3.14.0-16.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 983743
+    checksum: sha256:21b22518980f27cb9dc9546f8913489b31ae2f987e83414321de8f9e23b756d3
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+    sourcerpm: protobuf-3.14.0-16.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.5.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9159
+    checksum: sha256:589d36caea67e6e33607045cb1614aa0070de792fcca10a24d50d06280204496
+    name: python-unversioned-command
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.5.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 249908
+    checksum: sha256:df07ead3ac2f85a8e89bbae56696589bbbca4c2d010d99777d7dbe504261c15f
+    name: python3-devel
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9244150
+    checksum: sha256:09d417308a6ce42318880e7040d66e76b6a61bb4211cd2c0c35e6ca49279e491
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+    sourcerpm: skopeo-1.18.1-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/s/systemtap-sdt-devel-5.2-4.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 74919
+    checksum: sha256:9490e8f95648c6c4c251d91576ccd971b0a6c28f8504f38c957d86884ee5ce07
+    name: systemtap-sdt-devel
+    evr: 5.2-4.el9_6
+    sourcerpm: systemtap-5.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/t/tzdata-java-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 228444
+    checksum: sha256:6278f74c2029794cc7eea4a9bb298bda81e9ef165c689cb8e0a09584e0b7104c
+    name: tzdata-java
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.3-1.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 5062064
+    checksum: sha256:40d2b4c3a447f1ea5e9d462d607d634ba73e9656f8eb9eaf5ff7b32eb98004ef
+    name: webkit2gtk3-jsc
+    evr: 2.52.3-1.el9_6
+    sourcerpm: webkit2gtk3-2.52.3-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/b/binutils-2.35.2-63.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 4757649
+    checksum: sha256:fcf2ff28f9489cd9cbf736ce69a7ca0a378fccf38a22c3e524da7aef37f9970a
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 843426
+    checksum: sha256:83ee175631bc7e0bfc9f91230fb6e7e1c4a1983c5f4f84168cd660fe91e769e7
+    name: binutils-gold
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/c/curl-7.76.1-31.el9_6.3.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 297340
+    checksum: sha256:555cc7ff9d66b5e8dbb74b287123d1e80465280681494c5b9be94f8577930cbf
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/e/expat-2.5.0-5.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 116314
+    checksum: sha256:ad89484e5d8edff27198f4f098d8cd90bf422245c7fb100f421fb0a6d739f83e
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+    sourcerpm: expat-2.5.0-5.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.4.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2716440
+    checksum: sha256:0f3ed14394932ebdc037e4096e1626b90b353d53676f71df2eb0be8e71ad0716
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+    sourcerpm: glib2-2.68.4-16.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/g/gnupg2-2.3.3-4.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2573912
+    checksum: sha256:3c48d56d049db80da26242e5d8fa40ce6f585f395fd30be3c0bcd570033866ed
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+    sourcerpm: gnupg2-2.3.3-4.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.3.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 989654
+    checksum: sha256:4034e502bb17dc2f886a454fc231aebac05fc15956052d89779802e7fdda652b
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+    sourcerpm: gnutls-3.8.3-6.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 765219
+    checksum: sha256:d8b9199fd094f1c9a22068d48b030d9f97025c429057dfb439d5dca881165fb7
+    name: krb5-libs
+    evr: 1.21.1-8.el9_6.1
+    sourcerpm: krb5-1.21.1-8.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libarchive-3.5.3-7.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 394352
+    checksum: sha256:9c3674f7370e0ad6a28a9755b705806f3821751e670fee0d08a1d4faf229e6a8
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+    sourcerpm: libarchive-3.5.3-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 322163
+    checksum: sha256:64c858abe5ae6fc7cb49afd7f022183acbdb854dd43964519b16f53d02bd9d8d
+    name: libbrotli
+    evr: 1.0.9-7.el9_6.1
+    sourcerpm: brotli-1.0.9-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.3.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 283702
+    checksum: sha256:f4a8d4421015039b59f28db9370a9129691436253b0ac254cdd8d3f32f32f7e1
+    name: libcurl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 71505
+    checksum: sha256:c0bcb625a59a9b172504012f442da19df767a2fa1e86d15e2becdc1bbc88f663
+    name: libnghttp2
+    evr: 1.43.0-6.el9_6.1
+    sourcerpm: nghttp2-1.43.0-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 205634
+    checksum: sha256:8dd53e51c502cd9be76112b62cf74af271ac094c313000d49d6e2506e60a78ba
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8157
+    checksum: sha256:cb0bf985f9cbb43161d848b6849234c95fed7acdd0aeb1f8113ac17ba23a7ce2
+    name: libssh-config
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 726475
+    checksum: sha256:a0dd6bbbbe6f68d436743bdbd4cd75f851490f090ad6b05742bf05546081d2db
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+    sourcerpm: libxml2-2.9.13-12.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-10.el9_6.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1945884
+    checksum: sha256:aff7932ddcf427b535dabae69d155c7704d42199c33884db6b27cb485f04885c
+    name: NetworkManager-libnm
+    evr: 1:1.52.0-10.el9_6
+    sourcerpm: NetworkManager-1.52.0-10.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/o/openssh-8.7p1-45.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 452520
+    checksum: sha256:8d5e78edfd80cbf78bd0850422d078134f4cb185cf6202cdb464354a4e59a536
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 681456
+    checksum: sha256:17e8f5f43be43cc49c67d19479f41210912deeebf073d21d61317e3ad6247112
+    name: openssh-clients
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/o/openssl-3.2.2-7.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1393266
+    checksum: sha256:065dc01e057344f36d79c2ac0a0b88449542aa809556aad49f70e919c135b2a1
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/o/openssl-libs-3.2.2-7.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1817405
+    checksum: sha256:d5403da4026631de36ab7a8eb5747f607312e2e0be79638bbe08c5b8fbfa455d
+    name: openssl-libs
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/p/python3-3.9.21-2.el9_6.5.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 26038
+    checksum: sha256:577f8d44cfcd6c959e568ddf62c944110cb1b16aeeb64ecf38752f6d86948269
+    name: python3
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.5.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8303617
+    checksum: sha256:b457ce8343d502f39d8b0e3d626c6ebd1645460f5a505a94b4bdc44212584ef6
+    name: python3-libs
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-252-51.el9_6.4.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 4160983
+    checksum: sha256:b75f8cbce47c136c4177da7ba8cd67b51c62b6ce862c7944f59c38b310515bfe
+    name: systemd
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-libs-252-51.el9_6.4.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 644043
+    checksum: sha256:4ffbf40c5f64a23a4d00edc98ffde1cb138fc3a03e374f6695c12a0aab836e8c
+    name: systemd-libs
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-pam-252-51.el9_6.4.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 269485
+    checksum: sha256:8e23fdfe3a2bde607c6f2565746e3f89fd0006e90d8c99ee69b8115b2b20d14d
+    name: systemd-pam
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.4.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 62787
+    checksum: sha256:96fa8cf07e84e172156c7229a95cb74de5f1980389730d8fa5c4ef4113fe4ded
+    name: systemd-rpm-macros
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/s/systemd-udev-252-51.el9_6.4.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1953383
+    checksum: sha256:c8255a20473bb5ffda724f520e399363b050e0f0b50d39e4db5cbf6d12691ea3
+    name: systemd-udev
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/t/tar-1.34-7.el9_6.2.s390x.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 899894
+    checksum: sha256:b2fe7568400d69ae8a431812fec8ea37ff492d515fb2f37da76ac378a9e18a05
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+    sourcerpm: tar-1.34-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/t/tzdata-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 926162
+    checksum: sha256:ae429e8acbacad17e1b65a4571fcbf85122925cabeb97d25a9699774c1c38bbd
+    name: tzdata
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.2.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 13634
+    checksum: sha256:c5bdcda9be95aa6c7467bd64fb32f6a9cf2fee9421a728901889e850e83a4b29
+    name: vim-filesystem
+    evr: 2:8.2.2637-22.el9_6.2
+    sourcerpm: vim-8.2.2637-22.el9_6.2.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.4/source/SRPMS/Packages/l/libsndfile-1.2.2-6.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 750483
+    checksum: sha256:2ed7a90be00fa333f0274d17dd68bb11366f4543434f2b63b398fbd29416b9d7
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.4/source/SRPMS/Packages/t/texlive-tcolorbox-20200406-1.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 4964524
+    checksum: sha256:1bc9bb50498a035797cbe8cf8e2499f5d6e6f87ef6a97d5c682d3e98c41b7c2b
+    name: texlive-tcolorbox
+    evr: 20200406-1.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/source/SRPMS/Packages/c/containers-common-1-78.rhaos4.16.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 98665
+    checksum: sha256:7f31f05fa1f959849a1aead06559015cfbdcec919b7b5027e0c8c97785b636e3
+    name: containers-common
+    evr: 3:1-78.rhaos4.16.el9
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/source/SRPMS/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 16183933
+    checksum: sha256:0d3a9996f6287020460e6e91cfb22c636a047a5488d27a09ac6bbfce22d17810
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/abattis-cantarell-fonts-0.301-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 582900
+    checksum: sha256:ce11dc78d92b207947633e00a792a3c8c3b7b4f23c2b7912eaba587dc7893f4c
+    name: abattis-cantarell-fonts
+    evr: 0.301-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/adobe-mappings-cmap-20171205-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4127058
+    checksum: sha256:7c2f5be26bd8cee4e6a5b37a399484c9b230dd3fa8e93e45636d96c914d2504f
+    name: adobe-mappings-cmap
+    evr: 20171205-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/adobe-mappings-pdf-20180407-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1445392
+    checksum: sha256:84f5b00a6bf51f6b77ef54e7672da8dfb5aac1e55e88111dc8ef3384f6376d1c
+    name: adobe-mappings-pdf
+    evr: 20180407-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/adwaita-icon-theme-40.1.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17249062
+    checksum: sha256:0a59369173dca9368ed6b14bd4d068768ea45b4dab9a73cb8fa578990e8e53af
+    name: adwaita-icon-theme
+    evr: 40.1.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/alsa-lib-1.2.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1215277
+    checksum: sha256:1b9db2aa1e09cb40372bdcd1dfe6f613d20b7eaed88028687c96c934379e7d6f
+    name: alsa-lib
+    evr: 1.2.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/annobin-12.92-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 998524
+    checksum: sha256:65ee4ea686dfa6a8da136896ff590fb476248e998a14c38b28713a34a23cf1b9
+    name: annobin
+    evr: 12.92-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/at-spi2-atk-2.38.0-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111112
+    checksum: sha256:5713e30db407b1debad820ea89e57f3db5fe9c4e222ce44ab45d9e38ce52fe5a
+    name: at-spi2-atk
+    evr: 2.38.0-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/at-spi2-core-2.40.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 213364
+    checksum: sha256:3a5717b63603264a184a1ef26f606898c7f0ecc4b57ebd996d05b73a77bb8336
+    name: at-spi2-core
+    evr: 2.40.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/atk-2.36.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313725
+    checksum: sha256:171734f6cf9638497ccaccb73ab79b49d37085930e0c03d4c954aac2eaddbdc9
+    name: atk
+    evr: 2.36.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/autoconf-2.69-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1239007
+    checksum: sha256:946149054ebac72d6e6694d2525bca703c5faaa414f1f74ee7e12b0754c01cbd
+    name: autoconf
+    evr: 2.69-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/a/automake-1.16.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1598281
+    checksum: sha256:ac46e755161516f951c497c2794f344716a271ba68531883edb17bbbbab8958a
+    name: automake
+    evr: 1.16.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/cairo-1.17.4-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41864767
+    checksum: sha256:0185c51c6c00b3a238e9038addfa1be86fee1b3cc3933efdd4f05f8c5db775d6
+    name: cairo
+    evr: 1.17.4-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/cmake-3.26.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10671338
+    checksum: sha256:2f86bb96562eaf679969c2716738fbdfcc8a3966ecc3bb6317596fe2e214ea2b
+    name: cmake
+    evr: 3.26.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/colord-1.4.5-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1889181
+    checksum: sha256:e84bbbfb02504405637c022bb2cf90f2e278bbe1e136915a93b9f6e4d8402754
+    name: colord
+    evr: 1.4.5-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/composefs-1.0.8-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 8969650
+    checksum: sha256:13901e1b50ee0021eb56092859869125ea6ac9f2eafb2a880d758e87a18825e8
+    name: composefs
+    evr: 1.0.8-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/copy-jdk-configs-4.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17565
+    checksum: sha256:df1244121141d62420480aa1e07486bd0fa548360c2062c1ef138716dd7d68e8
+    name: copy-jdk-configs
+    evr: 4.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/criu-3.19-1.2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1397633
+    checksum: sha256:b055915dd2fd04c16c79a36775e1647f7c4f020cd341e94cda3a59898c3d6502
+    name: criu
+    evr: 3.19-1.2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/d/dconf-0.40.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133768
+    checksum: sha256:bbf4109630c6b65ff78bd4332c9a3b31c44776ff089361f0586cea1e758bbe25
+    name: dconf
+    evr: 0.40.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/d/dwz-0.14-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 159459
+    checksum: sha256:7565e0aed6cfb90c2c4be4ae2b33536fc4cf9b1b05a6a07da940ec564475580f
+    name: dwz
+    evr: 0.14-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 44824139
+    checksum: sha256:50a3faee5df3fd8d39609d97a62ef1297f668733105f4871d41a9257840269a3
+    name: emacs
+    evr: 1:27.2-14.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/e/exempi-2.6.0-0.2.20211007gite23c213.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19993045
+    checksum: sha256:2913c28e8198b0f722c4b16eebe6a102fdb4e33d934ad863aaf3fd25af4ff4aa
+    name: exempi
+    evr: 2.6.0-0.2.20211007gite23c213.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/e/exiv2-0.27.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32725837
+    checksum: sha256:65335824ab2515880092f0d0557882669e95f8c064aa4a18f2d36a3a3725913d
+    name: exiv2
+    evr: 0.27.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/f/fdk-aac-free-2.0.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2184629
+    checksum: sha256:2ccc9e447d4d1aa5ee0eccc9f06064bbb3f8c170c24f769a5dd7b580bf72537e
+    name: fdk-aac-free
+    evr: 2.0.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/f/flac-1.3.3-10.el9_2.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1063337
+    checksum: sha256:c9a340cb3e679da5f281425dcf1e785a2e882e733631638b45e76d3aa1f2e68f
+    name: flac
+    evr: 1.3.3-10.el9_2.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/f/flatpak-1.12.9-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1595419
+    checksum: sha256:5c870a95bee4384b536f3f53423e4e313dd5ebe0493ca12cfb71b09f84750ce2
+    name: flatpak
+    evr: 1.12.9-4.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/f/fontconfig-2.14.0-2.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1460194
+    checksum: sha256:623ac6b43061ad2f2b5d07861dfeb9b83ef70ead8df02319d375e71bc0110b67
+    name: fontconfig
+    evr: 2.14.0-2.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/f/fribidi-1.0.10-6.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1177189
+    checksum: sha256:d5e12deb110f7a5a8776435efa8f6c5e42ecf990e0ed27f95293020b65891254
+    name: fribidi
+    evr: 1.0.10-6.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 114235
+    checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/geoclue2-2.6.0-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108381
+    checksum: sha256:4ce03414616b5a8af25be3a451576b938b10c2c50a1ae9eab64627837f3f3ca8
+    name: geoclue2
+    evr: 2.6.0-8.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/ghc-srpm-macros-1.5.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10180
+    checksum: sha256:2d980af2311afd353583b200783cb39a5da7e89b6dbb9e67aa7d77a2c53e0cab
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/ghostscript-9.54.0-19.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 56071528
+    checksum: sha256:b2d608294cabab2b30197fa1ad90bff391840d5bfed4455081f627119c3cec87
+    name: ghostscript
+    evr: 9.54.0-19.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7707656
+    checksum: sha256:815c2ae9574006ecb596000492929264de785444736ee3968d5ee34cb6e75159
+    name: git
+    evr: 2.47.3-1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/google-droid-fonts-20200215-11.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3288061
+    checksum: sha256:b58b720be2c7a22d8a3c25731bfacaffc11f4d805f15a05022382cb456ec9f96
+    name: google-droid-fonts
+    evr: 20200215-11.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/graphene-1.10.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 345896
+    checksum: sha256:80bb7aed95ed969225d7b3b9d36103511b52b554c01f90c44681d18a861e2031
+    name: graphene
+    evr: 1.10.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/gsm-1.0.19-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80557
+    checksum: sha256:1a6ba3deaab6b12d3bcd23126c69340795d353e6b2eea36bf3696064db1be11c
+    name: gsm
+    evr: 1.0.19-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/gstreamer1-1.22.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1824267
+    checksum: sha256:cc25d402dff67470712a6032acc99f393898df78cdf30a2e346550db5a8ec091
+    name: gstreamer1
+    evr: 1.22.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/gtk3-3.24.31-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22491893
+    checksum: sha256:a6d0d395b3f0c64c10b8ccea931b318eee6ae36015b9852631c76d68283f0a68
+    name: gtk3
+    evr: 3.24.31-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/h/hicolor-icon-theme-0.17-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65737
+    checksum: sha256:8e62b8cf7aa5c7ef7a9ce6d1f1b159eeba7bc24519fbbb012e8a573ac072bcc6
+    name: hicolor-icon-theme
+    evr: 0.17-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/i/iso-codes-4.6.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14096241
+    checksum: sha256:3b17af011d4074e0fac62f3cf699090889892a45cf317df37942ebd2b39bc934
+    name: iso-codes
+    evr: 4.6.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/j/javapackages-tools-6.4.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 210942
+    checksum: sha256:7915590da093f42d4cfccb6196e1e3f22dce8d36f850ed2d46d0f41f238de01f
+    name: javapackages-tools
+    evr: 6.4.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/j/jbig2dec-0.19-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 584264
+    checksum: sha256:ac2fcfa2e65095617b1b9efef5ae8bf52e69e0f4b3b152ddd3c3c2fb7da0b3f7
+    name: jbig2dec
+    evr: 0.19-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/j/jbigkit-2.1-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 456145
+    checksum: sha256:7761a61c9cdaa019287d8daa7639d47e76f9ec1b177a50e94b46ceadf0c2cbfa
+    name: jbigkit
+    evr: 2.1-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/k/kernel-srpm-macros-1.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28536
+    checksum: sha256:6607ae4cf2e0ee6971a740ef64937853e4e636179822de40e709e8e3e0c7853b
+    name: kernel-srpm-macros
+    evr: 1.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/lame-3.100-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1537232
+    checksum: sha256:6e17b1767f6a8949f7ae4f549fbc4f93d4074072f3499a2346a2ce5f2b248d83
+    name: lame
+    evr: 3.100-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/langpacks-3.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28929
+    checksum: sha256:59d393e1505dc39e15cad9e0f0f54d5392f230aeaafadf4af09b31391ca573f4
+    name: langpacks
+    evr: 3.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/lcms2-2.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7428658
+    checksum: sha256:d0605c68533c1656eabe3d6d5a41b97513a9264030a28c46baad2cdcf57ec09c
+    name: lcms2
+    evr: 2.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libX11-1.7.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2436722
+    checksum: sha256:8720840bc38af119d62734144a5e8c95c1400ba42bd877e4279a786120d878d7
+    name: libX11
+    evr: 1.7.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXau-1.0.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335512
+    checksum: sha256:3a52f0d37183b84a7f8d37d6ca314ec17a32c1d4167c9131cf4000285d82c59a
+    name: libXau
+    evr: 1.0.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXcomposite-0.4.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 329141
+    checksum: sha256:10f74555246a4a992de429bf1139b762ca6b8d754d092a5eb85f0c55f576a9db
+    name: libXcomposite
+    evr: 0.4.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXcursor-1.2.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 347960
+    checksum: sha256:80bedd1206fa645654fbb6fd05fed788700ca3bf2cc0ade2408abc0a5802a801
+    name: libXcursor
+    evr: 1.2.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXdamage-1.1.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 315892
+    checksum: sha256:15c2c0d99190985a2a7d376b0cbb2d9f6172ebdcb1a3305ac0bbd7a394942e8c
+    name: libXdamage
+    evr: 1.1.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXext-1.3.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 401955
+    checksum: sha256:7f50b5d07f8e1782c4ad2c485416f210004db0477588465167c257aa62fd0b6c
+    name: libXext
+    evr: 1.3.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXfixes-5.0.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306511
+    checksum: sha256:3c8feb2710a52fe119d58369895cb2a17a10097a0a6b3a2bf469f0e34cf58db6
+    name: libXfixes
+    evr: 5.0.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXft-2.3.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 365800
+    checksum: sha256:b1ef5a942e759207022bf9bff3d122bc9596914d8dd7ab92ea56ebcad96ee9a6
+    name: libXft
+    evr: 2.3.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXi-1.7.10-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 498271
+    checksum: sha256:1de8a31cbe5edf8d10fe85fd96c1ebd1d0525c08a3ec75599ef12bad2945545c
+    name: libXi
+    evr: 1.7.10-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXinerama-1.1.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 297833
+    checksum: sha256:c9f68ea2938d52730688d24fc8b50f583193ab20ae158746e7751d8e092e92ed
+    name: libXinerama
+    evr: 1.1.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXrandr-1.5.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 343241
+    checksum: sha256:a565d64c7ff4b9c46cfc916097b1c8c9d886c006a7c18eac085f4ca6b4e8d310
+    name: libXrandr
+    evr: 1.5.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXrender-0.9.10-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:5fc0f3794b08cc71d89bf24c19a4a02c2d15c63850225327af9f20b45e1250e8
+    name: libXrender
+    evr: 0.9.10-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXtst-1.2.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 332563
+    checksum: sha256:59a99e7e1af8762969b9212aa5375be77a7bdafce73f416be82694b16ec388d5
+    name: libXtst
+    evr: 1.2.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXv-1.0.11-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 328666
+    checksum: sha256:fac6cc1bff31576443af0c71b3ffb1fbcd6e53b8fef38241ec0093cfba739c85
+    name: libXv
+    evr: 1.0.11-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libXxf86vm-1.1.4-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 305757
+    checksum: sha256:1e6c5a2d734c54d881523b50f1307ece5815574512fd7dedb10ee38282608532
+    name: libXxf86vm
+    evr: 1.1.4-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libappstream-glib-0.7.18-5.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2332780
+    checksum: sha256:a00834a072ed97371d8ffbccdbf5747d0d8e64ec2ae4e17f90d5c5e8bbdd22d8
+    name: libappstream-glib
+    evr: 0.7.18-5.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libasyncns-0.8-22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 351816
+    checksum: sha256:93c66acfdc39c88c4cced4056c53d2c637e667da2b09a8e9004f7c05bccb490e
+    name: libasyncns
+    evr: 0.8-22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libcanberra-0.30-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 336225
+    checksum: sha256:101d6e863d2b367a2d00cf29e75670c8190acfb8f19c0f31db66d4c5914f6ad6
+    name: libcanberra
+    evr: 0.30-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libdatrie-0.2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 325692
+    checksum: sha256:c9a3acd383ebb5f8d5d2c069dca717f147fddc461155cc12f07572972a82e7fe
+    name: libdatrie
+    evr: 0.2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libdrm-2.4.123-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 500530
+    checksum: sha256:8fd4b075f14ade405808c1ae309270aad50709f615bcd24d93aa39ae65e3a977
+    name: libdrm
+    evr: 2.4.123-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libepoxy-1.5.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 235419
+    checksum: sha256:53500b6a43fdf7e1a5083491d3ccdc808d2bec45a5559ff3eb9a14be798f8423
+    name: libepoxy
+    evr: 1.5.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libexif-0.6.22-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1123325
+    checksum: sha256:cbc3a148928165b570202330b52dd1baef75ff0b7479a0de16d7da0c252af8e3
+    name: libexif
+    evr: 0.6.22-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libfontenc-1.1.3-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313939
+    checksum: sha256:d169ca46af1a05f9f96805cb39acc44e794688b240e835c400353fb8f9e6302b
+    name: libfontenc
+    evr: 1.1.3-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libgexiv2-0.12.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 393822
+    checksum: sha256:5cba4e86ba7149ed6b9d90bd53fda20a17227218563b0ffc08b6ef0efc953914
+    name: libgexiv2
+    evr: 0.12.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libglvnd-1.3.4-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1046031
+    checksum: sha256:dbb82468e248c1dcb455f14b6c03b2a2772233f0c6b9e542c703bb3e4b96cb90
+    name: libglvnd
+    evr: 1:1.3.4-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libgsf-1.14.47-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 705600
+    checksum: sha256:393825b1ac768befa5cf2d1678c872231ebb77ceabb8eca8934d44eacf4ff0ea
+    name: libgsf
+    evr: 1.14.47-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libgxps-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91543
+    checksum: sha256:8a21727bce320f7736ce43cc5ffeeff3d6babc299b23b665df6b8fd1b450c770
+    name: libgxps
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libijs-0.35-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 423495
+    checksum: sha256:50aa92a3658366bf48452eb29154886da20761e885d7f52c3770c0e36aa6c562
+    name: libijs
+    evr: 0.35-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libiptcdata-1.0.5-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 604357
+    checksum: sha256:182950ba5b02a71634571889e11e70b94b4c91da56fa1836cb77bc85e44b3720
+    name: libiptcdata
+    evr: 1.0.5-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libjpeg-turbo-2.0.90-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2271766
+    checksum: sha256:6766d34e67f5bbfd82c5d543596b46790a2d98c97c2a33b67781829cac86c705
+    name: libjpeg-turbo
+    evr: 2.0.90-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 846236
+    checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
+    name: libmpc
+    evr: 1.2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 611553
+    checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
+    name: libnet
+    evr: 1.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libnotify-0.7.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 115322
+    checksum: sha256:ea8f8a235fb2feb6bf876c44024551e92c770f0d78b1f879485a5bcf5a6e964e
+    name: libnotify
+    evr: 0.7.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libogg-1.3.4-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 441193
+    checksum: sha256:5e218f83debe3dafbbe5795b0696d7ecb00b88b4c1c78bc4acb6e83b9cf9d56b
+    name: libogg
+    evr: 2:1.3.4-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libosinfo-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306786
+    checksum: sha256:2efb475aa7815e6f24efaa0ca26276785935ec611d9a13ff3ded1dcda59b5fae
+    name: libosinfo
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libpaper-1.1.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57233
+    checksum: sha256:1648c52d0e1f0e8e10101106eb7d95a4f069176846fee76b1f6c0a1904b0750f
+    name: libpaper
+    evr: 1.1.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/librsvg2-2.50.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22252235
+    checksum: sha256:5c0fdc6b36b2bb071c73d1181bd76ec6252b20b2ace475e86f0a69b27733f3a0
+    name: librsvg2
+    evr: 2.50.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libstemmer-0-18.585svn.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 142242
+    checksum: sha256:c21d9668bbfba8bcff8be8442c0dee31190efbcc362bd29e7e5e128869cb64f1
+    name: libstemmer
+    evr: 0-18.585svn.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libthai-0.1.28-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 426287
+    checksum: sha256:1bff93f9076778b16fea27d75a7434caf8e9fb5e9bcabbf2cf8f7f0069302d73
+    name: libthai
+    evr: 0.1.28-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libtheora-1.1.1-31.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1451614
+    checksum: sha256:c43318355a6c960e0685d789887cddf450fdfd7908ba1a02d375e1ff290b3483
+    name: libtheora
+    evr: 1:1.1.1-31.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libuv-1.42.0-2.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1300269
+    checksum: sha256:f9dfa0dc965675730184604570c6a2aa95ddc2dfa6a7cb209514b1e744a4e3d7
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libvorbis-1.3.7-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1216523
+    checksum: sha256:2c9f1a80c9f1b7c2d6872ef82bd385a68abb37be3ab8d3bfc26dcb6c7c5ef477
+    name: libvorbis
+    evr: 1:1.3.7-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libwebp-1.2.0-8.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4112860
+    checksum: sha256:34b9ace12d22dffba4277247a539bce83ccf6a517fd2ac3f603bd092a90e23fa
+    name: libwebp
+    evr: 1.2.0-8.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libxcb-1.13.1-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 519787
+    checksum: sha256:6e79beeac5762cb0f4eca5a4e09aaf9f607b8d54a8154e68a672c4d42e5a617b
+    name: libxcb
+    evr: 1.13.1-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libxkbcommon-1.0.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 446799
+    checksum: sha256:47b1254e062547a0e553b4e072498a91bf3c7364c8499c15a2762858197c50de
+    name: libxkbcommon
+    evr: 1.0.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libxshmfence-1.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 319069
+    checksum: sha256:9a36c33eafdf600040cb41cc1d8ca40395a3e00f2fd6a41a28ad66644d90edaa
+    name: libxshmfence
+    evr: 1.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/llvm-19.1.7-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141371853
+    checksum: sha256:2da62e4083e0f9ff5ca3d5ffc794682ff16004b2f0b38b4a103e34d18dbd322e
+    name: llvm
+    evr: 19.1.7-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/low-memory-monitor-2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34855
+    checksum: sha256:ddbf37a31d785971549ab83b2f554c112bf1cefc10ca2b36326e8367e04a68c2
+    name: low-memory-monitor
+    evr: 2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/lua-posix-35.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 193080
+    checksum: sha256:dba43478e632a56d95cdbbda1fba2e4c1e626126902cfe5ae9985f088928e431
+    name: lua-posix
+    evr: 35.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/lua-rpm-macros-1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12116
+    checksum: sha256:19fdee3aa469d583a7f48dce71513da47c5046018bc35bfbe57c818b7aae21d0
+    name: lua-rpm-macros
+    evr: 1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/m/m4-1.4.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1669463
+    checksum: sha256:c4098a14fdf286cce1c9981dcfbc9d2eefac08e2e80f68ac28b478e0d52ff837
+    name: m4
+    evr: 1.4.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/m/mkfontscale-1.2.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 161434
+    checksum: sha256:c517dd47af14b3a01e0abd6865252f0ed12f9f7041c909de43b37969d5a9e328
+    name: mkfontscale
+    evr: 1.2.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/m/mpg123-1.32.9-1.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1128174
+    checksum: sha256:b337b1eefaaa639a90ec349daa719d1c49222a31410eb1329299de16d1f37d4b
+    name: mpg123
+    evr: 1.32.9-1.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/ocaml-srpm-macros-6-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10233
+    checksum: sha256:198f33946c3b1c1e104109073449ac03fd59035e6c3f646ad847626aa646e336
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/openblas-0.3.26-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23507999
+    checksum: sha256:152ab881d01425b6b7e2b2ebecf419498b5c1ae4c673f450e1d63439ec8f923f
+    name: openblas
+    evr: 0.3.26-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/openblas-srpm-macros-2-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 9345
+    checksum: sha256:fe7a59edc21a63ddabfc48585a536d7c97dbcf27d46fa1e8b723df87a3c76bb3
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/openjpeg2-2.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2248257
+    checksum: sha256:d139d8a3730303ad1189b8a6949f43e2bde066d39c2d6e4ddce752c728c6a379
+    name: openjpeg2
+    evr: 2.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/opus-1.3.1-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1538330
+    checksum: sha256:f2f586f32a461d05e0c09a496a4b1cbf29e330967a68641deba1f7f9d4767962
+    name: opus
+    evr: 1.3.1-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/orc-0.4.31-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 192280
+    checksum: sha256:349e1f558859f7733899de6b5c43a975c730853869689914bd518153094c56bb
+    name: orc
+    evr: 0.4.31-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/osinfo-db-20250124-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 176763
+    checksum: sha256:8dee9b4e27b489e6808635f6fb9edaaea6900e4e09e3b4cfb6ef20e7f98e6937
+    name: osinfo-db
+    evr: 20250124-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/osinfo-db-tools-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 71184
+    checksum: sha256:2bd22032e8b549b1009783e61381ae8700f26556934ef93200cf441f717902fc
+    name: osinfo-db-tools
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/pango-1.48.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2073489
+    checksum: sha256:4efddadb4bf304a47e2cce96d6d63d1643f5bdcb06dace3c04f8d37410f8bc22
+    name: pango
+    evr: 1.48.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12786537
+    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43626
+    checksum: sha256:5bdfea020bfb4ee04c5fd3a5552724f21af7df49d8bf9b774060f1dd47c6b972
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Archive-Tar-2.38-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 79758
+    checksum: sha256:c543a9be1a2e718e3fa282b16fc058a4e3e3c21d75513591ed170a63c9944e37
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Archive-Zip-1.68-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 177506
+    checksum: sha256:0bc6505ab7fe87129f423e887a65153d015c38ddc68115ccf2149ebff5db92e1
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-CPAN-2.29-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 913914
+    checksum: sha256:ce91adec7194b6d7b65079f712418469db4b4d657251ddcf6643299b232644a1
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26900
+    checksum: sha256:2dde7ae0e396bf60d579f1c711a0ce6845c5a6dc8a3069fc125e64709c03e764
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-2.150010-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 129946
+    checksum: sha256:b93a6beedf64a4270dc4281fd9ea6fc5fabc08511bfd7ec95582bdcd5a3f50f3
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45057
+    checksum: sha256:cae76684fe68e4ef068523036a12aa65aa9ff697908aa448af0b5842507c8f11
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 63081
+    checksum: sha256:b0ae0d2859a6dbf7cd77de0e547370f85489f617319d8f55eb3b3533c22ea943
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Compress-Bzip2-2.28-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 908406
+    checksum: sha256:fd5ed562b1231e74f8dd6856e8b4494872a1afc84a11dc4b26eb3f59193cf78f
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 154607
+    checksum: sha256:06e2c818ae4ac7823ae67869037edb071cedb745bce8e010a268d1850999ac38
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133511
+    checksum: sha256:e73434426813ed9db9b82bdd301f4d0717b613fc8db3ff48e2e198d3b1e20fad
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 271620
+    checksum: sha256:f815738f7e64cb1912a188a57f32b9e3416192bdc2c80a61308cf668a0cb6ba9
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Config-Perl-V-0.33-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35359
+    checksum: sha256:77f7dbd94351b5cbe86859d557eb08525cb50bad76a344c7e4f5b16decb97be1
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-DB_File-1.855-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 158812
+    checksum: sha256:b0db40023b1387c9e1cb5f4a28914e4e7426e112132fd9e03a21a78c08a91bd9
+    name: perl-DB_File
+    evr: 1.855-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Data-OptList-0.110-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 31802
+    checksum: sha256:e2b75b4859a73491af1aa145027a54aeda204f31508f98c264ec719f0759fef0
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Data-Section-0.200007-14.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35026
+    checksum: sha256:29b50e2e9fcfd3ef490fde575e5651dd185d7bc10f62c97b2d7b6b525ecdd746
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Devel-PPPort-3.62-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 469970
+    checksum: sha256:1c4181c874720056a80d1ee015196f36ceef296709fe93d5d2b5282d6b90f80f
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Devel-Size-0.83-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 88128
+    checksum: sha256:5d65648105f4b21ba27f516113c995f25d19df091820d1fe6e99d72a6e89783c
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-SHA-6.02-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60965
+    checksum: sha256:6223e7b6ee3e168987685a0432eb30908b88a4e33503c4f71ffd1f4202be64d5
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-SHA1-2.13-34.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51532
+    checksum: sha256:24cb3be49a88473ca75fb773cca161a32a081afb243cd8b737aa7d3b6399a7f0
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Encode-Locale-1.05-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19941
+    checksum: sha256:4c7446c8690a0dc5a7e80a703ab32be8d7f8819493aec5e15a9468e5972f9070
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Env-1.04-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22963
+    checksum: sha256:f7872c1ec5309090bab03ab984ef49e7ab108f6e7f7a7acddc718e67847f2489
+    name: perl-Env
+    evr: 1.04-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54700
+    checksum: sha256:c4825f03bd2f125d4a7b9c361fdbae58e3eb888b40792d6ca740d4c9796529a3
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Install-2.20-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52908
+    checksum: sha256:a5a00213a6c11ebfe564f890525323981c10bb990ce06a1ad05163ccce239a54
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 504754
+    checksum: sha256:8f17335d16783c182512dfc1af5cd8a762b41944f024f456849f2dd475ad2648
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51571
+    checksum: sha256:db9319ce19481088c58205d252bc03fc816711399ac54b9cb90a0f12cc7a24c4
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 138437
+    checksum: sha256:aaa28538e07c7df4eb6e0d3ca1aa6d2806f7977116839c0605bf49962332e16b
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-File-Fetch-1.00-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32628
+    checksum: sha256:ee5ddafaff74bc4cbaafb81de847a4e5fcafe7d55ea39a3aad8acce1d3cfd9a2
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-File-HomeDir-1.006-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 48314
+    checksum: sha256:9324fc77f0cae4a487865f7168e58fefaf2a45dd44d5acb0c0ffd607bc79e972
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-File-Which-1.23-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35149
+    checksum: sha256:fd089f060aea15adcd7fe380a388fa8feb40daa0820b3d50dd20616c56bd6c68
+    name: perl-File-Which
+    evr: 1.23-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Filter-1.60-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108315
+    checksum: sha256:a9b8bb8bef551453366fab1f66883904c8ba996926d906fd32b759880a588dad
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Filter-Simple-0.96-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32804
+    checksum: sha256:a070b22cd4c09d06fa4078588f0a2a8735490defc6a93ebea7599ae5ee1ee557
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Compress-2.102-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 311395
+    checksum: sha256:6a4d183d03c58572ad99c44427d4f80174a74e88f82e815ef9b68ee367949414
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 117388
+    checksum: sha256:b98fc6c2bba6a5310eeea99c39c4eb4b4c9c5f6f115c1ca391ff9f983b3603b6
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Zlib-1.11-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22007
+    checksum: sha256:e83d2fcd26cbbac178ae8a77d75bb1e35ae697a0a1ebd9838787b0e7355b476f
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IPC-Cmd-1.04-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45145
+    checksum: sha256:d36b285269c9f8f186899296e922527b0d5efedae08d8ecef5e928369f344f04
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IPC-SysV-2.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80187
+    checksum: sha256:f3d99435bdc3bb3066a79ccf7e0e15b91ce2503a7ef2ef8a228238e03fd41b09
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-IPC-System-Simple-1.30-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46334
+    checksum: sha256:13c06559e1d68b47019a9e4ae4387d5962f0dd85a6ee77f2ed23ebcea92a7990
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Importer-0.026-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52799
+    checksum: sha256:52f89eb0a2d5f0a6a668679aa2d9adb4fb92e35fdd06e87d0b9d169d43d2e7ce
+    name: perl-Importer
+    evr: 0.026-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-JSON-PP-4.06-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 66646
+    checksum: sha256:25990b7a748140b948e4ad9a6aad236f7c82dc7a5c6eab6c2fb370de45d582d5
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Locale-Maketext-1.29-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68578
+    checksum: sha256:eb34611f4a8b295e9ba09f63b102db48b152e4915f90d9a9c33dba6e3331b3ed
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-MIME-Charset-1.012.2-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68860
+    checksum: sha256:375a66d8aadbde800a204d0681df4b0146dbd2cbcca577762162708d772095f4
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-MRO-Compat-0.13-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 21684
+    checksum: sha256:145780b93fce797e44ceb5911d79d150830ef976551d2a2dea4a64368002cd59
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3013100
+    checksum: sha256:6dc7b0f22726602de1368de52d7f4eae6c5144971ba6bf9dd6fe17a293f8da6d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2419116
+    checksum: sha256:b1221f5ccb5a07e8f87ba1397e17eea89ae9d9e152a724feb666985e76738e45
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Math-BigRat-0.2614-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62659
+    checksum: sha256:9e90c3abafc7b3b556ba1e1054834d95c79b698d4d72d31ad0d846ce9f8ba166
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Module-Build-0.42.31-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 321930
+    checksum: sha256:203f542dbb18437a7d0f30cfc819eb2b719f191b3a4e2b0456f20a291f68a0da
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Module-CoreList-5.20240609-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 139931
+    checksum: sha256:f40d3b1814a4a9d35a071732892b188cfe5ca7546f477944fb54b8ddc19676a5
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Module-Load-0.36-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 20494
+    checksum: sha256:d48889d7e5f4606b8de8d7886988274da466b047cb2434dc91bfe4d4339d1e24
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26054
+    checksum: sha256:69741f661710264f9aa8d97cdbde828b80323503bfa7da5c91330987a00d89ba
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Module-Metadata-1.000037-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65016
+    checksum: sha256:f3816981e19fb56a34bf13f1e288c01ef18613693bae505aa5ee0dc372d7aad1
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Module-Signature-0.88-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 113588
+    checksum: sha256:2777705793dd0cf55ac736f06632c02a93c47e5ef38c5eb0cd7603c3f2c76ec1
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Net-Ping-2.74-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 70563
+    checksum: sha256:e4a27ae525d6bf274e4f1612f3c5dc81e4557467bda40bd63ce8e5723e00a8cb
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Object-HashBase-0.009-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32480
+    checksum: sha256:5e8e5fb82b0a685c85f86490924ea1e0e3ac6364b07f43e087175d3f587c0e64
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Package-Generator-1.106-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 29367
+    checksum: sha256:6a5be4bb4322abe97c45c84cb26368b594b9d90a7e66d4841b74d179ecd72c9a
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Params-Check-0.38-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23416
+    checksum: sha256:aa052e7b8c96f6c4610ab34686928f0f7adbb41044e29378620e3d5e827cce76
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Params-Util-1.102-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 207956
+    checksum: sha256:a7eb296be9dc11401756128d84ae57a6e2e98fd0231cb5a52d7e86d42153ee56
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Perl-OSType-1.010-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32465
+    checksum: sha256:dd1ff7c7ef5ad251b1af9029f0555b4d21f3d96dd589ebb0d5989bd185f9abed
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24579
+    checksum: sha256:d06492c280011cd128a3e84fe071584470de288053375da173a6304ebafc0e87
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Checker-1.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35413
+    checksum: sha256:ce262ff36c0f737cd181b4e8974ded778cffcc6a6ca949b98b716e2a822b41fe
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Software-License-0.103014-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 135074
+    checksum: sha256:27c65fae4f13a24c6e3634b70f39b439bf5b90b8892b2987d4498dbb4ba2780f
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Sub-Exporter-0.987-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 59528
+    checksum: sha256:a552bfe187044ae29d0dc667e6e0a29c6340bf308d32d4b0c902f19d124e2c39
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Sub-Install-0.928-28.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30662
+    checksum: sha256:224662bdabe9c803615622a3adcb891165ddcdc3eb58aedfed1789576f9048f1
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Sys-Syslog-0.36-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 97885
+    checksum: sha256:8f3db804c924748fc7f7f3a10e093bd1195661657a404ab102a9c1fbb8fe5cb4
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Term-Size-Any-0.002-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 15436
+    checksum: sha256:f9aa001a28f500b09632dc321a4b46780f0cd02aa02ac8de8529684960fea05f
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Term-Size-Perl-0.031-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24324
+    checksum: sha256:c0283217d4d0998f3c2b24f42d956de7bc0c0c41478f40bdf6ef868748e003ec
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Term-Table-0.015-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 42326
+    checksum: sha256:a51423376f857f9720d3ad0e706db782758ac19bc3a28a0feaba80442ea7bd81
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 98184
+    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Test-Harness-3.42-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 226770
+    checksum: sha256:9c62f68a4bb3b0c1e6fbdfbbf2a840e50d93e1f6e0f8936931153725e0593c53
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Test-Simple-1.302183-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 355537
+    checksum: sha256:9b4b7c9a1a8723a1d4c1c353060ddb7f57e48343552506af10066d9ebaed37e6
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Balanced-2.04-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52612
+    checksum: sha256:41dca789e663140111944d257574c4eaa74b66d6169f256a9ffe407fa8070d27
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Diff-1.45-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41875
+    checksum: sha256:df1478044a0c7fb575b1324c0e9311a51e883ca61ff39952d0042ee1b2eb5fd1
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Glob-0.11-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 16200
+    checksum: sha256:9aa6c8502f05a42e5048063c2aff09e15cf8a44f6d00b3f8f154e58f051ff4cc
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Template-1.59-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62651
+    checksum: sha256:71bd67c547eec1d910a9c549be0ed7959a0f8e52a09e37d000a76bab1fd73cd3
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Unidecode-1.30-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 146381
+    checksum: sha256:8aa240add109758d1549e9fda86ea601bdde3a2f3b0afdc62f097859648145e6
+    name: perl-Text-Unidecode
+    evr: 1.30-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Thread-Queue-3.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 27710
+    checksum: sha256:d844642772b9a505fc9bd5aaf94b597f1cf66ba2a890462f33f0fa226ccde79b
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Tie-RefHash-1.40-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43611
+    checksum: sha256:d21a4a6ac093c7622f28c5ac2bd6aa7fae86c5b4c150249d9ca696b5461f3f6a
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Time-HiRes-1.9764-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 124567
+    checksum: sha256:c9e00767aec7da2661ca2785530bc7f35c120e7411cfcd6889437c20add7ade1
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Unicode-Collate-1.29-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 915935
+    checksum: sha256:9f5cd2c294c8f4383e9d6d8ea9b7e2c2a1e913c5a27d39e041885548a570dff4
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:52d4dd85581dfa68c432cab3bde847ee4f62285bbc18ee04fdd5fc5e87dd9a2d
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-Unicode-Normalize-1.27-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55458
+    checksum: sha256:514286df911a40dad2269810466a25279f07d2efab97db7479de337cfcedd971
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-XML-XPath-1.44-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68741
+    checksum: sha256:3484e0703eb0b88f31533dcc9f0f4ce2c4d1c0fd827f206de4c44038db541680
+    name: perl-XML-XPath
+    evr: 1.44-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-autodie-2.34-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 106197
+    checksum: sha256:82f0f75aaf2ac269983fc0c5a4a8c436e0382963ea15dd3e6b1b983865a6ae9b
+    name: perl-autodie
+    evr: 2.34-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-bignum-0.51-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 40019
+    checksum: sha256:065483710b985ef93e23a0a9d69826d777ac3b3580429b011ecc1db4b03f6f8d
+    name: perl-bignum
+    evr: 0.51-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-experimental-0.022-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24159
+    checksum: sha256:72d8e178ae3d2c2607e9ac4875957f841af9511398ddf07279b5e02a0e38034c
+    name: perl-experimental
+    evr: 0.022-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-inc-latest-0.500-20.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28925
+    checksum: sha256:3ac7d9dbcf90cfa75334d84853688e714b67a2982e4c9a33afac0ea4f79b1fb4
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-local-lib-2.000024-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 78260
+    checksum: sha256:4f60f5abc65be4e926262251a0a8d6ed0a86ac650dba678411b148c6a4ea34fd
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-perlfaq-5.20210520-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 212379
+    checksum: sha256:9d33eccd67de62a9793105ef005f4865af5d931471697c9aaf4fd6e2f3da3a16
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-srpm-macros-1-41.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10651
+    checksum: sha256:05990bf148e58515223b0936ee7b621e5d39bb875e2481a4d84522bd4b57d4e3
+    name: perl-srpm-macros
+    evr: 1-41.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-threads-2.25-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130514
+    checksum: sha256:92008f60b397b2e4380eddfe58aa788f78245a8fc44352d68bfa324fbec46655
+    name: perl-threads
+    evr: 1:2.25-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-threads-shared-1.61-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 119822
+    checksum: sha256:1b348ea3a479412c1236b95dc2d5d651a42e1c144626c38b8c08ef190b0c137b
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-version-0.99.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 180220
+    checksum: sha256:123e4f54296116246dfd22b4c6628fab4537c62c8a95394194085e6f60b3763c
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/pipewire-1.0.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2262481
+    checksum: sha256:9f0d3774bea6361293c6f949dca5e45ffae541e4dc24e5f2dac78d2d246008a5
+    name: pipewire
+    evr: 1.0.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/pixman-0.40.0-6.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 647633
+    checksum: sha256:0bd62940984b88bfd5914463d948999e29665450e6850ad5c9c4fbc129f3c3d0
+    name: pixman
+    evr: 0.40.0-6.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/poppler-data-0.4.9-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4130057
+    checksum: sha256:10a56ad2ab5d77157377805fc1481f40f5ccfb069fd34ec4bcf14e2a8ac309fe
+    name: poppler-data
+    evr: 0.4.9-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/pulseaudio-15.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1546014
+    checksum: sha256:01a1e060c7b753b68277a6274f0e16e438c75efd7add7d7aeb759721dde58f3a
+    name: pulseaudio
+    evr: 15.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 289973
+    checksum: sha256:cb7775937762f5ab13165854b5fab8d1e1ea8003451ccb02faaf60b4590c1949
+    name: pyproject-rpm-macros
+    evr: 1.16.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/python-rpm-macros-3.9-54.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32761
+    checksum: sha256:b48fc9a942da394ad4cefd19dd2ebf4c5839d0267a41c797fb04dc6173b5f296
+    name: python-rpm-macros
+    evr: 3.9-54.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/q/qt5-5.15.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 13771
+    checksum: sha256:149c54e64307cb3da96287a068f09c4ea5d3968bf2ba088383069f294695cc6d
+    name: qt5
+    evr: 5.15.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/r/redhat-rpm-config-209-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 96708
+    checksum: sha256:a6f4aa2f37f5c6205cca36ea99c640c6509587aa29732a3e145d7c3af304868f
+    name: redhat-rpm-config
+    evr: 209-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/r/rtkit-0.11-29.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 152904
+    checksum: sha256:c726c0b22b16017bf014107a15f313b18cdc0f09d9257822b027d1adc5bd47a8
+    name: rtkit
+    evr: 0.11-29.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/r/rust-srpm-macros-17-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35132
+    checksum: sha256:dfb94bc23f8c1be02f7d94e4b6d6dc05e98c7d4a162f5ef64f407bf6af738d42
+    name: rust-srpm-macros
+    evr: 17-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/sbc-1.4-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 261568
+    checksum: sha256:b4dbb3348492acf470f5d483cac09ec790c83270176a4d370e9ee6f40d785746
+    name: sbc
+    evr: 1.4-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/sgml-common-0.6.3-58.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111961
+    checksum: sha256:ca6fe92503402d24ebc976123288ec2169e75632bd63dd1c146e8d310eb5ee01
+    name: sgml-common
+    evr: 0.6.3-58.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 76240
+    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/sombok-2.4.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318398
+    checksum: sha256:5f192b4d26bb9550982e644248f675017ec3d85af2fc721c6509c329c6e1c2bc
+    name: sombok
+    evr: 2.4.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/sound-theme-freedesktop-0.8-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 488981
+    checksum: sha256:de474e09a97c0b6cbb54262b9d02f889ba350be1298285d732b06814375a068c
+    name: sound-theme-freedesktop
+    evr: 0.8-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/t/teckit-2.5.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1956688
+    checksum: sha256:57dab9e5aa55d6b2b558e4ef6efda7638176df62ee309d50ef979baa3a8efa3a
+    name: teckit
+    evr: 2.5.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/t/texlive-20200406-26.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 572348942
+    checksum: sha256:fc8a1cd1b58bfaf6f01d981027490920718905a722c7c988be4be28faf2b78fb
+    name: texlive
+    evr: 9:20200406-26.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/t/totem-pl-parser-3.26.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1517364
+    checksum: sha256:3fb99db442bf7988c725139716f102830efb05d559343b387d53fd98af029c9b
+    name: totem-pl-parser
+    evr: 3.26.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/t/tracker-3.1.2-3.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1474282
+    checksum: sha256:ae1dcc262f916002818ec6f6a54413e18ac570c536e299496aed99fd997fae74
+    name: tracker
+    evr: 3.1.2-3.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/t/tracker-miners-3.1.2-4.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4117590
+    checksum: sha256:80cad05049d22e5b7083be12d098f4add783886eff898c84547f89b1149ebff1
+    name: tracker-miners
+    evr: 3.1.2-4.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/t/ttmkfdir-3.0.9-65.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46879
+    checksum: sha256:e4d67a93e5605b5e8b4d0e0c8e5242b9137230b95ba5045c97815c216cfe1d71
+    name: ttmkfdir
+    evr: 3.0.9-65.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/u/unixODBC-2.3.9-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1693729
+    checksum: sha256:0f7bb1708709236922246be96a3cba788d404fbc3a58d4e2a4df8ddc8fc55313
+    name: unixODBC
+    evr: 2.3.9-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/u/upower-0.99.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 464654
+    checksum: sha256:6612bb4ed90e1d08b549615bdee8b36e5e7f46bf7e96d68c2af521a3f30097da
+    name: upower
+    evr: 0.99.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/u/urw-base35-fonts-20200910-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14393016
+    checksum: sha256:e47a39ecac5571addb3b1fc5c57c2cea8d999977eb3f8c29e9921ac29528a9c8
+    name: urw-base35-fonts
+    evr: 20200910-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/w/wayland-1.21.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 239785
+    checksum: sha256:f26f7fc3c60e1c5fe67abd6b6a0c26bb435e869f8451f092805eafe440b23172
+    name: wayland
+    evr: 1.21.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/w/webrtc-audio-processing-0.3.1-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 710526
+    checksum: sha256:70255f0b9784ad78d52f1f25e6e3bf683a1be9727a884760b7d6d9e6ac18b4ea
+    name: webrtc-audio-processing
+    evr: 0.3.1-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/w/wireplumber-0.4.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335147
+    checksum: sha256:efe9ba84e0851cf8cb2e2bf7b75d83b490182f0c55c6268923bc227e81c1bf67
+    name: wireplumber
+    evr: 0.4.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/x/xdg-dbus-proxy-0.1.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130185
+    checksum: sha256:18118ab2f72bb339fd444fceb08acd571a92ef478e8a0417c01aa080b4867c54
+    name: xdg-dbus-proxy
+    evr: 0.1.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-1.12.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 508933
+    checksum: sha256:2d5826de57e8bd5da82557abfd69d274f006c7055b32058a7d2d6cf64405964c
+    name: xdg-desktop-portal
+    evr: 1.12.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-gtk-1.12.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 388924
+    checksum: sha256:5779bc5047853ae2f09723fb92994841f7f54608bf734abecae20b68dbb650da
+    name: xdg-desktop-portal-gtk
+    evr: 1.12.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/x/xkeyboard-config-2.33-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1768610
+    checksum: sha256:fc472164cec4c2e4794081a476f00448bc8defadb7a863d079d4a782ba1f23c7
+    name: xkeyboard-config
+    evr: 2.33-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/x/xorg-x11-fonts-7.5-33.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 11582295
+    checksum: sha256:a9b2eceddc29f02bf49d3d4dee6d564d6b5a4b0f397190090f41a8426b1402ad
+    name: xorg-x11-fonts
+    evr: 7.5-33.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 101373
+    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
+    name: yajl
+    evr: 2.1.0-25.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/z/zziplib-0.13.71-11.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1157547
+    checksum: sha256:2ffa5b060b58d204e6686c07461c594d2f1cf1bdaf8e4a7d9309f9aa982484e3
+    name: zziplib
+    evr: 0.13.71-11.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/a/acl-2.3.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 535332
+    checksum: sha256:cb449bc6c85e0b50fa0bb98c969ff8481fee40517d8ebec5e28b72e5360fbe1e
+    name: acl
+    evr: 2.3.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8251850
+    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 482234
+    checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
+    name: attr
+    evr: 2.5.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1262288
+    checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
+    name: audit
+    evr: 3.1.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/a/avahi-0.8-22.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1629705
+    checksum: sha256:8e0cd07caf638b2d935ecc76fecc8d77adf5e399dbfb48958eacacb395b013d9
+    name: avahi
+    evr: 0.8-22.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/basesystem-11-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9884
+    checksum: sha256:5a4ed0779fc06f08115d6e06aa95486f1e1e251f8f9ddb6c7e14e811bb2e24ef
+    name: basesystem
+    evr: 11-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/bash-5.1.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 10512850
+    checksum: sha256:5d7bbbf2538361be1a11846602862c3a56809b3ea43b69b86bcf407538e9e260
+    name: bash
+    evr: 5.1.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/bash-completion-2.11-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 323037
+    checksum: sha256:e1da4ec276292a64279e9a62ae93a98295fb7be131618cc6ca48b053d0da8ca9
+    name: bash-completion
+    evr: 1:2.11-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/bluez-5.72-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2416940
+    checksum: sha256:5283227c6c84280f4956d9092d71d82f78176ff599adcf4be7d106387858a47b
+    name: bluez
+    evr: 5.72-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/bubblewrap-0.4.1-8.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 230660
+    checksum: sha256:0766cbd8405dd66aa93e316760405c0cdfb8b64f2a0e406fef915d3f51262a50
+    name: bubblewrap
+    evr: 0.4.1-8.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 824335
+    checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 711648
+    checksum: sha256:d3193e155ddd297042a944729fe54c1b90c17bdbd1876fc68e4f66d7857f9e81
+    name: ca-certificates
+    evr: 2025.2.80_v9.0.305-91.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/chkconfig-1.24-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 214658
+    checksum: sha256:b2618b278f5c8d6dacfae790c8c73b1fc1578b8f64011f325ced5a4a2e3b58bc
+    name: chkconfig
+    evr: 1.24-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/coreutils-8.32-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5692590
+    checksum: sha256:f042749974d210ad9049ffcb68172e4eaf91e3c0c249b33620e1f94effe82e6d
+    name: coreutils
+    evr: 8.32-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/cpio-2.13-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1395694
+    checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
+    name: cpio
+    evr: 2.13-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6414228
+    checksum: sha256:56a815a100d75c1d42c07090b632f05e51ea6d17df097d2936ab25d9aca49310
+    name: cracklib
+    evr: 2.9.6-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/crypto-policies-20250128-1.git5269e22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 102787
+    checksum: sha256:0f6081ad96e9d7cb80aa18736e3a06bbf7d2c19bdc0f95a707a4f3ed0926b878
+    name: crypto-policies
+    evr: 20250128-1.git5269e22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11657571
+    checksum: sha256:0a8b07dac531288c2fb1987106664a4e762e1b985c8851d577aa8aac60636a06
+    name: cryptsetup
+    evr: 2.7.2-3.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/cups-2.3.3op2-33.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8125712
+    checksum: sha256:d47b1ed7a8374a9881475617f7d1779e73960fbdc5a1402fd1327a144de06136
+    name: cups
+    evr: 1:2.3.3op2-33.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4030574
+    checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
+    name: cyrus-sasl
+    evr: 2.1.27-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/d/dbus-1.12.20-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2143916
+    checksum: sha256:3fe74a2b4fb4485c93e974010d9376e30a63dfcc628bfd6c01837c27b4953912
+    name: dbus
+    evr: 1:1.12.20-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/d/dbus-broker-28-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 254475
+    checksum: sha256:aced3097fbb8a424ca1816b8cb3e79960a9ccf7ba139538282886e692c317b29
+    name: dbus-broker
+    evr: 28-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/d/dejavu-fonts-2.37-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 13631421
+    checksum: sha256:4a325b197556c40187c2785302ede62d3e4cf300984ad6b8cf57e7a4974246aa
+    name: dejavu-fonts
+    evr: 2.37-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7418303
+    checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/e/elfutils-0.192-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11944670
+    checksum: sha256:afe7c9bef952ed086637fe83ac77bfafa70bf2ba28c1d7aaa51a18c9a75146b6
+    name: elfutils
+    evr: 0.192-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1003666
+    checksum: sha256:e8261cbcd55b85efdcd12ce1a2c6e63a72c64c872d618de4ba24557a1fda63c0
+    name: file
+    evr: 5.39-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/f/filesystem-3.16-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 20486
+    checksum: sha256:c795690df30c46e521372e2f649c995a2abc159b76c8ef6cd5da8a713ea17937
+    name: filesystem
+    evr: 3.16-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/f/findutils-4.8.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2010585
+    checksum: sha256:48bd4d4dd081120bcc6ab772b930a150f30b2fc89a4a14a24220383d24a30b3f
+    name: findutils
+    evr: 1:4.8.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/f/fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 50762
+    checksum: sha256:6da7d722d419e6e9ce5abb4f6adcb82613d0629261011ec42134cfe092078e83
+    name: fonts-rpm-macros
+    evr: 1:2.0.5-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/f/fuse-2.9.9-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1832743
+    checksum: sha256:9a11b340f925ae501331459e5d8d2edb819b947406d26cb565cf46a9f1b27f97
+    name: fuse
+    evr: 2.9.9-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gawk-5.1.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3190934
+    checksum: sha256:37571947707e835d36ceb5641b187aba13ef8f5f605a6762ce72aeea3e745b8d
+    name: gawk
+    evr: 5.1.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 81877102
+    checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
+    name: gcc
+    evr: 11.5.0-5.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gdbm-1.23-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130147
+    checksum: sha256:ad42264274c2a792220395a4dbe736a1de6100c4e14611707ec1dd447583271f
+    name: gdbm
+    evr: 1:1.23-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/glib-networking-2.68.3-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 256221
+    checksum: sha256:08f2d7a3c389bd63fb7ff6f8ac4a5a1fbb088451ca40f4fbe8ed70d2e820e897
+    name: glib-networking
+    evr: 2.68.3-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.24.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19844004
+    checksum: sha256:7c3dc8448748d98fb9af6f1ec0115ea61b0618135f5eb0104298bc1f9927eea3
+    name: glibc
+    evr: 2.34-168.el9_6.24
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gmp-6.2.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2503825
+    checksum: sha256:d0d8a795eea9ae555da63fbcfc3575425e86bb7e96d117b9ae2785b4f5e82f7c
+    name: gmp
+    evr: 1:6.2.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gobject-introspection-1.68.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1041521
+    checksum: sha256:cc54e6b0e1c09dd0ac59df81e8670434134ccc6adfd390a69fa11963be209231
+    name: gobject-introspection
+    evr: 1.68.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gpgme-1.15.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1737968
+    checksum: sha256:ceeb7d42bc8ddf6f09013439bfed4e591411b81293fe3db5e4edb06cbe1879fb
+    name: gpgme
+    evr: 1.15.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/grep-3.6-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1620891
+    checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
+    name: grep
+    evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gsettings-desktop-schemas-40.0-7.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 714013
+    checksum: sha256:6ad3eec701e251c7b04018c0148173961474f33477f7a68eaad4779c3d2aed62
+    name: gsettings-desktop-schemas
+    evr: 40.0-7.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/h/hwdata-0.348-9.18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2508307
+    checksum: sha256:af6cdae99470d14fa48057ac70a01cc8ab8567577eb74fc8c8be32ac080ad0ba
+    name: hwdata
+    evr: 0.348-9.18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/i/icu-67.1-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 23181317
+    checksum: sha256:3abe8dc1abc22213826dd6ffb214cdd88705def93dcb234ffc87c792909b0879
+    name: icu
+    evr: 67.1-10.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1505374
+    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
+    name: jq
+    evr: 1.6-17.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/j/json-c-0.14-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 341227
+    checksum: sha256:c4c76ebfd66ba6d00edf672797d7f077b29d279b7866a04e05258a257a5bc306
+    name: json-c
+    evr: 0.14-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/j/json-glib-1.6.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1319256
+    checksum: sha256:7ed60df640cc4c3cd08af33325b6ca4925a8b30c984e866a5abc1f66407634e9
+    name: json-glib
+    evr: 1.6.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/k/kbd-2.4.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1167414
+    checksum: sha256:8d50e573c7beff06b0167dd7d6bccfe542bc393aaf652bbecb205277af293231
+    name: kbd
+    evr: 2.4.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 150790
+    checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
+    name: keyutils
+    evr: 1.6.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libassuan-2.5.5-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 586136
+    checksum: sha256:dcc858194f9497ec86960651fa76413a9c731f94423d67298e8e3c0c7a5e7806
+    name: libassuan
+    evr: 2.5.5-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libcap-2.48-9.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 202341
+    checksum: sha256:cf258d269e2690617bbace76ec328e55c6f1431ddb47b67bcd4841472870d483
+    name: libcap
+    evr: 2.48-9.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 470599
+    checksum: sha256:48bb098662e2f3e1dbb94e27e4e612bc6794fbb62708e1f1a431cc2480fcdb00
+    name: libcap-ng
+    evr: 0.8.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libdb-5.3.28-57.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 35290920
+    checksum: sha256:6a74a3d96bd4657659524050945e2a47e93779addf2de374a13e1baf32b4ab8d
+    name: libdb
+    evr: 5.3.28-57.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libeconf-0.4.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 201501
+    checksum: sha256:4541a0915eca1e6fd1440253cf6bdfc5482c7b6dd3d3c7310a77faf852b7671a
+    name: libeconf
+    evr: 0.4.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libevent-2.1.12-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1123179
+    checksum: sha256:8c00dc837b8685fc660cc0bcdfd4f533888facaa8c83655c26d2fb068cb7b135
+    name: libevent
+    evr: 2.1.12-8.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libffi-3.4.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1367398
+    checksum: sha256:2b384204cc70c8f23d3a86e5cc9f736306a7a91a72e282044e3b23f3fd831647
+    name: libffi
+    evr: 3.4.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libgudev-237-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 40294
+    checksum: sha256:3ae56503c2508bfcba274b4bdaa169ee0a54294682edba202890f999d07b300a
+    name: libgudev
+    evr: 237-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libgusb-0.3.8-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 57034
+    checksum: sha256:18f50c2b798110da109d5d0b429948c762d5b98ba5d37705b6d1b4d327200847
+    name: libgusb
+    evr: 0.3.8-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libidn2-2.3.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2214169
+    checksum: sha256:c27f21437a76f07b0ee9f4f7e61d621cbb9c483c14563b31e55e320d19df99a6
+    name: libidn2
+    evr: 2.3.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libksba-1.5.1-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 677223
+    checksum: sha256:6d334a90bcbc270ee691183624e5664fdbe7dbf2d4a47319e6c75860e16abd43
+    name: libksba
+    evr: 1.5.1-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libproxy-0.4.15-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 123932
+    checksum: sha256:7b2cdc89e0020245af06c0b12f3e077c457cf3947d60c53b9303a0fe36d84002
+    name: libproxy
+    evr: 0.4.15-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9160109
+    checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
+    name: libpsl
+    evr: 0.21.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447225
+    checksum: sha256:14fbf335e2c6f22b441a9750a69b7c41e197c4dd21adac701fd81f17660ee0b4
+    name: libpwquality
+    evr: 1.4.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 653169
+    checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
+    name: libseccomp
+    evr: 2.5.2-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 271153
+    checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
+    name: libselinux
+    evr: 3.6-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 223978
+    checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
+    name: libsemanage
+    evr: 3.6-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libsepol-3.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 538074
+    checksum: sha256:2e02ff0ce3c6767962d1e7a3fbe657ea2a241bcd1c0182d9c552321ba4f8404b
+    name: libsepol
+    evr: 3.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libsigsegv-2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 473267
+    checksum: sha256:734651070d0113de033da80114b416931c4c0be21ce51f6b1c1641b1185c34f3
+    name: libsigsegv
+    evr: 2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libtasn1-4.16.0-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1895591
+    checksum: sha256:a3d9612fc631100fa0a528d7721bdee96acc33e35befb6a96544526eae169936
+    name: libtasn1
+    evr: 4.16.0-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libtdb-1.4.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 762833
+    checksum: sha256:d402a0c800081eb75cd81f27f632638e204fc210f24f911766f0484bc0a95313
+    name: libtdb
+    evr: 1.4.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libtool-2.4.6-46.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1002417
+    checksum: sha256:1130b15333736ad40a18b5924959a8b0c6c151305bc252c0cbd5276432e10002
+    name: libtool
+    evr: 2.4.6-46.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libunistring-0.9.10-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2065802
+    checksum: sha256:f6c329a60743d0d4955e070c5104407e47795b1ef617e7e59d052298961aec2b
+    name: libunistring
+    evr: 0.9.10-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libusbx-1.0.26-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 643959
+    checksum: sha256:e9359c9ad4fedd8d880f23c2c6a248fd0e17d657ee4ef5d17d572844dfe5f016
+    name: libusbx
+    evr: 1.0.26-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libutempter-1.2.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 30093
+    checksum: sha256:e48843d2734fefad084a86165860ea9575bdc53f63bb5845d8807ce9ccb4f914
+    name: libutempter
+    evr: 1.2.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 396005
+    checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
+    name: libverto
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543970
+    checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/lksctp-tools-1.0.19-3.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 594235
+    checksum: sha256:7f3e4ff54446b4e015958dc5bbe342cfb64151e4b6b886889921b116c373d640
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/lua-5.4.4-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 521629
+    checksum: sha256:18feaae23ff1b674acccf0f081f0d3c36ca482df0c468e9368d4f4432dff820c
+    name: lua
+    evr: 5.4.4-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/lvm2-2.03.28-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2992347
+    checksum: sha256:5361a813c7d6ea933fba20b461c5e3af5528b8876724460f8526f82564e0a063
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/lz4-1.9.3-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 333421
+    checksum: sha256:44e9e079f0f30476a0d8d9849ef1cd940fcc37abee11f481d6043b184bd0cf14
+    name: lz4
+    evr: 1.9.3-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/m/ModemManager-1.20.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1480103
+    checksum: sha256:81e6ab62ffedbf646500c284da42c11609b77c7ba57e1eb561cc95ca0ffe3a30
+    name: ModemManager
+    evr: 1.20.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2335546
+    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
+    name: make
+    evr: 1:4.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/m/mpfr-4.1.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1556195
+    checksum: sha256:1a6f60487d5ebb8998718c8246a49baf182e27318aa16e6a80b1ba7600b74e13
+    name: mpfr
+    evr: 4.1.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3587058
+    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
+    name: ncurses
+    evr: 6.2-10.20210508.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/n/nettle-3.10.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4331292
+    checksum: sha256:1f3587f2d59896bc3f427e4b5b9395095189dfb04237c242daa5cc536c7e02a9
+    name: nettle
+    evr: 3.10.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/n/npth-1.6-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 314570
+    checksum: sha256:3d0685cc559f0af453b6b3ace61944dec9b9cb090695e4de5f5579da7b35b750
+    name: npth
+    evr: 1.6-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/o/openldap-2.6.8-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6548889
+    checksum: sha256:0d21c12c55d40d1fc2f006c8ec187b5fcc799b794cfd31ed2d98434189c62800
+    name: openldap
+    evr: 2.6.8-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 89980613
+    checksum: sha256:4c7cd5a5b7095fcaa5850322ef1f1a7f42e69eacb0386d32fd6ced3dd7a9e7f5
+    name: openssl-fips-provider
+    evr: 3.0.7-6.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/p11-kit-0.25.3-3.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1027881
+    checksum: sha256:de598a2e1ca170df85cd69d6cc406402407a244988506f53f8736a7546135260
+    name: p11-kit
+    evr: 0.25.3-3.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/pam-1.5.1-26.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130406
+    checksum: sha256:9a351f0455da788ff63026af9a8ee30e744017941c82283f970d1ed066000bb6
+    name: pam
+    evr: 1.5.1-26.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/pcre-8.44-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1624356
+    checksum: sha256:7edbd87b866a3f6e3df1426d660b902e063193d6186027bf99f6d77626a43817
+    name: pcre
+    evr: 8.44-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/pcre2-10.40-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1789790
+    checksum: sha256:a570f7192be555222aa3704882b9199fb013a84ad4d7dcf40a93d8de2ecf6e0a
+    name: pcre2
+    evr: 10.40-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/polkit-0.117-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 336356709
+    checksum: sha256:29fafdd944809b56c0c2e9fe65c2f777e18e5d53473c95e14f6365af4287b131
+    name: polkit
+    evr: 0.117-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/polkit-pkla-compat-0.1-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 302278
+    checksum: sha256:8e4af06bc58994064b55ef7cdac31d48f9797f874fa82e011ad75b6233940636
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/popt-1.18-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 595630
+    checksum: sha256:1c5d47907a884ec21001c4965013fa70bea3f770d385fdc897cb7afc1cf62fe6
+    name: popt
+    evr: 1.18-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 93646
+    checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
+    name: publicsuffix-list
+    evr: 20210518-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/python-pip-21.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8984717
+    checksum: sha256:cb9e0cca3bd8dc24798cf1fb333d574774ce8288598331d44994d768f33648d3
+    name: python-pip
+    evr: 21.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/python-setuptools-53.0.0-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2080099
+    checksum: sha256:9cd7d11ed9e7fe2fa274de10d803f6fecd53cc1101bd0cbae386dbb66ce03824
+    name: python-setuptools
+    evr: 53.0.0-13.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/r/readline-8.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3009702
+    checksum: sha256:bc7a168b7275d1f9bd0f16b47029dd857ddce83fa80c3cb32eac63cb55f591f3
+    name: readline
+    evr: 8.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/r/redhat-release-9.6-0.1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 62469
+    checksum: sha256:6720f3d5c6675bbf8d79ce5424f891a34303e0c5c39be0e52ca51f70107f585b
+    name: redhat-release
+    evr: 9.6-0.1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4490587
+    checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
+    name: rpm
+    evr: 4.16.1.3-37.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/s/sed-4.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1424192
+    checksum: sha256:0590550f0cbdce0a26f98a73c756f663a7f220486d10f9c16d1ce0c8c4d14378
+    name: sed
+    evr: 4.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/s/setup-2.13.7-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 195940
+    checksum: sha256:3acdbbd63bd77dd8b18210b9d597bd59ddf455ff728067638c54194ac3a8a32b
+    name: setup
+    evr: 2.13.7-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1715281
+    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
+    name: shadow-utils
+    evr: 2:4.9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/s/shared-mime-info-2.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5257989
+    checksum: sha256:93b45d557d2958d316a6ee4645a9fdccb824cad2133c451ba22221fc933e6f9f
+    name: shared-mime-info
+    evr: 2.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/s/sqlite-3.34.1-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 25109243
+    checksum: sha256:ca9c26565fc4cdfdd8b813a116bb6bba1b36db634bb4b38602cc02f008db064c
+    name: sqlite
+    evr: 3.34.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/t/tpm2-tss-3.2.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1660943
+    checksum: sha256:11c9b6951d6823d120d310243f500f78ce13f9e206134309692e4a761294f3b9
+    name: tpm2-tss
+    evr: 3.2.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6281028
+    checksum: sha256:cde2d6a98345d49de9d225fc3acf7542fb35fde32832f1361415486a7839c222
+    name: util-linux
+    evr: 2.37.4-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/w/which-2.21-30.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 163429
+    checksum: sha256:3ab75392900a7b7d5b7e869c0d5beba9e184e970946e328f995f79f2e35397ff
+    name: which
+    evr: 2.21-30.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1168293
+    checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
+    name: xz
+    evr: 5.2.5-8.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/z/zip-3.0-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1137410
+    checksum: sha256:416b6957a4365204cfb2ba9e5b9b9f21075b615114c6afe46c83166de258bb5d
+    name: zip
+    evr: 3.0-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/z/zlib-1.2.11-40.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 561153
+    checksum: sha256:e47b884c132983fd0cc40c761de72e1a34ada9ee395cfe50997f9fb9257669d8
+    name: zlib
+    evr: 1.2.11-40.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2378112
+    checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
+    name: zstd
+    evr: 1.5.5-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7626843
+    checksum: sha256:9dbaca23d62c0bcb1f25ba74c73e3488a5878362bf35e302a64981befc3b7f3f
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/c/crun-1.26-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 896467
+    checksum: sha256:728c9ee33f9c4c2a8b9718c9b6b8e86be57897bf80b5bf1cc2fb195e824bb681
+    name: crun
+    evr: 1.26-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7737493
+    checksum: sha256:93923e9e509be34b01501dbc898e47ed8e5984110b424d12387cac9928372574
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/giflib-5.2.1-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 454644
+    checksum: sha256:7190afe993e439540a36a564f62c09dbd455f477a9e2b4223943b35c4ddf407d
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/git-lfs-3.6.1-2.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3704183
+    checksum: sha256:da9df4e5a770589c8d3a72ea5b7dde9860d5cf4869a3198009cafdad05beb10a
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/go-rpm-macros-3.6.0-13.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 134217
+    checksum: sha256:2b01ccb1ff201351069d5e7faed2b638bfabd63a58fe5dbac54c4fa77020efeb
+    name: go-rpm-macros
+    evr: 3.6.0-13.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2402853
+    checksum: sha256:b708fd816f9269983034eb5a4af7431a4d640885668e61020c18f21cc858b2b2
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 67369706
+    checksum: sha256:ccdf6f1911dbc397143a302aff66c575c035222a97fdfbc15dc4e18b4cbdec47
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libsoup-2.72.0-10.el9_6.6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 1524773
+    checksum: sha256:e09ab5c0baa53fd164dec50e512ec341aa7005fe4881df7fa7e008de5d7b1a5b
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libtiff-4.4.0-13.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2894616
+    checksum: sha256:fe00b8631ff587d510f42b10e15d9eeb0e248d559a8940029077c1846a79e81f
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/l/libxslt-1.1.34-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3560934
+    checksum: sha256:b3947676add0f33392769160c17de031191fd4af0caaddb009903b2f981cdd0f
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/m/mesa-24.2.8-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 33254288
+    checksum: sha256:0a6183042f15cad55922f1262d1df8d3836e950a4c2a4a92aa4655c5869772cb
+    name: mesa
+    evr: 24.2.8-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/n/nss-3.112.0-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 81985898
+    checksum: sha256:03e1f0c080506262cf5cf8198eedc16dbcab50f7ff3ab75eeec20bb6dffbf65a
+    name: nss
+    evr: 3.112.0-8.el9_4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/o/ostree-2025.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2151401
+    checksum: sha256:9be705455801c8632ce93ebe7d2d3f1ca1ca66ac20c6e0801a39b0626bd4fde5
+    name: ostree
+    evr: 2025.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 269666
+    checksum: sha256:712a5069cc5e3863ce0c84dacb69850ed20ce354d992a3f8773f577d6aa6801e
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/poppler-21.01.0-22.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 4696462
+    checksum: sha256:db66bfc8235cf25007f20d0b9c1422e577660cb6d1441b3de07e18cea988c738
+    name: poppler
+    evr: 21.01.0-22.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/postgresql-13.23-1.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 51333145
+    checksum: sha256:ad1a81d99d970d228aca114b49db118c692da06d5b5c9d43b3ece667730b50e1
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-16.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6493619
+    checksum: sha256:16c2aaa5191a3e816c32aa0543b5106f4042577e0336930ab22c5775606605c8
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 10642816
+    checksum: sha256:9d266472087f840a668e6eb2855a4021e054a48b0b7c9f7ad1fe5acb42e93b95
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/s/systemtap-5.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6602276
+    checksum: sha256:9f86d158ac1db2e0ed479f194ec9b9113a19f678b6d4a83ab1a42877ba9b779b
+    name: systemtap
+    evr: 5.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS/Packages/w/webkit2gtk3-2.52.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 65133497
+    checksum: sha256:bdd945c48a7e40a7daec8f6b2291fda7e3584a6e59f2d0a6b3ab7adecd12fc7d
+    name: webkit2gtk3
+    evr: 2.52.3-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 22423248
+    checksum: sha256:bd25b72280f9648cf99327b74dc03713a200a30068834bbca48a8ad7f7cfcd79
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 510894
+    checksum: sha256:299496cf3aafff9c162da9ec0cb6eaa65ee0d8dc8b8594998968959282e0b536
+    name: brotli
+    evr: 1.0.9-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2549990
+    checksum: sha256:9945d643a0ded5725b7fd4eaebc2f7350324c782ee7857e3a72d1e7fd1aa243b
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/e/expat-2.5.0-5.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8380127
+    checksum: sha256:207d7440755167a1049b86dafd99052a0162107167dfad2405386ab8452e6e76
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/glib2-2.68.4-16.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 5078743
+    checksum: sha256:452f757e564781db4e489cfabc4ab6062375e9f580da4dbd1fa7157f41fb8f39
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gnupg2-2.3.3-4.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7615913
+    checksum: sha256:cd27551144e10f730f613ade3c9f3c201c912941a8abfce2c3fc770f6845b9ab
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-6.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8612613
+    checksum: sha256:dc677685c729543c50bb6c99ae875ef7f83b36f2c25b74f55269c49f160409a9
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.110.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 149742415
+    checksum: sha256:95170092b5c7994be8941bf5b6ae3660a876a6691b3f06fdf46af7124de14a89
+    name: kernel
+    evr: 5.14.0-570.110.1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/k/krb5-1.21.1-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8943275
+    checksum: sha256:0e9b010a294e5358b4bd1e28b7cd1f1eb15256d4040f68814b0659f92f5a1ec2
+    name: krb5
+    evr: 1.21.1-8.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libarchive-3.5.3-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7054617
+    checksum: sha256:a590c3f706fbc8932245513fca3328d68708a0b11565da86eed8002399f80c65
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libssh-0.10.4-15.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 665493
+    checksum: sha256:dbe0318bea854b3a1f8af8f6aceab24d0beac8172d0afd30779afdf0b62d96f5
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/l/libxml2-2.9.13-12.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3287566
+    checksum: sha256:2bc2fd257740e6baa0555a9e98ae5731a5e18d98332afa10e2e6e8bd92b1880a
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/n/NetworkManager-1.52.0-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 6295554
+    checksum: sha256:fc995af619a89f8184e3d19b975e653615e6f1687c36de40b0ec63ff0df580d8
+    name: NetworkManager
+    evr: 1:1.52.0-10.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/n/nghttp2-1.43.0-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3997194
+    checksum: sha256:25c2a8aaef5b90676fe217d732db026441e110951ed66b00e7327b79886a7a72
+    name: nghttp2
+    evr: 1.43.0-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2410966
+    checksum: sha256:1ddf2a92b05dd9431ce5b6b884b449c7f855806a7586114f9034c2602172163f
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/o/openssl-3.2.2-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 17980237
+    checksum: sha256:2010e981778502acfddd21095efbb7bbe407e8d85ddf6185563f6a41508591a0
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/p/python3.9-3.9.21-2.el9_6.5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 20305745
+    checksum: sha256:28b422b6eddc8c6531629680290fbcfd4539ff4bbb199fb0fbf6e9a8262e8b1a
+    name: python3.9
+    evr: 3.9.21-2.el9_6.5
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/s/systemd-252-51.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 43231152
+    checksum: sha256:c7324d32266c9b398924b5495019101abb46013f2d4f348b19b5fe156c6140ff
+    name: systemd
+    evr: 252-51.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2282353
+    checksum: sha256:8845bf368f2fcda2e27130cf4ef8301fed4ac310c0b1ef048542bd85261bf21c
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 919356
+    checksum: sha256:eb238075d8e20f9b5bee4666e55572ec2762203a0040e1d1fc350b390e412c99
+    name: tzdata
+    evr: 2026a-1.el9_0
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS/Packages/v/vim-8.2.2637-22.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 12824612
+    checksum: sha256:7fec61a8292d8ed5cf71f95d47ae8b594967391eef07fe306899359735eda157
+    name: vim
+    evr: 2:8.2.2637-22.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/source/SRPMS/Packages/p/pybind11-2.10.4-2.el9.src.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-eus-source-rpms
+    size: 753907
+    checksum: sha256:7b09202a3413bd4d9b0ec480bc7135c5baa7951bac0044891ddaa64999af4f31
+    name: pybind11
+    evr: 2.10.4-2.el9
   module_metadata: []
 - arch: x86_64
   packages:
@@ -18013,6 +26083,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.4/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-rpms
+    size: 215457
+    checksum: sha256:167ca8bc6b7814514ba38057e8062274cb52c1b1dbdfaf5096f838d88ae6005a
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+    sourcerpm: libsndfile-1.2.2-6.el9ai.src.rpm
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.x86_64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
     size: 100670
@@ -18181,13 +26258,6 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1524135
-    checksum: sha256:e4573a2f07756624a20d93e967f840d5aee748965827067a7516ce0670a13031
-    name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_6.1
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 58172
@@ -18223,13 +26293,6 @@ arches:
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/c/crun-1.23.1-2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 249255
-    checksum: sha256:0f885a416fe6086cf8d5e2dca053fdc8366e7878be939da6fe049dbb685eaa06
-    name: crun
-    evr: 1.23.1-2.el9_6
-    sourcerpm: crun-1.23.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/d/dconf-0.40.0-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 119425
@@ -18377,20 +26440,6 @@ arches:
     name: gcc-plugin-annobin
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 502997
-    checksum: sha256:0a6c5574be7627d4e4bcd9afc4ee3ab671dddd0bbe6344dd5575c2fbbee785a8
-    name: gdk-pixbuf2
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 89943
-    checksum: sha256:1ca5c66e639bf8a7499747eb6fefe4cd4cc9318ef1525fe5745da986f46c7156
-    name: gdk-pixbuf2-modules
-    evr: 2.42.6-6.el9_6
-    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/geoclue2-2.6.0-8.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 131359
@@ -18426,13 +26475,6 @@ arches:
     name: ghostscript-tools-printing
     evr: 9.54.0-19.el9_6
     sourcerpm: ghostscript-9.54.0-19.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/giflib-5.2.1-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 52216
-    checksum: sha256:7766ed167067741005f900c43b0ab32cd6706b911338f0e9e405e774300693f0
-    name: giflib
-    evr: 5.2.1-9.el9
-    sourcerpm: giflib-5.2.1-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/git-core-2.47.3-1.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 4926340
@@ -18440,13 +26482,6 @@ arches:
     name: git-core
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4675809
-    checksum: sha256:185d671ef012697e361af0ebf6bdd18a65b0c829d21eba730778c1c2bebeca61
-    name: git-lfs
-    evr: 3.6.1-2.el9_6
-    sourcerpm: git-lfs-3.6.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.24.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32863
@@ -18461,13 +26496,6 @@ arches:
     name: glibc-headers
     evr: 2.34-168.el9_6.24
     sourcerpm: glibc-2.34-168.el9_6.24.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/go-srpm-macros-3.6.0-10.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 28143
-    checksum: sha256:c1cbc05c812994c77b7f7bf80e76039c94d6ba887c9169228833e7e702aa095a
-    name: go-srpm-macros
-    evr: 3.6.0-10.el9_6
-    sourcerpm: go-rpm-macros-3.6.0-10.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/google-droid-sans-fonts-20200215-11.el9.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2836183
@@ -18496,13 +26524,6 @@ arches:
     name: gstreamer1
     evr: 1.22.12-3.el9
     sourcerpm: gstreamer1-1.22.12-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2367155
-    checksum: sha256:0dc3dbd41054388a3927ac6d12b709776aa77b4cfba48aedb8327f9b5f1b62a8
-    name: gstreamer1-plugins-base
-    evr: 1.22.12-4.el9
-    sourcerpm: gstreamer1-plugins-base-1.22.12-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/gtk-update-icon-cache-3.24.31-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 35438
@@ -18531,20 +26552,6 @@ arches:
     name: iso-codes
     evr: 4.6.0-3.el9
     sourcerpm: iso-codes-4.6.0-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 465752
-    checksum: sha256:85c333058dd653947585c730ed45e46ab8511ef4c6a191a6e529f4752119471b
-    name: java-17-openjdk
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 47167725
-    checksum: sha256:0858a1ca40dcd23fc4edf4fa3f04e6103f1ceb62a410020108336d70c75c755e
-    name: java-17-openjdk-headless
-    evr: 1:17.0.17.0.10-1.el9
-    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/j/javapackages-filesystem-6.4.0-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17320
@@ -18566,13 +26573,6 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.62.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3743889
-    checksum: sha256:a4929b8d3e70b5d45c0fec63db454b600091433be8a8daa62142a9499a0d2dc6
-    name: kernel-headers
-    evr: 5.14.0-570.62.1.el9_6
-    sourcerpm: kernel-5.14.0-570.62.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17792
@@ -18580,6 +26580,13 @@ arches:
     name: kernel-srpm-macros
     evr: 1.0-13.el9
     sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/lame-libs-3.100-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 343558
+    checksum: sha256:d68c6ccdc801fd671c15fab7c9ebf8cf70890502ee75c106bb70cedb5c975c9a
+    name: lame-libs
+    evr: 3.100-12.el9
+    sourcerpm: lame-3.100-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/langpacks-core-font-en-3.0-16.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 10986
@@ -18923,20 +26930,6 @@ arches:
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libsndfile-1.0.31-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 213869
-    checksum: sha256:2398fd9dfd46af86ab11d6273559ce440eaf6841e3ff28447d3a5c26f6760cdb
-    name: libsndfile
-    evr: 1.0.31-9.el9
-    sourcerpm: libsndfile-1.0.31-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.3.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 412854
-    checksum: sha256:6f0c42f7474934ef8b1b18a15cd1cf4d1c50a18953971d10eb619b951791252c
-    name: libsoup
-    evr: 2.72.0-10.el9_6.3
-    sourcerpm: libsoup-2.72.0-10.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2531717
@@ -18965,13 +26958,6 @@ arches:
     name: libtheora
     evr: 1:1.1.1-31.el9
     sourcerpm: libtheora-1.1.1-31.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 200479
-    checksum: sha256:bf74083b2bcd330e4bbc59cafe7207aad13cb653ba029da5902e76ad40e2e3dd
-    name: libtiff
-    evr: 4.4.0-13.el9_6.2
-    sourcerpm: libtiff-4.4.0-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libtool-2.4.6-46.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 598907
@@ -19077,13 +27063,6 @@ arches:
     name: libxshmfence
     evr: 1.3-10.el9
     sourcerpm: libxshmfence-1.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 250837
-    checksum: sha256:b22bb9f995e96b2b00711760c57fe4e93b4328815de61c39d53717b6a61f6d8c
-    name: libxslt
-    evr: 1.1.34-13.el9_6
-    sourcerpm: libxslt-1.1.34-13.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/llvm-libs-19.1.7-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30399454
@@ -19126,48 +27105,6 @@ arches:
     name: m4
     evr: 1.4.19-1.el9
     sourcerpm: m4-1.4.19-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9837523
-    checksum: sha256:4baeac62f82dcd6ed1319cfa34ad1f7123a9dfdd42ba0b0c484d01fbf9f9b805
-    name: mesa-dri-drivers
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-filesystem-24.2.8-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 10776
-    checksum: sha256:cefd073cce1d96c2fa737da4cf255dc430ae1d8bc3793ee0cc067d2e3a4a4406
-    name: mesa-filesystem
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libEGL-24.2.8-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 144042
-    checksum: sha256:a329e58e9a1e938d1f60d1b8159832e7b99f89764af983a5ff227875db02bd57
-    name: mesa-libEGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libGL-24.2.8-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 174367
-    checksum: sha256:1d19e008c3a9f771b472b41a2938d5d2b1eb2e9e184e6b1f8a22f7efc8345b78
-    name: mesa-libGL
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libgbm-24.2.8-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 36446
-    checksum: sha256:436edc5022667a01cec4bd7499f16c1fa22eea36a99ecc0902fd82115d690091
-    name: mesa-libgbm
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libglapi-24.2.8-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 45330
-    checksum: sha256:4a70de296f3bec329440c23a28b17f05d5f533d6abcf23363a4ade863e711e33
-    name: mesa-libglapi
-    evr: 24.2.8-3.el9_6
-    sourcerpm: mesa-24.2.8-3.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mkfontscale-1.2.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 35081
@@ -19175,48 +27112,13 @@ arches:
     name: mkfontscale
     evr: 1.2.1-3.el9
     sourcerpm: mkfontscale-1.2.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/m/mpg123-libs-1.32.9-1.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 136524
-    checksum: sha256:dd9a598390e8adfebdcec7adbc5aa140d6584ede4d581d5fec328d2e4a5107db
-    name: nspr
-    evr: 4.36.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-3.112.0-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 740527
-    checksum: sha256:6eefe50251cf43934ea5c949a0f23e0da20d81262394e7824328e0f21aabbe88
-    name: nss
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 409821
-    checksum: sha256:ac09b91c717cf003714b62cb033bea51770c887fdc70426f625a677e50b0813f
-    name: nss-softokn
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 423244
-    checksum: sha256:1eb3fb60d885f3a1071dcb335e1ee34c156bbc50c797f42772d61412a91db8f5
-    name: nss-softokn-freebl
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 18225
-    checksum: sha256:5b5314ce6088f161b2a404b566c6d5016811b6c12e90c7bf70d3fd281168d659
-    name: nss-sysinit
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 91543
-    checksum: sha256:3904f1eab4e56789d8d818d0ca4a76c49d1ef5de947ccdabaf64f9d748ad05df
-    name: nss-util
-    evr: 3.112.0-4.el9_4
-    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+    size: 362145
+    checksum: sha256:9f9c76a079d233e8178090d2bf69c953cc426c25e394526c19528c93ab741a45
+    name: mpg123-libs
+    evr: 1.32.9-1.el9_5
+    sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 9270
@@ -19266,13 +27168,6 @@ arches:
     name: openjpeg2
     evr: 2.4.0-8.el9
     sourcerpm: openjpeg2-2.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 4650823
-    checksum: sha256:30cd1b3dec089a7da71e9167532693bef7c202a5dbe3c010af2a9387106a0b36
-    name: openssl-devel
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/o/opus-1.3.1-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 206132
@@ -19301,13 +27196,6 @@ arches:
     name: osinfo-db-tools
     evr: 1.10.0-1.el9
     sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/o/ostree-libs-2025.2-2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 486052
-    checksum: sha256:15100378a8cc1c6df692dc2d1d72cf4b26a3e8bdd270cc1523619f5d9ccd25fd
-    name: ostree-libs
-    evr: 2025.2-2.el9_6
-    sourcerpm: ostree-2025.2-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/p11-kit-server-0.25.3-3.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 253449
@@ -20603,13 +28491,6 @@ arches:
     name: perl-User-pwent
     evr: 1.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 245691
-    checksum: sha256:7d60f8bff904ad095882c8cd069fbe533032b26996f3621fa55cd33ea3263c23
-    name: perl-XML-Parser
-    evr: 2.46-9.el9
-    sourcerpm: perl-XML-Parser-2.46-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-XML-XPath-1.44-11.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94037
@@ -20988,13 +28869,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/poppler-21.01.0-21.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1116051
-    checksum: sha256:6e52436864891413290d8c50002b8fbed11bb07115a8a0972df3d0ae098395ff
-    name: poppler
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/poppler-data-0.4.9-9.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1971104
@@ -21002,34 +28876,6 @@ arches:
     name: poppler-data
     evr: 0.4.9-9.el9
     sourcerpm: poppler-data-0.4.9-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/poppler-glib-21.01.0-21.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 157327
-    checksum: sha256:138338c7494c0faeb1a5c00d83e9ca7d1e28fcbae4bd6bab25361f6717129326
-    name: poppler-glib
-    evr: 21.01.0-21.el9
-    sourcerpm: poppler-21.01.0-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/postgresql-13.22-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1694686
-    checksum: sha256:f18ae1194444ac4097c46ec7a279c7307f2bb43bc2e212fce064ff21d081b81f
-    name: postgresql
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/postgresql-private-libs-13.22-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 140011
-    checksum: sha256:2286958f60c0905e5efe89fddb39d95b93d8c5bed3549528bcba8bb484e12916
-    name: postgresql-private-libs
-    evr: 13.22-1.el9_6
-    sourcerpm: postgresql-13.22-1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/protobuf-3.14.0-16.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1057844
-    checksum: sha256:b1708ff32307536de8c9edcf530f7a057533566f3013297cf2239534b24a5ef6
-    name: protobuf
-    evr: 3.14.0-16.el9
-    sourcerpm: protobuf-3.14.0-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/pulseaudio-libs-15.0-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 695748
@@ -21051,20 +28897,6 @@ arches:
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.2.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9102
-    checksum: sha256:7aec11632e430e2d0ee4a4a4e60336ce36ebdd023e6a5645175654e3e339e688
-    name: python-unversioned-command
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 249990
-    checksum: sha256:11f8ba100e932d42a3204b0ee08c51fbdbc5b9434df07ebb156e369ea2979df4
-    name: python3-devel
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2133958
@@ -21100,13 +28932,6 @@ arches:
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9530108
-    checksum: sha256:039405094c2d9a353471b7c14a4cd1acde857472f2692b33ca486386a56f8cdc
-    name: skopeo
-    evr: 2:1.18.1-2.el9_6
-    sourcerpm: skopeo-1.18.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 50387
@@ -21128,13 +28953,6 @@ arches:
     name: sound-theme-freedesktop
     evr: 0.8-17.el9
     sourcerpm: sound-theme-freedesktop-0.8-17.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/s/systemtap-sdt-devel-5.2-2.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 79141
-    checksum: sha256:e02a565f7999c72dfb631838b52893942f63076997f276ccd4fefb6c4ccd46e0
-    name: systemtap-sdt-devel
-    evr: 5.2-2.el9
-    sourcerpm: systemtap-5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/t/teckit-2.5.9-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 460890
@@ -22346,13 +30164,6 @@ arches:
     name: ttmkfdir
     evr: 3.0.9-65.el9
     sourcerpm: ttmkfdir-3.0.9-65.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/t/tzdata-java-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 233483
-    checksum: sha256:952b215f1e04b08ddfbf4bf19f6285d23f5a9d0dead6a64b4b9a6e1492fb2da0
-    name: tzdata-java
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/u/unixODBC-2.3.9-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 507076
@@ -22451,13 +30262,6 @@ arches:
     name: urw-base35-z003-fonts
     evr: 20200910-6.el9
     sourcerpm: urw-base35-fonts-20200910-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.50.1-0.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 8967488
-    checksum: sha256:a1aed06443038aa7a6cb819ee922e721719a8df8db27cedae654605a2d017f86
-    name: webkit2gtk3-jsc
-    evr: 2.50.1-0.el9_6
-    sourcerpm: webkit2gtk3-2.50.1-0.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/w/webrtc-audio-processing-0.3.1-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 315539
@@ -22584,20 +30388,6 @@ arches:
     name: bash-completion
     evr: 1:2.11-5.el9
     sourcerpm: bash-completion-2.11-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4818636
-    checksum: sha256:4eb918b63dee7daf32117df2e3fcb02ad4ba3d96cb25677cf55315deceb7e22a
-    name: binutils
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 753176
-    checksum: sha256:339d9bb2dc0e41c4756f1a4f82e82f6654818b72de74f1f0377c76277617352b
-    name: binutils-gold
-    evr: 2.35.2-63.el9
-    sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/bluez-libs-5.72-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 86356
@@ -22689,13 +30479,6 @@ arches:
     name: cups-libs
     evr: 1:2.3.3op2-33.el9_6.1
     sourcerpm: cups-2.3.3op2-33.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 300609
-    checksum: sha256:210e1397abfccfab146f0cfd38f315a41959025e362a079bac1f740e0a781029
-    name: curl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-21.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 792070
@@ -22780,13 +30563,6 @@ arches:
     name: elfutils-libs
     evr: 0.192-6.el9_6
     sourcerpm: elfutils-0.192-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 121835
-    checksum: sha256:63522da84934e944305c9e206894031988ab9e561bba2e6c131d76093d1a0211
-    name: expat
-    evr: 2.5.0-5.el9_6
-    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 53222
@@ -22871,13 +30647,6 @@ arches:
     name: glib-networking
     evr: 2.68.3-3.el9
     sourcerpm: glib-networking-2.68.3-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.3.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2767603
-    checksum: sha256:eacba8e0418fe6036f7a8c9463bfd5dd14b719c2ad53a26f00e43be0968370b4
-    name: glib2
-    evr: 2.68.4-16.el9_6.3
-    sourcerpm: glib2-2.68.4-16.el9_6.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/glibc-2.34-168.el9_6.24.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 2050334
@@ -22913,20 +30682,6 @@ arches:
     name: gmp
     evr: 1:6.2.0-13.el9
     sourcerpm: gmp-6.2.0-13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gnupg2-2.3.3-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2641396
-    checksum: sha256:c6541c33c623ea78fe08e876218d4480923b499ba74de428686d015da984bd1d
-    name: gnupg2
-    evr: 2.3.3-4.el9
-    sourcerpm: gnupg2-2.3.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1127088
-    checksum: sha256:5f34b2963d72ab2698cc5d77b53b5e7c6044c1df805c290f124a5f3c4aeceb21
-    name: gnutls
-    evr: 3.8.3-6.el9_6.2
-    sourcerpm: gnutls-3.8.3-6.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gobject-introspection-1.68.0-11.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 260411
@@ -23053,13 +30808,6 @@ arches:
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 784176
-    checksum: sha256:41db5311bfcb620dd32078b72c6ac4a3f22c0a924d7de890770154aa016d2e93
-    name: krb5-libs
-    evr: 1.21.1-8.el9_6
-    sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 170758
@@ -23074,13 +30822,6 @@ arches:
     name: libacl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libarchive-3.5.3-6.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 395957
-    checksum: sha256:d6343b0a493a0d9cf513b7a9af31a89a5bffe1a9e3766fed088d20f611820537
-    name: libarchive
-    evr: 3.5.3-6.el9_6
-    sourcerpm: libarchive-3.5.3-6.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libassuan-2.5.5-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 72450
@@ -23102,13 +30843,6 @@ arches:
     name: libblkid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 323932
-    checksum: sha256:bb3175e435723e98cc1a5063eafa82231092eca3bf6276d24505eaeaaa817113
-    name: libbrotli
-    evr: 1.0.9-7.el9_5
-    sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libcap-2.48-9.el9_2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 76130
@@ -23137,13 +30871,6 @@ arches:
     name: libcom_err
     evr: 1.46.5-7.el9
     sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 290836
-    checksum: sha256:75ae001593af41a0f5afd6c7557abeeb67a4ff394cab731cec4bb696230fd614
-    name: libcurl
-    evr: 7.76.1-31.el9_6.1
-    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 755192
@@ -23270,13 +30997,6 @@ arches:
     name: libmount
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 76742
-    checksum: sha256:ebc37f2252164962b03dd3a4b5e53ab5e1e9234a8657219e8c8e9064dcb98b2e
-    name: libnghttp2
-    evr: 1.43.0-6.el9
-    sourcerpm: nghttp2-1.43.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 376137
@@ -23298,13 +31018,6 @@ arches:
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpng-1.6.37-12.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 121655
-    checksum: sha256:42e7addb96958b293571949829378c054d6a1a762dccb78d5a777f8c531fc811
-    name: libpng
-    evr: 2:1.6.37-12.el9
-    sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libproxy-0.4.15-35.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 79470
@@ -23375,20 +31088,6 @@ arches:
     name: libsmartcols
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 218637
-    checksum: sha256:7ee387359681560df2ed7df7a18b9ebd7c49b23d24342de891154599f8e6db8a
-    name: libssh
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 7991
-    checksum: sha256:845c662af1f78eee4a1f67977a805b551edc939e21d3b201cb332682b18443fb
-    name: libssh-config
-    evr: 0.10.4-15.el9_6
-    sourcerpm: libssh-0.10.4-15.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 759582
@@ -23452,13 +31151,6 @@ arches:
     name: libxcrypt
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 764646
-    checksum: sha256:b10ea00b8bb855fded7498ac63bdfa084aa1826740c4e7c515aab3c9ed0f3082
-    name: libxml2
-    evr: 2.9.13-12.el9_6
-    sourcerpm: libxml2-2.9.13-12.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 304135
@@ -23508,13 +31200,6 @@ arches:
     name: mpfr
     evr: 4.1.0-7.el9
     sourcerpm: mpfr-4.1.0-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-9.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1970311
-    checksum: sha256:bbfba4cafceb2e394be26d7c30765b4130dfd8b248f3bc6d4a0aec81c7c57e23
-    name: NetworkManager-libnm
-    evr: 1:1.52.0-9.el9_6
-    sourcerpm: NetworkManager-1.52.0-9.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9_6.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 416227
@@ -23564,27 +31249,6 @@ arches:
     name: openldap
     evr: 2.6.8-4.el9
     sourcerpm: openldap-2.6.8-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssh-8.7p1-45.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 474534
-    checksum: sha256:d43f19d3e736943bdadbda47db016e9da81ce1900f50ecfe470f7a8bc9bce243
-    name: openssh
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 735750
-    checksum: sha256:309d1c9c176bf35b494c8b31a0f3eeceddd0b27be1dfc9defbe9838b9d5a707c
-    name: openssh-clients
-    evr: 8.7p1-45.el9
-    sourcerpm: openssh-8.7p1-45.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1420999
-    checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 9625
@@ -23599,13 +31263,6 @@ arches:
     name: openssl-fips-provider-so
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2218318
-    checksum: sha256:287d11706d44a53455ed8ac62faab4c4a0b8c0fa5e367adf122c7a76c6ddbbb8
-    name: openssl-libs
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 548533
@@ -23711,20 +31368,6 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 26190
-    checksum: sha256:2572fc0f6c65dc5201c65a48f7d962a04a09669feae2fcdc4e5f9e910b9195c6
-    name: python3
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8474800
-    checksum: sha256:a8a433346daa16f25d8f672bdc6cbee9277631c60378006fb1056b4443ce505d
-    name: python3-libs
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1193706
@@ -23823,48 +31466,6 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-8.el9_6
     sourcerpm: sqlite-3.34.1-8.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-252-51.el9_6.3.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4398726
-    checksum: sha256:bdd7e241deb1f78db59971399d169fa08c09318adad9e78c349dba710dc190a5
-    name: systemd
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-libs-252-51.el9_6.3.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 687456
-    checksum: sha256:ddb782f136de4180adce2a91ae0eaa2319d99356fff5473c8dfbc94930b7b109
-    name: systemd-libs
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-pam-252-51.el9_6.3.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 280757
-    checksum: sha256:31a6de71fd3640db1af6576382295a0d49278bc3066a71160aae30b2779c6094
-    name: systemd-pam
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.3.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 63512
-    checksum: sha256:0735a7ac27891726d56502705f25d14ad243d49bf1f097c9dcf3ce0bd5ca7a97
-    name: systemd-rpm-macros
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-udev-252-51.el9_6.3.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2100262
-    checksum: sha256:94594160f8b39a0af1a0a3841721ba1d0ef10bcb89223ddec5a97bfc8a5c7df2
-    name: systemd-udev
-    evr: 252-51.el9_6.3
-    sourcerpm: systemd-252-51.el9_6.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/t/tar-1.34-7.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 910235
-    checksum: sha256:17f2e592a2c04c050b690afeb9042e02521a0b5ee3288dad837463f4acf542c3
-    name: tar
-    evr: 2:1.34-7.el9
-    sourcerpm: tar-1.34-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 621714
@@ -23872,13 +31473,6 @@ arches:
     name: tpm2-tss
     evr: 3.2.3-1.el9
     sourcerpm: tpm2-tss-3.2.3-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/t/tzdata-2025b-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 862160
-    checksum: sha256:0687e5a1115ba679137404c8d37a45141a31968ffd01677455530d24c126a0d2
-    name: tzdata
-    evr: 2025b-1.el9
-    sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/unzip-6.0-58.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 190785
@@ -23900,13 +31494,6 @@ arches:
     name: util-linux-core
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 13249
-    checksum: sha256:9298e32061a3bce9b94f8c1bd1ac3ee0bfa67a68863cc3a0cd97c5432b6e89ed
-    name: vim-filesystem
-    evr: 2:8.2.2637-22.el9_6.1
-    sourcerpm: vim-8.2.2637-22.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/w/which-2.21-30.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 42038
@@ -23998,5 +31585,3196 @@ arches:
     name: unixODBC-devel
     evr: 2.3.9-4.el9
     sourcerpm: unixODBC-2.3.9-4.el9.src.rpm
-  source: []
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1523894
+    checksum: sha256:b20b1083921f0bee978f4f6332205bbc49ceae4894f9eadc2017e1516d792fc4
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/crun-1.26-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 258553
+    checksum: sha256:b3cda6b34c737ffba190c553029ad65b492ce85665463814f65a63e1922f6362
+    name: crun
+    evr: 1.26-1.el9_6
+    sourcerpm: crun-1.26-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 502413
+    checksum: sha256:c965e7077ba0a107345780bc58f21ee94a260fda5e0f57525e9fd0c04b1f08c5
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.42.6-6.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 89506
+    checksum: sha256:5dd6def5c8e4c57797a996f3f2964a7ea5743980e64e6d544a98a5b14c8c7b3a
+    name: gdk-pixbuf2-modules
+    evr: 2.42.6-6.el9_6.1
+    sourcerpm: gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/giflib-5.2.1-9.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 47557
+    checksum: sha256:77c336ea947dd8ef427a978e5189e2b39b8c29a797514dfd2c158b1a3b1f3064
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+    sourcerpm: giflib-5.2.1-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/git-lfs-3.6.1-2.el9_6.3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4919760
+    checksum: sha256:6e950d5f372cf43115cf4a100b10c3b6ad735e33c25fbf50da83174902b68b9c
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+    sourcerpm: git-lfs-3.6.1-2.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/go-srpm-macros-3.6.0-13.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 27174
+    checksum: sha256:d045b514c2b217509ffa931e4647a613bd49f8aea31e42a030320cd6ab1f9b26
+    name: go-srpm-macros
+    evr: 3.6.0-13.el9_6
+    sourcerpm: go-rpm-macros-3.6.0-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 2358575
+    checksum: sha256:2bde6de4aebe16e6923313a1d8566c2ab76b97346ab572a1177f7e116a798927
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+    sourcerpm: gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 467034
+    checksum: sha256:c898fee97de0597f4084dbf7828d7573ff63cf7f6eed7bf4723d1f7fc6612d91
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.19.0.10-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 47277732
+    checksum: sha256:a946132c5033957d167d4eb7fd54575e7c08f7ded160248816b3181db6c7f892
+    name: java-17-openjdk-headless
+    evr: 1:17.0.19.0.10-1.el9
+    sourcerpm: java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.110.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 3826925
+    checksum: sha256:6509683a8504e2fedb35556b75ed43a5322887365dda10c4263c0efcfa66ffd6
+    name: kernel-headers
+    evr: 5.14.0-570.110.1.el9_6
+    sourcerpm: kernel-5.14.0-570.110.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 413144
+    checksum: sha256:c9d663ddc935b8da3aacd2d047b95fdd72a1e76ce3a372e0529e7b41c211e12a
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+    sourcerpm: libsoup-2.72.0-10.el9_6.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libtiff-4.4.0-13.el9_6.3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 200378
+    checksum: sha256:b1bf16a20c4173e094cd5bb5fe61e00db08f156e77c3079b590affcd8f7c2e9b
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+    sourcerpm: libtiff-4.4.0-13.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 247056
+    checksum: sha256:89efaa836dd7787e19f09426a306bcbbbe37cf061fd9c9406e43a9a420a3ab1e
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+    sourcerpm: libxslt-1.1.34-13.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-dri-drivers-24.2.8-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9835086
+    checksum: sha256:b0d4df7d645fa7d8477e042b0687b751f87366604800f17388d58fc0ffb7bcaa
+    name: mesa-dri-drivers
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-filesystem-24.2.8-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 10553
+    checksum: sha256:21dac9913018519d502dbc735c62a5b448e70582b48e5233df3670ff6ac630e7
+    name: mesa-filesystem
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libEGL-24.2.8-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 143819
+    checksum: sha256:f37b73c6998636d463f8af62a0b0877b1cbeba9305b0672c02881d0f64c736fb
+    name: mesa-libEGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libGL-24.2.8-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 173057
+    checksum: sha256:1a2c44c5477d07affbf439bf05fb6d59ebafb05fac9d210c7f4b0f7df7920a65
+    name: mesa-libGL
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libgbm-24.2.8-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 36222
+    checksum: sha256:4fef31c650900fed4c9008e1abc4d0672124f9308404993ae60204c4d002340a
+    name: mesa-libgbm
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/m/mesa-libglapi-24.2.8-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 45288
+    checksum: sha256:91aada48dd61029cf1cd86489bb84345df1aa847cf00ef7176688742fbadba6c
+    name: mesa-libglapi
+    evr: 24.2.8-5.el9_6
+    sourcerpm: mesa-24.2.8-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nspr-4.36.0-8.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 136884
+    checksum: sha256:dd84e03ec155228c5a9489f0d2184e3303a24e17107b943bdcde19f22a6a46af
+    name: nspr
+    evr: 4.36.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-3.112.0-8.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 741751
+    checksum: sha256:df2dc36ea504d4fcc7739cbe2c866cfd313a266f4335daecf6dbfc1a203a8cd8
+    name: nss
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-softokn-3.112.0-8.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 411899
+    checksum: sha256:301a158bb76422e2127583cd0fa60f19c70713bad412cfa4994f97a6690065b1
+    name: nss-softokn
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-8.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 426105
+    checksum: sha256:8912ba4e4057cdb463137fa149610974c824058c56d8cad240dcd2b43f9233e6
+    name: nss-softokn-freebl
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-sysinit-3.112.0-8.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 18340
+    checksum: sha256:169f7510b31fab5bcbf4ea9e689ea99184f8cf1fbba0b9b6221fb599989f63a6
+    name: nss-sysinit
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nss-util-3.112.0-8.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 91341
+    checksum: sha256:dfe93ee9bc42ba4fafe838db1d0c616b788b833be051841c0a882754f863fadd
+    name: nss-util
+    evr: 3.112.0-8.el9_4
+    sourcerpm: nss-3.112.0-8.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/o/openssl-devel-3.2.2-7.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 4629447
+    checksum: sha256:0fff18a263f807676867271254439ee40fa51edc1aa104e769211337c394a5c0
+    name: openssl-devel
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/o/ostree-libs-2025.2-4.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 486224
+    checksum: sha256:9b74d83dbf7cc92d5c757f2f54f89f07f56d499898a8f89a85c719a775001000
+    name: ostree-libs
+    evr: 2025.2-4.el9_6
+    sourcerpm: ostree-2025.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 244228
+    checksum: sha256:7ec4f5d02fd1de1da4a1ea22caac799c0e4e36d95e60346903d7fca3ff88448a
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+    sourcerpm: perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/poppler-21.01.0-22.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1109855
+    checksum: sha256:1b1aaaf08a70b9e0871a421dd7459e1e63ceed38c9e452697a754b2d3056a5bd
+    name: poppler
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/poppler-glib-21.01.0-22.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 154006
+    checksum: sha256:95a4fd7d20c1e8459fd638028c1dccba3265eb64837d1d8f79f061639e2f5411
+    name: poppler-glib
+    evr: 21.01.0-22.el9_6
+    sourcerpm: poppler-21.01.0-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/postgresql-13.23-1.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1703811
+    checksum: sha256:2b936db5db37f85a0660c9ab16d1073bcb9a0eee3a2cec472e42fe76650446be
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/postgresql-private-libs-13.23-1.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 141078
+    checksum: sha256:1d145857cbcd43d6772d473e9409e0be762a87f69e56b2b98b18673bd59601ec
+    name: postgresql-private-libs
+    evr: 13.23-1.el9_6.1
+    sourcerpm: postgresql-13.23-1.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/protobuf-3.14.0-16.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 1053185
+    checksum: sha256:59b9419de9723543788d9d28d9b5a455f9897d8de6457e813caf95666cfd421c
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+    sourcerpm: protobuf-3.14.0-16.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.5.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9159
+    checksum: sha256:589d36caea67e6e33607045cb1614aa0070de792fcca10a24d50d06280204496
+    name: python-unversioned-command
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3-devel-3.9.21-2.el9_6.5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 250075
+    checksum: sha256:3f773bea94041e606fe5d0da851be399f66eca710e466d7e47bcb80292ca7a36
+    name: python3-devel
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9812136
+    checksum: sha256:0db33dea8dffd2b357a0a5599852fa2cfb494e367d587b18d183477466b3c9a1
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+    sourcerpm: skopeo-1.18.1-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/systemtap-sdt-devel-5.2-4.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 74950
+    checksum: sha256:af463c13058ce3bbdfa2a1f09bafd549615d3dba3adfac2389a868ecf519df4d
+    name: systemtap-sdt-devel
+    evr: 5.2-4.el9_6
+    sourcerpm: systemtap-5.2-4.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/t/tzdata-java-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 228444
+    checksum: sha256:6278f74c2029794cc7eea4a9bb298bda81e9ef165c689cb8e0a09584e0b7104c
+    name: tzdata-java
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.3-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 9229535
+    checksum: sha256:bfbdf613853ebf1277932a8b1f8c1984c3d2e8bf16d1c187b0c7052cc22cde6a
+    name: webkit2gtk3-jsc
+    evr: 2.52.3-1.el9_6
+    sourcerpm: webkit2gtk3-2.52.3-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 4814390
+    checksum: sha256:f4e9c69737d83be539a8979fbe087b53f18d624f6b1e9f1d994d580510593a6a
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 751188
+    checksum: sha256:cbcfbd4ff91e4d946f7f58607984fe522341dbbbb264113df531c14d18387461
+    name: binutils-gold
+    evr: 2.35.2-63.el9_6.1
+    sourcerpm: binutils-2.35.2-63.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/c/curl-7.76.1-31.el9_6.3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 299082
+    checksum: sha256:642caad877bfa47f034dc2e801a0b4f7b640a24982e2d00874ccc32b9dc6353c
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 120247
+    checksum: sha256:069386b2c009f79c29dcea76a5d61f0a56f050c43bee05c4d1333dfa5bcb89e7
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+    sourcerpm: expat-2.5.0-5.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/g/glib2-2.68.4-16.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2767714
+    checksum: sha256:712a8fcfca9fd8fe4d4a8e6ec01ac615638445a175f2f358a89f9a6435b2eda9
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+    sourcerpm: glib2-2.68.4-16.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/g/gnupg2-2.3.3-4.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2636224
+    checksum: sha256:cece867dc3304c3b54134c9788209bc075376566e6cd752aeab67f30886d42aa
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+    sourcerpm: gnupg2-2.3.3-4.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1127462
+    checksum: sha256:d73092f88ac347214feec26215f0b063e04ae5f539be8a02d803e5aef5cedb95
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+    sourcerpm: gnutls-3.8.3-6.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-8.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 782939
+    checksum: sha256:3d89f75d21a92b3e31b02c82db853689174d323d6381884bdbc1b0dd292a29d0
+    name: krb5-libs
+    evr: 1.21.1-8.el9_6.1
+    sourcerpm: krb5-1.21.1-8.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libarchive-3.5.3-7.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 396447
+    checksum: sha256:27ecc3fe1bfcc05aa20ed368f2e070cd76b39c5ef6bbe1a2ebf8a1d761e2d814
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+    sourcerpm: libarchive-3.5.3-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 318827
+    checksum: sha256:8f94c8065b2d0541c8d396bafdc9e5ba737585e70c69206a4fd2fbd9343d28a7
+    name: libbrotli
+    evr: 1.0.9-7.el9_6.1
+    sourcerpm: brotli-1.0.9-7.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libcurl-7.76.1-31.el9_6.3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 288688
+    checksum: sha256:60847b9174295b4f8793b17a2da4bd5c88190f082bd3b3068b69a692f5a96764
+    name: libcurl
+    evr: 7.76.1-31.el9_6.3
+    sourcerpm: curl-7.76.1-31.el9_6.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 73763
+    checksum: sha256:675673323de162f54b6e12135d0ca78e5f111db23123cf882514821803aa4208
+    name: libnghttp2
+    evr: 1.43.0-6.el9_6.1
+    sourcerpm: nghttp2-1.43.0-6.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libpng-1.6.37-12.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 117951
+    checksum: sha256:e5e0195646c143d1af473b46aad8b9e6e7f4387d34fd67fc1937b3ea7c983b7c
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+    sourcerpm: libpng-1.6.37-12.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libssh-0.10.4-15.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 217890
+    checksum: sha256:41ad35e411013576f96ad6eb4d10e6fefbaf1885f45f084672e90b711b1bcbf8
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-15.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8157
+    checksum: sha256:cb0bf985f9cbb43161d848b6849234c95fed7acdd0aeb1f8113ac17ba23a7ce2
+    name: libssh-config
+    evr: 0.10.4-15.el9_6.1
+    sourcerpm: libssh-0.10.4-15.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libxml2-2.9.13-12.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 764543
+    checksum: sha256:4a8611931e62e9ebbb0cae4c857d6ec669a542f8939e97dce63c4e81a7257f71
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+    sourcerpm: libxml2-2.9.13-12.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/n/NetworkManager-libnm-1.52.0-10.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1968696
+    checksum: sha256:bd96b65f3a85f9347867768277f8f629e130342f3dc8fca1423f6379dde3e46c
+    name: NetworkManager-libnm
+    evr: 1:1.52.0-10.el9_6
+    sourcerpm: NetworkManager-1.52.0-10.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssh-8.7p1-45.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 467767
+    checksum: sha256:565be9396284a3e184e9ed191f0f37017ea38b746edc4d1e949ad325809ea3a8
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 728730
+    checksum: sha256:4773b6813ea7d5336140d853474333292470d4dc83842403d8eb7feaee45d5c4
+    name: openssh-clients
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-3.2.2-7.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1406687
+    checksum: sha256:5f63518de32c02062994d2b3bc73efbeede910ab2ef1c15563ce64d41796a840
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-libs-3.2.2-7.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2204136
+    checksum: sha256:7692898ed86ffa1469434a3399adddcc1c0dc40fd2cfedb6bbee0004424e18ab
+    name: openssl-libs
+    evr: 1:3.2.2-7.el9_6.2
+    sourcerpm: openssl-3.2.2-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 26241
+    checksum: sha256:7b315fcf1a697652b3a2e3929570a575a11099fc92baf0a2108dfb87cb8a29e7
+    name: python3
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 8472690
+    checksum: sha256:f4f6e56dacba14bb096e7cbd0825e6144a21d510e4ed14de7187018eab35ea50
+    name: python3-libs
+    evr: 3.9.21-2.el9_6.5
+    sourcerpm: python3.9-3.9.21-2.el9_6.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-252-51.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 4399245
+    checksum: sha256:15f33c171629a004c1efd2b7262461864b324226c2629b53087cc8f0642c7328
+    name: systemd
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-libs-252-51.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 683432
+    checksum: sha256:cc79c2e07fca26a8893b9e309b84c718ec89e275ba2b2c073172645afc6829cc
+    name: systemd-libs
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-pam-252-51.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 279893
+    checksum: sha256:1627696029f24cfb429859d6d85db8eebc9fa91ae0a9635ce2623f9afc75b0a6
+    name: systemd-pam
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.4.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 62787
+    checksum: sha256:96fa8cf07e84e172156c7229a95cb74de5f1980389730d8fa5c4ef4113fe4ded
+    name: systemd-rpm-macros
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-udev-252-51.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 2101215
+    checksum: sha256:6569ec4f2b10dc1ed71725090fd2542e72da7e312e4ab3f1c05c1588aa658343
+    name: systemd-udev
+    evr: 252-51.el9_6.4
+    sourcerpm: systemd-252-51.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/t/tar-1.34-7.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 906275
+    checksum: sha256:c8a8c68f036de31548baeba3c7bb6bce1fad2aa170c76d6aff00fde859943663
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+    sourcerpm: tar-1.34-7.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/t/tzdata-2026a-1.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 926162
+    checksum: sha256:ae429e8acbacad17e1b65a4571fcbf85122925cabeb97d25a9699774c1c38bbd
+    name: tzdata
+    evr: 2026a-1.el9_0
+    sourcerpm: tzdata-2026a-1.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.2.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 13634
+    checksum: sha256:c5bdcda9be95aa6c7467bd64fb32f6a9cf2fee9421a728901889e850e83a4b29
+    name: vim-filesystem
+    evr: 2:8.2.2637-22.el9_6.2
+    sourcerpm: vim-8.2.2637-22.el9_6.2.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.4/source/SRPMS/Packages/l/libsndfile-1.2.2-6.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 750483
+    checksum: sha256:2ed7a90be00fa333f0274d17dd68bb11366f4543434f2b63b398fbd29416b9d7
+    name: libsndfile
+    evr: 1.2.2-6.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.4/source/SRPMS/Packages/t/texlive-tcolorbox-20200406-1.el9ai.src.rpm
+    repoid: rhelai-3.4-for-rhel-9-x86_64-source-rpms
+    size: 4964524
+    checksum: sha256:1bc9bb50498a035797cbe8cf8e2499f5d6e6f87ef6a97d5c682d3e98c41b7c2b
+    name: texlive-tcolorbox
+    evr: 20200406-1.el9ai
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/source/SRPMS/Packages/c/containers-common-1-78.rhaos4.16.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 98665
+    checksum: sha256:7f31f05fa1f959849a1aead06559015cfbdcec919b7b5027e0c8c97785b636e3
+    name: containers-common
+    evr: 3:1-78.rhaos4.16.el9
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/source/SRPMS/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-source-rpms
+    size: 16183933
+    checksum: sha256:0d3a9996f6287020460e6e91cfb22c636a047a5488d27a09ac6bbfce22d17810
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/abattis-cantarell-fonts-0.301-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 582900
+    checksum: sha256:ce11dc78d92b207947633e00a792a3c8c3b7b4f23c2b7912eaba587dc7893f4c
+    name: abattis-cantarell-fonts
+    evr: 0.301-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/adobe-mappings-cmap-20171205-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4127058
+    checksum: sha256:7c2f5be26bd8cee4e6a5b37a399484c9b230dd3fa8e93e45636d96c914d2504f
+    name: adobe-mappings-cmap
+    evr: 20171205-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/adobe-mappings-pdf-20180407-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1445392
+    checksum: sha256:84f5b00a6bf51f6b77ef54e7672da8dfb5aac1e55e88111dc8ef3384f6376d1c
+    name: adobe-mappings-pdf
+    evr: 20180407-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/adwaita-icon-theme-40.1.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17249062
+    checksum: sha256:0a59369173dca9368ed6b14bd4d068768ea45b4dab9a73cb8fa578990e8e53af
+    name: adwaita-icon-theme
+    evr: 40.1.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/alsa-lib-1.2.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1215277
+    checksum: sha256:1b9db2aa1e09cb40372bdcd1dfe6f613d20b7eaed88028687c96c934379e7d6f
+    name: alsa-lib
+    evr: 1.2.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/annobin-12.92-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 998524
+    checksum: sha256:65ee4ea686dfa6a8da136896ff590fb476248e998a14c38b28713a34a23cf1b9
+    name: annobin
+    evr: 12.92-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/at-spi2-atk-2.38.0-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111112
+    checksum: sha256:5713e30db407b1debad820ea89e57f3db5fe9c4e222ce44ab45d9e38ce52fe5a
+    name: at-spi2-atk
+    evr: 2.38.0-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/at-spi2-core-2.40.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 213364
+    checksum: sha256:3a5717b63603264a184a1ef26f606898c7f0ecc4b57ebd996d05b73a77bb8336
+    name: at-spi2-core
+    evr: 2.40.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/atk-2.36.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313725
+    checksum: sha256:171734f6cf9638497ccaccb73ab79b49d37085930e0c03d4c954aac2eaddbdc9
+    name: atk
+    evr: 2.36.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/autoconf-2.69-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1239007
+    checksum: sha256:946149054ebac72d6e6694d2525bca703c5faaa414f1f74ee7e12b0754c01cbd
+    name: autoconf
+    evr: 2.69-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/a/automake-1.16.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1598281
+    checksum: sha256:ac46e755161516f951c497c2794f344716a271ba68531883edb17bbbbab8958a
+    name: automake
+    evr: 1.16.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/cairo-1.17.4-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41864767
+    checksum: sha256:0185c51c6c00b3a238e9038addfa1be86fee1b3cc3933efdd4f05f8c5db775d6
+    name: cairo
+    evr: 1.17.4-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/cmake-3.26.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10671338
+    checksum: sha256:2f86bb96562eaf679969c2716738fbdfcc8a3966ecc3bb6317596fe2e214ea2b
+    name: cmake
+    evr: 3.26.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/colord-1.4.5-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1889181
+    checksum: sha256:e84bbbfb02504405637c022bb2cf90f2e278bbe1e136915a93b9f6e4d8402754
+    name: colord
+    evr: 1.4.5-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/composefs-1.0.8-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 8969650
+    checksum: sha256:13901e1b50ee0021eb56092859869125ea6ac9f2eafb2a880d758e87a18825e8
+    name: composefs
+    evr: 1.0.8-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/copy-jdk-configs-4.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 17565
+    checksum: sha256:df1244121141d62420480aa1e07486bd0fa548360c2062c1ef138716dd7d68e8
+    name: copy-jdk-configs
+    evr: 4.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/criu-3.19-1.2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1397633
+    checksum: sha256:b055915dd2fd04c16c79a36775e1647f7c4f020cd341e94cda3a59898c3d6502
+    name: criu
+    evr: 3.19-1.2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/d/dconf-0.40.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133768
+    checksum: sha256:bbf4109630c6b65ff78bd4332c9a3b31c44776ff089361f0586cea1e758bbe25
+    name: dconf
+    evr: 0.40.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/d/dwz-0.14-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 159459
+    checksum: sha256:7565e0aed6cfb90c2c4be4ae2b33536fc4cf9b1b05a6a07da940ec564475580f
+    name: dwz
+    evr: 0.14-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 44824139
+    checksum: sha256:50a3faee5df3fd8d39609d97a62ef1297f668733105f4871d41a9257840269a3
+    name: emacs
+    evr: 1:27.2-14.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/e/exempi-2.6.0-0.2.20211007gite23c213.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19993045
+    checksum: sha256:2913c28e8198b0f722c4b16eebe6a102fdb4e33d934ad863aaf3fd25af4ff4aa
+    name: exempi
+    evr: 2.6.0-0.2.20211007gite23c213.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/e/exiv2-0.27.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32725837
+    checksum: sha256:65335824ab2515880092f0d0557882669e95f8c064aa4a18f2d36a3a3725913d
+    name: exiv2
+    evr: 0.27.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/f/fdk-aac-free-2.0.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2184629
+    checksum: sha256:2ccc9e447d4d1aa5ee0eccc9f06064bbb3f8c170c24f769a5dd7b580bf72537e
+    name: fdk-aac-free
+    evr: 2.0.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/f/flac-1.3.3-10.el9_2.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1063337
+    checksum: sha256:c9a340cb3e679da5f281425dcf1e785a2e882e733631638b45e76d3aa1f2e68f
+    name: flac
+    evr: 1.3.3-10.el9_2.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/f/flatpak-1.12.9-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1595419
+    checksum: sha256:5c870a95bee4384b536f3f53423e4e313dd5ebe0493ca12cfb71b09f84750ce2
+    name: flatpak
+    evr: 1.12.9-4.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/f/fontconfig-2.14.0-2.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1460194
+    checksum: sha256:623ac6b43061ad2f2b5d07861dfeb9b83ef70ead8df02319d375e71bc0110b67
+    name: fontconfig
+    evr: 2.14.0-2.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/f/fribidi-1.0.10-6.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1177189
+    checksum: sha256:d5e12deb110f7a5a8776435efa8f6c5e42ecf990e0ed27f95293020b65891254
+    name: fribidi
+    evr: 1.0.10-6.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 114235
+    checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
+    name: fuse-overlayfs
+    evr: 1.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/geoclue2-2.6.0-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108381
+    checksum: sha256:4ce03414616b5a8af25be3a451576b938b10c2c50a1ae9eab64627837f3f3ca8
+    name: geoclue2
+    evr: 2.6.0-8.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/ghc-srpm-macros-1.5.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10180
+    checksum: sha256:2d980af2311afd353583b200783cb39a5da7e89b6dbb9e67aa7d77a2c53e0cab
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/ghostscript-9.54.0-19.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 56071528
+    checksum: sha256:b2d608294cabab2b30197fa1ad90bff391840d5bfed4455081f627119c3cec87
+    name: ghostscript
+    evr: 9.54.0-19.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7707656
+    checksum: sha256:815c2ae9574006ecb596000492929264de785444736ee3968d5ee34cb6e75159
+    name: git
+    evr: 2.47.3-1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/google-droid-fonts-20200215-11.el9.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3288061
+    checksum: sha256:b58b720be2c7a22d8a3c25731bfacaffc11f4d805f15a05022382cb456ec9f96
+    name: google-droid-fonts
+    evr: 20200215-11.el9.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/graphene-1.10.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 345896
+    checksum: sha256:80bb7aed95ed969225d7b3b9d36103511b52b554c01f90c44681d18a861e2031
+    name: graphene
+    evr: 1.10.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/gsm-1.0.19-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80557
+    checksum: sha256:1a6ba3deaab6b12d3bcd23126c69340795d353e6b2eea36bf3696064db1be11c
+    name: gsm
+    evr: 1.0.19-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/gstreamer1-1.22.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1824267
+    checksum: sha256:cc25d402dff67470712a6032acc99f393898df78cdf30a2e346550db5a8ec091
+    name: gstreamer1
+    evr: 1.22.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/gtk3-3.24.31-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22491893
+    checksum: sha256:a6d0d395b3f0c64c10b8ccea931b318eee6ae36015b9852631c76d68283f0a68
+    name: gtk3
+    evr: 3.24.31-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/h/hicolor-icon-theme-0.17-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65737
+    checksum: sha256:8e62b8cf7aa5c7ef7a9ce6d1f1b159eeba7bc24519fbbb012e8a573ac072bcc6
+    name: hicolor-icon-theme
+    evr: 0.17-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/i/iso-codes-4.6.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14096241
+    checksum: sha256:3b17af011d4074e0fac62f3cf699090889892a45cf317df37942ebd2b39bc934
+    name: iso-codes
+    evr: 4.6.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/j/javapackages-tools-6.4.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 210942
+    checksum: sha256:7915590da093f42d4cfccb6196e1e3f22dce8d36f850ed2d46d0f41f238de01f
+    name: javapackages-tools
+    evr: 6.4.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/j/jbig2dec-0.19-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 584264
+    checksum: sha256:ac2fcfa2e65095617b1b9efef5ae8bf52e69e0f4b3b152ddd3c3c2fb7da0b3f7
+    name: jbig2dec
+    evr: 0.19-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/j/jbigkit-2.1-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 456145
+    checksum: sha256:7761a61c9cdaa019287d8daa7639d47e76f9ec1b177a50e94b46ceadf0c2cbfa
+    name: jbigkit
+    evr: 2.1-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/k/kernel-srpm-macros-1.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28536
+    checksum: sha256:6607ae4cf2e0ee6971a740ef64937853e4e636179822de40e709e8e3e0c7853b
+    name: kernel-srpm-macros
+    evr: 1.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/lame-3.100-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1537232
+    checksum: sha256:6e17b1767f6a8949f7ae4f549fbc4f93d4074072f3499a2346a2ce5f2b248d83
+    name: lame
+    evr: 3.100-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/langpacks-3.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28929
+    checksum: sha256:59d393e1505dc39e15cad9e0f0f54d5392f230aeaafadf4af09b31391ca573f4
+    name: langpacks
+    evr: 3.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/lcms2-2.12-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7428658
+    checksum: sha256:d0605c68533c1656eabe3d6d5a41b97513a9264030a28c46baad2cdcf57ec09c
+    name: lcms2
+    evr: 2.12-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libX11-1.7.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2436722
+    checksum: sha256:8720840bc38af119d62734144a5e8c95c1400ba42bd877e4279a786120d878d7
+    name: libX11
+    evr: 1.7.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXau-1.0.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335512
+    checksum: sha256:3a52f0d37183b84a7f8d37d6ca314ec17a32c1d4167c9131cf4000285d82c59a
+    name: libXau
+    evr: 1.0.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXcomposite-0.4.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 329141
+    checksum: sha256:10f74555246a4a992de429bf1139b762ca6b8d754d092a5eb85f0c55f576a9db
+    name: libXcomposite
+    evr: 0.4.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXcursor-1.2.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 347960
+    checksum: sha256:80bedd1206fa645654fbb6fd05fed788700ca3bf2cc0ade2408abc0a5802a801
+    name: libXcursor
+    evr: 1.2.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXdamage-1.1.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 315892
+    checksum: sha256:15c2c0d99190985a2a7d376b0cbb2d9f6172ebdcb1a3305ac0bbd7a394942e8c
+    name: libXdamage
+    evr: 1.1.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXext-1.3.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 401955
+    checksum: sha256:7f50b5d07f8e1782c4ad2c485416f210004db0477588465167c257aa62fd0b6c
+    name: libXext
+    evr: 1.3.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXfixes-5.0.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306511
+    checksum: sha256:3c8feb2710a52fe119d58369895cb2a17a10097a0a6b3a2bf469f0e34cf58db6
+    name: libXfixes
+    evr: 5.0.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXft-2.3.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 365800
+    checksum: sha256:b1ef5a942e759207022bf9bff3d122bc9596914d8dd7ab92ea56ebcad96ee9a6
+    name: libXft
+    evr: 2.3.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXi-1.7.10-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 498271
+    checksum: sha256:1de8a31cbe5edf8d10fe85fd96c1ebd1d0525c08a3ec75599ef12bad2945545c
+    name: libXi
+    evr: 1.7.10-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXinerama-1.1.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 297833
+    checksum: sha256:c9f68ea2938d52730688d24fc8b50f583193ab20ae158746e7751d8e092e92ed
+    name: libXinerama
+    evr: 1.1.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXrandr-1.5.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 343241
+    checksum: sha256:a565d64c7ff4b9c46cfc916097b1c8c9d886c006a7c18eac085f4ca6b4e8d310
+    name: libXrandr
+    evr: 1.5.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXrender-0.9.10-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:5fc0f3794b08cc71d89bf24c19a4a02c2d15c63850225327af9f20b45e1250e8
+    name: libXrender
+    evr: 0.9.10-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXtst-1.2.3-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 332563
+    checksum: sha256:59a99e7e1af8762969b9212aa5375be77a7bdafce73f416be82694b16ec388d5
+    name: libXtst
+    evr: 1.2.3-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXv-1.0.11-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 328666
+    checksum: sha256:fac6cc1bff31576443af0c71b3ffb1fbcd6e53b8fef38241ec0093cfba739c85
+    name: libXv
+    evr: 1.0.11-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libXxf86vm-1.1.4-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 305757
+    checksum: sha256:1e6c5a2d734c54d881523b50f1307ece5815574512fd7dedb10ee38282608532
+    name: libXxf86vm
+    evr: 1.1.4-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libappstream-glib-0.7.18-5.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2332780
+    checksum: sha256:a00834a072ed97371d8ffbccdbf5747d0d8e64ec2ae4e17f90d5c5e8bbdd22d8
+    name: libappstream-glib
+    evr: 0.7.18-5.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libasyncns-0.8-22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 351816
+    checksum: sha256:93c66acfdc39c88c4cced4056c53d2c637e667da2b09a8e9004f7c05bccb490e
+    name: libasyncns
+    evr: 0.8-22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libcanberra-0.30-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 336225
+    checksum: sha256:101d6e863d2b367a2d00cf29e75670c8190acfb8f19c0f31db66d4c5914f6ad6
+    name: libcanberra
+    evr: 0.30-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libdatrie-0.2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 325692
+    checksum: sha256:c9a3acd383ebb5f8d5d2c069dca717f147fddc461155cc12f07572972a82e7fe
+    name: libdatrie
+    evr: 0.2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libdrm-2.4.123-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 500530
+    checksum: sha256:8fd4b075f14ade405808c1ae309270aad50709f615bcd24d93aa39ae65e3a977
+    name: libdrm
+    evr: 2.4.123-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libepoxy-1.5.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 235419
+    checksum: sha256:53500b6a43fdf7e1a5083491d3ccdc808d2bec45a5559ff3eb9a14be798f8423
+    name: libepoxy
+    evr: 1.5.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libexif-0.6.22-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1123325
+    checksum: sha256:cbc3a148928165b570202330b52dd1baef75ff0b7479a0de16d7da0c252af8e3
+    name: libexif
+    evr: 0.6.22-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libfontenc-1.1.3-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 313939
+    checksum: sha256:d169ca46af1a05f9f96805cb39acc44e794688b240e835c400353fb8f9e6302b
+    name: libfontenc
+    evr: 1.1.3-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libgexiv2-0.12.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 393822
+    checksum: sha256:5cba4e86ba7149ed6b9d90bd53fda20a17227218563b0ffc08b6ef0efc953914
+    name: libgexiv2
+    evr: 0.12.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libglvnd-1.3.4-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1046031
+    checksum: sha256:dbb82468e248c1dcb455f14b6c03b2a2772233f0c6b9e542c703bb3e4b96cb90
+    name: libglvnd
+    evr: 1:1.3.4-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libgsf-1.14.47-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 705600
+    checksum: sha256:393825b1ac768befa5cf2d1678c872231ebb77ceabb8eca8934d44eacf4ff0ea
+    name: libgsf
+    evr: 1.14.47-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libgxps-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91543
+    checksum: sha256:8a21727bce320f7736ce43cc5ffeeff3d6babc299b23b665df6b8fd1b450c770
+    name: libgxps
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libijs-0.35-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 423495
+    checksum: sha256:50aa92a3658366bf48452eb29154886da20761e885d7f52c3770c0e36aa6c562
+    name: libijs
+    evr: 0.35-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libiptcdata-1.0.5-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 604357
+    checksum: sha256:182950ba5b02a71634571889e11e70b94b4c91da56fa1836cb77bc85e44b3720
+    name: libiptcdata
+    evr: 1.0.5-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libjpeg-turbo-2.0.90-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2271766
+    checksum: sha256:6766d34e67f5bbfd82c5d543596b46790a2d98c97c2a33b67781829cac86c705
+    name: libjpeg-turbo
+    evr: 2.0.90-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libldac-2.0.2.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 86540
+    checksum: sha256:28903f22a062d976f8ff02786c4006fea01c0de6b5702a511351a9180e82d68b
+    name: libldac
+    evr: 2.0.2.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 846236
+    checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
+    name: libmpc
+    evr: 1.2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 611553
+    checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
+    name: libnet
+    evr: 1.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libnotify-0.7.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 115322
+    checksum: sha256:ea8f8a235fb2feb6bf876c44024551e92c770f0d78b1f879485a5bcf5a6e964e
+    name: libnotify
+    evr: 0.7.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libogg-1.3.4-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 441193
+    checksum: sha256:5e218f83debe3dafbbe5795b0696d7ecb00b88b4c1c78bc4acb6e83b9cf9d56b
+    name: libogg
+    evr: 2:1.3.4-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libosinfo-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306786
+    checksum: sha256:2efb475aa7815e6f24efaa0ca26276785935ec611d9a13ff3ded1dcda59b5fae
+    name: libosinfo
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libpaper-1.1.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57233
+    checksum: sha256:1648c52d0e1f0e8e10101106eb7d95a4f069176846fee76b1f6c0a1904b0750f
+    name: libpaper
+    evr: 1.1.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/librsvg2-2.50.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22252235
+    checksum: sha256:5c0fdc6b36b2bb071c73d1181bd76ec6252b20b2ace475e86f0a69b27733f3a0
+    name: librsvg2
+    evr: 2.50.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libstemmer-0-18.585svn.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 142242
+    checksum: sha256:c21d9668bbfba8bcff8be8442c0dee31190efbcc362bd29e7e5e128869cb64f1
+    name: libstemmer
+    evr: 0-18.585svn.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libthai-0.1.28-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 426287
+    checksum: sha256:1bff93f9076778b16fea27d75a7434caf8e9fb5e9bcabbf2cf8f7f0069302d73
+    name: libthai
+    evr: 0.1.28-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libtheora-1.1.1-31.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1451614
+    checksum: sha256:c43318355a6c960e0685d789887cddf450fdfd7908ba1a02d375e1ff290b3483
+    name: libtheora
+    evr: 1:1.1.1-31.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libuv-1.42.0-2.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1300269
+    checksum: sha256:f9dfa0dc965675730184604570c6a2aa95ddc2dfa6a7cb209514b1e744a4e3d7
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libvorbis-1.3.7-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1216523
+    checksum: sha256:2c9f1a80c9f1b7c2d6872ef82bd385a68abb37be3ab8d3bfc26dcb6c7c5ef477
+    name: libvorbis
+    evr: 1:1.3.7-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libwebp-1.2.0-8.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4112860
+    checksum: sha256:34b9ace12d22dffba4277247a539bce83ccf6a517fd2ac3f603bd092a90e23fa
+    name: libwebp
+    evr: 1.2.0-8.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libxcb-1.13.1-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 519787
+    checksum: sha256:6e79beeac5762cb0f4eca5a4e09aaf9f607b8d54a8154e68a672c4d42e5a617b
+    name: libxcb
+    evr: 1.13.1-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libxkbcommon-1.0.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 446799
+    checksum: sha256:47b1254e062547a0e553b4e072498a91bf3c7364c8499c15a2762858197c50de
+    name: libxkbcommon
+    evr: 1.0.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libxshmfence-1.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 319069
+    checksum: sha256:9a36c33eafdf600040cb41cc1d8ca40395a3e00f2fd6a41a28ad66644d90edaa
+    name: libxshmfence
+    evr: 1.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/llvm-19.1.7-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141371853
+    checksum: sha256:2da62e4083e0f9ff5ca3d5ffc794682ff16004b2f0b38b4a103e34d18dbd322e
+    name: llvm
+    evr: 19.1.7-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/low-memory-monitor-2.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34855
+    checksum: sha256:ddbf37a31d785971549ab83b2f554c112bf1cefc10ca2b36326e8367e04a68c2
+    name: low-memory-monitor
+    evr: 2.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/lua-posix-35.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 193080
+    checksum: sha256:dba43478e632a56d95cdbbda1fba2e4c1e626126902cfe5ae9985f088928e431
+    name: lua-posix
+    evr: 35.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/lua-rpm-macros-1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12116
+    checksum: sha256:19fdee3aa469d583a7f48dce71513da47c5046018bc35bfbe57c818b7aae21d0
+    name: lua-rpm-macros
+    evr: 1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/m/m4-1.4.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1669463
+    checksum: sha256:c4098a14fdf286cce1c9981dcfbc9d2eefac08e2e80f68ac28b478e0d52ff837
+    name: m4
+    evr: 1.4.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/m/mkfontscale-1.2.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 161434
+    checksum: sha256:c517dd47af14b3a01e0abd6865252f0ed12f9f7041c909de43b37969d5a9e328
+    name: mkfontscale
+    evr: 1.2.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/m/mpg123-1.32.9-1.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1128174
+    checksum: sha256:b337b1eefaaa639a90ec349daa719d1c49222a31410eb1329299de16d1f37d4b
+    name: mpg123
+    evr: 1.32.9-1.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/ocaml-srpm-macros-6-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10233
+    checksum: sha256:198f33946c3b1c1e104109073449ac03fd59035e6c3f646ad847626aa646e336
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/openblas-0.3.26-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23507999
+    checksum: sha256:152ab881d01425b6b7e2b2ebecf419498b5c1ae4c673f450e1d63439ec8f923f
+    name: openblas
+    evr: 0.3.26-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/openblas-srpm-macros-2-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 9345
+    checksum: sha256:fe7a59edc21a63ddabfc48585a536d7c97dbcf27d46fa1e8b723df87a3c76bb3
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/openjpeg2-2.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2248257
+    checksum: sha256:d139d8a3730303ad1189b8a6949f43e2bde066d39c2d6e4ddce752c728c6a379
+    name: openjpeg2
+    evr: 2.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/opus-1.3.1-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1538330
+    checksum: sha256:f2f586f32a461d05e0c09a496a4b1cbf29e330967a68641deba1f7f9d4767962
+    name: opus
+    evr: 1.3.1-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/orc-0.4.31-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 192280
+    checksum: sha256:349e1f558859f7733899de6b5c43a975c730853869689914bd518153094c56bb
+    name: orc
+    evr: 0.4.31-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/osinfo-db-20250124-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 176763
+    checksum: sha256:8dee9b4e27b489e6808635f6fb9edaaea6900e4e09e3b4cfb6ef20e7f98e6937
+    name: osinfo-db
+    evr: 20250124-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/osinfo-db-tools-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 71184
+    checksum: sha256:2bd22032e8b549b1009783e61381ae8700f26556934ef93200cf441f717902fc
+    name: osinfo-db-tools
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/pango-1.48.7-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2073489
+    checksum: sha256:4efddadb4bf304a47e2cce96d6d63d1643f5bdcb06dace3c04f8d37410f8bc22
+    name: pango
+    evr: 1.48.7-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12786537
+    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43626
+    checksum: sha256:5bdfea020bfb4ee04c5fd3a5552724f21af7df49d8bf9b774060f1dd47c6b972
+    name: perl-Algorithm-Diff
+    evr: 1.2010-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Archive-Tar-2.38-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 79758
+    checksum: sha256:c543a9be1a2e718e3fa282b16fc058a4e3e3c21d75513591ed170a63c9944e37
+    name: perl-Archive-Tar
+    evr: 2.38-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Archive-Zip-1.68-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 177506
+    checksum: sha256:0bc6505ab7fe87129f423e887a65153d015c38ddc68115ccf2149ebff5db92e1
+    name: perl-Archive-Zip
+    evr: 1.68-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-CPAN-2.29-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 913914
+    checksum: sha256:ce91adec7194b6d7b65079f712418469db4b4d657251ddcf6643299b232644a1
+    name: perl-CPAN
+    evr: 2.29-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26900
+    checksum: sha256:2dde7ae0e396bf60d579f1c711a0ce6845c5a6dc8a3069fc125e64709c03e764
+    name: perl-CPAN-DistnameInfo
+    evr: 0.12-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-2.150010-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 129946
+    checksum: sha256:b93a6beedf64a4270dc4281fd9ea6fc5fabc08511bfd7ec95582bdcd5a3f50f3
+    name: perl-CPAN-Meta
+    evr: 2.150010-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45057
+    checksum: sha256:cae76684fe68e4ef068523036a12aa65aa9ff697908aa448af0b5842507c8f11
+    name: perl-CPAN-Meta-Requirements
+    evr: 2.140-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 63081
+    checksum: sha256:b0ae0d2859a6dbf7cd77de0e547370f85489f617319d8f55eb3b3533c22ea943
+    name: perl-CPAN-Meta-YAML
+    evr: 0.018-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Compress-Bzip2-2.28-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 908406
+    checksum: sha256:fd5ed562b1231e74f8dd6856e8b4494872a1afc84a11dc4b26eb3f59193cf78f
+    name: perl-Compress-Bzip2
+    evr: 2.28-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 154607
+    checksum: sha256:06e2c818ae4ac7823ae67869037edb071cedb745bce8e010a268d1850999ac38
+    name: perl-Compress-Raw-Bzip2
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133511
+    checksum: sha256:e73434426813ed9db9b82bdd301f4d0717b613fc8db3ff48e2e198d3b1e20fad
+    name: perl-Compress-Raw-Lzma
+    evr: 2.101-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 271620
+    checksum: sha256:f815738f7e64cb1912a188a57f32b9e3416192bdc2c80a61308cf668a0cb6ba9
+    name: perl-Compress-Raw-Zlib
+    evr: 2.101-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Config-Perl-V-0.33-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35359
+    checksum: sha256:77f7dbd94351b5cbe86859d557eb08525cb50bad76a344c7e4f5b16decb97be1
+    name: perl-Config-Perl-V
+    evr: 0.33-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-DB_File-1.855-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 158812
+    checksum: sha256:b0db40023b1387c9e1cb5f4a28914e4e7426e112132fd9e03a21a78c08a91bd9
+    name: perl-DB_File
+    evr: 1.855-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-OptList-0.110-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 31802
+    checksum: sha256:e2b75b4859a73491af1aa145027a54aeda204f31508f98c264ec719f0759fef0
+    name: perl-Data-OptList
+    evr: 0.110-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-Section-0.200007-14.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35026
+    checksum: sha256:29b50e2e9fcfd3ef490fde575e5651dd185d7bc10f62c97b2d7b6b525ecdd746
+    name: perl-Data-Section
+    evr: 0.200007-14.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Devel-PPPort-3.62-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 469970
+    checksum: sha256:1c4181c874720056a80d1ee015196f36ceef296709fe93d5d2b5282d6b90f80f
+    name: perl-Devel-PPPort
+    evr: 3.62-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Devel-Size-0.83-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 88128
+    checksum: sha256:5d65648105f4b21ba27f516113c995f25d19df091820d1fe6e99d72a6e89783c
+    name: perl-Devel-Size
+    evr: 0.83-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-SHA-6.02-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60965
+    checksum: sha256:6223e7b6ee3e168987685a0432eb30908b88a4e33503c4f71ffd1f4202be64d5
+    name: perl-Digest-SHA
+    evr: 1:6.02-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-SHA1-2.13-34.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51532
+    checksum: sha256:24cb3be49a88473ca75fb773cca161a32a081afb243cd8b737aa7d3b6399a7f0
+    name: perl-Digest-SHA1
+    evr: 2.13-34.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Encode-Locale-1.05-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19941
+    checksum: sha256:4c7446c8690a0dc5a7e80a703ab32be8d7f8819493aec5e15a9468e5972f9070
+    name: perl-Encode-Locale
+    evr: 1.05-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Env-1.04-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22963
+    checksum: sha256:f7872c1ec5309090bab03ab984ef49e7ab108f6e7f7a7acddc718e67847f2489
+    name: perl-Env
+    evr: 1.04-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54700
+    checksum: sha256:c4825f03bd2f125d4a7b9c361fdbae58e3eb888b40792d6ca740d4c9796529a3
+    name: perl-ExtUtils-CBuilder
+    evr: 1:0.280236-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Install-2.20-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52908
+    checksum: sha256:a5a00213a6c11ebfe564f890525323981c10bb990ce06a1ad05163ccce239a54
+    name: perl-ExtUtils-Install
+    evr: 2.20-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 504754
+    checksum: sha256:8f17335d16783c182512dfc1af5cd8a762b41944f024f456849f2dd475ad2648
+    name: perl-ExtUtils-MakeMaker
+    evr: 2:7.60-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 51571
+    checksum: sha256:db9319ce19481088c58205d252bc03fc816711399ac54b9cb90a0f12cc7a24c4
+    name: perl-ExtUtils-Manifest
+    evr: 1:1.73-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 138437
+    checksum: sha256:aaa28538e07c7df4eb6e0d3ca1aa6d2806f7977116839c0605bf49962332e16b
+    name: perl-ExtUtils-ParseXS
+    evr: 1:3.40-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Fetch-1.00-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32628
+    checksum: sha256:ee5ddafaff74bc4cbaafb81de847a4e5fcafe7d55ea39a3aad8acce1d3cfd9a2
+    name: perl-File-Fetch
+    evr: 1.00-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-File-HomeDir-1.006-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 48314
+    checksum: sha256:9324fc77f0cae4a487865f7168e58fefaf2a45dd44d5acb0c0ffd607bc79e972
+    name: perl-File-HomeDir
+    evr: 1.006-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Which-1.23-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35149
+    checksum: sha256:fd089f060aea15adcd7fe380a388fa8feb40daa0820b3d50dd20616c56bd6c68
+    name: perl-File-Which
+    evr: 1.23-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Filter-1.60-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 108315
+    checksum: sha256:a9b8bb8bef551453366fab1f66883904c8ba996926d906fd32b759880a588dad
+    name: perl-Filter
+    evr: 2:1.60-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Filter-Simple-0.96-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32804
+    checksum: sha256:a070b22cd4c09d06fa4078588f0a2a8735490defc6a93ebea7599ae5ee1ee557
+    name: perl-Filter-Simple
+    evr: 0.96-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Compress-2.102-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 311395
+    checksum: sha256:6a4d183d03c58572ad99c44427d4f80174a74e88f82e815ef9b68ee367949414
+    name: perl-IO-Compress
+    evr: 2.102-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 117388
+    checksum: sha256:b98fc6c2bba6a5310eeea99c39c4eb4b4c9c5f6f115c1ca391ff9f983b3603b6
+    name: perl-IO-Compress-Lzma
+    evr: 2.101-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Zlib-1.11-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22007
+    checksum: sha256:e83d2fcd26cbbac178ae8a77d75bb1e35ae697a0a1ebd9838787b0e7355b476f
+    name: perl-IO-Zlib
+    evr: 1:1.11-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IPC-Cmd-1.04-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45145
+    checksum: sha256:d36b285269c9f8f186899296e922527b0d5efedae08d8ecef5e928369f344f04
+    name: perl-IPC-Cmd
+    evr: 2:1.04-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IPC-SysV-2.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 80187
+    checksum: sha256:f3d99435bdc3bb3066a79ccf7e0e15b91ce2503a7ef2ef8a228238e03fd41b09
+    name: perl-IPC-SysV
+    evr: 2.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-IPC-System-Simple-1.30-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46334
+    checksum: sha256:13c06559e1d68b47019a9e4ae4387d5962f0dd85a6ee77f2ed23ebcea92a7990
+    name: perl-IPC-System-Simple
+    evr: 1.30-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Importer-0.026-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52799
+    checksum: sha256:52f89eb0a2d5f0a6a668679aa2d9adb4fb92e35fdd06e87d0b9d169d43d2e7ce
+    name: perl-Importer
+    evr: 0.026-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-JSON-PP-4.06-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 66646
+    checksum: sha256:25990b7a748140b948e4ad9a6aad236f7c82dc7a5c6eab6c2fb370de45d582d5
+    name: perl-JSON-PP
+    evr: 1:4.06-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Locale-Maketext-1.29-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68578
+    checksum: sha256:eb34611f4a8b295e9ba09f63b102db48b152e4915f90d9a9c33dba6e3331b3ed
+    name: perl-Locale-Maketext
+    evr: 1.29-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-MIME-Charset-1.012.2-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68860
+    checksum: sha256:375a66d8aadbde800a204d0681df4b0146dbd2cbcca577762162708d772095f4
+    name: perl-MIME-Charset
+    evr: 1.012.2-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-MRO-Compat-0.13-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 21684
+    checksum: sha256:145780b93fce797e44ceb5911d79d150830ef976551d2a2dea4a64368002cd59
+    name: perl-MRO-Compat
+    evr: 0.13-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3013100
+    checksum: sha256:6dc7b0f22726602de1368de52d7f4eae6c5144971ba6bf9dd6fe17a293f8da6d
+    name: perl-Math-BigInt
+    evr: 1:1.9998.18-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2419116
+    checksum: sha256:b1221f5ccb5a07e8f87ba1397e17eea89ae9d9e152a724feb666985e76738e45
+    name: perl-Math-BigInt-FastCalc
+    evr: 0.500.900-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Math-BigRat-0.2614-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62659
+    checksum: sha256:9e90c3abafc7b3b556ba1e1054834d95c79b698d4d72d31ad0d846ce9f8ba166
+    name: perl-Math-BigRat
+    evr: 0.2614-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Module-Build-0.42.31-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 321930
+    checksum: sha256:203f542dbb18437a7d0f30cfc819eb2b719f191b3a4e2b0456f20a291f68a0da
+    name: perl-Module-Build
+    evr: 2:0.42.31-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Module-CoreList-5.20240609-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 139931
+    checksum: sha256:f40d3b1814a4a9d35a071732892b188cfe5ca7546f477944fb54b8ddc19676a5
+    name: perl-Module-CoreList
+    evr: 1:5.20240609-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Module-Load-0.36-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 20494
+    checksum: sha256:d48889d7e5f4606b8de8d7886988274da466b047cb2434dc91bfe4d4339d1e24
+    name: perl-Module-Load
+    evr: 1:0.36-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 26054
+    checksum: sha256:69741f661710264f9aa8d97cdbde828b80323503bfa7da5c91330987a00d89ba
+    name: perl-Module-Load-Conditional
+    evr: 0.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Module-Metadata-1.000037-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 65016
+    checksum: sha256:f3816981e19fb56a34bf13f1e288c01ef18613693bae505aa5ee0dc372d7aad1
+    name: perl-Module-Metadata
+    evr: 1.000037-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Module-Signature-0.88-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 113588
+    checksum: sha256:2777705793dd0cf55ac736f06632c02a93c47e5ef38c5eb0cd7603c3f2c76ec1
+    name: perl-Module-Signature
+    evr: 0.88-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-Ping-2.74-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 70563
+    checksum: sha256:e4a27ae525d6bf274e4f1612f3c5dc81e4557467bda40bd63ce8e5723e00a8cb
+    name: perl-Net-Ping
+    evr: 2.74-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Object-HashBase-0.009-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32480
+    checksum: sha256:5e8e5fb82b0a685c85f86490924ea1e0e3ac6364b07f43e087175d3f587c0e64
+    name: perl-Object-HashBase
+    evr: 0.009-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Package-Generator-1.106-23.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 29367
+    checksum: sha256:6a5be4bb4322abe97c45c84cb26368b594b9d90a7e66d4841b74d179ecd72c9a
+    name: perl-Package-Generator
+    evr: 1.106-23.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Params-Check-0.38-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23416
+    checksum: sha256:aa052e7b8c96f6c4610ab34686928f0f7adbb41044e29378620e3d5e827cce76
+    name: perl-Params-Check
+    evr: 1:0.38-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Params-Util-1.102-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 207956
+    checksum: sha256:a7eb296be9dc11401756128d84ae57a6e2e98fd0231cb5a52d7e86d42153ee56
+    name: perl-Params-Util
+    evr: 1.102-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Perl-OSType-1.010-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32465
+    checksum: sha256:dd1ff7c7ef5ad251b1af9029f0555b4d21f3d96dd589ebb0d5989bd185f9abed
+    name: perl-Perl-OSType
+    evr: 1.010-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24579
+    checksum: sha256:d06492c280011cd128a3e84fe071584470de288053375da173a6304ebafc0e87
+    name: perl-PerlIO-via-QuotedPrint
+    evr: 0.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Checker-1.74-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35413
+    checksum: sha256:ce262ff36c0f737cd181b4e8974ded778cffcc6a6ca949b98b716e2a822b41fe
+    name: perl-Pod-Checker
+    evr: 4:1.74-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Software-License-0.103014-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 135074
+    checksum: sha256:27c65fae4f13a24c6e3634b70f39b439bf5b90b8892b2987d4498dbb4ba2780f
+    name: perl-Software-License
+    evr: 0.103014-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Sub-Exporter-0.987-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 59528
+    checksum: sha256:a552bfe187044ae29d0dc667e6e0a29c6340bf308d32d4b0c902f19d124e2c39
+    name: perl-Sub-Exporter
+    evr: 0.987-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Sub-Install-0.928-28.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30662
+    checksum: sha256:224662bdabe9c803615622a3adcb891165ddcdc3eb58aedfed1789576f9048f1
+    name: perl-Sub-Install
+    evr: 0.928-28.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Sys-Syslog-0.36-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 97885
+    checksum: sha256:8f3db804c924748fc7f7f3a10e093bd1195661657a404ab102a9c1fbb8fe5cb4
+    name: perl-Sys-Syslog
+    evr: 0.36-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Size-Any-0.002-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 15436
+    checksum: sha256:f9aa001a28f500b09632dc321a4b46780f0cd02aa02ac8de8529684960fea05f
+    name: perl-Term-Size-Any
+    evr: 0.002-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Size-Perl-0.031-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24324
+    checksum: sha256:c0283217d4d0998f3c2b24f42d956de7bc0c0c41478f40bdf6ef868748e003ec
+    name: perl-Term-Size-Perl
+    evr: 0.031-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Table-0.015-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 42326
+    checksum: sha256:a51423376f857f9720d3ad0e706db782758ac19bc3a28a0feaba80442ea7bd81
+    name: perl-Term-Table
+    evr: 0.015-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 98184
+    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Test-Harness-3.42-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 226770
+    checksum: sha256:9c62f68a4bb3b0c1e6fbdfbbf2a840e50d93e1f6e0f8936931153725e0593c53
+    name: perl-Test-Harness
+    evr: 1:3.42-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Test-Simple-1.302183-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 355537
+    checksum: sha256:9b4b7c9a1a8723a1d4c1c353060ddb7f57e48343552506af10066d9ebaed37e6
+    name: perl-Test-Simple
+    evr: 3:1.302183-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Balanced-2.04-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 52612
+    checksum: sha256:41dca789e663140111944d257574c4eaa74b66d6169f256a9ffe407fa8070d27
+    name: perl-Text-Balanced
+    evr: 2.04-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Diff-1.45-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 41875
+    checksum: sha256:df1478044a0c7fb575b1324c0e9311a51e883ca61ff39952d0042ee1b2eb5fd1
+    name: perl-Text-Diff
+    evr: 1.45-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Glob-0.11-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 16200
+    checksum: sha256:9aa6c8502f05a42e5048063c2aff09e15cf8a44f6d00b3f8f154e58f051ff4cc
+    name: perl-Text-Glob
+    evr: 0.11-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Template-1.59-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 62651
+    checksum: sha256:71bd67c547eec1d910a9c549be0ed7959a0f8e52a09e37d000a76bab1fd73cd3
+    name: perl-Text-Template
+    evr: 1.59-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Unidecode-1.30-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 146381
+    checksum: sha256:8aa240add109758d1549e9fda86ea601bdde3a2f3b0afdc62f097859648145e6
+    name: perl-Text-Unidecode
+    evr: 1.30-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Thread-Queue-3.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 27710
+    checksum: sha256:d844642772b9a505fc9bd5aaf94b597f1cf66ba2a890462f33f0fa226ccde79b
+    name: perl-Thread-Queue
+    evr: 3.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Tie-RefHash-1.40-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43611
+    checksum: sha256:d21a4a6ac093c7622f28c5ac2bd6aa7fae86c5b4c150249d9ca696b5461f3f6a
+    name: perl-Tie-RefHash
+    evr: 1.40-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Time-HiRes-1.9764-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 124567
+    checksum: sha256:c9e00767aec7da2661ca2785530bc7f35c120e7411cfcd6889437c20add7ade1
+    name: perl-Time-HiRes
+    evr: 4:1.9764-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Unicode-Collate-1.29-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 915935
+    checksum: sha256:9f5cd2c294c8f4383e9d6d8ea9b7e2c2a1e913c5a27d39e041885548a570dff4
+    name: perl-Unicode-Collate
+    evr: 1.29-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 320828
+    checksum: sha256:52d4dd85581dfa68c432cab3bde847ee4f62285bbc18ee04fdd5fc5e87dd9a2d
+    name: perl-Unicode-LineBreak
+    evr: 2019.001-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-Unicode-Normalize-1.27-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55458
+    checksum: sha256:514286df911a40dad2269810466a25279f07d2efab97db7479de337cfcedd971
+    name: perl-Unicode-Normalize
+    evr: 1.27-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-XML-XPath-1.44-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 68741
+    checksum: sha256:3484e0703eb0b88f31533dcc9f0f4ce2c4d1c0fd827f206de4c44038db541680
+    name: perl-XML-XPath
+    evr: 1.44-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-autodie-2.34-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 106197
+    checksum: sha256:82f0f75aaf2ac269983fc0c5a4a8c436e0382963ea15dd3e6b1b983865a6ae9b
+    name: perl-autodie
+    evr: 2.34-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-bignum-0.51-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 40019
+    checksum: sha256:065483710b985ef93e23a0a9d69826d777ac3b3580429b011ecc1db4b03f6f8d
+    name: perl-bignum
+    evr: 0.51-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-experimental-0.022-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 24159
+    checksum: sha256:72d8e178ae3d2c2607e9ac4875957f841af9511398ddf07279b5e02a0e38034c
+    name: perl-experimental
+    evr: 0.022-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-inc-latest-0.500-20.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28925
+    checksum: sha256:3ac7d9dbcf90cfa75334d84853688e714b67a2982e4c9a33afac0ea4f79b1fb4
+    name: perl-inc-latest
+    evr: 2:0.500-20.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-local-lib-2.000024-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 78260
+    checksum: sha256:4f60f5abc65be4e926262251a0a8d6ed0a86ac650dba678411b148c6a4ea34fd
+    name: perl-local-lib
+    evr: 2.000024-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-perlfaq-5.20210520-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 212379
+    checksum: sha256:9d33eccd67de62a9793105ef005f4865af5d931471697c9aaf4fd6e2f3da3a16
+    name: perl-perlfaq
+    evr: 5.20210520-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-srpm-macros-1-41.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10651
+    checksum: sha256:05990bf148e58515223b0936ee7b621e5d39bb875e2481a4d84522bd4b57d4e3
+    name: perl-srpm-macros
+    evr: 1-41.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-threads-2.25-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130514
+    checksum: sha256:92008f60b397b2e4380eddfe58aa788f78245a8fc44352d68bfa324fbec46655
+    name: perl-threads
+    evr: 1:2.25-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-threads-shared-1.61-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 119822
+    checksum: sha256:1b348ea3a479412c1236b95dc2d5d651a42e1c144626c38b8c08ef190b0c137b
+    name: perl-threads-shared
+    evr: 1.61-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-version-0.99.28-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 180220
+    checksum: sha256:123e4f54296116246dfd22b4c6628fab4537c62c8a95394194085e6f60b3763c
+    name: perl-version
+    evr: 7:0.99.28-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/pipewire-1.0.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2262481
+    checksum: sha256:9f0d3774bea6361293c6f949dca5e45ffae541e4dc24e5f2dac78d2d246008a5
+    name: pipewire
+    evr: 1.0.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/pixman-0.40.0-6.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 647633
+    checksum: sha256:0bd62940984b88bfd5914463d948999e29665450e6850ad5c9c4fbc129f3c3d0
+    name: pixman
+    evr: 0.40.0-6.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/poppler-data-0.4.9-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4130057
+    checksum: sha256:10a56ad2ab5d77157377805fc1481f40f5ccfb069fd34ec4bcf14e2a8ac309fe
+    name: poppler-data
+    evr: 0.4.9-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/pulseaudio-15.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1546014
+    checksum: sha256:01a1e060c7b753b68277a6274f0e16e438c75efd7add7d7aeb759721dde58f3a
+    name: pulseaudio
+    evr: 15.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 289973
+    checksum: sha256:cb7775937762f5ab13165854b5fab8d1e1ea8003451ccb02faaf60b4590c1949
+    name: pyproject-rpm-macros
+    evr: 1.16.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/python-rpm-macros-3.9-54.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32761
+    checksum: sha256:b48fc9a942da394ad4cefd19dd2ebf4c5839d0267a41c797fb04dc6173b5f296
+    name: python-rpm-macros
+    evr: 3.9-54.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/q/qt5-5.15.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 13771
+    checksum: sha256:149c54e64307cb3da96287a068f09c4ea5d3968bf2ba088383069f294695cc6d
+    name: qt5
+    evr: 5.15.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/r/redhat-rpm-config-209-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 96708
+    checksum: sha256:a6f4aa2f37f5c6205cca36ea99c640c6509587aa29732a3e145d7c3af304868f
+    name: redhat-rpm-config
+    evr: 209-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/r/rtkit-0.11-29.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 152904
+    checksum: sha256:c726c0b22b16017bf014107a15f313b18cdc0f09d9257822b027d1adc5bd47a8
+    name: rtkit
+    evr: 0.11-29.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/r/rust-srpm-macros-17-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35132
+    checksum: sha256:dfb94bc23f8c1be02f7d94e4b6d6dc05e98c7d4a162f5ef64f407bf6af738d42
+    name: rust-srpm-macros
+    evr: 17-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/sbc-1.4-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 261568
+    checksum: sha256:b4dbb3348492acf470f5d483cac09ec790c83270176a4d370e9ee6f40d785746
+    name: sbc
+    evr: 1.4-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/sgml-common-0.6.3-58.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 111961
+    checksum: sha256:ca6fe92503402d24ebc976123288ec2169e75632bd63dd1c146e8d310eb5ee01
+    name: sgml-common
+    evr: 0.6.3-58.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 76240
+    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/sombok-2.4.0-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318398
+    checksum: sha256:5f192b4d26bb9550982e644248f675017ec3d85af2fc721c6509c329c6e1c2bc
+    name: sombok
+    evr: 2.4.0-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/sound-theme-freedesktop-0.8-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 488981
+    checksum: sha256:de474e09a97c0b6cbb54262b9d02f889ba350be1298285d732b06814375a068c
+    name: sound-theme-freedesktop
+    evr: 0.8-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/t/teckit-2.5.9-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1956688
+    checksum: sha256:57dab9e5aa55d6b2b558e4ef6efda7638176df62ee309d50ef979baa3a8efa3a
+    name: teckit
+    evr: 2.5.9-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/t/texlive-20200406-26.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 572348942
+    checksum: sha256:fc8a1cd1b58bfaf6f01d981027490920718905a722c7c988be4be28faf2b78fb
+    name: texlive
+    evr: 9:20200406-26.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/t/totem-pl-parser-3.26.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1517364
+    checksum: sha256:3fb99db442bf7988c725139716f102830efb05d559343b387d53fd98af029c9b
+    name: totem-pl-parser
+    evr: 3.26.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/t/tracker-3.1.2-3.el9_1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1474282
+    checksum: sha256:ae1dcc262f916002818ec6f6a54413e18ac570c536e299496aed99fd997fae74
+    name: tracker
+    evr: 3.1.2-3.el9_1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/t/tracker-miners-3.1.2-4.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 4117590
+    checksum: sha256:80cad05049d22e5b7083be12d098f4add783886eff898c84547f89b1149ebff1
+    name: tracker-miners
+    evr: 3.1.2-4.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/t/ttmkfdir-3.0.9-65.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46879
+    checksum: sha256:e4d67a93e5605b5e8b4d0e0c8e5242b9137230b95ba5045c97815c216cfe1d71
+    name: ttmkfdir
+    evr: 3.0.9-65.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/u/unixODBC-2.3.9-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1693729
+    checksum: sha256:0f7bb1708709236922246be96a3cba788d404fbc3a58d4e2a4df8ddc8fc55313
+    name: unixODBC
+    evr: 2.3.9-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/u/upower-0.99.13-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 464654
+    checksum: sha256:6612bb4ed90e1d08b549615bdee8b36e5e7f46bf7e96d68c2af521a3f30097da
+    name: upower
+    evr: 0.99.13-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/u/urw-base35-fonts-20200910-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 14393016
+    checksum: sha256:e47a39ecac5571addb3b1fc5c57c2cea8d999977eb3f8c29e9921ac29528a9c8
+    name: urw-base35-fonts
+    evr: 20200910-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/w/wayland-1.21.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 239785
+    checksum: sha256:f26f7fc3c60e1c5fe67abd6b6a0c26bb435e869f8451f092805eafe440b23172
+    name: wayland
+    evr: 1.21.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/w/webrtc-audio-processing-0.3.1-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 710526
+    checksum: sha256:70255f0b9784ad78d52f1f25e6e3bf683a1be9727a884760b7d6d9e6ac18b4ea
+    name: webrtc-audio-processing
+    evr: 0.3.1-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/w/wireplumber-0.4.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 335147
+    checksum: sha256:efe9ba84e0851cf8cb2e2bf7b75d83b490182f0c55c6268923bc227e81c1bf67
+    name: wireplumber
+    evr: 0.4.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/x/xdg-dbus-proxy-0.1.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 130185
+    checksum: sha256:18118ab2f72bb339fd444fceb08acd571a92ef478e8a0417c01aa080b4867c54
+    name: xdg-dbus-proxy
+    evr: 0.1.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-1.12.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 508933
+    checksum: sha256:2d5826de57e8bd5da82557abfd69d274f006c7055b32058a7d2d6cf64405964c
+    name: xdg-desktop-portal
+    evr: 1.12.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/x/xdg-desktop-portal-gtk-1.12.0-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 388924
+    checksum: sha256:5779bc5047853ae2f09723fb92994841f7f54608bf734abecae20b68dbb650da
+    name: xdg-desktop-portal-gtk
+    evr: 1.12.0-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/x/xkeyboard-config-2.33-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1768610
+    checksum: sha256:fc472164cec4c2e4794081a476f00448bc8defadb7a863d079d4a782ba1f23c7
+    name: xkeyboard-config
+    evr: 2.33-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/x/xorg-x11-fonts-7.5-33.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 11582295
+    checksum: sha256:a9b2eceddc29f02bf49d3d4dee6d564d6b5a4b0f397190090f41a8426b1402ad
+    name: xorg-x11-fonts
+    evr: 7.5-33.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 101373
+    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
+    name: yajl
+    evr: 2.1.0-25.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/z/zziplib-0.13.71-11.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1157547
+    checksum: sha256:2ffa5b060b58d204e6686c07461c594d2f1cf1bdaf8e4a7d9309f9aa982484e3
+    name: zziplib
+    evr: 0.13.71-11.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/a/acl-2.3.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 535332
+    checksum: sha256:cb449bc6c85e0b50fa0bb98c969ff8481fee40517d8ebec5e28b72e5360fbe1e
+    name: acl
+    evr: 2.3.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8251850
+    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 482234
+    checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
+    name: attr
+    evr: 2.5.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1262288
+    checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
+    name: audit
+    evr: 3.1.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/a/avahi-0.8-22.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1629705
+    checksum: sha256:8e0cd07caf638b2d935ecc76fecc8d77adf5e399dbfb48958eacacb395b013d9
+    name: avahi
+    evr: 0.8-22.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/basesystem-11-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9884
+    checksum: sha256:5a4ed0779fc06f08115d6e06aa95486f1e1e251f8f9ddb6c7e14e811bb2e24ef
+    name: basesystem
+    evr: 11-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/bash-5.1.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 10512850
+    checksum: sha256:5d7bbbf2538361be1a11846602862c3a56809b3ea43b69b86bcf407538e9e260
+    name: bash
+    evr: 5.1.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/bash-completion-2.11-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 323037
+    checksum: sha256:e1da4ec276292a64279e9a62ae93a98295fb7be131618cc6ca48b053d0da8ca9
+    name: bash-completion
+    evr: 1:2.11-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/bluez-5.72-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2416940
+    checksum: sha256:5283227c6c84280f4956d9092d71d82f78176ff599adcf4be7d106387858a47b
+    name: bluez
+    evr: 5.72-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/bubblewrap-0.4.1-8.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 230660
+    checksum: sha256:0766cbd8405dd66aa93e316760405c0cdfb8b64f2a0e406fef915d3f51262a50
+    name: bubblewrap
+    evr: 0.4.1-8.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 824335
+    checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 711648
+    checksum: sha256:d3193e155ddd297042a944729fe54c1b90c17bdbd1876fc68e4f66d7857f9e81
+    name: ca-certificates
+    evr: 2025.2.80_v9.0.305-91.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/chkconfig-1.24-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 214658
+    checksum: sha256:b2618b278f5c8d6dacfae790c8c73b1fc1578b8f64011f325ced5a4a2e3b58bc
+    name: chkconfig
+    evr: 1.24-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/coreutils-8.32-39.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5692590
+    checksum: sha256:f042749974d210ad9049ffcb68172e4eaf91e3c0c249b33620e1f94effe82e6d
+    name: coreutils
+    evr: 8.32-39.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/cpio-2.13-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1395694
+    checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
+    name: cpio
+    evr: 2.13-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-27.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6414228
+    checksum: sha256:56a815a100d75c1d42c07090b632f05e51ea6d17df097d2936ab25d9aca49310
+    name: cracklib
+    evr: 2.9.6-27.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/crypto-policies-20250128-1.git5269e22.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 102787
+    checksum: sha256:0f6081ad96e9d7cb80aa18736e3a06bbf7d2c19bdc0f95a707a4f3ed0926b878
+    name: crypto-policies
+    evr: 20250128-1.git5269e22.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11657571
+    checksum: sha256:0a8b07dac531288c2fb1987106664a4e762e1b985c8851d577aa8aac60636a06
+    name: cryptsetup
+    evr: 2.7.2-3.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/cups-2.3.3op2-33.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8125712
+    checksum: sha256:d47b1ed7a8374a9881475617f7d1779e73960fbdc5a1402fd1327a144de06136
+    name: cups
+    evr: 1:2.3.3op2-33.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4030574
+    checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
+    name: cyrus-sasl
+    evr: 2.1.27-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/d/dbus-1.12.20-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2143916
+    checksum: sha256:3fe74a2b4fb4485c93e974010d9376e30a63dfcc628bfd6c01837c27b4953912
+    name: dbus
+    evr: 1:1.12.20-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/d/dbus-broker-28-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 254475
+    checksum: sha256:aced3097fbb8a424ca1816b8cb3e79960a9ccf7ba139538282886e692c317b29
+    name: dbus-broker
+    evr: 28-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/d/dejavu-fonts-2.37-18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 13631421
+    checksum: sha256:4a325b197556c40187c2785302ede62d3e4cf300984ad6b8cf57e7a4974246aa
+    name: dejavu-fonts
+    evr: 2.37-18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7418303
+    checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/e/efi-rpm-macros-6-2.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 26255
+    checksum: sha256:a8fc8e505e79f9a3f2cead3e4705f08469195659f4761889e6011ecac6c75610
+    name: efi-rpm-macros
+    evr: 6-2.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.192-6.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11944670
+    checksum: sha256:afe7c9bef952ed086637fe83ac77bfafa70bf2ba28c1d7aaa51a18c9a75146b6
+    name: elfutils
+    evr: 0.192-6.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1003666
+    checksum: sha256:e8261cbcd55b85efdcd12ce1a2c6e63a72c64c872d618de4ba24557a1fda63c0
+    name: file
+    evr: 5.39-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/filesystem-3.16-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 20486
+    checksum: sha256:c795690df30c46e521372e2f649c995a2abc159b76c8ef6cd5da8a713ea17937
+    name: filesystem
+    evr: 3.16-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/findutils-4.8.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2010585
+    checksum: sha256:48bd4d4dd081120bcc6ab772b930a150f30b2fc89a4a14a24220383d24a30b3f
+    name: findutils
+    evr: 1:4.8.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 50762
+    checksum: sha256:6da7d722d419e6e9ce5abb4f6adcb82613d0629261011ec42134cfe092078e83
+    name: fonts-rpm-macros
+    evr: 1:2.0.5-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/freetype-2.10.4-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4767581
+    checksum: sha256:b5f1bbbd25b22e01fc2508188b49a97fdf5f72d069039358cb5837dffcf9f2c1
+    name: freetype
+    evr: 2.10.4-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/fuse-2.9.9-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1832743
+    checksum: sha256:9a11b340f925ae501331459e5d8d2edb819b947406d26cb565cf46a9f1b27f97
+    name: fuse
+    evr: 2.9.9-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gawk-5.1.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3190934
+    checksum: sha256:37571947707e835d36ceb5641b187aba13ef8f5f605a6762ce72aeea3e745b8d
+    name: gawk
+    evr: 5.1.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 81877102
+    checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
+    name: gcc
+    evr: 11.5.0-5.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gdbm-1.23-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130147
+    checksum: sha256:ad42264274c2a792220395a4dbe736a1de6100c4e14611707ec1dd447583271f
+    name: gdbm
+    evr: 1:1.23-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/glib-networking-2.68.3-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 256221
+    checksum: sha256:08f2d7a3c389bd63fb7ff6f8ac4a5a1fbb088451ca40f4fbe8ed70d2e820e897
+    name: glib-networking
+    evr: 2.68.3-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.24.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19844004
+    checksum: sha256:7c3dc8448748d98fb9af6f1ec0115ea61b0618135f5eb0104298bc1f9927eea3
+    name: glibc
+    evr: 2.34-168.el9_6.24
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gmp-6.2.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2503825
+    checksum: sha256:d0d8a795eea9ae555da63fbcfc3575425e86bb7e96d117b9ae2785b4f5e82f7c
+    name: gmp
+    evr: 1:6.2.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gobject-introspection-1.68.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1041521
+    checksum: sha256:cc54e6b0e1c09dd0ac59df81e8670434134ccc6adfd390a69fa11963be209231
+    name: gobject-introspection
+    evr: 1.68.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gpgme-1.15.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1737968
+    checksum: sha256:ceeb7d42bc8ddf6f09013439bfed4e591411b81293fe3db5e4edb06cbe1879fb
+    name: gpgme
+    evr: 1.15.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/graphite2-1.3.14-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6312801
+    checksum: sha256:5e2022500d0c9129817bb77916e6b55375344ed2737e05cc82e0f53f295cf2d6
+    name: graphite2
+    evr: 1.3.14-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/grep-3.6-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1620891
+    checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
+    name: grep
+    evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gsettings-desktop-schemas-40.0-7.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 714013
+    checksum: sha256:6ad3eec701e251c7b04018c0148173961474f33477f7a68eaad4779c3d2aed62
+    name: gsettings-desktop-schemas
+    evr: 40.0-7.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/h/harfbuzz-2.7.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9551851
+    checksum: sha256:d0ea2d865c05da90d7a32c6ad835bc3ba2067e759aaec2b0ca94a148735e43f8
+    name: harfbuzz
+    evr: 2.7.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/h/hwdata-0.348-9.18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2508307
+    checksum: sha256:af6cdae99470d14fa48057ac70a01cc8ab8567577eb74fc8c8be32ac080ad0ba
+    name: hwdata
+    evr: 0.348-9.18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/i/icu-67.1-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 23181317
+    checksum: sha256:3abe8dc1abc22213826dd6ffb214cdd88705def93dcb234ffc87c792909b0879
+    name: icu
+    evr: 67.1-10.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1505374
+    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
+    name: jq
+    evr: 1.6-17.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/j/json-c-0.14-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 341227
+    checksum: sha256:c4c76ebfd66ba6d00edf672797d7f077b29d279b7866a04e05258a257a5bc306
+    name: json-c
+    evr: 0.14-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/j/json-glib-1.6.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1319256
+    checksum: sha256:7ed60df640cc4c3cd08af33325b6ca4925a8b30c984e866a5abc1f66407634e9
+    name: json-glib
+    evr: 1.6.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/k/kbd-2.4.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1167414
+    checksum: sha256:8d50e573c7beff06b0167dd7d6bccfe542bc393aaf652bbecb205277af293231
+    name: kbd
+    evr: 2.4.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 150790
+    checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
+    name: keyutils
+    evr: 1.6.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libassuan-2.5.5-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 586136
+    checksum: sha256:dcc858194f9497ec86960651fa76413a9c731f94423d67298e8e3c0c7a5e7806
+    name: libassuan
+    evr: 2.5.5-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libcap-2.48-9.el9_2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 202341
+    checksum: sha256:cf258d269e2690617bbace76ec328e55c6f1431ddb47b67bcd4841472870d483
+    name: libcap
+    evr: 2.48-9.el9_2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 470599
+    checksum: sha256:48bb098662e2f3e1dbb94e27e4e612bc6794fbb62708e1f1a431cc2480fcdb00
+    name: libcap-ng
+    evr: 0.8.2-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libdb-5.3.28-57.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 35290920
+    checksum: sha256:6a74a3d96bd4657659524050945e2a47e93779addf2de374a13e1baf32b4ab8d
+    name: libdb
+    evr: 5.3.28-57.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libeconf-0.4.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 201501
+    checksum: sha256:4541a0915eca1e6fd1440253cf6bdfc5482c7b6dd3d3c7310a77faf852b7671a
+    name: libeconf
+    evr: 0.4.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libevent-2.1.12-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1123179
+    checksum: sha256:8c00dc837b8685fc660cc0bcdfd4f533888facaa8c83655c26d2fb068cb7b135
+    name: libevent
+    evr: 2.1.12-8.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libffi-3.4.2-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1367398
+    checksum: sha256:2b384204cc70c8f23d3a86e5cc9f736306a7a91a72e282044e3b23f3fd831647
+    name: libffi
+    evr: 3.4.2-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libgudev-237-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 40294
+    checksum: sha256:3ae56503c2508bfcba274b4bdaa169ee0a54294682edba202890f999d07b300a
+    name: libgudev
+    evr: 237-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libgusb-0.3.8-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 57034
+    checksum: sha256:18f50c2b798110da109d5d0b429948c762d5b98ba5d37705b6d1b4d327200847
+    name: libgusb
+    evr: 0.3.8-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libidn2-2.3.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2214169
+    checksum: sha256:c27f21437a76f07b0ee9f4f7e61d621cbb9c483c14563b31e55e320d19df99a6
+    name: libidn2
+    evr: 2.3.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libksba-1.5.1-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 677223
+    checksum: sha256:6d334a90bcbc270ee691183624e5664fdbe7dbf2d4a47319e6c75860e16abd43
+    name: libksba
+    evr: 1.5.1-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libpciaccess-0.16-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 382367
+    checksum: sha256:1db6df2f1176960c34a4c87ee533b039ea2db8a2e2f1cb0312399a2ec5d37f8b
+    name: libpciaccess
+    evr: 0.16-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libproxy-0.4.15-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 123932
+    checksum: sha256:7b2cdc89e0020245af06c0b12f3e077c457cf3947d60c53b9303a0fe36d84002
+    name: libproxy
+    evr: 0.4.15-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9160109
+    checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
+    name: libpsl
+    evr: 0.21.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447225
+    checksum: sha256:14fbf335e2c6f22b441a9750a69b7c41e197c4dd21adac701fd81f17660ee0b4
+    name: libpwquality
+    evr: 1.4.4-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 653169
+    checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
+    name: libseccomp
+    evr: 2.5.2-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 271153
+    checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
+    name: libselinux
+    evr: 3.6-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 223978
+    checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
+    name: libsemanage
+    evr: 3.6-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libsepol-3.6-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 538074
+    checksum: sha256:2e02ff0ce3c6767962d1e7a3fbe657ea2a241bcd1c0182d9c552321ba4f8404b
+    name: libsepol
+    evr: 3.6-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libsigsegv-2.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 473267
+    checksum: sha256:734651070d0113de033da80114b416931c4c0be21ce51f6b1c1641b1185c34f3
+    name: libsigsegv
+    evr: 2.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libtasn1-4.16.0-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1895591
+    checksum: sha256:a3d9612fc631100fa0a528d7721bdee96acc33e35befb6a96544526eae169936
+    name: libtasn1
+    evr: 4.16.0-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libtdb-1.4.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 762833
+    checksum: sha256:d402a0c800081eb75cd81f27f632638e204fc210f24f911766f0484bc0a95313
+    name: libtdb
+    evr: 1.4.12-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libtool-2.4.6-46.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1002417
+    checksum: sha256:1130b15333736ad40a18b5924959a8b0c6c151305bc252c0cbd5276432e10002
+    name: libtool
+    evr: 2.4.6-46.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libunistring-0.9.10-15.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2065802
+    checksum: sha256:f6c329a60743d0d4955e070c5104407e47795b1ef617e7e59d052298961aec2b
+    name: libunistring
+    evr: 0.9.10-15.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libusbx-1.0.26-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 643959
+    checksum: sha256:e9359c9ad4fedd8d880f23c2c6a248fd0e17d657ee4ef5d17d572844dfe5f016
+    name: libusbx
+    evr: 1.0.26-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libutempter-1.2.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 30093
+    checksum: sha256:e48843d2734fefad084a86165860ea9575bdc53f63bb5845d8807ce9ccb4f914
+    name: libutempter
+    evr: 1.2.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 396005
+    checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
+    name: libverto
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543970
+    checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/lksctp-tools-1.0.19-3.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 594235
+    checksum: sha256:7f3e4ff54446b4e015958dc5bbe342cfb64151e4b6b886889921b116c373d640
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/lua-5.4.4-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 521629
+    checksum: sha256:18feaae23ff1b674acccf0f081f0d3c36ca482df0c468e9368d4f4432dff820c
+    name: lua
+    evr: 5.4.4-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/lvm2-2.03.28-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2992347
+    checksum: sha256:5361a813c7d6ea933fba20b461c5e3af5528b8876724460f8526f82564e0a063
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/lz4-1.9.3-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 333421
+    checksum: sha256:44e9e079f0f30476a0d8d9849ef1cd940fcc37abee11f481d6043b184bd0cf14
+    name: lz4
+    evr: 1.9.3-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/m/ModemManager-1.20.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1480103
+    checksum: sha256:81e6ab62ffedbf646500c284da42c11609b77c7ba57e1eb561cc95ca0ffe3a30
+    name: ModemManager
+    evr: 1.20.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2335546
+    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
+    name: make
+    evr: 1:4.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/m/mpfr-4.1.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1556195
+    checksum: sha256:1a6f60487d5ebb8998718c8246a49baf182e27318aa16e6a80b1ba7600b74e13
+    name: mpfr
+    evr: 4.1.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3587058
+    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
+    name: ncurses
+    evr: 6.2-10.20210508.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/n/nettle-3.10.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4331292
+    checksum: sha256:1f3587f2d59896bc3f427e4b5b9395095189dfb04237c242daa5cc536c7e02a9
+    name: nettle
+    evr: 3.10.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/n/npth-1.6-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 314570
+    checksum: sha256:3d0685cc559f0af453b6b3ace61944dec9b9cb090695e4de5f5579da7b35b750
+    name: npth
+    evr: 1.6-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/o/openldap-2.6.8-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6548889
+    checksum: sha256:0d21c12c55d40d1fc2f006c8ec187b5fcc799b794cfd31ed2d98434189c62800
+    name: openldap
+    evr: 2.6.8-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 89980613
+    checksum: sha256:4c7cd5a5b7095fcaa5850322ef1f1a7f42e69eacb0386d32fd6ced3dd7a9e7f5
+    name: openssl-fips-provider
+    evr: 3.0.7-6.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/p11-kit-0.25.3-3.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1027881
+    checksum: sha256:de598a2e1ca170df85cd69d6cc406402407a244988506f53f8736a7546135260
+    name: p11-kit
+    evr: 0.25.3-3.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/pam-1.5.1-26.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1130406
+    checksum: sha256:9a351f0455da788ff63026af9a8ee30e744017941c82283f970d1ed066000bb6
+    name: pam
+    evr: 1.5.1-26.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/pcre-8.44-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1624356
+    checksum: sha256:7edbd87b866a3f6e3df1426d660b902e063193d6186027bf99f6d77626a43817
+    name: pcre
+    evr: 8.44-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/pcre2-10.40-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1789790
+    checksum: sha256:a570f7192be555222aa3704882b9199fb013a84ad4d7dcf40a93d8de2ecf6e0a
+    name: pcre2
+    evr: 10.40-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/polkit-0.117-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 336356709
+    checksum: sha256:29fafdd944809b56c0c2e9fe65c2f777e18e5d53473c95e14f6365af4287b131
+    name: polkit
+    evr: 0.117-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/polkit-pkla-compat-0.1-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 302278
+    checksum: sha256:8e4af06bc58994064b55ef7cdac31d48f9797f874fa82e011ad75b6233940636
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/popt-1.18-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 595630
+    checksum: sha256:1c5d47907a884ec21001c4965013fa70bea3f770d385fdc897cb7afc1cf62fe6
+    name: popt
+    evr: 1.18-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 93646
+    checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
+    name: publicsuffix-list
+    evr: 20210518-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/python-pip-21.3.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8984717
+    checksum: sha256:cb9e0cca3bd8dc24798cf1fb333d574774ce8288598331d44994d768f33648d3
+    name: python-pip
+    evr: 21.3.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/python-setuptools-53.0.0-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2080099
+    checksum: sha256:9cd7d11ed9e7fe2fa274de10d803f6fecd53cc1101bd0cbae386dbb66ce03824
+    name: python-setuptools
+    evr: 53.0.0-13.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/r/readline-8.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3009702
+    checksum: sha256:bc7a168b7275d1f9bd0f16b47029dd857ddce83fa80c3cb32eac63cb55f591f3
+    name: readline
+    evr: 8.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/r/redhat-release-9.6-0.1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 62469
+    checksum: sha256:6720f3d5c6675bbf8d79ce5424f891a34303e0c5c39be0e52ca51f70107f585b
+    name: redhat-release
+    evr: 9.6-0.1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4490587
+    checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
+    name: rpm
+    evr: 4.16.1.3-37.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/s/sed-4.8-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1424192
+    checksum: sha256:0590550f0cbdce0a26f98a73c756f663a7f220486d10f9c16d1ce0c8c4d14378
+    name: sed
+    evr: 4.8-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/s/setup-2.13.7-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 195940
+    checksum: sha256:3acdbbd63bd77dd8b18210b9d597bd59ddf455ff728067638c54194ac3a8a32b
+    name: setup
+    evr: 2.13.7-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1715281
+    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
+    name: shadow-utils
+    evr: 2:4.9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/s/shared-mime-info-2.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5257989
+    checksum: sha256:93b45d557d2958d316a6ee4645a9fdccb824cad2133c451ba22221fc933e6f9f
+    name: shared-mime-info
+    evr: 2.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/s/sqlite-3.34.1-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 25109243
+    checksum: sha256:ca9c26565fc4cdfdd8b813a116bb6bba1b36db634bb4b38602cc02f008db064c
+    name: sqlite
+    evr: 3.34.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/t/tpm2-tss-3.2.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1660943
+    checksum: sha256:11c9b6951d6823d120d310243f500f78ce13f9e206134309692e4a761294f3b9
+    name: tpm2-tss
+    evr: 3.2.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 6281028
+    checksum: sha256:cde2d6a98345d49de9d225fc3acf7542fb35fde32832f1361415486a7839c222
+    name: util-linux
+    evr: 2.37.4-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/w/which-2.21-30.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 163429
+    checksum: sha256:3ab75392900a7b7d5b7e869c0d5beba9e184e970946e328f995f79f2e35397ff
+    name: which
+    evr: 2.21-30.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1168293
+    checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
+    name: xz
+    evr: 5.2.5-8.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/z/zip-3.0-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1137410
+    checksum: sha256:416b6957a4365204cfb2ba9e5b9b9f21075b615114c6afe46c83166de258bb5d
+    name: zip
+    evr: 3.0-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/z/zlib-1.2.11-40.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 561153
+    checksum: sha256:e47b884c132983fd0cc40c761de72e1a34ada9ee395cfe50997f9fb9257669d8
+    name: zlib
+    evr: 1.2.11-40.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2378112
+    checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
+    name: zstd
+    evr: 1.5.5-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/compat-openssl11-1.1.1k-5.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7626843
+    checksum: sha256:9dbaca23d62c0bcb1f25ba74c73e3488a5878362bf35e302a64981befc3b7f3f
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/c/crun-1.26-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 896467
+    checksum: sha256:728c9ee33f9c4c2a8b9718c9b6b8e86be57897bf80b5bf1cc2fb195e824bb681
+    name: crun
+    evr: 1.26-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/gdk-pixbuf2-2.42.6-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 7737493
+    checksum: sha256:93923e9e509be34b01501dbc898e47ed8e5984110b424d12387cac9928372574
+    name: gdk-pixbuf2
+    evr: 2.42.6-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/giflib-5.2.1-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 454644
+    checksum: sha256:7190afe993e439540a36a564f62c09dbd455f477a9e2b4223943b35c4ddf407d
+    name: giflib
+    evr: 5.2.1-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/git-lfs-3.6.1-2.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3704183
+    checksum: sha256:da9df4e5a770589c8d3a72ea5b7dde9860d5cf4869a3198009cafdad05beb10a
+    name: git-lfs
+    evr: 3.6.1-2.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/go-rpm-macros-3.6.0-13.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 134217
+    checksum: sha256:2b01ccb1ff201351069d5e7faed2b638bfabd63a58fe5dbac54c4fa77020efeb
+    name: go-rpm-macros
+    evr: 3.6.0-13.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/g/gstreamer1-plugins-base-1.22.12-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2402853
+    checksum: sha256:b708fd816f9269983034eb5a4af7431a4d640885668e61020c18f21cc858b2b2
+    name: gstreamer1-plugins-base
+    evr: 1.22.12-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/j/java-17-openjdk-17.0.19.0.10-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 67369706
+    checksum: sha256:ccdf6f1911dbc397143a302aff66c575c035222a97fdfbc15dc4e18b4cbdec47
+    name: java-17-openjdk
+    evr: 1:17.0.19.0.10-1.el9
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libsoup-2.72.0-10.el9_6.6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 1524773
+    checksum: sha256:e09ab5c0baa53fd164dec50e512ec341aa7005fe4881df7fa7e008de5d7b1a5b
+    name: libsoup
+    evr: 2.72.0-10.el9_6.6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libtiff-4.4.0-13.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2894616
+    checksum: sha256:fe00b8631ff587d510f42b10e15d9eeb0e248d559a8940029077c1846a79e81f
+    name: libtiff
+    evr: 4.4.0-13.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/l/libxslt-1.1.34-13.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 3560934
+    checksum: sha256:b3947676add0f33392769160c17de031191fd4af0caaddb009903b2f981cdd0f
+    name: libxslt
+    evr: 1.1.34-13.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/m/mesa-24.2.8-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 33254288
+    checksum: sha256:0a6183042f15cad55922f1262d1df8d3836e950a4c2a4a92aa4655c5869772cb
+    name: mesa
+    evr: 24.2.8-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/n/nss-3.112.0-8.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 81985898
+    checksum: sha256:03e1f0c080506262cf5cf8198eedc16dbcab50f7ff3ab75eeec20bb6dffbf65a
+    name: nss
+    evr: 3.112.0-8.el9_4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/o/ostree-2025.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 2151401
+    checksum: sha256:9be705455801c8632ce93ebe7d2d3f1ca1ca66ac20c6e0801a39b0626bd4fde5
+    name: ostree
+    evr: 2025.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/perl-XML-Parser-2.46-9.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 269666
+    checksum: sha256:712a5069cc5e3863ce0c84dacb69850ed20ce354d992a3f8773f577d6aa6801e
+    name: perl-XML-Parser
+    evr: 2.46-9.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/poppler-21.01.0-22.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 4696462
+    checksum: sha256:db66bfc8235cf25007f20d0b9c1422e577660cb6d1441b3de07e18cea988c738
+    name: poppler
+    evr: 21.01.0-22.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/postgresql-13.23-1.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 51333145
+    checksum: sha256:ad1a81d99d970d228aca114b49db118c692da06d5b5c9d43b3ece667730b50e1
+    name: postgresql
+    evr: 13.23-1.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/p/protobuf-3.14.0-16.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6493619
+    checksum: sha256:16c2aaa5191a3e816c32aa0543b5106f4042577e0336930ab22c5775606605c8
+    name: protobuf
+    evr: 3.14.0-16.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 10642816
+    checksum: sha256:9d266472087f840a668e6eb2855a4021e054a48b0b7c9f7ad1fe5acb42e93b95
+    name: skopeo
+    evr: 2:1.18.1-5.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/s/systemtap-5.2-4.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 6602276
+    checksum: sha256:9f86d158ac1db2e0ed479f194ec9b9113a19f678b6d4a83ab1a42877ba9b779b
+    name: systemtap
+    evr: 5.2-4.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS/Packages/w/webkit2gtk3-2.52.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-source-rpms
+    size: 65133497
+    checksum: sha256:bdd945c48a7e40a7daec8f6b2291fda7e3584a6e59f2d0a6b3ab7adecd12fc7d
+    name: webkit2gtk3
+    evr: 2.52.3-1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 22423248
+    checksum: sha256:bd25b72280f9648cf99327b74dc03713a200a30068834bbca48a8ad7f7cfcd79
+    name: binutils
+    evr: 2.35.2-63.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 510894
+    checksum: sha256:299496cf3aafff9c162da9ec0cb6eaa65ee0d8dc8b8594998968959282e0b536
+    name: brotli
+    evr: 1.0.9-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2549990
+    checksum: sha256:9945d643a0ded5725b7fd4eaebc2f7350324c782ee7857e3a72d1e7fd1aa243b
+    name: curl
+    evr: 7.76.1-31.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/e/expat-2.5.0-5.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8380127
+    checksum: sha256:207d7440755167a1049b86dafd99052a0162107167dfad2405386ab8452e6e76
+    name: expat
+    evr: 2.5.0-5.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/glib2-2.68.4-16.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 5078743
+    checksum: sha256:452f757e564781db4e489cfabc4ab6062375e9f580da4dbd1fa7157f41fb8f39
+    name: glib2
+    evr: 2.68.4-16.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gnupg2-2.3.3-4.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7615913
+    checksum: sha256:cd27551144e10f730f613ade3c9f3c201c912941a8abfce2c3fc770f6845b9ab
+    name: gnupg2
+    evr: 2.3.3-4.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-6.el9_6.3.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8612613
+    checksum: sha256:dc677685c729543c50bb6c99ae875ef7f83b36f2c25b74f55269c49f160409a9
+    name: gnutls
+    evr: 3.8.3-6.el9_6.3
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.110.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 149742415
+    checksum: sha256:95170092b5c7994be8941bf5b6ae3660a876a6691b3f06fdf46af7124de14a89
+    name: kernel
+    evr: 5.14.0-570.110.1.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/k/krb5-1.21.1-8.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 8943275
+    checksum: sha256:0e9b010a294e5358b4bd1e28b7cd1f1eb15256d4040f68814b0659f92f5a1ec2
+    name: krb5
+    evr: 1.21.1-8.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libarchive-3.5.3-7.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 7054617
+    checksum: sha256:a590c3f706fbc8932245513fca3328d68708a0b11565da86eed8002399f80c65
+    name: libarchive
+    evr: 3.5.3-7.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libpng-1.6.37-12.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 1530809
+    checksum: sha256:4ad341aec16d15a0b68009e84704662aebb9238f8ca98b521083de05b0dcc861
+    name: libpng
+    evr: 2:1.6.37-12.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libssh-0.10.4-15.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 665493
+    checksum: sha256:dbe0318bea854b3a1f8af8f6aceab24d0beac8172d0afd30779afdf0b62d96f5
+    name: libssh
+    evr: 0.10.4-15.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/l/libxml2-2.9.13-12.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3287566
+    checksum: sha256:2bc2fd257740e6baa0555a9e98ae5731a5e18d98332afa10e2e6e8bd92b1880a
+    name: libxml2
+    evr: 2.9.13-12.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/n/NetworkManager-1.52.0-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 6295554
+    checksum: sha256:fc995af619a89f8184e3d19b975e653615e6f1687c36de40b0ec63ff0df580d8
+    name: NetworkManager
+    evr: 1:1.52.0-10.el9_6
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/n/nghttp2-1.43.0-6.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 3997194
+    checksum: sha256:25c2a8aaef5b90676fe217d732db026441e110951ed66b00e7327b79886a7a72
+    name: nghttp2
+    evr: 1.43.0-6.el9_6.1
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2410966
+    checksum: sha256:1ddf2a92b05dd9431ce5b6b884b449c7f855806a7586114f9034c2602172163f
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 17980237
+    checksum: sha256:2010e981778502acfddd21095efbb7bbe407e8d85ddf6185563f6a41508591a0
+    name: openssl
+    evr: 1:3.2.2-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/p/python3.9-3.9.21-2.el9_6.5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 20305745
+    checksum: sha256:28b422b6eddc8c6531629680290fbcfd4539ff4bbb199fb0fbf6e9a8262e8b1a
+    name: python3.9
+    evr: 3.9.21-2.el9_6.5
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-51.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 43231152
+    checksum: sha256:c7324d32266c9b398924b5495019101abb46013f2d4f348b19b5fe156c6140ff
+    name: systemd
+    evr: 252-51.el9_6.4
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 2282353
+    checksum: sha256:8845bf368f2fcda2e27130cf4ef8301fed4ac310c0b1ef048542bd85261bf21c
+    name: tar
+    evr: 2:1.34-7.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 919356
+    checksum: sha256:eb238075d8e20f9b5bee4666e55572ec2762203a0040e1d1fc350b390e412c99
+    name: tzdata
+    evr: 2026a-1.el9_0
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS/Packages/v/vim-8.2.2637-22.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-source-rpms
+    size: 12824612
+    checksum: sha256:7fec61a8292d8ed5cf71f95d47ae8b594967391eef07fe306899359735eda157
+    name: vim
+    evr: 2:8.2.2637-22.el9_6.2
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/source/SRPMS/Packages/p/pybind11-2.10.4-2.el9.src.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-eus-source-rpms
+    size: 753907
+    checksum: sha256:7b09202a3413bd4d9b0ec480bc7135c5baa7951bac0044891ddaa64999af4f31
+    name: pybind11
+    evr: 2.10.4-2.el9
   module_metadata: []


### PR DESCRIPTION
[RHAIENG-4728](https://redhat.atlassian.net/browse/RHAIENG-4728): Regenerate rpms.lock.yaml to update s390x

## Description
[RHAIENG-4728](https://redhat.atlassian.net/browse/RHAIENG-4728): Regenerate rpms.lock.yaml to update s390x

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
