### PR TITLE
[GH 3486](chore:renovate)Split up renovate rule to two 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -162,30 +162,39 @@
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false,
     },
+    // Exception: allow major/minor on main branch of upstream repo only.
+    // main is the development branch where version bumps are expected.
+    // Forks (e.g. red-hat-data-services/notebooks) and release branches stay blocked.
+    //
+    // NOTE: Renovate warns "You must configure baseBranchPatterns in order to
+    // use them inside matchBaseBranches."  This warning is cosmetic:
+    //   - MintMaker sets baseBranchPatterns per-branch at the self-hosted level
+    //     (konflux-ci/mintmaker internal/component/github/github.go), so
+    //     matchBaseBranches works correctly at runtime.
+    //   - Do NOT add a top-level baseBranches/baseBranchPatterns here — repo-level
+    //     baseBranchPatterns overrides MintMaker's per-branch config, breaking
+    //     release branch processing on the downstream fork
+    //     (red-hat-data-services/notebooks: rhoai-2.25, rhoai-3.3, etc.).
+    //     Ref: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1774946461904449
+    //   - Local dry-runs (--platform=local) cannot evaluate matchBaseBranches;
+    //     this is a known limitation of local mode.
     {
-      // Exception: allow major/minor on main branch of upstream repo only.
-      // main is the development branch where version bumps are expected.
-      // Forks (e.g. red-hat-data-services/notebooks) and release branches stay blocked.
-      //
-      // NOTE: Renovate warns "You must configure baseBranchPatterns in order to
-      // use them inside matchBaseBranches."  This warning is cosmetic:
-      //   - MintMaker sets baseBranchPatterns per-branch at the self-hosted level
-      //     (konflux-ci/mintmaker internal/component/github/github.go), so
-      //     matchBaseBranches works correctly at runtime.
-      //   - Do NOT add a top-level baseBranches/baseBranchPatterns here — repo-level
-      //     baseBranchPatterns overrides MintMaker's per-branch config, breaking
-      //     release branch processing on the downstream fork
-      //     (red-hat-data-services/notebooks: rhoai-2.25, rhoai-3.3, etc.).
-      //     Ref: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1774946461904449
-      //   - Local dry-runs (--platform=local) cannot evaluate matchBaseBranches;
-      //     this is a known limitation of local mode.
+      // Re-enables the major/minor updates that packageRules[4] blocks by default.
       "description": "Allow major/minor base image upgrades on upstream main",
       "matchManagers": ["custom.regex"],
       "matchUpdateTypes": ["major", "minor"],
       "matchBaseBranches": ["main"],
       "matchRepositories": ["opendatahub-io/notebooks"],
-      "ignoreUnstable": false,
       "enabled": true,
+    },
+    {
+      // Renovate forbids combining matchUpdateTypes + ignoreUnstable in one rule,
+      // so unstable (EA prerelease) opt-in lives in its own rule.
+      "description": "Allow unstable (EA) base image tags on upstream main",
+      "matchManagers": ["custom.regex"],
+      "matchBaseBranches": ["main"],
+      "matchRepositories": ["opendatahub-io/notebooks"],
+      "ignoreUnstable": false,
     },
     {
       // ubi9/go-toolset tags use Go version (1.24, 1.25) but Red Hat also


### PR DESCRIPTION


follow up fix for: https://github.com/opendatahub-io/notebooks/pull/3485


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The first rule satisfies the matchUpdateTypes-gated enabled: true ove…rride. The second rule separately sets ignoreUnstable: false with only branch/repo match conditions, which Renovate allows. Both conditions apply to the same packages — Renovate merges overlapping packageRule effects additively.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to better handle base image versions on the main branch, including support for unstable and early-access releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->