### PR TITLE
RHAIENG-4999: ci(linting): add golangci-lint to Go CI

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -80,6 +80,8 @@ jobs:
 
   go-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -87,6 +89,12 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: scripts/buildinputs/go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa  # v7.0.1
+        with:
+          version: v2.12.2
+          working-directory: scripts/buildinputs
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0

--- a/scripts/buildinputs/.golangci.yml
+++ b/scripts/buildinputs/.golangci.yml
@@ -1,0 +1,27 @@
+---
+# https://golangci-lint.run/docs/configuration/file
+version: "2"
+linters:
+  default: none
+  enable:
+    - gosec
+    - staticcheck
+    - errcheck
+    - govet
+    - ineffassign
+  exclusions:
+    # https://golangci-lint.run/docs/configuration/linters-exclusions/
+    #
+    # Inline suppression: place on its own line ABOVE the statement:
+    #   //nolint:gosec // G304: reason why this is safe
+    # Must include explanation (v2 enforces this). Place above, not at
+    # end of multi-line expressions — linter reports on the opening line.
+    rules:
+      # Test files write temp Dockerfiles with 0644; permissions are irrelevant.
+      - path: '(.+)_test\.go'
+        linters: [gosec]
+        text: "G306"
+      # dockerfile.go reads paths from trusted build system input (Makefile targets).
+      - path: dockerfile\.go
+        linters: [gosec]
+        text: "G304"


### PR DESCRIPTION
## Summary

Add golangci-lint to the existing `go-tests` job in `code-quality.yaml`, enabling:
- **gosec** — security-focused linting (command injection, hardcoded creds)
- **staticcheck** — Go best practices and bug detection
- **errcheck** — unchecked error returns
- **govet** — suspicious constructs
- **ineffassign** — unused variable assignments

Config lives at `scripts/buildinputs/.golangci.yml` next to the Go code it analyzes.

## Motivation

`scripts/buildinputs/` constructs shell commands and file paths — exactly the code that benefits from gosec's taint analysis (CWE-78 command injection). No Go linting existed in CI previously.

## Test plan

- [x] golangci-lint step passes in the `go-tests` job
- [x] No false positives blocking the pipeline
- [x] Existing Go tests still pass

Ref #3528
Jira: [RHAIENG-4999](https://redhat.atlassian.net/browse/RHAIENG-4999)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI by adding a pinned golangci-lint step to the pipeline to run security, static-analysis, error-check, vet, and assignment linters.
  * Updated lint configuration to enable selected linters and add targeted exclusions for test and Docker-related code.
  * Adjusted workflow permissions to grant the lint job required repository read access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->