### PR TITLE
RHAIENG-5137: ci: parameterize Dockerfile LABEL blocks via build-args

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -265,15 +265,29 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-code-server-ubi9-python-3.12" \
-      summary="code-server image with python 3.12 based on UBI 9" \
-      description="code-server image with python 3.12 based on UBI9" \
-      io.k8s.display-name="code-server image with python 3.12 based on UBI9" \
-      io.k8s.description="code-server image with python 3.12 based on UBI9" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/ubi9-python-3.12" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 USER 0
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -264,13 +264,29 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
-      summary="code-server image with python 3.12 based on UBI 9" \
-      description="code-server image with python 3.12 based on UBI9" \
-      io.k8s.description="code-server image with python 3.12 based on UBI9" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 USER 0
 

--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=odh-notebook-code-server-ubi9-python-3.12
+LABEL_SUMMARY=code-server image with python 3.12 based on UBI 9
+LABEL_DESCRIPTION=code-server image with python 3.12 based on UBI9
+LABEL_DISPLAY_NAME=code-server image with python 3.12 based on UBI9
+LABEL_K8S_DESCRIPTION=code-server image with python 3.12 based on UBI9
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/codeserver/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.12

--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
+LABEL_SUMMARY=code-server image with python 3.12 based on UBI 9
+LABEL_DESCRIPTION=code-server image with python 3.12 based on UBI9
+LABEL_DISPLAY_NAME=odh-workbench-codeserver-datascience-cpu-py312-rhel9
+LABEL_K8S_DESCRIPTION=code-server image with python 3.12 based on UBI9
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -110,15 +110,29 @@ FROM jupyter-minimal AS jupyter-datascience
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.12" \
-    summary="Jupyter data science notebook image for ODH notebooks" \
-    description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter data science notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -110,13 +110,29 @@ FROM jupyter-minimal AS jupyter-datascience
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-datascience-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-datascience-cpu-py312-rhel9" \
-      summary="Jupyter data science notebook image for ODH notebooks" \
-      description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=odh-notebook-jupyter-datascience-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter data science notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter data science notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.12

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
+LABEL_SUMMARY=Jupyter data science notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-datascience-cpu-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -41,15 +41,29 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.12" \
-    summary="Minimal Jupyter notebook image for ODH notebooks" \
-    description="Minimal Jupyter notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Minimal Jupyter notebook image for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -40,15 +40,29 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12" \
-    summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \
-    description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Minimal Jupyter CUDA notebook image for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-minimal-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -41,13 +41,29 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9" \
-    com.redhat.component="odh-workbench-jupyter-minimal-cpu-py312-rhel9" \
-    io.k8s.display-name="odh-workbench-jupyter-minimal-cpu-py312-rhel9" \
-    summary="Minimal Jupyter CPU notebook image for ODH notebooks" \
-    description="Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -40,13 +40,29 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9" \
-    com.redhat.component="odh-workbench-jupyter-minimal-cuda-py312-rhel9" \
-    io.k8s.display-name="odh-workbench-jupyter-minimal-cuda-py312-rhel9" \
-    summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \
-    description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -42,13 +42,29 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-minimal-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-minimal-rocm-py312-rhel9" \
-      summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \
-      description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -42,15 +42,29 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12" \
-    summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \
-    description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Minimal Jupyter ROCm notebook image for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-minimal-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=odh-notebook-jupyter-minimal-ubi9-python-3.12
+LABEL_SUMMARY=Minimal Jupyter notebook image for ODH notebooks
+LABEL_DESCRIPTION=Minimal Jupyter notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Minimal Jupyter notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Minimal Jupyter notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.12

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12
+LABEL_SUMMARY=Minimal Jupyter CUDA notebook image for ODH notebooks
+LABEL_DESCRIPTION=Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Minimal Jupyter CUDA notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:cuda-jupyter-minimal-ubi9-python-3.12

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9
+LABEL_SUMMARY=Minimal Jupyter CPU notebook image for ODH notebooks
+LABEL_DESCRIPTION=Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-minimal-cpu-py312-rhel9
+LABEL_K8S_DESCRIPTION=Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777398786
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9
+LABEL_SUMMARY=Minimal Jupyter CUDA notebook image for ODH notebooks
+LABEL_DESCRIPTION=Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-minimal-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1777398681
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9
+LABEL_SUMMARY=Minimal Jupyter ROCm notebook image for ODH notebooks
+LABEL_DESCRIPTION=Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-minimal-rocm-py312-rhel9
+LABEL_K8S_DESCRIPTION=Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12
+LABEL_SUMMARY=Minimal Jupyter ROCm notebook image for ODH notebooks
+LABEL_DESCRIPTION=Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Minimal Jupyter ROCm notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:rocm-jupyter-minimal-ubi9-python-3.12

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -148,15 +148,29 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12" \
-    summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch+llmcompressor/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # Install Python packages and Jupyterlab extensions from lockfile (requirements.cuda.txt used only for Cachi2 prefetch)
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -148,13 +148,29 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9" \
-      summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-      description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # Install Python packages and Jupyterlab extensions from lockfile (requirements.cuda.txt used only for Cachi2 prefetch)
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch+llmcompressor/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777398786
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
+LABEL_SUMMARY=Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -130,15 +130,29 @@ WORKDIR /opt/app-root/bin
 
 USER root
 
-LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
-    summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \
-    description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter CUDA pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # pylock.toml documents the graph; requirements.cuda.txt drives Cachi2 prefetch and hermetic uv install
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -130,13 +130,29 @@ WORKDIR /opt/app-root/bin
 
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-pytorch-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-pytorch-cuda-py312-rhel9" \
-      summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \
-      description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # pylock.toml documents the graph; requirements.cuda.txt drives Cachi2 prefetch and hermetic uv install
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1776718261
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter CUDA pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter CUDA pytorch notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.12

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777398786
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
+LABEL_SUMMARY=Jupyter CUDA pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-pytorch-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -129,13 +129,29 @@ ARG PYLOCK_FLAVOR
 
 WORKDIR /opt/app-root/bin
 
-LABEL name="rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
-      summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \
-      description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -129,15 +129,29 @@ ARG PYLOCK_FLAVOR
 
 WORKDIR /opt/app-root/bin
 
-LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
-    summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \
-    description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter ROCm pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1777398681
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
+LABEL_SUMMARY=Jupyter ROCm pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-pytorch-rocm-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter ROCm pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter ROCm pytorch notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/pytorch/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.12

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -148,13 +148,29 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-tensorflow-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-tensorflow-rocm-py312-rhel9" \
-      summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
-      description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # Install Python packages from lockfile (requirements.rocm.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -148,15 +148,29 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12" \
-    summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
-    description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter AMD tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-tensorflow-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # Install Python packages from lockfile (requirements.rocm.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1777398681
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
+LABEL_SUMMARY=Jupyter AMD tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter AMD tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter AMD tensorflow notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/tensorflow/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:rocm-jupyter-tensorflow-ubi9-python-3.12

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -147,15 +147,29 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
-    summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
-    description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # Install Python packages and Jupyterlab extensions from lockfile (requirements.cuda.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -147,13 +147,29 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
-      summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
-      description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 # Install Python packages and Jupyterlab extensions from lockfile (requirements.cuda.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter CUDA tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter CUDA tensorflow notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.12

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1777398846
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
+LABEL_SUMMARY=Jupyter CUDA tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -136,15 +136,29 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.12" \
-    summary="Jupyter trustyai notebook image for ODH notebooks" \
-    description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter trustyai notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -136,13 +136,29 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
-      summary="Jupyter trustyai notebook image for ODH notebooks" \
-      description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=odh-notebook-jupyter-trustyai-ubi9-python-3.12
+LABEL_SUMMARY=Jupyter trustyai notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Jupyter trustyai notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi9-python-3.12

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
+LABEL_SUMMARY=Jupyter trustyai notebook image for ODH notebooks
+LABEL_DESCRIPTION=Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-workbench-jupyter-trustyai-cpu-py312-rhel9
+LABEL_K8S_DESCRIPTION=Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -47,15 +47,29 @@ ARG TARGETARCH
 ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.12" \
-    summary="Runtime data science notebook image for ODH notebooks" \
-    description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime data science notebook image for ODH notebooks" \
-    io.k8s.description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/datascience/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -85,10 +85,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
-      io.k8s.description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      summary="Runtime data science notebook image for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=odh-notebook-runtime-datascience-ubi9-python-3.12
+LABEL_SUMMARY=Runtime data science notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime data science notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/datascience/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.12

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9
+LABEL_SUMMARY=Runtime data science notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-datascience-cpu-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -46,15 +46,29 @@ FROM cpu-base AS runtime-minimal
 ARG MINIMAL_SOURCE_CODE=runtimes/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.12" \
-    summary="Runtime minimal image for ODH notebooks" \
-    description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime minimal image for ODH notebooks" \
-    io.k8s.description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-minimal-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -74,10 +74,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-minimal-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-minimal-cpu-py312-rhel9" \
-      summary="Runtime minimal image for ODH notebooks" \
-      description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=odh-notebook-runtime-minimal-ubi9-python-3.12
+LABEL_SUMMARY=Runtime minimal image for ODH notebooks
+LABEL_DESCRIPTION=Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime minimal image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/minimal/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:runtime-minimal-ubi9-python-3.12

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu
+LABEL_NAME=rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9
+LABEL_SUMMARY=Runtime minimal image for ODH notebooks
+LABEL_DESCRIPTION=Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-minimal-cpu-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -36,15 +36,29 @@ FROM cuda-base AS cuda-runtime-pytorch
 ARG PYTORCH_SOURCE_CODE=runtimes/pytorch+llmcompressor/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12" \
-    summary="Runtime CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    description="Runtime CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    io.k8s.description="Runtime CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch+llmcompressor/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-llmcompressor-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,10 +67,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      summary="Runtime pytorch-llmcompressor notebook image for ODH notebooks" \
-      description="Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12
+LABEL_SUMMARY=Runtime CUDA pytorch-llmcompressor notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime CUDA pytorch-llmcompressor notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch+llmcompressor/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:runtime-pytorch-llmcompressor-ubi9-python-3.12

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777398786
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
+LABEL_SUMMARY=Runtime pytorch-llmcompressor notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -38,15 +38,29 @@ FROM cuda-base AS cuda-runtime-pytorch
 ARG PYTORCH_SOURCE_CODE=runtimes/pytorch/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.12" \
-    summary="Runtime pytorch notebook image for ODH notebooks" \
-    description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,10 +67,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      summary="Runtime pytorch notebook image for ODH notebooks" \
-      description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1776718261
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-runtime-pytorch-ubi9-python-3.12
+LABEL_SUMMARY=Runtime pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime pytorch notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.12

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777398786
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+LABEL_SUMMARY=Runtime pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -75,10 +75,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-pytorch-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-pytorch-rocm-py312-rhel9" \
-      summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
-      description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -34,15 +34,29 @@ FROM rocm-base AS rocm-runtime-pytorch
 ARG PYTORCH_SOURCE_CODE=runtimes/rocm-pytorch/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12" \
-    summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
-    description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime ROCm pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/rocm-pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-runtime-pytorch-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1777398681
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+LABEL_SUMMARY=Runtime ROCm pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12
+LABEL_SUMMARY=Runtime ROCm pytorch notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime ROCm pytorch notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/rocm-pytorch/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:rocm-runtime-pytorch-ubi9-python-3.12

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -70,10 +70,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-tensorflow-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-tensorflow-rocm-py312-rhel9" \
-      summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
-      description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -34,15 +34,29 @@ FROM rocm-base AS rocm-runtime-tensorflow
 ARG TENSORFLOW_SOURCE_CODE=runtimes/rocm-tensorflow/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12" \
-    summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
-    description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime ROCm tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/rocm-tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-runtime-tensorflow-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1777398681
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+LABEL_SUMMARY=Runtime ROCm tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+LABEL_NAME=odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12
+LABEL_SUMMARY=Runtime ROCm tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime ROCm tensorflow notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/rocm-tensorflow/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:rocm-runtime-tensorflow-ubi9-python-3.12

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -36,15 +36,29 @@ FROM cuda-base AS cuda-runtime-tensorflow
 ARG TENSORFLOW_SOURCE_CODE=runtimes/tensorflow/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12" \
-    summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
-    description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime CUDA tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi9-python-3.12"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"
 
 WORKDIR /opt/app-root/bin
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,10 +67,26 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-tensorflow-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-tensorflow-cuda-py312-rhel9" \
-      summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
-      description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+ARG LABEL_NAME=""
+ARG LABEL_SUMMARY=""
+ARG LABEL_DESCRIPTION=""
+ARG LABEL_DISPLAY_NAME=""
+ARG LABEL_K8S_DESCRIPTION=""
+ARG LABEL_COM_REDHAT_COMPONENT=""
+ARG LABEL_COM_REDHAT_LICENSE_TERMS=""
+ARG LABEL_AUTHORITATIVE_SOURCE_URL=""
+ARG LABEL_BUILD_COMMIT_REF=""
+ARG LABEL_BUILD_SOURCE_LOCATION=""
+ARG LABEL_BUILD_IMAGE=""
+
+LABEL name="${LABEL_NAME}" \
+      summary="${LABEL_SUMMARY}" \
+      description="${LABEL_DESCRIPTION}" \
+      io.k8s.display-name="${LABEL_DISPLAY_NAME}" \
+      io.k8s.description="${LABEL_K8S_DESCRIPTION}" \
+      com.redhat.component="${LABEL_COM_REDHAT_COMPONENT}" \
+      com.redhat.license_terms="${LABEL_COM_REDHAT_LICENSE_TERMS}" \
+      authoritative-source-url="${LABEL_AUTHORITATIVE_SOURCE_URL}" \
+      io.openshift.build.commit.ref="${LABEL_BUILD_COMMIT_REF}" \
+      io.openshift.build.source-location="${LABEL_BUILD_SOURCE_LOCATION}" \
+      io.openshift.build.image="${LABEL_BUILD_IMAGE}"

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9-test/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12
+LABEL_SUMMARY=Runtime CUDA tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=Runtime CUDA tensorflow notebook image for ODH notebooks
+LABEL_K8S_DESCRIPTION=Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=
+LABEL_COM_REDHAT_LICENSE_TERMS=
+LABEL_AUTHORITATIVE_SOURCE_URL=https://github.com/opendatahub-io/notebooks
+LABEL_BUILD_COMMIT_REF=main
+LABEL_BUILD_SOURCE_LOCATION=https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi9-python-3.12
+LABEL_BUILD_IMAGE=quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi9-python-3.12

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,14 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9-test/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1777398846
 PYLOCK_FLAVOR=cuda
+LABEL_NAME=rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+LABEL_SUMMARY=Runtime CUDA tensorflow notebook image for ODH notebooks
+LABEL_DESCRIPTION=Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_DISPLAY_NAME=odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+LABEL_K8S_DESCRIPTION=Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks
+LABEL_COM_REDHAT_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+LABEL_COM_REDHAT_LICENSE_TERMS=https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf
+LABEL_AUTHORITATIVE_SOURCE_URL=
+LABEL_BUILD_COMMIT_REF=
+LABEL_BUILD_SOURCE_LOCATION=
+LABEL_BUILD_IMAGE=

--- a/scripts/check_dockerfile_alignment.sh
+++ b/scripts/check_dockerfile_alignment.sh
@@ -84,6 +84,9 @@ strip() {
             next
         }
 
+        # Skip ARG declarations for label parameters
+        /^[[:space:]]*ARG[[:space:]]+LABEL_/ { next }
+
         # Print all other lines (trimmed)
         {
             # Trim leading and trailing whitespace


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5137

## Summary
- Replace hardcoded LABEL blocks in all 36 Dockerfiles (18 pairs across `jupyter/`, `codeserver/`, `runtimes/`) with ARG-driven labels
- Move label values into corresponding `build-args/*.conf` files, where they are consumed as `--build-arg` by the Makefile and `--build-arg-file` by Tekton/buildah
- Update `check_dockerfile_alignment.sh` to skip `ARG LABEL_*` lines during semantic comparison
- First step toward making `Dockerfile` and `Dockerfile.konflux` files byte-identical (refs #3355, [RHOAIENG-54488](https://issues.redhat.com/browse/RHOAIENG-54488))

The LABEL blocks now use the same 11 ARGs in both variants; only the values in the conf files differ (ODH branding vs RHOAI branding). No Makefile changes needed -- the existing awk parser already handles the new `KEY=VALUE` entries as `--build-arg`.

Follow-up PRs will align minor comment differences and standardize LABEL placement in `runtimes/` to achieve full byte-identity.

## Test plan
- [x] `scripts/check_dockerfile_alignment.sh` passes
- [x] `make test` -- all Dockerfile alignment and pipeline validation tests pass (pre-existing failures in pyproject/pylock tests are unrelated)
- [ ] Verify labels appear correctly in a built image via `podman inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Image metadata labels (name, summary, description, component, and build attribution information) are now configurable at build time instead of hardcoded, enabling flexible customization across all notebook and runtime image variants.
  * Updated build configuration files and Dockerfile specifications to support parameterized metadata labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->