### PR TITLE
fix: add sast-unicode-check to generator taskRunSpecs

### DIFF
--- a/ci/cached-builds/konflux_generate_component_build_pipelines.py
+++ b/ci/cached-builds/konflux_generate_component_build_pipelines.py
@@ -725,7 +725,15 @@ def component_build_pipeline(component_name, dockerfile_path, release, is_pr: bo
                     # leaving out "prefetch-dependencies" because we don't do hermetic build yet
                     # leaving out "build-images" for now, it already has a limit of 8Gi by default
                 }
-                for task_name in ("ecosystem-cert-preflight-checks", "clair-scan")
+                for task_name in (
+                    "ecosystem-cert-preflight-checks",
+                    "clair-scan",
+                    # sast-unicode-check: upstream default is 4Gi, OOMs on large source trees.
+                    # Other projects also override this, e.g.
+                    # https://github.com/RedHatInsights/vmaas/blob/master/.tekton/vmaas-push.yaml
+                    # Related: KONFLUX-12286, KONFLUX-12587
+                    "sast-unicode-check",
+                )
             ],
             "taskRunTemplate": {},
             "workspaces": [{"name": "git-auth", "secret": {"secretName": "{{ git_auth_secret }}"}}],


### PR DESCRIPTION
## Summary

- Add `sast-unicode-check` to the tuple of tasks that get an 8Gi memory limit override in the PipelineRun generator script
- Prevents regression when PipelineRun files are regenerated

## Context

The actual PipelineRun files are fixed in #3482. This PR ensures the generator stays in sync so future regenerations don't drop the override.

The generator already overrides `ecosystem-cert-preflight-checks` and `clair-scan` for the same reason. This adds `sast-unicode-check` to the same list.

## Test plan

- [ ] Run `PYTHONPATH=. uv run ci/cached-builds/konflux_generate_component_build_pipelines.py` and verify generated files include the override

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to include Unicode validation in task resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->