### PR TITLE
NO-JIRA: chore(gha): add CI workflow to run container tests on test-only PRs

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -1,0 +1,135 @@
+---
+name: Test Infrastructure Self-Test
+
+"on":
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tests/containers/**'
+      - 'tests/conftest.py'
+      - 'pytest.ini'
+      - '.github/workflows/test-containers.yaml'
+  push:
+    branches: [main, stable, 'rhoai-*']
+    paths:
+      - 'tests/containers/**'
+      - 'tests/conftest.py'
+      - 'pytest.ini'
+      - '.github/workflows/test-containers.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  TESTCONTAINERS_RYUK_DISABLED: "true"
+  IMAGE_REGISTRY: "ghcr.io/opendatahub-io/notebooks/workbench-images"
+
+jobs:
+  find-images:
+    name: Find test images
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+    steps:
+      - name: Find images for test matrix
+        id: find
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          GH_TOKEN: ${{ github.token }}
+        shell: python
+        # language=python
+        run: |
+          import json, os, subprocess, sys
+
+          registry = os.environ["IMAGE_REGISTRY"]
+          suffix = "_odh_linux_amd64"
+          required = [
+              "jupyter-minimal-ubi9-python-3.12",
+              "jupyter-datascience-ubi9-python-3.12",
+              "runtime-datascience-ubi9-python-3.12",
+          ]
+
+          result = subprocess.run(
+              ["skopeo", "list-tags", "--creds", f"token:{os.environ['GH_TOKEN']}", f"docker://{registry}"],
+              capture_output=True, text=True, timeout=180,
+          )
+          if result.returncode != 0:
+              print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
+              sys.exit(1)
+
+          tags = set(json.loads(result.stdout)["Tags"])
+
+          sha_sets = []
+          for img in required:
+              prefix = f"{img}-main_"
+              shas = {t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)}
+              print(f"  {img}: {len(shas)} builds")
+              sha_sets.append(shas)
+
+          common = set.intersection(*sha_sets)
+          if not common:
+              print(f"::error::No SHA has all required images: {required}", file=sys.stderr)
+              sys.exit(1)
+
+          sha = common.pop()
+          matrix = {"include": [
+              {"image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
+          ]}
+          print(f"Using SHA {sha} ({len(common)+1} candidates)")
+          print(json.dumps(matrix, indent=2))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={json.dumps(matrix)}\n")
+
+  container-tests:
+    name: "${{ matrix.image }}"
+    needs: find-images
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
+      - name: Install deps
+        run: uv sync --locked
+
+      - name: Start Podman socket
+        run: |
+          podman --version
+          systemctl --user enable --now podman.socket
+          echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and run tests
+        env:
+          TEST_IMAGE: ${{ matrix.image }}
+        run: |
+          set -Eeuxo pipefail
+          podman pull "${TEST_IMAGE}"
+          uv run pytest tests/containers \
+            -m 'not openshift and not cuda and not rocm and not manifest_validation' \
+            --image="${TEST_IMAGE}" \
+            -v
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -254,6 +254,10 @@ def grab_and_check_logs(subtests: pytest_subtests.SubTests, container: Workbench
         "WARNING: The Jupyter server is listening on all IP addresses and not using encryption. This is not recommended.",
     ]
 
+    if container.get_wrapped_container() is None:
+        logging.warning("Skipping log check: container was never started")
+        return
+
     # Let's wait a couple of seconds to give a chance to log eventual extra startup messages just to be sure we don't
     # miss anything important in this test.
     time.sleep(3)


### PR DESCRIPTION
## Summary

Add `.github/workflows/test-containers.yaml` -- a CI workflow that runs `tests/containers/` on PRs that only change test infrastructure, closing the gap where test-only PRs got no container test coverage.

The workflow:
- **Triggers** on changes to `tests/containers/**`, `tests/conftest.py`, `pytest.ini`
- **Finds images** by querying GHCR tags, intersecting SHA sets across image types to find a commit where all required images were built
- **Runs a matrix** of 3 image types in parallel: `jupyter-minimal`, `jupyter-datascience`, `runtime-datascience`
- **Uses pre-installed podman** on ubuntu-24.04 runners (no custom install step)

Also fixes `grab_and_check_logs` crashing with `ContainerStartException` when called on a container that was never started.

## Design

```
find-images job (once):
  skopeo list-tags → collect all GHCR tags
  → intersect SHA sets across required image types
  → output dynamic matrix with full image refs

container-tests job (3x parallel):
  podman pull ${{ matrix.image }}
  → pytest tests/containers/ --image=...
```

Image types are defined once in the Python step; the matrix is generated dynamically via `fromJSON`.

## Test plan

- [x] Workflow triggers on this PR
- [x] `find-images` job discovers a valid SHA with all 3 image types
- [x] All 3 matrix jobs pass (podman pull + container tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated container-based testing infrastructure to GitHub Actions for enhanced validation of container images.
  * Improved test resilience by adding safeguards against container startup failures in test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->