### PR TITLE
[RHAIENG-4520] chore(manfest) create 3.5 tag on the imagestream for rhoai

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -29,8 +29,8 @@ if [ "${KONFLUX:-no}" = 'yes' ]; then
     _MANIFESTS_VARIANT="rhoai"
     # This value needs to be updated everytime we deliberately change number of the
     # images we want to have in the `params.env` or `params-latest.env` file.
-    EXPECTED_COMMIT_NUM_RECORDS=39
-    EXPECTED_PARAMS_NUM_RECORDS=39
+    EXPECTED_COMMIT_NUM_RECORDS=50
+    EXPECTED_PARAMS_NUM_RECORDS=50
 else
     _MANIFESTS_VARIANT="odh"
     # This value needs to be updated everytime we deliberately change number of the
@@ -65,7 +65,7 @@ function check_variables_uniq() {
     echo "Checking that all variables in the file '${env_file_path_1}' & '${env_file_path_2}' are unique and expected"
 
     local content
-    content=$(sed '/^$/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#\(.*\)=.*#\1#' | sort)
+    content=$(sed '/^$/d;/^[[:space:]]*#/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#\(.*\)=.*#\1#' | sort)
 
     local num_records
     num_records=$(echo "${content}" | wc -l)
@@ -83,7 +83,7 @@ function check_variables_uniq() {
         echo "Checking that all values assigned to variables in the file '${env_file_path_1}' & '${env_file_path_2}' are unique and expected"
 
         # Exclude "dummy" placeholder values (RHOAI params-latest.env uses these)
-        content=$(sed '/^$/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#.*=##' | grep -v '^dummy$' | sort)
+        content=$(sed '/^$/d;/^[[:space:]]*#/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#.*=##' | grep -v '^dummy$' | sort)
 
         local num_values
         num_values=$(echo "${content}" | wc -l)
@@ -149,10 +149,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9"
+                expected_img_size=1010
+            else
+                expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.12"
+                expected_img_size=1017
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=1017
             ;;
         odh-workbench-jupyter-minimal-cuda-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-minimal-cuda-py311-rhel9"
@@ -185,10 +190,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9"
+                expected_img_size=3479
+            else
+                expected_name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12"
+                expected_img_size=6018
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=6018
             ;;
         odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-pytorch-cuda-py311-rhel9"
@@ -221,10 +231,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9"
+                expected_img_size=9372
+            else
+                expected_name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12"
+                expected_img_size=11722
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=11722
             ;;
         odh-workbench-jupyter-minimal-rocm-py312-ubi9-2025-2)
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -241,10 +256,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9"
+                expected_img_size=5068
+            else
+                expected_name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12"
+                expected_img_size=5102
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=5102
             ;;
         odh-workbench-jupyter-datascience-cpu-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-datascience-cpu-py311-rhel9"
@@ -273,10 +293,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9"
+                expected_img_size=1625
+            else
+                expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.12"
+                expected_img_size=1592
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=1592
             ;;
         odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-tensorflow-cuda-py311-rhel9"
@@ -309,10 +334,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4)
-            expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9"
+                expected_img_size=8814
+            else
+                expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12"
+                expected_img_size=10623
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=10623
             ;;
         odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-trustyai-cpu-py311-rhel9"
@@ -345,10 +375,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9"
+                expected_img_size=5746
+            else
+                expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.12"
+                expected_img_size=2530
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=2530
             ;;
         odh-workbench-codeserver-datascience-cpu-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-codeserver-datascience-cpu-py311-rhel9"
@@ -381,10 +416,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4)
-            expected_name="odh-notebook-code-server-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9"
+                expected_img_size=1228
+            else
+                expected_name="odh-notebook-code-server-ubi9-python-3.12"
+                expected_img_size=1098
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=1098
             ;;
         odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n)
             expected_name="odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12"
@@ -411,10 +451,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9"
+                expected_img_size=9347
+            else
+                expected_name="odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12"
+                expected_img_size=11447
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=11447
             ;;
         odh-workbench-jupyter-minimal-rocm-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-minimal-rocm-py311-rhel9"
@@ -459,10 +504,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9"
+                expected_img_size=8805
+            else
+                expected_name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12"
+                expected_img_size=6519
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=6519
             ;;
         odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-2025-1)
             expected_name="rhoai/odh-workbench-jupyter-tensorflow-rocm-py311-rhel9"
@@ -495,10 +545,15 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4)
-            expected_name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12"
+            if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
+                expected_name="rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9"
+                expected_img_size=6264
+            else
+                expected_name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12"
+                expected_img_size=6269
+            fi
             expected_commitref="main"
             expected_build_name="konflux"
-            expected_img_size=6269
             ;;
         # The following are pipeline runtime images
         odh-pipeline-runtime-minimal-cpu-py312-ubi9-n)
@@ -789,6 +844,8 @@ process_file() {
     while IFS= read -r LINE; do
         # If the line is empty, skip to the next one
         [[ -z "$LINE" ]] && continue
+        # Skip shell-style comments (common in params.env headers)
+        [[ "${LINE}" =~ ^[[:space:]]*# ]] && continue
 
         echo "Checking format of: '${LINE}'"
         [[ "${LINE}" = *[[:space:]]* ]] && {
@@ -820,6 +877,18 @@ process_file() {
             local_ret_code=1
             continue
         }
+
+        if [[ "${IMAGE_URL}" == "dummy" ]]; then
+            if [[ "${_MANIFESTS_VARIANT}" == "rhoai" && "${1}" == "${PARAMS_LATEST_ENV_PATH}" ]]; then
+                echo "Skipping image validation for '${IMAGE_VARIABLE}' (dummy placeholder)"
+                echo "------------------------"
+                continue
+            fi
+            echo "ERROR: dummy placeholder is only allowed in '${PARAMS_LATEST_ENV_PATH}'"
+            echo "------------------------"
+            local_ret_code=1
+            continue
+        fi
 
         check_image "${IMAGE_VARIABLE}" "${IMAGE_URL}" || {
             echo "ERROR: Image definition for '${IMAGE_VARIABLE}' isn't okay!"

--- a/ci/expected-image-metadata.yaml
+++ b/ci/expected-image-metadata.yaml
@@ -387,3 +387,211 @@ odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n:
   variants:
     - odh
     - rhoai
+
+# --- 3.4 GA (ubi9-3-4) + pipeline runtime 3.4 (aligned with ci/check-params-env.sh) ---
+
+odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-minimal-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 1017
+    rhoai: 1010
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 6018
+    rhoai: 3479
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 5102
+    rhoai: 5068
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-datascience-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 1592
+    rhoai: 1625
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 11722
+    rhoai: 9372
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 6519
+    rhoai: 8805
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 10623
+    rhoai: 8814
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 6269
+    rhoai: 6264
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-trustyai-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 2530
+    rhoai: 5746
+  variants:
+    - odh
+    - rhoai
+odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-code-server-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 1098
+    rhoai: 1228
+  variants:
+    - odh
+    - rhoai
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12
+    rhoai: rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 11447
+    rhoai: 9347
+  variants:
+    - odh
+    - rhoai
+
+odh-pipeline-runtime-minimal-cpu-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-runtime-minimal-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 692
+  variants:
+    - odh
+    - rhoai
+odh-pipeline-runtime-datascience-cpu-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-runtime-datascience-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 1461
+  variants:
+    - odh
+    - rhoai
+odh-pipeline-runtime-pytorch-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-runtime-pytorch-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb:
+    odh: 11180
+    rhoai: 6253
+  variants:
+    - odh
+    - rhoai
+odh-pipeline-runtime-pytorch-rocm-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 6117
+  variants:
+    - odh
+    - rhoai
+odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 10217
+  variants:
+    - odh
+    - rhoai
+odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 5859
+  variants:
+    - odh
+    - rhoai
+odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-3-4:
+  name:
+    odh: odh-notebook-runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12
+    rhoai: rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 8793
+  variants:
+    - odh
+    - rhoai

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -43,10 +43,39 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-codeserver-datascience-cpu-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "code-server", "version": "4.106"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "ipykernel", "version": "6.29"},
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/commit.env
+++ b/manifests/rhoai/base/commit.env
@@ -1,3 +1,17 @@
+# Git short hashes for 3.4 GA images (align with product build when available)
+odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-3-4=d3137ca
+odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-3-4=d3137ca
+odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-3-4=bff12e2
+odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-3-4=d3137ca
+odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-3-4=8e73cac
+odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-3-4=d3137ca
+odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-3-4=8e73cac
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-3-4=8e73cac
+odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-3-4=06da715
+odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-3-4=06703a3
+odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-3-4=8e73cac
+
+
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-2025-2=a2a3d89
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-2025-2=a2a3d89
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-2025-2=a2a3d89

--- a/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
@@ -50,10 +50,49 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-datascience-cpu-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Feast", "version": "0.59"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
+    # N - 2 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |
@@ -91,7 +130,7 @@ spec:
       name: "2025.2"
       referencePolicy:
         type: Source
-    # N - 2 Version of the image
+    # N - 3 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -34,10 +34,29 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-minimal-cuda-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "13.0"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
@@ -33,10 +33,31 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-minimal-cpu-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
+    # N - 2 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |
@@ -57,7 +78,7 @@ spec:
       name: "2025.2"
       referencePolicy:
         type: Source
-    # N - 2 Version of the image
+    # N - 3 Version of the image
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -56,6 +56,48 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n_PLACEHOLDER
+      name: "3.5"
+      referencePolicy:
+        type: Source
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "13.0"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.10"},
+            {"name": "LLM-Compressor", "version": "0.10"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.5"},
+            {"name": "PyTorch", "version": "2.10"},
+            {"name": "LLM-Compressor", "version": "0.10"},
+            {"name": "Tensorboard", "version": "2.20"},
+            {"name": "Boto3", "version": "1.42"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.16"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.3"},
+            {"name": "Pandas", "version": "2.3"},
+            {"name": "Scikit-learn", "version": "1.8"},
+            {"name": "Scipy", "version": "1.17"},
+            {"name": "Odh-Elyra", "version": "5.0"},
+            {"name": "PyMongo", "version": "4.16"},
+            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.36"},
+            {"name": "Feast", "version": "0.62"},
+            {"name": "Sklearn-onnx", "version": "1.20"},
+            {"name": "Psycopg", "version": "3.3"},
+            {"name": "MySQL Connector/Python", "version": "9.6"},
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4_PLACEHOLDER
       name: "3.4"
       referencePolicy:
         type: Source

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -55,10 +55,50 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.9"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.6"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"},
+            {"name": "PyTorch", "version": "2.6"},
+            {"name": "Tensorboard", "version": "2.19"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Feast", "version": "0.62"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -34,10 +34,29 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-minimal-rocm-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "ROCm", "version": "6.4"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -53,10 +53,48 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "ROCm", "version": "v6.4"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "ROCm-PyTorch", "version": "2.6"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"},
+            {"name": "ROCm-PyTorch", "version": "2.6"},
+            {"name": "Tensorboard", "version": "2.18"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.2"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Feast", "version": "0.59"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -51,10 +51,46 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "ROCm", "version": "v7.1"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "TensorFlow-ROCm", "version": "2.19"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.5"},
+            {"name": "TensorFlow-ROCm", "version": "2.19"},
+            {"name": "Tensorboard", "version": "2.19"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "2.1"},
+            {"name": "Pandas", "version": "2.3"},
+            {"name": "Scikit-learn", "version": "1.8"},
+            {"name": "Scipy", "version": "1.17"},
+            {"name": "Odh-Elyra", "version": "5.0"},
+            {"name": "PyMongo", "version": "4.16"},
+            {"name": "Pyodbc", "version": "5.3"},
+            {"name": "Codeflare-SDK", "version": "0.36"},
+            {"name": "Sklearn-onnx", "version": "1.20"},
+            {"name": "Psycopg", "version": "3.3"},
+            {"name": "MySQL Connector/Python", "version": "9.6"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -54,10 +54,49 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "12.9"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "TensorFlow", "version": "2.18"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"},
+            {"name": "TensorFlow", "version": "2.18"},
+            {"name": "Tensorboard", "version": "2.18"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "2.2"},
+            {"name": "Scikit-learn", "version": "1.6"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.30"},
+            {"name": "Feast", "version": "0.62"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.2"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -55,10 +55,50 @@ spec:
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n_PLACEHOLDER
-      name: "3.4"
+      name: "3.5"
       referencePolicy:
         type: Source
     # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "JupyterLab", "version": "4.2"},
+            {"name": "TrustyAI", "version": "0.6"},
+            {"name": "Transformers", "version": "4.50"},
+            {"name": "Datasets", "version": "3.4"},
+            {"name": "Accelerate", "version": "1.5"},
+            {"name": "Torch", "version": "2.6"},
+            {"name": "Boto3", "version": "1.37"},
+            {"name": "Kafka-Python-ng", "version": "2.2"},
+            {"name": "Kfp", "version": "2.12"},
+            {"name": "Matplotlib", "version": "3.10"},
+            {"name": "Numpy", "version": "1.26"},
+            {"name": "Pandas", "version": "1.5"},
+            {"name": "Scikit-learn", "version": "1.7"},
+            {"name": "Scipy", "version": "1.15"},
+            {"name": "Odh-Elyra", "version": "4.2"},
+            {"name": "PyMongo", "version": "4.11"},
+            {"name": "Pyodbc", "version": "5.2"},
+            {"name": "Codeflare-SDK", "version": "0.29"},
+            {"name": "Sklearn-onnx", "version": "1.18"},
+            {"name": "Psycopg", "version": "3.2"},
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/workbench-images
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-3-4_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4_PLACEHOLDER
+      name: "3.4"
+      referencePolicy:
+        type: Source
     - annotations:
         # language=json
         opendatahub.io/notebook-software: |

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -53,7 +53,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -66,13 +66,26 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: s2i-minimal-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -92,7 +105,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -105,13 +118,26 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: s2i-generic-data-science-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -131,7 +157,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -144,13 +170,26 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: minimal-gpu
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -170,7 +209,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -183,13 +222,26 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: pytorch
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -209,7 +261,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -222,13 +274,26 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: tensorflow
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -248,7 +313,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -261,13 +326,26 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: odh-trustyai-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -287,7 +365,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -300,13 +378,26 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: code-server-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -326,7 +417,7 @@ replacements:
           name: jupyter-rocm-minimal
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -339,13 +430,26 @@ replacements:
           name: jupyter-rocm-minimal
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-rocm-minimal
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -365,7 +469,7 @@ replacements:
           name: jupyter-rocm-pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -378,13 +482,26 @@ replacements:
           name: jupyter-rocm-pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-rocm-pytorch
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -404,7 +521,7 @@ replacements:
           name: jupyter-rocm-tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
@@ -417,13 +534,26 @@ replacements:
           name: jupyter-rocm-tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-2025-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-2025-2
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-rocm-tensorflow
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-2025-1
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -443,13 +573,26 @@ replacements:
           name: jupyter-pytorch-llmcompressor
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-2025-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4
       kind: ConfigMap
       name: notebook-image-params
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.1.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-pytorch-llmcompressor
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.2.from.name
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -469,7 +612,7 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -482,13 +625,26 @@ replacements:
           name: s2i-minimal-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: s2i-minimal-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-minimal-cpu-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -508,7 +664,7 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -521,13 +677,26 @@ replacements:
           name: s2i-generic-data-science-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: s2i-generic-data-science-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-datascience-cpu-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -547,7 +716,7 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -560,13 +729,26 @@ replacements:
           name: minimal-gpu
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: minimal-gpu
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-minimal-cuda-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -586,7 +768,7 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -599,13 +781,26 @@ replacements:
           name: pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: pytorch
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-cuda-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -625,7 +820,7 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -638,13 +833,26 @@ replacements:
           name: tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: tensorflow
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-tensorflow-cuda-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -664,7 +872,7 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -677,13 +885,26 @@ replacements:
           name: odh-trustyai-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: odh-trustyai-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-trustyai-cpu-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -703,7 +924,7 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -716,13 +937,26 @@ replacements:
           name: code-server-notebook
           version: v1
   - source:
-      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: code-server-notebook
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -742,7 +976,7 @@ replacements:
           name: jupyter-rocm-minimal
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -755,13 +989,26 @@ replacements:
           name: jupyter-rocm-minimal
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-rocm-minimal
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-minimal-rocm-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -781,7 +1028,7 @@ replacements:
           name: jupyter-rocm-pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -794,13 +1041,26 @@ replacements:
           name: jupyter-rocm-pytorch
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-rocm-pytorch
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-rocm-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -820,7 +1080,7 @@ replacements:
           name: jupyter-rocm-tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
@@ -833,13 +1093,26 @@ replacements:
           name: jupyter-rocm-tensorflow
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-commit-2025-1
+      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-2025-2
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-rocm-tensorflow
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-commit-2025-1
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.3.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream
@@ -859,13 +1132,26 @@ replacements:
           name: jupyter-pytorch-llmcompressor
           version: v1
   - source:
-      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-2025-2
+      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-3-4
       kind: ConfigMap
       name: notebook-image-commithash
       version: v1
     targets:
       - fieldPaths:
           - spec.tags.1.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-pytorch-llmcompressor
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-2025-2
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.2.annotations.[opendatahub.io/notebook-build-commit]
         select:
           group: image.openshift.io
           kind: ImageStream

--- a/manifests/rhoai/base/params.env
+++ b/manifests/rhoai/base/params.env
@@ -1,3 +1,16 @@
+# TODO: https://redhat.atlassian.net/browse/RHAIENG-4791
+odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:e8ab6c3573191cdee72bf45e1c3a73b11fad69074c470b853ee88a75a29b2537
+odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:a93104cb8658c83cce32fd3342ef61e4d2ca8b12222ea4086265c2480739abe7
+odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:ee8083db7dd2f47a02feec2abebdfe60ea3ac24a4b917bd9566cdea2f4faf9e0
+odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:9475a642a9c89e95aed528265b5bbf87efc8a6ddf87c0c49e442c0a63b42fdda
+odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:345f24be761230703c7c2e57c355dea731d70faeba7147e7c09a39ea94c126d0
+odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:f2e5aac8abece4427e906d3a6ce58a743e6d8445c2c63de515ea5c762341ab40
+odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:7bb644561348fa3cbc4ca678e699a4b5a87096747d7558e30719a9cedb8ebe99
+odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:b6ee72d4f32a6cee578ae159eb2c7e69dc4b3452e83c194ad9f141b3f36856d5
+odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:6d7fa5ed8af3af0671218475500ef3c97babf26685a1336cb62410c4038bb24c
+odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:d558e13aff317da9aa1e7808998176c187e67f11c04d660905c3b31749298de7
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:c839409bb1c519f27b62944a578c33bbb90570ad9a00bffbf08987904923bec2
+
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:792c7c809440655e19da5d50e4b7568f39b403e61eeacd9e0fa095fc01a5e167
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:bd15088088dd6258da62e6658fa66790036acc6bb9af43bdcc240b389ef52f47
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:9ba87a487d36694890868b26da34e8d4421488c5c862cc7409d26ee8aa0af63d

--- a/tests/containers/params_env_validation_test.py
+++ b/tests/containers/params_env_validation_test.py
@@ -259,7 +259,7 @@ def test_params_env_record_count(
     variant = "rhoai" if "rhoai" in str(base_dir) else "odh"
     expected_counts = {
         "odh": {"commit": 35, "params": 29},
-        "rhoai": {"commit": 39, "params": 39},
+        "rhoai": {"commit": 50, "params": 50},
     }
 
     for env_name, expected in expected_counts[variant].items():

--- a/tests/test_pylock_downgrade.py
+++ b/tests/test_pylock_downgrade.py
@@ -123,8 +123,13 @@ def _parse_pylock_versions_for_linux(pylock_text: str, python_full: str) -> dict
             continue
         if "marker" in p and not packaging.markers.Marker(p["marker"]).evaluate(marker_env):
             continue
-        if name in out:
-            raise AssertionError(f"Duplicate package {name!r} after marker filter (python {python_full})")
+        # Last wins when the lockfile lists the same name multiple times for overlapping markers.
+        prev = out.get(name)
+        if prev is not None and prev != version:
+            raise AssertionError(
+                f"Ambiguous pylock for {name!r} under linux/{python_full}: "
+                f"matched multiple versions ({prev}, {version})"
+            )
         out[name] = version
     return out
 
@@ -188,10 +193,24 @@ def test_pylock_tracked_packages_not_downgraded_vs_git_base(subtests):
         current_text = lock_path.read_text(encoding="utf-8")
         try:
             cur_map = _parse_pylock_versions_for_linux(current_text, python_full)
-            base_map = _parse_pylock_versions_for_linux(base_text, python_full)
-        except (tomllib.TOMLDecodeError, AssertionError) as e:
+        except tomllib.TOMLDecodeError as e:
             with subtests.test(msg=rel):
-                raise AssertionError(f"Failed to parse pylock for downgrade check: {rel}") from e
+                raise AssertionError(f"Invalid TOML in current pylock (downgrade check): {rel}") from e
+            continue
+        except AssertionError as e:
+            with subtests.test(msg=rel):
+                raise AssertionError(f"Failed to parse current pylock for downgrade check: {rel}") from e
+            continue
+
+        try:
+            base_map = _parse_pylock_versions_for_linux(base_text, python_full)
+        except tomllib.TOMLDecodeError:
+            # Baseline ref may not have valid TOML at this path (e.g. older lockfile format).
+            continue
+        except AssertionError as e:
+            with subtests.test(msg=rel):
+                raise AssertionError(f"Failed to parse baseline pylock for downgrade check: {rel}") from e
+            continue
 
         downgrades = list(_iter_downgrades(cur_map, base_map))
         with subtests.test(msg=rel):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- manifests/odh/base: Regenerated params.env and commit.env so ConfigMap keys and digests/commit hashes move from the *-2025-2 suffix to *-3-4, and updated every affected ImageStream YAML plus kustomization.yaml replacements so ImageStreams resolve the new keys.
- ci/check-params-env-odh.sh: Renamed expected variable names to match the new suffix and refreshed expected compressed image sizes for the pinned references.
- tests/test_main.py: Prepended 3.5 to CANONICAL_TAG_ORDER so manifest/tag ordering tests treat 3.5 as the newest canonical train.
- scripts/update-commit-latest-env.py: Reads/writes manifests/odh/base/ (params-latest.env, commit-latest.env) instead of the old manifests/base/ paths.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Workbench/runtimes entries for the 3.4 image set across multiple notebook and pipeline variants.

* **Updates**
  * Promoted 3.5 as the primary/recommended image; 3.4 retained as the previous release.
  * Bumped notebook dependency annotations across images (Python/CUDA/ROCm/PyTorch/TensorFlow and related libs).

* **Bug Fixes**
  * Improved env-file parsing to ignore blank/comment lines and tightened handling of placeholder values.

* **Tests**
  * Updated CI expected image metadata and adjusted validation tests to expect increased record counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->