### PR TITLE
ISSUE#3552: fix: add upper bound to uv-build requirement in build-system

### DIFF
--- a/base-images/copr/pyproject.toml
+++ b/base-images/copr/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 copr-rebuild = "copr_rebuild.rebuild:main"
 
 [build-system]
-requires = ["uv-build"]
+requires = ["uv-build>=0.11,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/base-images/copr/pyproject.toml
+++ b/base-images/copr/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 copr-rebuild = "copr_rebuild.rebuild:main"
 
 [build-system]
-requires = ["uv-build>=0.11,<0.12"]
+requires = ["uv-build>=0.11.8,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ members = ["base-images/copr"]
 
 # https://github.com/astral-sh/uv/issues/3957#issuecomment-2659350181
 [build-system]
-requires = ["uv-build"]
+requires = ["uv-build>=0.11,<0.12"]
 build-backend = "uv_build"
 
 # https://docs.astral.sh/uv/concepts/build-backend/#modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ members = ["base-images/copr"]
 
 # https://github.com/astral-sh/uv/issues/3957#issuecomment-2659350181
 [build-system]
-requires = ["uv-build>=0.11,<0.12"]
+requires = ["uv-build>=0.11.8,<0.12"]
 build-backend = "uv_build"
 
 # https://docs.astral.sh/uv/concepts/build-backend/#modules


### PR DESCRIPTION
The `build_system.requires = ["uv-build"]` was missing an upper bound, which could lead to build failures if a future breaking version of uv-build is released.

This change pins `uv-build` to `>=0.11, <0.12`.

Fixes https://github.com/opendatahub-io/notebooks/issues/3552

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Constrained the build backend dependency to a specific compatible range (uv-build >=0.11.8, <0.12) to ensure more consistent and reliable builds across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->