### PR TITLE
docs: expand konflux.md with repository ecosystem and pipeline architecture

### DIFF
--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -13,11 +13,20 @@ Each notebook image (workbench or pipeline runtime) has:
 - A `Dockerfile.konflux.<variant>` twin that currently differs only in LABEL metadata
 - Build-args conf files in `build-args/` (e.g., `cpu.conf`, `konflux.cpu.conf`) containing `BASE_IMAGE`, `INDEX_URL`, `PYLOCK_FLAVOR`
 
-The Makefile selects which Dockerfile and conf file to use based on the `KONFLUX` environment variable.
+The Makefile selects which Dockerfile and conf file to use based on the `KONFLUX` environment variable. The conf file is parsed by awk into `--build-arg KEY=VALUE` flags (see the `build_image` function in the Makefile). In Tekton pipelines, the same conf file is passed to buildah via `--build-arg-file`.
 
-The two repos have **different Tekton pipelines**:
-- **`opendatahub-io/notebooks`** (this repo) -- `.tekton/` contains ODH-main push/PR pipelines (e.g., `*-odh-main-push.yaml`) and ODH stable push pipelines (e.g., `*-push.yaml`). These reference the standard `Dockerfile.<variant>` and `build-args/<variant>.conf`. The stable push pipelines use a shared pipeline definition from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central/tree/main/pipeline).
+### Pipeline generation
+
+The `.tekton/` PipelineRun YAMLs in this repo are **generated** by `ci/cached-builds/konflux_generate_component_build_pipelines.py`. This script reads the Makefile to determine the Dockerfile path for each image target and generates both push and pull-request PipelineRun YAMLs. The generated pipelines already include an `image-labels` parameter (currently set to `release=<version>`) and a `build-args-file` parameter pointing to the appropriate conf file.
+
+### ODH vs RHOAI pipelines
+
+The two repos have **different Tekton pipelines** with different Dockerfile/conf file references:
+
+- **`opendatahub-io/notebooks`** (this repo) -- `.tekton/` contains ODH-main push/PR pipelines (e.g., `*-odh-main-push.yaml`) and ODH stable push pipelines (e.g., `*-push.yaml`). These reference the standard `Dockerfile.<variant>` and `build-args/<variant>.conf`. The stable push pipelines use a shared pipeline definition from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central/tree/main/pipeline) via a git `pipelineRef` resolver. The ODH-main pipelines embed the pipeline spec inline.
 - **`red-hat-data-services/notebooks`** (the fork) -- `.tekton/` contains RHOAI push/PR pipelines synced from [red-hat-data-services/konflux-central](https://github.com/red-hat-data-services/konflux-central/tree/main/pipelineruns/notebooks/.tekton). These reference the Konflux-specific `Dockerfile.konflux.<variant>` and `build-args/konflux.<variant>.conf`.
+
+Previously, the ODH notebook PipelineRuns lived in `odh-konflux-central/pipelineruns/notebooks/`. They were migrated back into this repo's `.tekton/` so that pipeline definition changes (e.g., resource limits, CEL trigger expressions) ship alongside the code on the `stable` branch, rather than requiring a separate PR to a central repo.
 
 ## Repository ecosystem
 

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -2,6 +2,63 @@
 
 This file provides an overview and quick access links to the **Konflux** environments used for building and deploying components for the **Open Data Hub (ODH)** and **Red Hat Data Services (RHDS)** projects.
 
+## Build system overview
+
+[Konflux](https://konflux-ci.dev/) is Red Hat's supply-chain-security-focused CI/CD system built on Tekton. It replaced Brew/OSBS for building RHOAI container images. The build pipeline includes: git clone, dependency prefetch (Cachi2), multi-arch buildah builds, image index creation, source image creation, and security scans (Clair vulnerability, ClamAV malware, Snyk SAST, shell-check, unicode check, RPM signature scan, deprecated-base-image check). It also handles SBOM generation, Tekton Chains attestation, tagging, Slack failure notifications, and triggering downstream operator builds.
+
+### How notebooks images are built
+
+Each notebook image (workbench or pipeline runtime) has:
+- A `Dockerfile.<variant>` (e.g., `Dockerfile.cpu`, `Dockerfile.cuda`, `Dockerfile.rocm`)
+- A `Dockerfile.konflux.<variant>` twin that currently differs only in LABEL metadata
+- Build-args conf files in `build-args/` (e.g., `cpu.conf`, `konflux.cpu.conf`) containing `BASE_IMAGE`, `INDEX_URL`, `PYLOCK_FLAVOR`
+
+The Makefile selects which Dockerfile and conf file to use based on the `KONFLUX` environment variable.
+
+The two repos have **different Tekton pipelines**:
+- **`opendatahub-io/notebooks`** (this repo) -- `.tekton/` contains ODH-main push/PR pipelines (e.g., `*-odh-main-push.yaml`) and ODH stable push pipelines (e.g., `*-push.yaml`). These reference the standard `Dockerfile.<variant>` and `build-args/<variant>.conf`. The stable push pipelines use a shared pipeline definition from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central/tree/main/pipeline).
+- **`red-hat-data-services/notebooks`** (the fork) -- `.tekton/` contains RHOAI push/PR pipelines synced from [red-hat-data-services/konflux-central](https://github.com/red-hat-data-services/konflux-central/tree/main/pipelineruns/notebooks/.tekton). These reference the Konflux-specific `Dockerfile.konflux.<variant>` and `build-args/konflux.<variant>.conf`.
+
+## Repository ecosystem
+
+### [opendatahub-io/odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central)
+
+Central configuration store for Konflux CI/CD artifacts across all ODH components (~44 components).
+
+- **`pipeline/`** -- Shared Tekton Pipeline definitions (e.g., `multi-arch-container-build.yaml`) that define the full build-and-scan workflow. The ODH stable push pipelines in this repo's `.tekton/*-push.yaml` reference these via `pipelineRef`.
+- **`pipelineruns/`** -- Per-component PipelineRun definitions. The notebooks PipelineRuns have been **migrated back** into this repo's `.tekton/` directory (see `pipelineruns/notebooks/README.md` deprecation notice), so pipeline updates sync to the `stable` branch alongside code changes.
+- **`gitops/`** -- Kubernetes/Konflux resource manifests that register each component with the Konflux application (`opendatahub-builds`). `Component` CRs point to each repo's source, output image in `quay.io/opendatahub/`, and the build pipeline to use.
+- **`integration-tests/`** -- Integration test configurations, including a `notebooks/` subdirectory.
+- **`workflows/notebooks/`** -- Contains `insta-merge.yaml` for auto-merging notebook changes.
+
+### [red-hat-data-services/konflux-central](https://github.com/red-hat-data-services/konflux-central)
+
+Centralized configuration hub for the RHOAI/RHDS Konflux system (~50 components). Analogous to `odh-konflux-central` but for downstream.
+
+- **Pipeline Sync** -- Tekton PipelineRun YAMLs are authored under `pipelineruns/<component>/.tekton/` and automatically distributed to each component repo's `.tekton/` directory via the `sync-pipelineruns.yml` GitHub Actions workflow.
+- **Renovate Sync** -- Centralizes Renovate dependency-update configs, mapped via `config.yaml`, and pushed to target repos.
+- **Validation and release management** -- Workflows validate PipelineRun correctness, handle release branch patterns (`rhoai-X.Y`, `rhoai-X.Y-ea.N`), apply z-stream changes, and retrigger builds.
+- **Reusable Pipelines** -- `pipelines/` holds container-build, multi-arch-container-build, and fbc-fragment-build definitions.
+
+### [red-hat-data-services/RHOAI-Konflux-Automation](https://github.com/red-hat-data-services/RHOAI-Konflux-Automation)
+
+Release engineering toolbox for RHOAI. It is the glue between Konflux builds and RHOAI releases.
+
+- **`utils/processors/`** -- `operator-processor.py` and `bundle-processor.py` sync operator manifests, update image digests from Quay.io, and manage Tekton push-pipeline toggles.
+- **`utils/fbc-processor/`** -- Handles File-Based Catalog (FBC) operations: patching OLM catalog YAML with new bundles, remapping image registries to Red Hat production, and extracting container images from build snapshots.
+- **`utils/release-helper/`** -- Shell and Python scripts that generate stage and production release artifacts, validate consistency, and automate the release sequence.
+- **`utils/stage-promoter/`** -- Merges catalog patches for staging, polls Quay.io for completed FBC fragment builds, verifies image signatures, and sends Slack notifications.
+- **`utils/sprint-onboarder/`** -- YAML templates defining Konflux Component resources for each RHOAI version, pointing to source repos with their Dockerfiles.
+- **`utils/commons/`** -- Shared Quay.io controller/onboarder utilities and `repos.yaml` listing ~29 ODH component repos.
+
+### [red-hat-data-services/rhods-devops-infra](https://github.com/red-hat-data-services/rhods-devops-infra)
+
+Automated synchronization infrastructure between upstream ODH and downstream RHDS repositories.
+
+- **[Upstream to Downstream Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/upstream-auto-merge.yaml)** -- Runs daily at UTC 0:00. Syncs changes from upstream repos (e.g., `opendatahub-io/notebooks`) to downstream repos (e.g., `red-hat-data-services/notebooks`) based on [upstream-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/upstream-source-map.yaml). Can be manually triggered per-component.
+- **[Main to Release Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/main-release-auto-merge.yaml)** -- Runs daily at UTC 1:00. Syncs from downstream `main` to `rhoai-x.y` release branches based on [main-release-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/main-release-source-map.yaml). Automatically creates release branches on sprint start and disables auto-merge after code freeze.
+- **Jira Ticket Automation** -- Generates sprint tickets from YAML templates via [create-jira-tickets.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/create-jira-tickets.yaml).
+
 ## Pipeline resource overrides
 
 All PipelineRuns in `.tekton/` override compute resources for several tasks that OOM with Konflux defaults on this repo's large source tree. The standard overrides (4 CPU / 8Gi) cover `prefetch-dependencies`, `build-images`, `clair-scan`, `sast-shell-check`, `sast-unicode-check`, and `sast-snyk-check`. The codeserver pipelines use higher limits (**8 CPU / 32Gi**) for `prefetch-dependencies` and `build-images` because the codeserver image is significantly larger. This follows [Konflux: Overriding compute resources](https://konflux-ci.dev/docs/building/overriding-compute-resources/) (PipelineRun `spec.taskRunSpecs` in `.tekton`).
@@ -237,3 +294,31 @@ These GitHub Actions workflows manage the automated synchronization of configura
     * [RHDS/main -> rhoai-* auto-merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/main-release-auto-merge.yaml)
 * **ODH main -> stable Auto-Merge:** Merges `main` into `stable` for the notebooks repo (RHOAIENG-60781).
     * [main -> stable auto-merge](https://github.com/opendatahub-io/notebooks/actions/workflows/merge-main-to-stable-fast-forward.yaml)
+
+## Dockerfile deduplication
+
+The repo has ~59 Dockerfiles with two axes of duplication:
+1. **ODH vs Konflux** -- every `Dockerfile.<variant>` has a `Dockerfile.konflux.<variant>` twin that differs only in LABEL metadata (~21 Konflux files)
+2. **cpu/cuda/rocm variants** -- within the same directory, these are ~95% identical (only 3 directories have multiple variants that could be merged)
+
+Tracking issues:
+- GitHub: [opendatahub-io/notebooks#3355 -- Dockerfile Deduplication Plan](https://github.com/opendatahub-io/notebooks/issues/3355)
+- Jira: [RHOAIENG-54488 -- Merge Dockerfiles into single unified Dockerfile per component](https://issues.redhat.com/browse/RHOAIENG-54488)
+
+**Phase 1** (Konflux dedup): Parameterize LABEL blocks via build-args so `Dockerfile.cpu` and `Dockerfile.konflux.cpu` become byte-identical. The CI alignment check (`scripts/check_dockerfile_alignment.sh`) already verifies semantic identity; the goal is to achieve byte-identity.
+
+**Phase 2** (variant merge): Merge cpu/cuda/rocm variants into a single Dockerfile per component using build-args for the accelerator-specific differences. Only 3 directories have multiple variants to merge (`jupyter/minimal`, `rstudio/c9s-python-3.12`, `rstudio/rhel9-python-3.12`).
+
+## Future direction: E2E TestOps ecosystem
+
+The [E2E TestOps Ecosystem across ODH & RHOAI](https://docs.google.com/document/d/1LNkQDDN1g--3UYmLzi_c8WZjNSNudzDmhRrqQ7IaDeM/edit) design document (Jira: [RHAISTRAT-903](https://issues.redhat.com/browse/RHAISTRAT-903), status: In-Progress, created Dec 2025) defines a phased plan to standardize the entire TestOps ecosystem across ODH and RHOAI. The document has 9 tabs covering:
+
+1. **Design + Plan** -- Architecture with five logical planes (Orchestration, Test Selection, Test Execution, Reporting, Gating) and a Knowledge Layer. Six phases from actionable reporting (Phase 1, target end Apr 2026) through AI-driven optimization (Phase 6).
+2. **Redefining CI Quality Gate Strategy** -- Proposes a fail-fast model: Cluster Verification Test (CVT) and Build Verification Test (BVT) first (~15 min), then Smoke (~1-2h), then Tier 1/2/3 (~5-10h).
+3. **CI Build Test Failure Response Framework** -- Defines failure ownership (automation issue vs product issue), SLAs (24h triage), and fix-vs-revert strategy across Stream/Lake/Ocean stages.
+4. **TestOps Downstream Release Testing** -- Nightly (daily smoke, weekly deep) and RC quality gates with pass/fail criteria for promotion.
+5. **Test Infrastructure & Quality Gate Strategy** -- Maps test gates to Stream (dev sandbox), Lake (ODH integration), and Ocean (RHOAI integration) stages of the Bodies of Water framework.
+6. **ODH Nightly Pipeline Ownership & Triage** -- Weekly on-call rotation for ODH nightly smoke pipeline triage, automated via Slack bot.
+7. **Component-Based Pipelines in Jenkins CI** -- Standardized per-component Jenkins pipelines (implemented via [RHOAIENG-43188](https://issues.redhat.com/browse/RHOAIENG-43188)).
+8. **Test Reporting System** -- Bot-based architecture using Data Router + ReportPortal as central hub, with Jira TFA integration and Slack notifications.
+9. **Sign Off** -- Team sign-off tracking.

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -64,7 +64,7 @@ Release engineering toolbox for RHOAI. It is the glue between Konflux builds and
 
 Automated synchronization infrastructure between upstream ODH and downstream RHDS repositories.
 
-- **[Upstream to Downstream Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/upstream-auto-merge.yaml)** -- Runs daily at UTC 0:00. Syncs changes from upstream repos (e.g., `opendatahub-io/notebooks`) to downstream repos (e.g., `red-hat-data-services/notebooks`) based on [upstream-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/upstream-source-map.yaml). Can be manually triggered per-component.
+- **[Upstream to Downstream Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/upstream-auto-merge.yaml)** -- Runs daily at 00:00 UTC. Syncs changes from upstream repos (e.g., `opendatahub-io/notebooks`) to downstream repos (e.g., `red-hat-data-services/notebooks`) based on [upstream-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/upstream-source-map.yaml). It can also be manually triggered per component.
 - **[Main to Release Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/main-release-auto-merge.yaml)** -- Runs daily at UTC 1:00. Syncs from downstream `main` to `rhoai-x.y` release branches based on [main-release-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/main-release-source-map.yaml). Automatically creates release branches on sprint start and disables auto-merge after code freeze.
 - **Jira Ticket Automation** -- Generates sprint tickets from YAML templates via [create-jira-tickets.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/create-jira-tickets.yaml).
 
@@ -330,4 +330,4 @@ The [E2E TestOps Ecosystem across ODH & RHOAI](https://docs.google.com/document/
 6. **ODH Nightly Pipeline Ownership & Triage** -- Weekly on-call rotation for ODH nightly smoke pipeline triage, automated via Slack bot.
 7. **Component-Based Pipelines in Jenkins CI** -- Standardized per-component Jenkins pipelines (implemented via [RHOAIENG-43188](https://issues.redhat.com/browse/RHOAIENG-43188)).
 8. **Test Reporting System** -- Bot-based architecture using Data Router + ReportPortal as central hub, with Jira TFA integration and Slack notifications.
-9. **Sign Off** -- Team sign-off tracking.
+9. **Sign-off** -- Team sign-off tracking.

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -65,7 +65,7 @@ Release engineering toolbox for RHOAI. It is the glue between Konflux builds and
 Automated synchronization infrastructure between upstream ODH and downstream RHDS repositories.
 
 - **[Upstream to Downstream Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/upstream-auto-merge.yaml)** -- Runs daily at 00:00 UTC. Syncs changes from upstream repos (e.g., `opendatahub-io/notebooks`) to downstream repos (e.g., `red-hat-data-services/notebooks`) based on [upstream-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/upstream-source-map.yaml). It can also be manually triggered per component.
-- **[Main to Release Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/main-release-auto-merge.yaml)** -- Runs daily at UTC 1:00. Syncs from downstream `main` to `rhoai-x.y` release branches based on [main-release-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/main-release-source-map.yaml). Automatically creates release branches on sprint start and disables auto-merge after code freeze.
+- **[Main to Release Auto-Merge](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/main-release-auto-merge.yaml)** -- Runs daily at 01:00 UTC. Syncs from downstream `main` to `rhoai-x.y` release branches based on [main-release-source-map.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/src/config/main-release-source-map.yaml). Automatically creates release branches on sprint start and disables auto-merge after code freeze.
 - **Jira Ticket Automation** -- Generates sprint tickets from YAML templates via [create-jira-tickets.yaml](https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/create-jira-tickets.yaml).
 
 ## Pipeline resource overrides
@@ -308,7 +308,7 @@ These GitHub Actions workflows manage the automated synchronization of configura
 
 The repo has ~59 Dockerfiles with two axes of duplication:
 1. **ODH vs Konflux** -- every `Dockerfile.<variant>` has a `Dockerfile.konflux.<variant>` twin that differs only in LABEL metadata (~21 Konflux files)
-2. **cpu/cuda/rocm variants** -- within the same directory, these are ~95% identical (only 3 directories have multiple variants that could be merged)
+2. **cpu/cuda/rocm variants** -- within the same directory, these are ~95% identical
 
 Tracking issues:
 - GitHub: [opendatahub-io/notebooks#3355 -- Dockerfile Deduplication Plan](https://github.com/opendatahub-io/notebooks/issues/3355)


### PR DESCRIPTION
## Summary
- Document the four key repos in the Konflux ecosystem (`odh-konflux-central`, `konflux-central`, `RHOAI-Konflux-Automation`, `rhods-devops-infra`) and their roles
- Clarify that `opendatahub-io/notebooks` and `red-hat-data-services/notebooks` have **different Tekton pipelines** referencing different Dockerfiles and conf files
- Add build system overview explaining how notebook images are built with Konflux
- Add Dockerfile deduplication tracking section (GitHub #3355, [RHOAIENG-54488](https://redhat.atlassian.net/browse/RHOAIENG-54488))
- Link the E2E TestOps Ecosystem design doc ([RHAISTRAT-903](https://redhat.atlassian.net/browse/RHAISTRAT-903)) as future direction

## Test plan
- [x] Verify markdown renders correctly on GitHub
- [x] Verify all links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Tekton-based build-system overview describing end-to-end build-and-scan flow
  * Documented how notebook images are built, Makefile-driven selections, and pipeline generation approaches
  * Expanded repository ecosystem and upstream/downstream automation notes, preserving auto-merge workflow context
  * Introduced Dockerfile deduplication phases with tracking guidance
  * Outlined future E2E TestOps direction, governance, and phased CI quality gates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->