### PR TITLE
RHAIENG-5020: docs: add CI systems reference (Tide/Prow, Konflux triggers, slash commands)

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -77,7 +77,7 @@ GHA workflow, use the GitHub UI "Re-run" button on the Actions or Checks tab.
 
 ## How the systems interact
 
-```
+```text
 PR opened/updated
   ├── GitHub Actions: runs automatically (code-quality, security, etc.)
   ├── Konflux/PaC: runs if pathChanged() matches .tekton/ CEL expressions

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,91 @@
+# CI Systems Overview
+
+This repo uses three CI systems simultaneously. Each handles a different concern:
+
+| System | What it does | Config location |
+|--------|-------------|-----------------|
+| **GitHub Actions** | Code quality, static analysis, security scans, docs, notifications | `.github/workflows/` |
+| **Konflux / Pipelines-as-Code** | Container image builds, integration testing | `.tekton/` |
+| **Prow / Tide** | Merge automation, label management (`/lgtm`, `/approve`, `/hold`) | [openshift/release](https://github.com/openshift/release) |
+
+Detailed docs for each:
+- [docs/tide.md](tide.md) -- Prow/Tide merge automation, OWNERS file, Prow commands
+- [docs/konflux.md](konflux.md) -- Konflux build system, pipeline triggers, Renovate/MintMaker
+- [docs/konflux-integration.md](konflux-integration.md) -- Konflux group testing, ephemeral clusters
+
+## Slash commands
+
+All three systems use PR comment commands, and some commands are consumed by multiple
+systems simultaneously. Prow and PaC both watch for `/retest` and `/test`, responding
+independently based on their own job/pipeline registries.
+
+### Common commands (shared between Prow and PaC)
+
+| Command | Prow response | PaC/Konflux response |
+|---------|--------------|---------------------|
+| `/retest` (bare) | Retriggers all failed Prow presubmit jobs | Retriggers all failed PaC pipelines. Ignores successful and in-progress ones. |
+| `/retest <name>` | Retriggers the named Prow job if it failed | Triggers the named PaC pipeline regardless of previous outcome — even if it never ran on this PR |
+| `/test <name>` | Same as `/retest <name>` for Prow | Same as `/retest <name>` for PaC |
+| `/ok-to-test` | Trusts a fork PR for Prow CI | Trusts a fork PR for PaC pipelines |
+
+Since Prow presubmit jobs are no longer configured for `main`, Prow responds to `/test`
+and `/retest` with *"No presubmit jobs available"* while PaC proceeds to trigger the
+matching pipeline.
+
+### Prow-only commands (merge automation)
+
+These commands are handled exclusively by Prow. See [docs/tide.md](tide.md) for details.
+
+| Command | Effect |
+|---------|--------|
+| `/lgtm` | Adds `lgtm` label (required for merge) |
+| `/approve` | Adds `approved` label (required for merge) |
+| `/hold` | Adds `do-not-merge/hold` to block merge |
+| `/override <context>` | Forces a failing check to pass |
+
+Clicking the GitHub "Approve" review button triggers `/lgtm` and `/approve` automatically
+for OWNERS approvers. See the [review mapping table](tide.md#github-review-approval-vs-prow-lgtm-and-approve).
+
+### Konflux-only commands (build triggers)
+
+These commands are handled exclusively by PaC. See [docs/konflux.md](konflux.md#triggering-builds)
+for the full list.
+
+**ODH (`opendatahub-io/notebooks`):**
+
+| Command | Effect |
+|---------|--------|
+| `/kfbuild all` | Triggers all PR build pipelines |
+| `/kfbuild <component>` | Triggers a single component build |
+| `/kfbuild <source-path>` | Triggers by source directory |
+| `/group-test` | Triggers the integration test pipeline |
+
+**RHDS (`red-hat-data-services/notebooks`):**
+
+| Command | Effect |
+|---------|--------|
+| `/build-konflux` | Triggers all RHDS PR build pipelines |
+| `/build-<image-type>` | Triggers a specific image build |
+
+RHDS also supports label-based triggers (`kfbuild-all`, `kfbuild-cuda`, etc.).
+
+### GitHub Actions
+
+GitHub Actions workflows are **not** triggered by slash commands. They run automatically
+on PR events based on `on:` triggers in `.github/workflows/*.yaml`. To re-run a failed
+GHA workflow, use the GitHub UI "Re-run" button on the Actions or Checks tab.
+
+## How the systems interact
+
+```
+PR opened/updated
+  ├── GitHub Actions: runs automatically (code-quality, security, etc.)
+  ├── Konflux/PaC: runs if pathChanged() matches .tekton/ CEL expressions
+  │                 or triggered manually via /kfbuild, /test, /retest
+  └── Prow/Tide: watches for label state
+                  └── When lgtm + approved + all checks green → auto-merge
+```
+
+Tide considers checks from **all** systems when deciding to merge. A failing GitHub
+Actions workflow or a failing Konflux pipeline will both block Tide from merging,
+unless overridden with `/override <context-name>`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -41,7 +41,7 @@ These commands are handled exclusively by Prow. See [docs/tide.md](tide.md) for 
 | `/lgtm` | Adds `lgtm` label (required for merge) |
 | `/approve` | Adds `approved` label (required for merge) |
 | `/hold` | Adds `do-not-merge/hold` to block merge |
-| `/override <context>` | Forces a failing check to pass |
+| `/override <context>` | Marks a failing context as overridden (OWNERS approvers or admins only) |
 
 Clicking the GitHub "Approve" review button triggers `/lgtm` and `/approve` automatically
 for OWNERS approvers. See the [review mapping table](tide.md#github-review-approval-vs-prow-lgtm-and-approve).

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -45,7 +45,7 @@ List your contexts with `oc config get-contexts -o name | grep stone`.
 
 ## ODH-io (Open Data Hub)
 
-This section covers the Konflux setup for the upstream **Open Data Hub** community project.
+This section covers the Konflux setup for the midstream **Open Data Hub** community project.
 
 project: `open-data-hub-tenant`
 
@@ -242,7 +242,42 @@ oc annotate components/<component-name> \
 
 This requires `oc` access to the respective cluster and namespace. The annotation is consumed immediately, but the PipelineRun takes ~2 minutes to appear. The component must have PaC `state: enabled` in its build status annotation. The same action is available as the "Start new build" button in the Konflux UI.
 
-See also: [Running Build Pipelines (Konflux docs)](https://konflux-ci.dev/docs/building/running/)
+#### Retrying a push build via GitHub commit comment
+
+You can trigger push pipelines by commenting on a **commit** page (not on a PR).
+The most reliable command is `/test <pipelinerun-name>`, which uses the PipelineRun's
+`metadata.name` from `.tekton/` (e.g., `odh-base-image-cpu-py312-ubi9-on-push` -- note
+this is the PipelineRun name, not the component name or filename).
+
+1. Navigate to the **latest commit on the branch** on GitHub
+2. Scroll to the Comments section at the bottom of the commit page
+3. To trigger a specific push pipeline:
+   `/test <pipelinerun-name>` (always works, even if the pipeline never ran)
+4. To retrigger all failed push pipelines:
+   `/retest` (only retriggers previously failed runs -- does nothing if no prior failures)
+5. For non-default branches:
+   `/test <pipelinerun-name> branch:<branch-name>` (pipeline name first, then `branch:`)
+
+**Constraints** ([source: PaC `handleCommitCommentEvent`](https://github.com/tektoncd/pipelines-as-code/blob/main/pkg/provider/github/parse_payload.go)):
+- Only works on the **latest commit (HEAD)** of the branch -- PaC calls `isHeadCommitOfBranch`
+  and rejects comments on older commits ([source](https://github.com/tektoncd/pipelines-as-code/blob/main/pkg/provider/github/github.go))
+- Without `branch:`, defaults to the **default branch** (`main`). For `stable` or `rhoai-*`
+  branches, you must specify `branch:<name>`
+- Does **not** trigger nudging PRs (use `trigger-pac-build` annotation when you need nudge propagation)
+
+**Verified** on `opendatahub-io/notebooks` (May 10, 2026):
+`/test odh-base-image-cpu-py312-ubi9-on-push` on commit `22d8b92` (HEAD of `main`)
+successfully triggered a push pipeline. Also confirmed working in
+[ACS](https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1771841918073429) and
+[AAP Hub](https://redhat-internal.slack.com/archives/C07BMJL2X42/p1771333521169669).
+
+**Warning:** Custom `on-comment` triggers (like `/kfbuild`) also work on commit comments,
+but they match **all** pipelines with a matching regex -- including PR pipelines. Commenting
+`/kfbuild all` on a commit triggers all PR build pipelines, not push pipelines. Use the
+built-in `/test <name>` for commit comments instead.
+
+See also: [Running Build Pipelines (Konflux docs)](https://konflux-ci.dev/docs/building/running/),
+[RHAIENG-5020](https://redhat.atlassian.net/browse/RHAIENG-5020)
 
 ## Build trigger internals
 

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -183,7 +183,7 @@ All PipelineRuns in `.tekton/` override compute resources for several tasks that
 
 ### PR builds
 
-Comment `/retest` on the pull request to retrigger all **failed** PR pipelines (successful ones are skipped). To retrigger a specific pipeline regardless of its previous outcome, use `/test <pipelinerun-name>` or `/retest <pipelinerun-name>`. See [PaC GitOps Commands](https://pipelinesascode.com/docs/guides/gitops-commands/).
+Comment `/retest` on the pull request to retrigger all **failed** PR pipelines (successful and in-progress ones are skipped). To trigger a specific pipeline regardless of its previous outcome -- including pipelines that never ran on the PR -- use `/test <pipelinerun-name>` or `/retest <pipelinerun-name>`. See [PaC GitOps Commands](https://pipelinesascode.com/docs/guides/gitops-commands/).
 
 The GitHub Checks tab "Re-run" button restarts **all** Konflux pipelines in the check suite, including those still running or already succeeded (it can cancel in-progress checks, causing them to fail). There is no way to re-run a single check from the UI. The GitHub API endpoints `POST /check-runs/{id}/rerequest` and `POST /check-suites/{id}/rerequest` do not work with user tokens — classic OAuth returns 404, fine-grained PATs return 403 ("Resource not accessible by personal access token"). Checks API write access is [limited to GitHub Apps](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens); the API reference pages incorrectly list fine-grained PATs as supported ([doc bug](https://github.com/github/rest-api-description/issues/4290)).
 

--- a/docs/tide.md
+++ b/docs/tide.md
@@ -1,0 +1,226 @@
+# Tide & Prow Reference for opendatahub-io/notebooks
+
+Tide is the Prow component that automatically merges PRs when all conditions are met.
+This document describes how Tide, Prow commands, and GitHub reviews interact for this repository.
+
+## Where the configuration lives
+
+All Prow/Tide configuration is centralized in the [openshift/release](https://github.com/openshift/release) repository.
+Nothing can be configured locally in this repo (except the `OWNERS` file).
+
+There are **separate configs** for the midstream and downstream repos:
+
+| Repo | Config in openshift/release |
+|------|----------------------------------|
+| `opendatahub-io/notebooks` | [`core-services/prow/02_config/opendatahub-io/notebooks/_prowconfig.yaml`](https://github.com/openshift/release/blob/master/core-services/prow/02_config/opendatahub-io/notebooks/_prowconfig.yaml) |
+| `red-hat-data-services/notebooks` | [`core-services/prow/02_config/red-hat-data-services/notebooks/_prowconfig.yaml`](https://github.com/openshift/release/blob/master/core-services/prow/02_config/red-hat-data-services/notebooks/_prowconfig.yaml) |
+
+The config for `opendatahub-io/notebooks` currently looks like this:
+
+```yaml
+branch-protection:
+  orgs:
+    opendatahub-io:
+      repos:
+        notebooks:
+          branches:
+            main:
+              protect: false
+tide:
+  merge_method:
+    opendatahub-io/notebooks: merge
+  queries:
+  - labels:
+    - approved
+    - lgtm
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - opendatahub-io/notebooks
+```
+
+## Prow vs GitHub Actions on main
+
+We previously used Prow presubmit jobs (ci-operator based) to build and test images on PRs to `main`.
+These have been replaced by GitHub Actions workflows and Konflux pipelines. Prow presubmit jobs are still used on
+other branches (e.g. older `rhoai-2.*` branches in `red-hat-data-services/notebooks`).
+
+Tide (the merge automation) and the Prow label-management plugins (`/lgtm`, `/approve`, `/hold`)
+remain active on `main` for `opendatahub-io/notebooks`.
+
+## Merge requirements (our config)
+
+These requirements come from the `tide.queries` and `tide.context_options` sections in
+[`_prowconfig.yaml`](#where-the-configuration-lives) shown above. They can be changed by
+submitting a PR to openshift/release.
+
+For Tide to merge a PR on this repo, **all** of these must be true:
+
+1. The PR has the **`approved`** label (from `/approve`)
+2. The PR has the **`lgtm`** label (from `/lgtm`)
+3. The PR does **not** have any blocking labels:
+   - `do-not-merge/hold`
+   - `do-not-merge/invalid-owners-file`
+   - `do-not-merge/work-in-progress`
+   - `needs-rebase`
+4. All reported commit status checks and check runs are **passing**
+
+## OWNERS file
+
+The `OWNERS` file at the repo root controls who can use `/approve` and `/lgtm`:
+
+```yaml
+approvers:    # can use /approve
+  - atheo89
+  - daniellutz
+  - jiridanek
+  - ysok
+
+reviewers:    # can use /lgtm
+  - atheo89
+  - ayush17
+  - daniellutz
+  - dibryant
+  - jiridanek
+  - ysok
+```
+
+Subdirectories can have their own `OWNERS` files to scope approval rights to specific paths.
+
+## Prow commands
+
+### `/lgtm`
+
+- Adds the `lgtm` label to the PR.
+- Can be used by anyone listed in `reviewers` or `approvers` in the `OWNERS` file.
+- Removed automatically when new commits are pushed (to force re-review).
+- To remove manually: `/lgtm cancel`.
+
+### `/approve`
+
+- Adds the `approved` label to the PR.
+- Can only be used by people listed in `approvers` in the `OWNERS` file.
+- **Not** removed when new commits are pushed (unlike `/lgtm`).
+- To remove: `/approve cancel`.
+
+### `/hold`
+
+- Adds the `do-not-merge/hold` label, preventing Tide from merging.
+- Any contributor can use it.
+- To remove: `/hold cancel`.
+
+### `/override <context-name>`
+
+- Forces a specific commit status context to be reported as passing.
+- Useful when a CI check fails for infrastructure reasons unrelated to the PR.
+- Requires the commenter to be listed in the `OWNERS` file (approver level) or have admin access.
+- Example: `/override validation-of-sw-versions-in-imagestreams`
+- The override applies to the current HEAD commit only; pushing new commits requires a new override.
+
+### `/retest`
+
+- Re-triggers all failed Prow presubmit jobs.
+- Does **not** re-trigger GitHub Actions workflows (use the GitHub UI "Re-run" for those).
+
+### Other useful commands
+
+| Command | Effect |
+|---------|--------|
+| `/cc @user` | Request review from a specific user |
+| `/uncc @user` | Remove review request |
+| `/assign @user` | Assign the PR |
+| `/unassign @user` | Unassign |
+| `/label <name>` | Add a label |
+| `/remove-label <name>` | Remove a label |
+| `/retitle <new title>` | Change PR title |
+| `/wip` | Toggle `do-not-merge/work-in-progress` |
+
+Full command reference: <https://prow.ci.openshift.org/command-help?repo=opendatahub-io%2Fnotebooks>
+
+## GitHub review approval vs Prow `/lgtm` and `/approve`
+
+GitHub's built-in review system (the "Approve" / "Request changes" buttons) and Prow's
+label-based system are **independent but complementary**:
+
+| Action | What it does | Effect on Tide |
+|--------|-------------|----------------|
+| GitHub "Approve" review | Sets GitHub review state to "approved" | No direct effect on Tide labels |
+| GitHub "Request changes" review | Sets GitHub review state to "changes requested" | No direct effect on Tide labels |
+| `/lgtm` comment | Adds `lgtm` label via Prow | Required for Tide to merge |
+| `/approve` comment | Adds `approved` label via Prow | Required for Tide to merge |
+
+Tide merges based on **labels**, not GitHub review state. A PR can have a GitHub "Approve"
+review but still lack the `lgtm` or `approved` labels if nobody commented the Prow commands.
+
+In practice, for users who are listed in the `OWNERS` file (which includes everyone on the
+dev team), clicking the GitHub "Approve" button automatically triggers both `/lgtm` and
+`/approve`, adding both labels at once. This means a single GitHub approval review from an
+OWNERS approver is sufficient to satisfy Tide's merge requirements.
+
+If branch protection requires GitHub approvals (e.g. `required_approving_review_count: 1`
+in `_prowconfig.yaml`), then GitHub review state matters too. For `opendatahub-io/notebooks`
+on `main`, branch protection is currently **disabled** (`protect: false`), so only Prow
+labels matter.
+
+## Context options and optional checks
+
+By default, Tide requires **all** reported commit statuses and check runs to pass.
+There is no `context_options` configured for this repo, which means:
+
+- Every GitHub Actions workflow that runs on a PR commit must pass.
+- Every Prow check must pass.
+- There is no way to mark a check as optional without modifying the config in openshift/release.
+
+To make a check optional, add `context_options` to the `_prowconfig.yaml`:
+
+```yaml
+tide:
+  context_options:
+    orgs:
+      opendatahub-io:
+        repos:
+          notebooks:
+            optional-contexts:
+            - "some-flaky-check-name"
+            # or skip all unknown contexts:
+            # skip-unknown-contexts: true
+```
+
+## Related Jira tickets
+
+- [RHAIENG-2346](https://redhat.atlassian.net/browse/RHAIENG-2346) -- Whether to switch from Prow `OWNERS` to GitHub `CODEOWNERS`
+- [RHAIENG-4232](https://redhat.atlassian.net/browse/RHAIENG-4232) -- Disable Prow/Tide auto-merge on `main` (documents a race condition where Tide merged a PR after `lgtm` was removed)
+- [RHAIENG-4233](https://redhat.atlassian.net/browse/RHAIENG-4233) -- Adopt Mergify as a Tide replacement
+- [RHAIENG-5018](https://redhat.atlassian.net/browse/RHAIENG-5018) -- Evaluate GitOps-based GitHub settings management tooling
+
+## Tide dashboard and endpoints
+
+Tide has no CLI. It runs as a controller inside the OpenShift CI cluster, watching GitHub
+state and merging PRs that meet all conditions. You interact with it only through PR labels
+and the config in openshift/release.
+
+For observability, Prow exposes these web endpoints:
+
+| Endpoint | What it shows |
+|----------|---------------|
+| [Tide Status](https://prow.ci.openshift.org/tide) | Current merge pool: which PRs are queued, batched, or blocked, and why |
+| [Tide History](https://prow.ci.openshift.org/tide-history?repo=opendatahub-io/notebooks) | Log of recent merge actions for the `opendatahub-io/notebooks` repo |
+| [tide.js](https://prow.ci.openshift.org/tide.js) | Raw JSON of the current merge pool (internal/undocumented, but useful for scripting) |
+
+Tide also posts a `tide` commit status on every PR explaining its merge pool state.
+You can query it via the GitHub API:
+
+```bash
+gh api /repos/opendatahub-io/notebooks/commits/<sha>/statuses \
+  --jq '.[] | select(.context == "tide") | .description'
+```
+
+## Useful links
+
+- [Prow plugins for this repo](https://prow.ci.openshift.org/plugins?repo=opendatahub-io%2Fnotebooks)
+- [Prow command help](https://prow.ci.openshift.org/command-help?repo=opendatahub-io%2Fnotebooks)
+- [OpenShift CI docs: Branch Protection](https://docs.ci.openshift.org/architecture/branch-protection/)
+- [OpenShift CI docs: Tide](https://docs.ci.openshift.org/docs/architecture/ci-operator/#automating-merges-with-tide)

--- a/docs/tide.md
+++ b/docs/tide.md
@@ -1,7 +1,9 @@
 # Tide & Prow Reference for opendatahub-io/notebooks
 
-Tide is the Prow component that automatically merges PRs when all conditions are met.
-This document describes how Tide, Prow commands, and GitHub reviews interact for this repository.
+[Tide](https://docs.prow.k8s.io/docs/components/core/tide/) is the
+[Prow](https://docs.prow.k8s.io/docs/) component that automatically merges PRs when all
+conditions are met. This document describes how Tide, Prow commands, and GitHub reviews
+interact for this repository.
 
 ## Where the configuration lives
 
@@ -15,32 +17,19 @@ There are **separate configs** for the midstream and downstream repos:
 | `opendatahub-io/notebooks` | [`core-services/prow/02_config/opendatahub-io/notebooks/_prowconfig.yaml`](https://github.com/openshift/release/blob/master/core-services/prow/02_config/opendatahub-io/notebooks/_prowconfig.yaml) |
 | `red-hat-data-services/notebooks` | [`core-services/prow/02_config/red-hat-data-services/notebooks/_prowconfig.yaml`](https://github.com/openshift/release/blob/master/core-services/prow/02_config/red-hat-data-services/notebooks/_prowconfig.yaml) |
 
-The config for `opendatahub-io/notebooks` currently looks like this:
+Key points from the current config (click the links above to see the full up-to-date YAML):
 
-```yaml
-branch-protection:
-  orgs:
-    opendatahub-io:
-      repos:
-        notebooks:
-          branches:
-            main:
-              protect: false
-tide:
-  merge_method:
-    opendatahub-io/notebooks: merge
-  queries:
-  - labels:
-    - approved
-    - lgtm
-    missingLabels:
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    repos:
-    - opendatahub-io/notebooks
-```
+- **Branch protection on `main` is disabled** (`protect: false`).
+  Initially enabled, then removed in [openshift/release#56929](https://github.com/openshift/release/pull/56929)
+  (Sep 2024) and explicitly disabled in [openshift/release#59991](https://github.com/openshift/release/pull/59991)
+  (Dec 2024, [RHOAIENG-15393](https://issues.redhat.com/browse/RHOAIENG-15393)) because the
+  `piplock-renewal` GitHub Action needs to push directly to `main` without status checks blocking it.
+- **Merge method is `merge`** (not squash), changed in [openshift/release#43851](https://github.com/openshift/release/pull/43851)
+  (Sep 2023, related to [notebooks#231](https://github.com/opendatahub-io/notebooks/issues/231)).
+- **Tide requires** `approved` + `lgtm` labels.
+- **Tide blocks on** `do-not-merge/hold`, `do-not-merge/work-in-progress`,
+  `do-not-merge/invalid-owners-file`, and `needs-rebase` labels.
+  Use `/hold` and `/wip` commands to prevent merge while work is in progress.
 
 ## Prow vs GitHub Actions on main
 
@@ -54,7 +43,7 @@ remain active on `main` for `opendatahub-io/notebooks`.
 ## Merge requirements (our config)
 
 These requirements come from the `tide.queries` and `tide.context_options` sections in
-[`_prowconfig.yaml`](#where-the-configuration-lives) shown above. They can be changed by
+[`_prowconfig.yaml`](#where-the-configuration-lives) above. They can be changed by
 submitting a PR to openshift/release.
 
 For Tide to merge a PR on this repo, **all** of these must be true:
@@ -70,124 +59,59 @@ For Tide to merge a PR on this repo, **all** of these must be true:
 
 ## OWNERS file
 
-The `OWNERS` file at the repo root controls who can use `/approve` and `/lgtm`:
-
-```yaml
-approvers:    # can use /approve
-  - atheo89
-  - daniellutz
-  - jiridanek
-  - ysok
-
-reviewers:    # can use /lgtm
-  - atheo89
-  - ayush17
-  - daniellutz
-  - dibryant
-  - jiridanek
-  - ysok
-```
-
+The [`OWNERS`](/OWNERS) file at the repo root lists `approvers` and `reviewers`.
 Subdirectories can have their own `OWNERS` files to scope approval rights to specific paths.
+See the [Kubernetes OWNERS reference](https://www.kubernetes.dev/docs/guide/owners/) for
+the full spec (`approvers`, `reviewers`, `labels`, `emeritus_approvers`, `options`).
 
 ## Prow commands
 
-### `/lgtm`
+Key commands used in this repo:
 
-- Adds the `lgtm` label to the PR.
-- Can be used by anyone listed in `reviewers` or `approvers` in the `OWNERS` file.
-- Removed automatically when new commits are pushed (to force re-review).
-- To remove manually: `/lgtm cancel`.
-
-### `/approve`
-
-- Adds the `approved` label to the PR.
-- Can only be used by people listed in `approvers` in the `OWNERS` file.
-- **Not** removed when new commits are pushed (unlike `/lgtm`).
-- To remove: `/approve cancel`.
-
-### `/hold`
-
-- Adds the `do-not-merge/hold` label, preventing Tide from merging.
-- Any contributor can use it.
-- To remove: `/hold cancel`.
-
-### `/override <context-name>`
-
-- Forces a specific commit status context to be reported as passing.
-- Useful when a CI check fails for infrastructure reasons unrelated to the PR.
-- Requires the commenter to be listed in the `OWNERS` file (approver level) or have admin access.
-- Example: `/override validation-of-sw-versions-in-imagestreams`
-- The override applies to the current HEAD commit only; pushing new commits requires a new override.
-
-### `/retest`
-
-- Re-triggers all failed Prow presubmit jobs.
-- Does **not** re-trigger GitHub Actions workflows (use the GitHub UI "Re-run" for those).
-
-### Other useful commands
-
-| Command | Effect |
-|---------|--------|
-| `/cc @user` | Request review from a specific user |
-| `/uncc @user` | Remove review request |
-| `/assign @user` | Assign the PR |
-| `/unassign @user` | Unassign |
-| `/label <name>` | Add a label |
-| `/remove-label <name>` | Remove a label |
-| `/retitle <new title>` | Change PR title |
-| `/wip` | Toggle `do-not-merge/work-in-progress` |
+- **`/lgtm`** -- adds the `lgtm` label. Any org member can use it (not restricted
+  to OWNERS reviewers). Automatically removed when new commits are pushed.
+- **`/approve`** -- adds the `approved` label. Only OWNERS `approvers` can use it.
+  **Not** removed on new commits (unlike `/lgtm`).
+- **`/hold`** -- adds `do-not-merge/hold` to block merge. Any contributor can use it.
+  Remove with `/hold cancel`.
+- **`/override <context-name>`** -- forces a failing check to pass. Requires approver
+  or admin access. Applies to the current HEAD commit only.
+  Example: `/override validation-of-sw-versions-in-imagestreams`
+- **`/retest`** -- re-triggers failed Prow presubmit jobs.
+  Does **not** re-trigger GitHub Actions (use the GitHub UI "Re-run" for those).
+- **`/wip`** -- toggles `do-not-merge/work-in-progress`.
 
 Full command reference: <https://prow.ci.openshift.org/command-help?repo=opendatahub-io%2Fnotebooks>
 
 ## GitHub review approval vs Prow `/lgtm` and `/approve`
 
-GitHub's built-in review system (the "Approve" / "Request changes" buttons) and Prow's
-label-based system are **independent but complementary**:
+Prow's [`lgtm`](https://docs.prow.k8s.io/docs/components/core/plugins/lgtm/) and
+[`approve`](https://docs.prow.k8s.io/docs/components/core/plugins/approve/) plugins
+watch GitHub review events and map them to labels (unless
+[`ignore_review_state`](https://docs.prow.k8s.io/docs/components/core/plugins/approve/)
+is set to `true`, which is not the case for this repo):
 
-| Action | What it does | Effect on Tide |
-|--------|-------------|----------------|
-| GitHub "Approve" review | Sets GitHub review state to "approved" | No direct effect on Tide labels |
-| GitHub "Request changes" review | Sets GitHub review state to "changes requested" | No direct effect on Tide labels |
-| `/lgtm` comment | Adds `lgtm` label via Prow | Required for Tide to merge |
-| `/approve` comment | Adds `approved` label via Prow | Required for Tide to merge |
+| Who clicks "Approve" | `lgtm` label | `approved` label |
+|----------------------|-------------|-----------------|
+| OWNERS **approver** | Added | Added |
+| OWNERS **reviewer** (not approver) | Added | Not added |
+| Non-OWNERS collaborator | Not added | Not added |
 
-Tide merges based on **labels**, not GitHub review state. A PR can have a GitHub "Approve"
-review but still lack the `lgtm` or `approved` labels if nobody commented the Prow commands.
+A "Request Changes" review from an OWNERS approver removes the `approved` label.
 
-In practice, for users who are listed in the `OWNERS` file (which includes everyone on the
-dev team), clicking the GitHub "Approve" button automatically triggers both `/lgtm` and
-`/approve`, adding both labels at once. This means a single GitHub approval review from an
-OWNERS approver is sufficient to satisfy Tide's merge requirements.
-
-If branch protection requires GitHub approvals (e.g. `required_approving_review_count: 1`
-in `_prowconfig.yaml`), then GitHub review state matters too. For `opendatahub-io/notebooks`
-on `main`, branch protection is currently **disabled** (`protect: false`), so only Prow
-labels matter.
+Since everyone on the dev team is an OWNERS approver, a single GitHub "Approve" review
+is sufficient to satisfy Tide's merge requirements.
 
 ## Context options and optional checks
 
 By default, Tide requires **all** reported commit statuses and check runs to pass.
-There is no `context_options` configured for this repo, which means:
+There is no `context_options` configured for this repo, which means every GitHub Actions
+workflow and Prow check must pass before Tide will merge.
 
-- Every GitHub Actions workflow that runs on a PR commit must pass.
-- Every Prow check must pass.
-- There is no way to mark a check as optional without modifying the config in openshift/release.
-
-To make a check optional, add `context_options` to the `_prowconfig.yaml`:
-
-```yaml
-tide:
-  context_options:
-    orgs:
-      opendatahub-io:
-        repos:
-          notebooks:
-            optional-contexts:
-            - "some-flaky-check-name"
-            # or skip all unknown contexts:
-            # skip-unknown-contexts: true
-```
+To mark a check as optional or skip unknown contexts, add `context_options` to the
+[`_prowconfig.yaml`](#where-the-configuration-lives). See the
+[Tide context policy docs](https://docs.prow.k8s.io/docs/components/core/tide/config/#context-policy-options)
+for the available fields (`optional-contexts`, `required-contexts`, `skip-unknown-contexts`).
 
 ## Related Jira tickets
 
@@ -223,4 +147,4 @@ gh api /repos/opendatahub-io/notebooks/commits/<sha>/statuses \
 - [Prow plugins for this repo](https://prow.ci.openshift.org/plugins?repo=opendatahub-io%2Fnotebooks)
 - [Prow command help](https://prow.ci.openshift.org/command-help?repo=opendatahub-io%2Fnotebooks)
 - [OpenShift CI docs: Branch Protection](https://docs.ci.openshift.org/architecture/branch-protection/)
-- [OpenShift CI docs: Tide](https://docs.ci.openshift.org/docs/architecture/ci-operator/#automating-merges-with-tide)
+- [OpenShift CI docs: Tide](https://docs.ci.openshift.org/architecture/ci-operator/#automating-merges-with-tide)

--- a/docs/tide.md
+++ b/docs/tide.md
@@ -20,10 +20,15 @@ There are **separate configs** for the midstream and downstream repos:
 Key points from the current config (click the links above to see the full up-to-date YAML):
 
 - **Branch protection on `main` is disabled** (`protect: false`).
-  Initially enabled, then removed in [openshift/release#56929](https://github.com/openshift/release/pull/56929)
-  (Sep 2024) and explicitly disabled in [openshift/release#59991](https://github.com/openshift/release/pull/59991)
-  (Dec 2024, [RHOAIENG-15393](https://issues.redhat.com/browse/RHOAIENG-15393)) because the
-  `piplock-renewal` GitHub Action needs to push directly to `main` without status checks blocking it.
+  Initially set up in [openshift/release#32113](https://github.com/openshift/release/pull/32113)
+  (Sep 2022). Removed in [openshift/release#56929](https://github.com/openshift/release/pull/56929)
+  (Sep 2024) and explicitly set to `protect: false` in [openshift/release#59991](https://github.com/openshift/release/pull/59991)
+  (Dec 2024, [RHOAIENG-15393](https://issues.redhat.com/browse/RHOAIENG-15393)).
+  The `unmanaged: true` alternative was considered but rejected -- it appears only in OpenShift CI
+  docs (not upstream Prow) and its behavior was uncertain; `protect: false` was already proven
+  to work on `red-hat-data-services/notebooks`.
+  Root cause: GitHub Actions workflows (`piplock-renewal`, `insta-merge.yaml`) need to push
+  directly to `main` without status checks, which is incompatible with active branch protection.
 - **Merge method is `merge`** (not squash), changed in [openshift/release#43851](https://github.com/openshift/release/pull/43851)
   (Sep 2023, related to [notebooks#231](https://github.com/opendatahub-io/notebooks/issues/231)).
 - **Tide requires** `approved` + `lgtm` labels.
@@ -72,7 +77,7 @@ Key commands used in this repo:
   to OWNERS reviewers). Automatically removed when new commits are pushed.
 - **`/approve`** -- adds the `approved` label. Only OWNERS `approvers` can use it.
   **Not** removed on new commits (unlike `/lgtm`).
-- **`/hold`** -- adds `do-not-merge/hold` to block merge. Any contributor can use it.
+- **`/hold`** -- adds `do-not-merge/hold` to block merge. Any org member can use it.
   Remove with `/hold cancel`.
 - **`/override <context-name>`** -- forces a failing check to pass. Requires approver
   or admin access. Applies to the current HEAD commit only.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5020

## Summary

Add reference documentation for the three CI systems used in this repo, and update existing Konflux docs with verified findings from live testing.

### New files

- **`docs/tide.md`** -- Tide & Prow reference: config location in openshift/release (with PR history for why `protect: false`), merge requirements, OWNERS file, Prow commands (`/lgtm`, `/approve`, `/hold`, `/override`), GitHub review-to-label mapping, Tide dashboard endpoints, related Jira tickets
- **`docs/ci.md`** -- Unified CI overview: how GitHub Actions, Konflux/PaC, and Prow/Tide coexist; slash command comparison table showing which system handles `/retest`, `/test`, `/kfbuild`, `/approve`, etc.

### Updated files

- **`docs/konflux.md`** -- Fix `/retest` behavior docs (bare `/retest` also skips in-progress pipelines; `/test <name>` triggers pipelines that never ran). Add verified instructions for retriggering push builds via commit comments (`/test <pipelinerun-name>` on commit page). Fix "upstream" to "midstream" for ODH.

### Key findings from live testing (PR #3590, commit 22d8b92)

**PR comment tests:**
- `/test <name>` and `/retest <name>` both trigger Konflux pipelines, even ones that never ran
- Bare `/retest` skips in-progress and successful pipelines
- Prow responds "No presubmit jobs available" (no Prow jobs on main anymore)
- `/cancel` cancels in-progress Konflux pipelines

**Commit comment tests:**
- `/test odh-base-image-cpu-py312-ubi9-on-push` on HEAD of main -- triggered push pipeline successfully
- `/kfbuild all` on a commit -- triggered 27 **PR** pipelines (not push!) because `on-comment` ignores `on-event` filter
- `/retest branch:stable` -- nothing (commit wasn't HEAD of stable)
- PaC source analysis: `branch:` syntax only works with built-in `/test`/`/retest`, not custom `on-comment` triggers

### Related Jira stories created

- [RHAIENG-5020](https://redhat.atlassian.net/browse/RHAIENG-5020) -- Add on-comment trigger to push pipelines

## Test plan

- [x] Verify slash commands on PR (tested live)
- [x] Verify `/test` on commit page (tested live)
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all links are reachable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide on Tide auto-merge behavior, merge eligibility rules, label/command effects, and how check contexts are evaluated.
  * Added CI overview describing GitHub Actions, Konflux/Pipelines-as-Code, and Prow/Tide interactions and shared vs. system-specific PR commands.
  * Updated Konflux guidance: refined PR build retry behavior, commit-comment push build triggers, and trigger usage nuances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->