### PR TITLE
NO-JIRA: fix(rstudio): re-pin micropipenv and uv versions in Dockerfiles

### DIFF
--- a/rstudio/c9s-python-3.12/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.12/Dockerfile.cpu
@@ -14,7 +14,7 @@ WORKDIR /opt/app-root/bin
 
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]" "uv"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.10.8"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 # OS Packages needs to be installed as root

--- a/rstudio/c9s-python-3.12/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.12/Dockerfile.cuda
@@ -39,7 +39,7 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]" "uv"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.10.8"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -41,7 +41,7 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]" "uv"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.10.8"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -41,7 +41,7 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]" "uv"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.10.8"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.konflux.cpu
@@ -38,7 +38,7 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]" "uv"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.10.8"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src

--- a/rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.konflux.cuda
@@ -38,7 +38,7 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 USER 1001
 
 ### BEGIN Install micropipenv and uv to deploy packages from requirements.txt
-RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]" "uv"
+RUN pip install --no-cache-dir --extra-index-url https://pypi.org/simple -U "micropipenv[toml]==1.10.0" "uv==0.10.8"
 ### END Install micropipenv and uv to deploy packages from requirements.txt
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
## Summary
- Commit 77f02423 (PR #3417) unpinned `micropipenv` and `uv` in 6 rstudio Dockerfiles per Slack advice, but `dockerfile_fragments.py` still pins them
- This causes the `check-generated-code` CI job to fail on every subsequent PR (e.g. #3459)
- Re-pins by running `bash ci/generate_code.sh` to match what the code generator produces

## Context
The unpinning was discussed in [this Slack thread](https://redhat-internal.slack.com/archives/C096ZR053RQ/p1776769633361869) — atheo89 and vsok agreed to update `dockerfile_fragments.py` as a follow-up post-hermetic work. Until that follow-up lands, the Dockerfiles need to stay pinned to match the generator.

## Test plan
- [ ] `check-generated-code` CI job passes (this was the only failing check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Docker image build dependencies to specific versions of Python tooling for improved consistency and reproducibility across all deployment image variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->