### PR TITLE
RHAIENG-4997: Add test conventions rule for AI agents

### DIFF
--- a/.cursor/rules/test-conventions.mdc
+++ b/.cursor/rules/test-conventions.mdc
@@ -1,0 +1,293 @@
+---
+description: Test creation conventions for the notebooks repository — pytest patterns, testcontainers, markers, fixtures, allure, and test organization.
+globs: "tests/**,ci/**/*.py,scripts/**/*.py,ntb/**/*.py"
+alwaysApply: false
+---
+
+# Test Conventions for opendatahub-io/notebooks
+
+## Test Types Overview
+
+| Type | Location | Command | Requires |
+|------|----------|---------|----------|
+| Static / manifest | `tests/test_*.py` | `make test` | Nothing (no container engine) |
+| Unit | `tests/unit/` | `make test-unit` | Nothing |
+| Container integration | `tests/containers/` | `make test-integration PYTEST_ARGS="--image=<img>"` | Podman/Docker |
+| Browser E2E | `tests/browser/` | `npx playwright test` (from `tests/browser/`) | Node, Playwright |
+| K8s notebook smoke | `make test-<notebook>` | `scripts/test_jupyter_with_papermill.sh` | kubectl, deployed workbench |
+| Go | `scripts/buildinputs/` | `make test-unit` | Go toolchain |
+
+## Framework and Tools
+
+| Tool | Purpose |
+|------|---------|
+| pytest | Test runner for all Python tests |
+| pytest-subtests | Granular sub-assertions within a single test |
+| pytest-cov | Coverage (XML + terminal) |
+| allure-pytest | Issue tracking + step decoration |
+| testcontainers | Container lifecycle for integration tests |
+| docker (Python) | Low-level container operations |
+| pyfakefs | Filesystem mocking for unit tests |
+| Playwright | Browser tests (TypeScript) |
+| papermill | Notebook execution verification |
+
+## File Naming and Location
+
+- Static/manifest tests: `tests/test_*.py` (module-level functions)
+- Unit tests: `tests/unit/<mirror-source-path>/test_*.py`
+- Container tests: `tests/containers/**/*_test.py` (class-based)
+- Browser tests: `tests/browser/tests/*.spec.ts`
+
+## Test Organization
+
+### Static tests (`tests/test_*.py`)
+
+Use **module-level functions**. Group related assertions with `subtests`:
+
+```python
+from __future__ import annotations
+
+import pytest
+import pytest_subtests
+
+from tests import PROJECT_ROOT
+
+
+def test_something_across_manifests(subtests: pytest_subtests.SubTests):
+    for file in PROJECT_ROOT.glob("**/pyproject.toml"):
+        with subtests.test(msg=str(file.relative_to(PROJECT_ROOT))):
+            # assertion per file
+            assert condition, f"Failed for {file}"
+```
+
+### Container tests (`tests/containers/**/*_test.py`)
+
+Use **`Test*` classes** with typed fixture parameters:
+
+```python
+from __future__ import annotations
+
+import allure
+import pytest
+
+from tests.containers import conftest, docker_utils
+from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
+
+
+class TestMyFeature:
+    def test_something(
+        self,
+        workbench_image: conftest.Image,
+        subtests: pytest_subtests.SubTests,
+    ):
+        with WorkbenchContainer(workbench_image) as container:
+            container.start()
+            ecode, output = container.exec(["command", "arg"])
+            assert ecode == 0, output.decode()
+```
+
+## Markers
+
+All markers must be registered in `pytest.ini` (strict mode). Current markers:
+
+| Marker | Purpose | Excluded from default integration run |
+|--------|---------|--------------------------------------|
+| `openshift` | Needs live OpenShift cluster | Yes |
+| `cuda` | Needs NVIDIA GPU | Yes |
+| `rocm` | Needs AMD GPU | Yes |
+| `manifest_validation` | Slow registry/skopeo checks | Yes |
+| `buildonlytest` | Only run during build CI, not `make test` | Yes (different filter) |
+
+Usage:
+
+```python
+@pytest.mark.openshift
+def test_image_run_on_openshift(self, ...):
+    ...
+```
+
+## Parametrize Patterns
+
+### Directory/matrix parametrize
+
+```python
+@pytest.mark.parametrize("manifests_directory", [
+    manifests.MANIFESTS_ODH_DIR,
+    manifests.MANIFESTS_RHOAI_DIR,
+])
+def test_image_manifests(manifests_directory: Path, subtests):
+    ...
+```
+
+### Session-scoped image parametrize (via `--image` CLI)
+
+Do NOT use `@pytest.mark.parametrize` for the `image` fixture — it's handled by `pytest_generate_tests` in `tests/containers/conftest.py` with `scope="session"`. Just declare `image: str` as a parameter.
+
+## Fixture Conventions
+
+### Session-scoped image chain
+
+Fixtures skip automatically based on image labels:
+
+```python
+def test_jupyterlab_feature(self, jupyterlab_image: conftest.Image):
+    # Auto-skips if image is not a JupyterLab workbench
+    ...
+```
+
+Available session fixtures: `image`, `workbench_image`, `jupyterlab_image`, `datascience_image`, `codeserver_image`, `runtime_image`, `cuda_image`, `rocm_image`, `container_arch`.
+
+### Function-scoped fixtures
+
+- `tf` — `TestFrame` for Kubernetes resource management
+- `test_frame` — local resource list with deferred cleanup
+- `subtests` — from pytest-subtests plugin (always available)
+
+## Testcontainers Patterns
+
+### Container lifecycle
+
+```python
+from tests.containers.docker_utils import running_container, NotebookContainer, BestEffortCleanup
+
+# Short-lived check
+with running_container(image) as container:
+    ecode, output = container.exec(["rpm", "-qa"])
+    assert ecode == 0
+
+# Long-lived with WorkbenchContainer (HTTP readiness)
+with WorkbenchContainer(workbench_image) as container:
+    container.start(wait_for_readiness=True)
+    resp = requests.get(container.base_url)
+    assert resp.status_code == 200
+```
+
+### Exec and file operations
+
+```python
+# Execute command
+ecode, output = container.exec(["/bin/sh", "-c", "echo hello"])
+assert ecode == 0, output.decode()
+
+# Copy file into container
+docker_utils.container_cp(container, local_path, container_path)
+
+# Copy file from container
+docker_utils.from_container_cp(container, container_path, local_path)
+```
+
+### Cleanup
+
+Always use `BestEffortCleanup` for ordering; `NotebookContainer(container).stop(timeout=0)` for fast teardown.
+
+## Allure Integration
+
+### Issue tracking (link test to Jira)
+
+```python
+@allure.issue("RHOAIENG-16568")
+@allure.description("Verify PDF export works from JupyterLab")
+def test_pdf_export(self, jupyterlab_image: conftest.Image, container_arch: str):
+    ...
+```
+
+### Step decoration (reusable helpers)
+
+```python
+@allure.step("Check AIPCC environment variables")
+def _check_aipcc_env_vars(self, container, subtests):
+    ...
+```
+
+## Assertion Patterns
+
+### Prefer plain `assert` with messages
+
+```python
+assert ecode == 0, f"Command failed: {output.decode()}"
+assert len(recommended_tags) <= 1, "at most one tag may be recommended"
+```
+
+### Use `pytest.fail` for aggregate/multi-line failures
+
+```python
+if failures:
+    pytest.fail("\n".join(failures))
+```
+
+### Use `pytest.skip` for missing capabilities
+
+```python
+if container_arch in ("s390x", "ppc64le"):
+    pytest.skip(f"PDF export not supported on {container_arch}")
+```
+
+### Use subtests for per-item assertions (don't fail-fast)
+
+```python
+def test_all_images_have_labels(self, subtests):
+    for img in images:
+        with subtests.test(msg=img.name):
+            assert "name" in img.labels
+```
+
+## Collection Behavior
+
+- `tests/containers/` is **excluded from default collection** via `collect_ignore` in `tests/conftest.py`
+- Run container tests explicitly: `pytest tests/containers --image=<image>`
+- Default `make test` runs only `tests/` (non-container) + `ntb/` doctests + Dockerfile alignment script
+
+## Import Conventions
+
+```python
+from __future__ import annotations  # Always first
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest_subtests
+    from pathlib import Path
+```
+
+## DO
+
+- Register new markers in `pytest.ini`
+- Use `subtests` for iterating over multiple items in one test
+- Use `@allure.issue("RHOAIENG-XXXXX")` when a test covers a specific bug
+- Use session-scoped fixtures for expensive container operations
+- Keep container test classes in `tests/containers/` with `*_test.py` naming
+- Use `BestEffortCleanup` for container teardown ordering
+- Use `pytest.skip` for platform/capability checks (not `skipIf`)
+- Put static/fast assertions as module-level functions in `tests/test_*.py`
+
+## DON'T
+
+- Don't add heavy imports (docker, testcontainers) to files collected by default `make test`
+- Don't use `@pytest.mark.parametrize` for the `image` fixture (it's session-scoped via hook)
+- Don't create test files outside `tests/` or `ntb/` (they won't be collected)
+- Don't use `unittest.TestCase` (use plain pytest classes/functions)
+- Don't skip marker registration — `--strict-markers` will fail the run
+- Don't put container integration tests as module-level functions (use `Test*` classes)
+- Don't hardcode image names — accept via `--image` fixture chain
+
+## Implementation Checklist
+
+### Before writing a new test
+
+- [ ] Identify correct test type (static, unit, container, browser, K8s)
+- [ ] Place file in correct directory with correct naming (`test_*.py` or `*_test.py`)
+- [ ] Check if a related fixture chain already exists in `conftest.py`
+
+### During implementation
+
+- [ ] Use `from __future__ import annotations`
+- [ ] Use `subtests` when asserting over collections
+- [ ] Add `@allure.issue` if test covers a known Jira bug
+- [ ] Register any new marker in `pytest.ini`
+- [ ] Use typed fixture parameters (`workbench_image: conftest.Image`)
+
+### After implementation
+
+- [ ] Verify `make test` still passes (if static test)
+- [ ] Verify `make test-integration PYTEST_ARGS="--image=<img>"` passes (if container test)
+- [ ] Check coverage didn't regress: `pytest --cov --cov-report=term-missing`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
 ## References
 
 - Jira conventions (project IDs, custom fields, MCP call patterns): see `.cursor/rules/jira-conventions.mdc`
+- Test conventions (pytest patterns, markers, testcontainers, allure, fixture chains): see `.cursor/rules/test-conventions.mdc`


### PR DESCRIPTION
## Summary

- Add `.cursor/rules/test-conventions.mdc` documenting pytest patterns, markers, testcontainers usage, allure integration, and fixture chains for this repository
- Reference it from `CLAUDE.md` so both Cursor and Claude Code apply the conventions when generating tests

Generated using the [quality-tooling test-rules-generator](https://opendatahub-io.github.io/skills-registry/plugins/quality-tooling/test-rules-generator/) methodology from the AI Quality Tiger Team.

## Test plan

- [ ] Verify `make test` still passes (no functional change, documentation only)
- [ ] Confirm Cursor/Claude Code picks up the rule when writing tests in `tests/` paths

Jira: [RHAIENG-4997](https://redhat.atlassian.net/browse/RHAIENG-4997)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal development documentation references.

*Note: This release contains only internal documentation updates with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->