### PR TITLE
docs: add Slack build notification channels to konflux.md

### DIFF
--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -20,6 +20,8 @@ project: `open-data-hub-tenant`
     * [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central):
         * [pipelines](https://github.com/opendatahub-io/odh-konflux-central/tree/main/pipelines/notebooks): Definitions of the **Tekton** pipelines used for building and testing components (e.g., notebook images).
         * [gitops](https://github.com/opendatahub-io/odh-konflux-central/tree/main/gitops): Configuration for deployed components and End-to-End (e2e) tests.
+* **Build Notifications (Slack):** Push pipeline results (successes and failures) are posted automatically.
+    * [#odh-build-notifications](https://redhat-internal.slack.com/archives/C07ANR0T9KJ)
 * **Release Data (`konflux-release-data`):** Release engineering configuration for the ODH tenant.
     * [konflux-release-data](https://gitlab.cee.redhat.com/releng/konflux-release-data)
         * [stone-prd-rh01/tenants/open-data-hub-tenant](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/tree/main/tenants-config/cluster/stone-prd-rh01/tenants/open-data-hub-tenant)
@@ -37,6 +39,8 @@ project: `rhoai-tenant`
 * **Configuration Repository (`konflux-central`):** GitOps repository for RHDS Konflux definitions.
     * [konflux-central](https://github.com/red-hat-data-services/konflux-central):
         * [pipelineruns](https://github.com/red-hat-data-services/konflux-central/tree/main/pipelineruns/notebooks/.tekton): Specific **PipelineRun** definitions used for execution.
+* **Build Notifications (Slack):** Push pipeline failures are posted automatically.
+    * [#rhoai-build-notifications](https://redhat-internal.slack.com/archives/C07ANR2U56C)
 * **Release Data (`konflux-release-data`):** Release engineering configuration for the RHDS tenant.
     * [konflux-release-data](https://gitlab.cee.redhat.com/releng/konflux-release-data)
         * [stone-prod-p02/tenants/rhoai-tenant](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/tree/main/tenants-config/cluster/stone-prod-p02/tenants/rhoai-tenant)

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -20,7 +20,7 @@ project: `open-data-hub-tenant`
     * [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central):
         * [pipelines](https://github.com/opendatahub-io/odh-konflux-central/tree/main/pipelines/notebooks): Definitions of the **Tekton** pipelines used for building and testing components (e.g., notebook images).
         * [gitops](https://github.com/opendatahub-io/odh-konflux-central/tree/main/gitops): Configuration for deployed components and End-to-End (e2e) tests.
-* **Build Notifications (Slack):** Push pipeline results (successes and failures) are posted automatically.
+* **Build Notifications (Slack):** Push pipeline failures are posted automatically.
     * [#odh-build-notifications](https://redhat-internal.slack.com/archives/C07ANR0T9KJ)
 * **Release Data (`konflux-release-data`):** Release engineering configuration for the ODH tenant.
     * [konflux-release-data](https://gitlab.cee.redhat.com/releng/konflux-release-data)


### PR DESCRIPTION
## Summary

- Add links to `#odh-build-notifications` and `#rhoai-build-notifications` Slack channels under each tenant section in `docs/konflux.md`
- These channels receive automated Konflux push pipeline success/failure notifications and are useful for monitoring build health

## Test plan

- [ ] Verify links resolve correctly in Slack

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Konflux documentation updated to list Slack channels for build pipeline failures: #odh-build-notifications for ODH-io and #rhoai-build-notifications for RHDS/RHOAI, improving visibility of pipeline issues. No code or configuration changes were made; this is documentation-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->