### PR TITLE
feat(.tekton): enable hermetic builds for stable-branch push pipelines

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -30,6 +30,20 @@ spec:
     value: runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.cpu.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/datascience/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
@@ -43,16 +57,49 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: clair-scan
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
@@ -61,14 +108,6 @@ spec:
       limits:
         memory: 8Gi
   - pipelineTaskName: clamav-scan
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: sast-shell-check
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: build-images
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -30,6 +30,20 @@ spec:
     value: runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.cpu.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/minimal/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
@@ -43,16 +57,53 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
-
-  - pipelineTaskName: prefetch-dependencies
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: clair-scan
+  - pipelineTaskName: sast-snyk-check
     computeResources:
       limits:
         memory: 8Gi
@@ -64,19 +115,7 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: sast-shell-check
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: build-images
-    computeResources:
-      limits:
-        memory: 8Gi
   - pipelineTaskName: rpms-signature-scan
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: sast-snyk-check
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -32,12 +32,50 @@ spec:
     value: runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.cuda.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/pytorch/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
@@ -46,15 +84,15 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: prefetch-dependencies
-    computeResources:
-      limits:
-        memory: 8Gi
   - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
@@ -63,10 +101,6 @@ spec:
       limits:
         memory: 8Gi
   - pipelineTaskName: clamav-scan
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: sast-shell-check
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -32,11 +32,51 @@ spec:
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.cuda.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/pytorch+llmcompressor/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -44,42 +84,38 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -32,6 +32,20 @@ spec:
     value: runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.rocm.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/rocm-pytorch/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
@@ -45,15 +59,40 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-
   - pipelineTaskName: prefetch-dependencies
     computeResources:
-      limits:
+      requests:
+        cpu: '4'
         memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:
@@ -62,15 +101,15 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: clamav-scan
-    computeResources:
-      limits:
-        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: build-images
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -32,11 +32,51 @@ spec:
     value: runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.cuda.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/tensorflow/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -44,42 +84,38 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -32,11 +32,51 @@ spec:
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context
     value: .
+  # Hermetic: RPMs + generic (prefetch-input/odh); pip from requirements.rocm.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: runtimes/rocm-tensorflow/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -44,42 +84,38 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -32,12 +32,52 @@ spec:
     value: jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
+  # Hermetic: Cachi2 prefetches gomod (mongocli), RPMs+generic (shared minimal/odh), pip (requirements.cpu.txt)
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/datascience/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
     - name: build
       computeResources:
         requests:
@@ -47,10 +87,6 @@ spec:
           cpu: '16'
           memory: 32Gi
   - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: prefetch-dependencies
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -30,11 +30,51 @@ spec:
     value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
+  # Hermetic build: RPMs + generic artifacts from repo-root prefetch-input/odh; pip from requirements.cpu.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/minimal/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -42,42 +82,30 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -30,11 +30,51 @@ spec:
     value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic build: RPMs + generic artifacts from repo-root prefetch-input/odh; pip from requirements.cuda.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/minimal/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -42,42 +82,30 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -32,11 +32,51 @@ spec:
     value: jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context
     value: .
+  # Hermetic build: RPMs + generic artifacts from repo-root prefetch-input/odh; pip from requirements.rocm.txt
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/minimal/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -44,42 +84,30 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -32,11 +32,53 @@ spec:
     value: jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic: gomod (mongocli), RPM+generic (prefetch-input/odh), pip (requirements.cuda.txt)
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/pytorch/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -44,42 +86,30 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -30,11 +30,53 @@ spec:
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic build: no network during build; mongocli source from submodule, Go deps prefetched by Cachi2
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
-    - pipelineTaskName: build-images
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
+      limits:
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
       computeResources:
         requests:
           cpu: '8'
@@ -42,42 +84,30 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-    - pipelineTaskName: clair-scan
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: ecosystem-cert-preflight-checks
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
-    - pipelineTaskName: sast-unicode-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: prefetch-dependencies
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: sast-shell-check
-      computeResources:
-        limits:
-          memory: 8Gi
-    - pipelineTaskName: rpms-signature-scan
-      computeResources:
-        limits:
-          memory: 8Gi
+  - pipelineTaskName: clair-scan
+    computeResources:
+      limits:
+        memory: 32Gi
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: rpms-signature-scan
+    computeResources:
+      limits:
+        memory: 8Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -32,12 +32,52 @@ spec:
     value: jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context
     value: .
+  # Hermetic: Cachi2 prefetches gomod (mongocli), RPMs+generic (prefetch-input/odh), pip (requirements.rocm.txt)
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/rocm/pytorch/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
@@ -46,14 +86,6 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: prefetch-dependencies
-    computeResources:
-      limits:
-        memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:
@@ -62,11 +94,15 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: clamav-scan
+  - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: clamav-scan
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -30,6 +30,22 @@ spec:
     value: jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context
     value: .
+  # Hermetic build: no network during build; mongocli source from submodule, Go deps prefetched by Cachi2
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/tensorflow/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
@@ -43,15 +59,40 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-
   - pipelineTaskName: prefetch-dependencies
     computeResources:
-      limits:
+      requests:
+        cpu: '4'
         memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:
@@ -60,7 +101,7 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: clamav-scan
+  - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
@@ -68,7 +109,7 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: build-images
+  - pipelineTaskName: clamav-scan
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -32,6 +32,22 @@ spec:
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context
     value: .
+  # Hermetic: Cachi2 prefetches gomod (mongocli), RPMs+generic (prefetch-input/odh), pip (requirements.rocm.txt)
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/rocm/tensorflow/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
@@ -45,24 +61,49 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 32Gi
       limits:
-        memory: 8Gi
+        cpu: '8'
+        memory: 32Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:
-        memory: 8Gi
+        memory: 32Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: clamav-scan
+  - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
@@ -70,7 +111,7 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: build-images
+  - pipelineTaskName: clamav-scan
     computeResources:
       limits:
         memory: 8Gi

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -32,6 +32,22 @@ spec:
     value: jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context
     value: .
+  # Hermetic: Cachi2 prefetches gomod (mongocli), RPMs+generic (shared minimal/odh), pip (datascience + trustyai requirements.cpu.txt)
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value:
+    - path: prefetch-input/mongocli
+      type: gomod
+    - path: prefetch-input/odh
+      type: rpm
+    - path: prefetch-input/odh
+      type: generic
+    - path: jupyter/trustyai/ubi9-python-3.12
+      type: pip
+      binary:
+        arch: x86_64
+      requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
     - 3.5_ea1-v1.44
@@ -45,15 +61,40 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:
-  - pipelineTaskName: sast-unicode-check
-    computeResources:
-      limits:
-        memory: 8Gi
-
   - pipelineTaskName: prefetch-dependencies
     computeResources:
-      limits:
+      requests:
+        cpu: '4'
         memory: 8Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:
@@ -62,7 +103,11 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: clamav-scan
+  - pipelineTaskName: sast-unicode-check
+    computeResources:
+      limits:
+        memory: 8Gi
+  - pipelineTaskName: sast-snyk-check
     computeResources:
       limits:
         memory: 8Gi
@@ -70,15 +115,11 @@ spec:
     computeResources:
       limits:
         memory: 8Gi
-  - pipelineTaskName: build-images
+  - pipelineTaskName: clamav-scan
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: rpms-signature-scan
-    computeResources:
-      limits:
-        memory: 8Gi
-  - pipelineTaskName: sast-snyk-check
     computeResources:
       limits:
         memory: 8Gi


### PR DESCRIPTION
## Summary

- Added `hermetic: 'true'` and `prefetch-input` configuration to all 17 stable-branch push pipeline files (`*-ci-push.yaml`)
- Updated `taskRunSpecs` with proper compute resources for `prefetch-dependencies` task
- Added `build-images` stepSpecs for `prepare-sboms` and `sbom-syft-generate`

This fixes the stable branch build failures where packages like `openshift-clients` are not available from public CentOS Stream 9 repositories. With hermetic builds enabled, these packages are now prefetched using Cachi2.

## Problem

All 17 stable-branch push pipeline files were missing hermetic build configuration, causing builds to fail with:

```
No match for argument: openshift-clients
Error: Unable to find a match: openshift-clients
```

## Solution

For each stable push file, added:
- `hermetic: 'true'`
- `prefetch-input` matching the main-branch counterpart (RPM, generic, pip, and gomod where applicable)
- Appropriate `taskRunSpecs` for `prefetch-dependencies` (compute resource requests/limits)
- `build-images` stepSpecs for SBOM generation

## Test plan

- [ ] CI passes on this PR
- [ ] After merging to main, sync main to stable
- [ ] Re-trigger Konflux builds on stable branch
- [ ] Verify builds complete successfully with prefetched `openshift-clients`

## Related

- Fixes: https://github.com/opendatahub-io/notebooks/issues/3520
- Jira: [RHAIENG-4907](https://redhat.atlassian.net/browse/RHAIENG-4907)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated CI/CD pipeline configurations across multiple runtime and workbench environments to implement hermetic builds with automatic dependency prefetching for improved build efficiency.
* Added SBOM (Software Bill of Materials) generation steps to build workflows for enhanced supply chain security.
* Enhanced resource allocation and memory limits across pipeline tasks to improve build stability and performance across Python environments and specialized compute frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->