### PR TITLE
RHAIENG-4347: chore(tests/browser): rename @stage tags to @tier, document quality gates

### DIFF
--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -103,7 +103,7 @@ Test results (JUnit XML, screenshots) are written to the `results/` volume mount
 Tests are tagged using [Playwright's tag API](https://playwright.dev/docs/test-annotations#tag-tests)
 and filtered at runtime with `--grep @tagname`.
 
-Each test should have exactly one tier tag. The tier definitions follow the
+Each test should have at least one tier tag. The upstream RHOAI TestOps standard assigns exactly one tier per test; this repository allows multiple tier tags when a test is critical enough to run at several gates. The tier definitions follow the
 [RHOAI TestOps quality gate standard](https://docs.google.com/document/d/1LNkQDDN1g--3UYmLzi_c8WZjNSNudzDmhRrqQ7IaDeM/edit?tab=t.0#heading=h.ef6799ef5ld5)
 (agreed in `#wg-openshift-ai-quality`, Feb 2026):
 

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -98,6 +98,28 @@ podman run --rm -t \
 
 Test results (JUnit XML, screenshots) are written to the `results/` volume mount.
 
+## Test tags and quality gates
+
+Tests are tagged using [Playwright's tag API](https://playwright.dev/docs/test-annotations#tag-tests)
+and filtered at runtime with `--grep @tagname`.
+
+Each test should have exactly one tier tag. The tier definitions follow the
+[RHOAI TestOps quality gate standard](https://docs.google.com/document/d/1LNkQDDN1g--3UYmLzi_c8WZjNSNudzDmhRrqQ7IaDeM/edit?tab=t.0#heading=h.ef6799ef5ld5)
+(agreed in `#wg-openshift-ai-quality`, Feb 2026):
+
+| Tag | Gate | Meaning | Cadence |
+|---|---|---|---|
+| `@smoke` | Smoke | Very high / critical priority tests. Minimal validation that the component works at all. | Every nightly build |
+| `@tier1` | Tier 1 | High-priority tests (excluding Smoke). Core functionality and common user workflows. | Daily on nightly builds |
+| `@tier2` | Tier 2 | Medium/low-priority positive tests. Broader coverage, less critical paths. | Weekly |
+| `@tier3` | Tier 3 | Negative and destructive tests. Error handling, edge cases, recovery scenarios. | Weekly |
+
+A test that belongs to multiple tiers (e.g. a basic check that should run in every gate)
+can carry multiple tags: `{ tag: ['@smoke', '@tier1', '@tier2', '@tier3'] }`.
+
+Additional tags like `@codeserver` or `@openshift` group tests by feature area
+and are orthogonal to the tier tags.
+
 ## Good practices
 
 * https://playwright.dev/docs/best-practices

--- a/tests/browser/tests/openshift_console.spec.ts
+++ b/tests/browser/tests/openshift_console.spec.ts
@@ -35,7 +35,7 @@ test.describe('OpenShift console', { tag: '@openshift' }, () => {
 
   test.use({ ignoreHTTPSErrors: true });
 
-  test('OCP console loads', { tag: ['@smoke', '@stage1', '@stage2', '@stage3'] }, async ({ page }) => {
+  test('OCP console loads', { tag: ['@smoke', '@tier1', '@tier2', '@tier3'] }, async ({ page }) => {
     await page.goto(consoleUrl, { waitUntil: 'load' });
     // Console shows login page or redirects to OAuth — either counts
     await expect(page).toHaveTitle(/Log in|OpenShift|Red Hat/i);


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4347

## Summary
- Rename `@stage1`/`@stage2`/`@stage3` to `@tier1`/`@tier2`/`@tier3` in Playwright tests to align with the RHOAI TestOps quality gate standard agreed in `#wg-openshift-ai-quality` (Feb 2026).
- Add a "Test tags and quality gates" section to the browser tests README documenting what each tier means and when it runs.

## Context

The RHOAI TestOps quality gate standard defines:
- **Smoke**: very high / critical priority tests, every nightly build
- **Tier 1**: high-priority tests (excluding Smoke), daily on nightly builds
- **Tier 2**: medium/low-priority positive tests, weekly
- **Tier 3**: negative and destructive tests, weekly

The `@stage` naming was an interim choice; `@tier` is the org-wide standard used by all other component teams.

## Test plan
- [x] `pnpm exec playwright test --list --grep @tier1` lists the OCP console test
- [x] `pnpm exec playwright test --list --grep @smoke` still lists the OCP console test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Test tags and quality gates” guidance describing Playwright tag usage, tiered classifications (@smoke, @tier1, @tier2, @tier3) with cadence, and support for multiple orthogonal feature-area tags.

* **Tests**
  * Updated test metadata to adopt the new tier-based tag scheme for selecting/running tagged test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->