### PR TITLE
RHAIENG-4982: check-payload, add filter_files for /usr/bin/skopeo on s390x

### DIFF
--- a/scripts/check-payload/config.toml
+++ b/scripts/check-payload/config.toml
@@ -24,6 +24,13 @@ filter_dirs = [
     "/sysroot",
 ]
 
+# Skip FIPS scan of skopeo: on s390x the Go pclntab walk fails ("could not find magic number") so
+# [[rpm.skopeo.ignore]] KnownErrors never match (RHAIENG-4982). /usr/bin/skopeo is already waived for
+# several Go tag/symbol checks below; excluding the path matches that posture for scan local.
+filter_files = [
+    "/usr/bin/skopeo",
+]
+
 java_fips_disabled_algorithms = [
     "DH keySize < 2048",
     "TLSv1.1",


### PR DESCRIPTION
[RHAIENG-4982](https://redhat.atlassian.net/browse/RHAIENG-4982): check-payload, add filter_files for /usr/bin/skopeo on s390x

## Description
[RHAIENG-4982](https://redhat.atlassian.net/browse/RHAIENG-4982): check-payload, add filter_files for /usr/bin/skopeo on s390x

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
