### PR TITLE
RHAIENG-4984: cuda-jupyter-tensorflow tests fail — Kubeflow-Training missing in expected_versions

### DIFF
--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -46,7 +46,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
@@ -86,7 +87,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
             {"name": "MySQL Connector/Python", "version": "9.2"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'
@@ -127,7 +129,8 @@ spec:
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.4"}
+            {"name": "MySQL Connector/Python", "version": "9.4"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/workbench-image-recommended: 'false'
@@ -168,7 +171,8 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.3"}
+            {"name": "MySQL Connector/Python", "version": "9.3"},
+            {"name": "Kubeflow-Training", "version": "1.9"}
           ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"


### PR DESCRIPTION
[RHAIENG-4984](https://redhat.atlassian.net/browse/RHAIENG-4984): uda-jupyter-tensorflow tests fail — Kubeflow-Training missing in expected_versions

## Description
[RHAIENG-4984](https://redhat.atlassian.net/browse/RHAIENG-4984): uda-jupyter-tensorflow tests fail — Kubeflow-Training missing in expected_versions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubeflow-Training (v1.9) as a Python dependency to Jupyter TensorFlow Notebook images across multiple versions, providing enhanced training capabilities within the notebook environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->