### PR TITLE
[GH 3418] (chore:renovate)Update renovate regex to catch prereleases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -116,9 +116,9 @@
       // reconstruct the BASE_IMAGE=… line correctly.
       "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}",
       "datasourceTemplate": "docker",
-      // Parses 3.4.0-1773428606 as major=3, minor=4, patch=0, build=1773428606
+      // Parses 3.4.0-ea.1-1773428606 as major=3, minor=4, patch=0, prerelease=ea.x, build=1773428606
       // so Renovate can correctly classify update types and block cross-version upgrades.
-      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?:-ea\\.(?<prerelease>\\d+))?-(?<build>\\d+)$",
     },
   ],
 
@@ -184,6 +184,7 @@
       "matchUpdateTypes": ["major", "minor"],
       "matchBaseBranches": ["main"],
       "matchRepositories": ["opendatahub-io/notebooks"],
+      "ignoreUnstable": false,
       "enabled": true,
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Related to: https://github.com/opendatahub-io/notebooks/issues/3418 

## Description
<!--- Describe your changes in detail -->

Update renovate regex to catch prereleases


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version parsing to recognize prerelease base image formats
  * Updated build configuration to allow unstable version upgrades on the main development branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->