### PR TITLE
RHOAIENG-60781: Add GHA workflow to merge main → stable

### DIFF
--- a/.github/workflows/merge-main-to-stable-fast-forward.yaml
+++ b/.github/workflows/merge-main-to-stable-fast-forward.yaml
@@ -1,0 +1,62 @@
+---
+# Fast-forward `stable` to match `main` when `stable` is an ancestor of `main`.
+# See https://redhat.atlassian.net/browse/RHOAIENG-60781
+name: Merge main into stable (fast-forward only)
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: If true, only verify that a fast-forward is possible; do not push
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: merge-main-to-stable-fast-forward
+  cancel-in-progress: false
+
+jobs:
+  fast-forward-stable:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout (stable, full history)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: stable
+          fetch-depth: 0
+
+      # Pushing to a protected `stable` usually needs branch rules to allow
+      # github-actions[bot] (or this workflow) to push, or a PAT with bypass —
+      # see repository / organization branch protection settings.
+      - name: Fast-forward stable to main
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          git fetch origin main stable
+
+          git checkout stable
+          git pull --ff-only origin stable
+
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Cannot fast-forward: stable is not an ancestor of main." \
+              "Resolve divergence (e.g. reset stable to main via policy, or merge with a regular merge commit) before using this workflow."
+            exit 1
+          fi
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "Dry run: fast-forward is possible."
+            if git rev-parse HEAD >/dev/null && [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
+              echo "stable already points at the same commit as main; nothing to merge."
+            else
+              echo "Commits that would be brought in:"
+              git log --oneline HEAD..origin/main
+            fi
+            exit 0
+          fi
+
+          git merge --ff-only origin/main
+          git push origin stable


### PR DESCRIPTION
[RHOAIENG-60781](https://redhat.atlassian.net/browse/RHOAIENG-60781): Add GHA workflow to merge main → stable

## Description
check out stable, fetch main, ensure stable is behind main on the same line (ancestor check). If dry run, stop after showing commits. Else git merge --ff-only origin/main and git push origin stable. If a fast-forward isn’t possible, the job fails and nothing is pushed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to fast-forward the stable branch to main, including a manual dry-run option that verifies fast-forward viability and previews commits.
  * Workflow enforces fast-forward pushes when possible, fails if fast-forward isn't possible, and prevents overlapping runs via a concurrency group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->