### PR TITLE
Fix requests 2.33.0 pin — version was yanked from PyPI

### DIFF
--- a/ci/requirements-elyra.txt
+++ b/ci/requirements-elyra.txt
@@ -16,7 +16,7 @@ nbformat==5.10.4
 papermill==2.7.0
 pyzmq==27.1.0
 prompt-toolkit==3.0.52
-requests==2.33.0
+requests==2.33.1
 tornado==6.5.5
 traitlets==5.14.3
 urllib3==2.6.3

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ required-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-21T07:54:28.058001651Z"
+exclude-newer = "2026-04-27T12:05:06.621129Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.0"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1600,9 +1600,9 @@ dependencies = [
     { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `requests==2.33.0` was yanked from PyPI and replaced by `2.33.1` (fixes CVE-2026-25645 and Content-Type header parsing)
- pip refuses to install yanked versions, breaking runtime image builds (e.g. `rocm-runtime-tensorflow-ubi9-python-3.12`)
- Updates the pin in `ci/requirements-elyra.txt` and regenerates `uv.lock`

Fixes: https://github.com/opendatahub-io/notebooks/actions/runs/25130331757/job/73654668393?pr=3470

## Test plan
- [ ] CI passes on runtime images that install from `ci/requirements-elyra.txt`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->