### PR TITLE
fix: add sast-unicode-check memory override to all PipelineRuns

### DIFF
--- a/.tekton/odh-base-image-cpu-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-odh-main-pull-request.yaml
@@ -81,6 +81,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cpu-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-odh-main-push.yaml
@@ -76,6 +76,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cpu-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-ubi9-odh-main-pull-request.yaml
@@ -79,6 +79,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-ubi9-odh-main-push.yaml
@@ -70,6 +70,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-odh-main-pull-request.yaml
@@ -81,6 +81,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-odh-main-push.yaml
@@ -74,6 +74,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-12-9-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-ubi9-odh-main-pull-request.yaml
@@ -81,6 +81,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-12-9-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-ubi9-odh-main-push.yaml
@@ -74,6 +74,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-odh-main-pull-request.yaml
@@ -81,6 +81,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-odh-main-push.yaml
@@ -73,6 +73,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-4-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-c9s-odh-main-pull-request.yaml
@@ -80,6 +80,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-4-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-c9s-odh-main-push.yaml
@@ -73,6 +73,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-4-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-ubi9-odh-main-pull-request.yaml
@@ -82,6 +82,10 @@ spec:
         cpu: '8'
         memory: 32Gi
 
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-6-4-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-base-image-rocm-6-4-py312-ubi9-odh-main-push.yaml
@@ -74,6 +74,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-7-1-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-1-py312-c9s-odh-main-pull-request.yaml
@@ -80,6 +80,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-base-image-rocm-7-1-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-base-image-rocm-7-1-py312-c9s-odh-main-push.yaml
@@ -73,6 +73,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -42,6 +42,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-pipeline-runtime-datascience-cpu-py312-ubi9
   workspaces:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -42,6 +42,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-pipeline-runtime-minimal-cpu-py312-ubi9
   workspaces:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -46,6 +46,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -44,6 +44,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-pipeline-runtime-pytorch-rocm-py312-poc
   workspaces:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-odh-main-pull-request.yaml
@@ -206,6 +206,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-odh-main-push.yaml
@@ -203,6 +203,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -197,6 +197,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-odh-main-pull-request.yaml
@@ -97,4 +97,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-odh-main-push.yaml
@@ -93,6 +93,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -46,6 +46,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-odh-main-pull-request.yaml
@@ -118,6 +118,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-odh-main-push.yaml
@@ -106,4 +106,8 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -58,6 +58,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -58,10 +58,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-odh-main-pull-request.yaml
@@ -116,6 +116,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-odh-main-push.yaml
@@ -105,4 +105,8 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -58,6 +58,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -58,10 +58,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-odh-main-pull-request.yaml
@@ -116,6 +116,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-odh-main-push.yaml
@@ -98,6 +98,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-odh-main-pull-request.yaml
@@ -130,6 +130,10 @@ spec:
       limits:
         cpu: '4'
         memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-odh-main-push.yaml
@@ -110,6 +110,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-pull-request.yaml
@@ -96,6 +96,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-odh-main-push.yaml
@@ -84,6 +84,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -58,6 +58,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -58,10 +58,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-odh-main-pull-request.yaml
@@ -104,6 +104,10 @@ spec:
       limits:
         cpu: '4'
         memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-odh-main-push.yaml
@@ -109,6 +109,10 @@ spec:
       limits:
         cpu: '4'
         memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -46,6 +46,10 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-pull-request.yaml
@@ -103,4 +103,8 @@ spec:
       limits:
         cpu: '4'
         memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
@@ -100,6 +100,10 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-odh-main-push.yaml
@@ -100,10 +100,10 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -42,6 +42,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
   workspaces:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-pull-request.yaml
@@ -112,6 +112,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
@@ -108,6 +108,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-odh-main-push.yaml
@@ -108,10 +108,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -44,6 +44,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-tensorflow-rocm-py312-ubi9
   workspaces:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -44,6 +44,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-jupyter-trustyai-cpu-py312-ubi9
   workspaces:

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-odh-main-pull-request.yaml
@@ -79,6 +79,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-odh-main-push.yaml
@@ -65,4 +65,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-c9s-push.yaml
@@ -44,6 +44,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-rstudio-minimal-cpu-py312-c9s
   workspaces:

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-odh-main-pull-request.yaml
@@ -73,4 +73,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-odh-main-push.yaml
@@ -64,4 +64,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cpu-py312-rhel9-push.yaml
@@ -44,6 +44,12 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-workbench-rstudio-minimal-cpu-py312-rhel9
   workspaces:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-odh-main-pull-request.yaml
@@ -71,4 +71,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-odh-main-push.yaml
@@ -64,4 +64,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-c9s-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-odh-main-pull-request.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-odh-main-pull-request.yaml
@@ -82,6 +82,10 @@ spec:
       limits:
         cpu: '8'
         memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     name: multiarch-odh-main-combined-pipeline
   taskRunTemplate:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-odh-main-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-odh-main-push.yaml
@@ -64,4 +64,8 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
 status: {}

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-push.yaml
@@ -60,6 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-push.yaml
+++ b/.tekton/odh-workbench-rstudio-minimal-cuda-py312-rhel9-push.yaml
@@ -60,10 +60,10 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
+    - pipelineTaskName: sast-unicode-check
+      computeResources:
+        limits:
+          memory: 8Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

- Add `sast-unicode-check` memory limit override (8Gi) to all PipelineRun files that were missing it
- Fix YAML indentation in 12 files where the override was placed outside the `taskRunSpecs` list (2-space instead of 4-space indent), breaking YAML parsing
- Update the generator script (`ci/cached-builds/konflux_generate_component_build_pipelines.py`) to include `sast-unicode-check` in the `taskRunSpecs` memory-limits list, so the override survives regeneration
- PR #3160 ([KONFLUX-12587](https://redhat.atlassian.net/browse/KONFLUX-12587)) added this override to 16 files but missed the rest
- The upstream task default is 4Gi, which OOM-kills on the notebooks repo's large source tree

## Background

The `sast-unicode-check` task scans source code for non-printable unicode characters. The upstream task definition (`konflux-ci/konflux-sast-tasks` v0.4) sets a 4Gi memory limit. For repos with large source trees like notebooks, this is insufficient and the task gets OOMKilled intermittently.

Most recent occurrence: May 2, 2026 on PR #3470 (`odh-workbench-jupyter-minimal-cuda-py312-ubi9` failed with sast-unicode-check OOM).

Other Konflux users apply the same workaround:
- https://github.com/RedHatInsights/vmaas/blob/master/.tekton/vmaas-push.yaml
- https://github.com/openshift/lightspeed-service
- https://github.com/ansible/ansible-ai-connect-service

Related: KONFLUX-12286, [KONFLUX-12587](https://redhat.atlassian.net/browse/KONFLUX-12587)

## Test plan

- [x] Verify YAML syntax is valid (`yamllint`) — all 82 PipelineRun files pass `yaml.safe_load()` and `yamllint` (relaxed config)
- [x] Confirm no PipelineRun files are missing the override — all 82 PipelineRun files have `sast-unicode-check` in `taskRunSpecs`
- [x] `test_rhds_pipelines_use_rhds_args` passes (was failing with 12 subtests due to broken YAML)
- [ ] Monitor next few pipeline runs for sast-unicode-check OOM occurrences

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD Pipeline: increased memory allocation (8Gi) for the security/validation check run across multiple pipeline variants to improve stability and reduce OOM failures during automated validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->