### PR TITLE
RHAIENG-4999: Add CodeQL and Semgrep SAST workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,52 @@
+---
+name: CodeQL
+
+"on":
+  push:
+    branches:
+      - main
+      - stable
+      - 'rhoai-*'
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, go]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        if: matrix.language != 'go'
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+
+      - name: Build Go
+        if: matrix.language == 'go'
+        run: |
+          cd scripts/buildinputs
+          go build ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,6 +40,12 @@ jobs:
         if: matrix.language != 'go'
         uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
 
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: scripts/buildinputs/go.mod
+
       - name: Build Go
         if: matrix.language == 'go'
         run: |

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,40 @@
+---
+name: Semgrep
+
+"on":
+  push:
+    branches:
+      - main
+      - stable
+      - 'rhoai-*'
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: semgrep-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  scan:
+    name: Semgrep scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Run Semgrep
+        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d  # v1
+        with:
+          config: semgrep.yaml
+          generateSarif: "1"
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-pipx-semgrep
 
       - name: Install Semgrep
-        run: pipx install semgrep || true
+        run: pipx install --force semgrep
 
       - name: Run Semgrep
         run: semgrep scan --config semgrep.yaml --sarif-output=semgrep.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -27,11 +27,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Run Semgrep
-        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d  # v1
+      - name: Cache Semgrep
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          config: semgrep.yaml
-          generateSarif: "1"
+          path: ~/.local/pipx/venvs/semgrep
+          key: ${{ runner.os }}-pipx-semgrep
+
+      - name: Install Semgrep
+        run: pipx install semgrep || true
+
+      - name: Run Semgrep
+        run: semgrep scan --config semgrep.yaml --sarif-output=semgrep.sarif
 
       - name: Upload SARIF
         if: always()


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4999

## Summary

- Add `.github/workflows/codeql.yaml` — CodeQL SAST for Python and Go (matrix build)
- Add `.github/workflows/semgrep.yaml` — Wire existing `semgrep.yaml` custom rules (~50 rules covering CWE-78, CWE-89, CWE-94, CWE-502, CWE-798) into CI

Both workflows upload SARIF to the GitHub Security tab. All action references are SHA-pinned per `.github/AGENTS.md`.

## Motivation

The repo has Trivy for dependency/container CVE scanning but no source-code SAST. CodeQL adds taint tracking for injection flaws in Python/Go scripts. Semgrep rules were already authored (`semgrep.yaml` at repo root) but never wired into CI.

## Test plan

- [ ] CodeQL workflow succeeds on Python and Go (autobuild or explicit `go build`)
- [ ] Semgrep workflow succeeds with existing `semgrep.yaml` rules
- [ ] SARIF results appear in GitHub Security tab
- [ ] No false-positive noise blocking PRs (both are informational initially)

Closes #3528
Jira: [RHAIENG-4999](https://redhat.atlassian.net/browse/RHAIENG-4999)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated CodeQL security analysis for Python and Go across pushes, pull requests, weekly runs, and manual dispatches, with concurrency controls and minimal job permissions.
  * Added Semgrep static analysis with scheduled and on-change scans, SARIF result uploads, venv caching for faster runs, and safeguards to prevent overlapping executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->