### PR TITLE
NO-JIRA: chore(manfests/odh): add kubeflow-training to tf ImageStream to fix failing test

### DIFF
--- a/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -46,7 +46,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
@@ -87,7 +88,8 @@ spec:
             {"name": "Feast", "version": "0.61"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
-            {"name": "MySQL Connector/Python", "version": "9.6"}
+            {"name": "MySQL Connector/Python", "version": "9.6"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Identified a build failure caused by a missing dependency: kubeflow-training is required by TensorFlow but was omitted from the manifest

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/mtchoum1/notebooks/actions/runs/25458176884

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubeflow Training 1.9 to Jupyter TensorFlow notebook images (versions 3.4 and 3.5), enabling advanced machine learning training workflows. Version 3.5 includes MLflow 3.10 and version 3.4 includes MySQL Connector/Python 9.6 for enhanced data and workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->