### PR TITLE
RHAIENG-5020: docs: add GitHub apps and org configuration reference

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -87,6 +87,30 @@ Mergify is already installed on the org but only enabled for select repos.
 To enable it on an additional repo, request in `#rhoai-devtestops-requests` — an org admin
 needs to add the repo to the Mergify app's repository access list.
 
+## Org-level push rulesets
+
+The opendatahub-io org has a **push ruleset** that protects security configuration files
+from being modified directly in repos. These files are managed centrally via
+[opendatahub-io/security-config](https://github.com/opendatahub-io/security-config) and
+synced to repos listed in `sync-config.yml`:
+
+- `semgrep.yaml` -- custom security rules for CodeRabbit PR reviews
+- `.coderabbit.yaml` -- org-wide CodeRabbit configuration (inheritance baseline)
+- `.gitleaks.toml` -- gitleaks secret scanning configuration
+- `.gitleaksignore` -- gitleaks false positive suppressions
+
+Changes to these files must go through the security-config repo. PRs that modify them
+directly in a repo will be rejected by the push ruleset. See the
+[security-config sync config](https://github.com/opendatahub-io/security-config/blob/main/sync-config.yml)
+for the full list of synced repos.
+
+**Known issue with Renovate:** The file path restriction ruleset can block Renovate's
+`pushFiles` API call even when Renovate isn't modifying protected files. Renovate's
+`POST /git/trees` sends the full tree without `base_tree`, causing GitHub to validate
+all file paths including unchanged protected ones. Workaround: add the Renovate bot/PAT
+as a bypass actor on the ruleset. Upstream bug:
+[renovatebot/renovate#42555](https://github.com/renovatebot/renovate/discussions/42555).
+
 ## Branch protection
 
 Branch protection for repos using OpenShift CI is managed by Prow's **branchprotector**

--- a/docs/github.md
+++ b/docs/github.md
@@ -76,6 +76,7 @@ Individual team members cannot install apps — even repo maintainers.
 
 1. Post a request in one of these Slack channels:
    - `#rhoai-devtestops-requests` — for RHOAI / notebooks team requests
+   - `#ai-core-platform-requests` — for OpenShift AI platform-level requests
    - `#forum-pge-cloud-ops` — for broader OpenShift org-level requests (handled by PGE Cloud Ops team)
 2. A **DPP-\*** Jira ticket is created (or create one yourself via the [DevServices portal](https://devservices.dpp.openshift.com/support/))
 3. PGE Cloud Ops team reviews and installs the app

--- a/docs/github.md
+++ b/docs/github.md
@@ -7,25 +7,27 @@ Reference for GitHub apps, org settings, and tooling across the opendatahub-io o
 - **Org**: [opendatahub-io](https://github.com/opendatahub-io) (ID: `57720972`)
 - **Total repos**: ~184 (many archived)
 - **Org-level `.github` repo**: [opendatahub-io/.github](https://github.com/opendatahub-io/.github) — contains only `ISSUE_TEMPLATE/`, `PULL_REQUEST_TEMPLATE.md`, `LICENSE`, and `profile/`
-- **No GitOps repo config tool** (no `settings.yml`, no safe-settings, no Probot Settings)
-- Repo settings (merge buttons, labels, team permissions, Actions permissions) are configured manually via the GitHub UI by org admins
+- **No GitOps repo settings tool** (no `settings.yml`, no safe-settings, no Probot Settings).
+  Repo settings (merge buttons, labels, team permissions, Actions permissions) are configured
+  manually via the GitHub UI by org admins. However, security config files are managed as code
+  via [security-config](#org-level-push-rulesets).
 
 ## Installed GitHub Apps
 
 As of May 2026, these apps are active across the org (detected via check-runs and commit statuses on default branches):
 
-| App | Repos | Notes |
-|-----|-------|-------|
-| **GitHub Actions** | most repos | Primary CI |
-| **Red Hat Konflux** | [notebooks](https://github.com/opendatahub-io/notebooks), [kubeflow](https://github.com/opendatahub-io/kubeflow), [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator), +23 more | Container image builds (Tekton pipelines) |
-| **GitHub Advanced Security** | [kserve](https://github.com/opendatahub-io/kserve), [guardrails-detectors](https://github.com/opendatahub-io/guardrails-detectors), [eval-hub](https://github.com/opendatahub-io/eval-hub), +2 more | Code scanning (CodeQL) |
-| **Tide** (Prow) | [kserve](https://github.com/opendatahub-io/kserve), [model-registry](https://github.com/opendatahub-io/model-registry), [model-registry-operator](https://github.com/opendatahub-io/model-registry-operator), [models-as-a-service](https://github.com/opendatahub-io/models-as-a-service) | Merge automation; see [docs/tide.md](tide.md) |
-| **Codecov** | [odh-dashboard](https://github.com/opendatahub-io/odh-dashboard), [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator), [spark-operator](https://github.com/opendatahub-io/spark-operator) | Coverage reporting |
-| **Mergify** | [trainer](https://github.com/opendatahub-io/trainer), [trustyai-service-operator](https://github.com/opendatahub-io/trustyai-service-operator) | Auto-merge and auto-backport |
-| **CodeRabbit** | org-wide | AI code review (free plan) |
-| **pre-commit.ci** | [opendatahub-tests](https://github.com/opendatahub-io/opendatahub-tests) | Auto-fix linting |
-| **Dependabot** | [autofix-skills](https://github.com/opendatahub-io/autofix-skills) | Dependency updates |
-| **DCO** | [modelmesh-serving](https://github.com/opendatahub-io/modelmesh-serving) | Developer Certificate of Origin check |
+| App | Notes |
+|-----|-------|
+| [GitHub Actions](https://github.com/features/actions) | Primary CI for most repos |
+| [Red Hat Konflux](https://github.com/konflux-ci) | Container image builds (Tekton pipelines); 26 repos |
+| [GitHub Advanced Security](https://github.com/features/security) | Code scanning (CodeQL); 5 repos |
+| [Tide](https://docs.prow.k8s.io/docs/components/core/tide/) (Prow) | Merge automation; see [docs/tide.md](tide.md). Scan undercounts -- Tide only posts status on PR commits. |
+| [Codecov](https://github.com/apps/codecov) | Coverage reporting; 3 repos |
+| [Mergify](https://github.com/apps/mergify) | Auto-merge and auto-backport; 2 repos |
+| [CodeRabbit](https://github.com/apps/coderabbitai) | AI code review (free plan); org-wide |
+| [pre-commit.ci](https://github.com/apps/pre-commit-ci) | Auto-fix linting; 1 repo |
+| [Dependabot](https://github.com/dependabot) | Dependency updates; 1 repo |
+| [DCO](https://github.com/apps/dco) | Developer Certificate of Origin check; 1 repo |
 
 ### Apps on notebooks specifically
 
@@ -132,9 +134,10 @@ and the workflow at `.github/workflows/renovate-self-hosted.yaml`.
 
 ## CodeRabbit
 
-Configured org-wide via [opendatahub-io/coderabbit](https://github.com/opendatahub-io/coderabbit).
-Per-repo overrides in `.coderabbit.yaml` (this repo has one with custom branch filters and
-PR title conventions).
+Org-wide fallback config lives in [opendatahub-io/coderabbit](https://github.com/opendatahub-io/coderabbit).
+Per-repo `.coderabbit.yaml` overrides are synced from [security-config](#org-level-push-rulesets)
+for repos in the sync list. This repo has its own `.coderabbit.yaml` with custom branch filters
+and PR title conventions (set `inheritance: true` to inherit the org baseline).
 
 Also used for [spam PR detection](https://github.com/opendatahub-io/security-config/pull/12)
 across the org — flags reputation-farming PRs from automated accounts.
@@ -148,7 +151,9 @@ User licenses requested separately via
 
 ## Related docs
 
+- [docs/ci.md](ci.md) — CI systems overview, slash command comparison
 - [docs/tide.md](tide.md) — Tide merge automation, Prow commands, OWNERS file
+- [docs/konflux.md](konflux.md) — Konflux build system, pipeline triggers
 - [CONTRIBUTING.md](/CONTRIBUTING.md) — Review and merge process
 - [OWNERS](/OWNERS) — Approvers and reviewers list
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,0 +1,135 @@
+# GitHub Configuration for opendatahub-io/notebooks
+
+Reference for GitHub apps, org settings, and tooling across the opendatahub-io org.
+
+## Org overview
+
+- **Org**: [opendatahub-io](https://github.com/opendatahub-io) (ID: `57720972`)
+- **Total repos**: ~184 (many archived)
+- **Org-level `.github` repo**: [opendatahub-io/.github](https://github.com/opendatahub-io/.github) — contains only `ISSUE_TEMPLATE/`, `PULL_REQUEST_TEMPLATE.md`, `LICENSE`, and `profile/`
+- **No GitOps repo config tool** (no `settings.yml`, no safe-settings, no Probot Settings)
+- Repo settings (merge buttons, labels, team permissions, Actions permissions) are configured manually via the GitHub UI by org admins
+
+## Installed GitHub Apps
+
+As of May 2026, these apps are active across the org (detected via check-runs and commit statuses on default branches):
+
+| App | Repos | Notes |
+|-----|-------|-------|
+| **GitHub Actions** | 96 | Primary CI for most repos |
+| **Red Hat Konflux** | 26 | Container image builds (Tekton pipelines) |
+| **GitHub Advanced Security** | 5 | Code scanning (CodeQL) |
+| **Tide** (Prow) | 4 | Merge automation via commit status; see [docs/tide.md](tide.md) |
+| **Codecov** | 3 | Coverage reporting (odh-dashboard, opendatahub-operator, spark-operator) |
+| **Mergify** | 2 | Auto-merge and auto-backport (trainer, trustyai-service-operator) |
+| **CodeRabbit** | org-wide | AI code review, installed on free plan across all repos |
+| **pre-commit.ci** | 1 | Auto-fix linting (opendatahub-tests) |
+| **Dependabot** | 1 | Dependency updates (autofix-skills) |
+| **DCO** | 1 | Developer Certificate of Origin check (modelmesh-serving) |
+
+### Apps on notebooks specifically
+
+On PRs to `opendatahub-io/notebooks`, these are active:
+
+- **GitHub Actions** — all CI workflows (code-quality, software-versions, build, etc.)
+- **GitHub Advanced Security** — code scanning
+- **OpenShift CI** — Prow check runs (label management, `/lgtm`, `/approve`)
+- **CodeRabbit** — AI review comments (commit status)
+- **Tide** — merge automation (commit status)
+
+### Checking installed apps
+
+To see which apps posted check runs on a specific commit:
+
+```bash
+gh api /repos/opendatahub-io/notebooks/commits/<sha>/check-runs --paginate \
+  --jq '[.check_runs[].app.slug] | unique[]'
+```
+
+To see commit status contexts (Tide, CodeRabbit, etc.):
+
+```bash
+gh api /repos/opendatahub-io/notebooks/commits/<sha>/statuses --paginate \
+  --jq '[.[].context] | unique[]'
+```
+
+To check if a specific app is installed on the org via the browser, visit:
+
+```
+https://github.com/apps/<app-slug>/installations/new/permissions?target_id=57720972
+```
+
+Repos showing "installed" already have the app enabled. This requires org member access.
+
+The org admin install page (requires admin role):
+
+```
+https://github.com/organizations/opendatahub-io/settings/installations
+```
+
+## Requesting new app installations
+
+GitHub app installations for the opendatahub-io org require **org admin approval**.
+Individual team members cannot install apps — even repo maintainers.
+
+### Process
+
+1. Post a request in one of these Slack channels:
+   - `#rhoai-devtestops-requests` — for RHOAI / notebooks team requests
+   - `#forum-pge-cloud-ops` — for broader OpenShift org-level requests (handled by PGE Cloud Ops team)
+2. A **DPP-\*** Jira ticket is created (or create one yourself via the [DevServices portal](https://devservices.dpp.openshift.com/support/))
+3. PGE Cloud Ops team reviews and installs the app
+
+### Requesting Mergify on a new repo
+
+Mergify is already installed on the org but only enabled for select repos.
+To enable it on an additional repo, request in `#rhoai-devtestops-requests` — an org admin
+needs to add the repo to the Mergify app's repository access list.
+
+## Branch protection
+
+Branch protection for repos using OpenShift CI is managed by Prow's **branchprotector**
+component, configured in [openshift/release](https://github.com/openshift/release).
+See [docs/tide.md](tide.md) for details.
+
+For `opendatahub-io/notebooks` on `main`, branch protection is currently **disabled**
+(`protect: false`). Merge gating is handled entirely by Tide's label requirements.
+
+GitHub-native branch protection (configured in the UI under Settings > Branches) is
+independent of Prow's config. Both can coexist, but conflicts can cause confusion —
+e.g., GitHub requiring approvals while Prow uses OWNERS-based `/approve`.
+
+## Renovate
+
+Self-hosted Renovate runs via GitHub Actions (not as a GitHub App).
+See [ADR 0013](architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md)
+and the workflow at `.github/workflows/renovate-self-hosted.yaml`.
+
+## CodeRabbit
+
+Configured org-wide via [opendatahub-io/coderabbit](https://github.com/opendatahub-io/coderabbit).
+Per-repo overrides in `.coderabbit.yaml` (this repo has one with custom branch filters and
+PR title conventions).
+
+Also used for [spam PR detection](https://github.com/opendatahub-io/security-config/pull/12)
+across the org — flags reputation-farming PRs from automated accounts.
+
+## Qodo
+
+AI code review tool, GA across Red Hat since March 2026. Per-repo enablement via
+[DPP request form](https://devservices.dpp.openshift.com/support/install_qodo_on_a_repo/).
+User licenses requested separately via
+[license request form](https://devservices.dpp.openshift.com/support/qodo_user_license_request/).
+
+## Related docs
+
+- [docs/tide.md](tide.md) — Tide merge automation, Prow commands, OWNERS file
+- [CONTRIBUTING.md](/CONTRIBUTING.md) — Review and merge process
+- [OWNERS](/OWNERS) — Approvers and reviewers list
+
+## Related Jira tickets
+
+- [RHAIENG-5018](https://redhat.atlassian.net/browse/RHAIENG-5018) — Evaluate GitOps-based GitHub settings management tooling
+- [RHAIENG-4233](https://redhat.atlassian.net/browse/RHAIENG-4233) — Adopt Mergify as Tide replacement
+- [RHAIENG-4232](https://redhat.atlassian.net/browse/RHAIENG-4232) — Disable Prow/Tide auto-merge on main
+- [RHAIENG-2346](https://redhat.atlassian.net/browse/RHAIENG-2346) — Switch from Prow OWNERS to GitHub CODEOWNERS

--- a/docs/github.md
+++ b/docs/github.md
@@ -55,7 +55,7 @@ gh api /repos/opendatahub-io/notebooks/commits/<sha>/statuses --paginate \
 
 To check if a specific app is installed on the org via the browser, visit:
 
-```
+```text
 https://github.com/apps/<app-slug>/installations/new/permissions?target_id=57720972
 ```
 
@@ -63,7 +63,7 @@ Repos showing "installed" already have the app enabled. This requires org member
 
 The org admin install page (requires admin role):
 
-```
+```text
 https://github.com/organizations/opendatahub-io/settings/installations
 ```
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -12,9 +12,11 @@ Reference for GitHub apps, org settings, and tooling across the opendatahub-io o
   manually via the GitHub UI by org admins. However, security config files are managed as code
   via [security-config](#org-level-push-rulesets).
 
-## Installed GitHub Apps
+## Active GitHub Apps
 
-As of May 2026, these apps are active across the org (detected via check-runs and commit statuses on default branches):
+As of May 2026, these apps were observed active across the org (detected via check-runs
+and commit statuses on default branches -- may undercount apps that only act on PRs).
+For authoritative installation state, see [Checking installed apps](#checking-installed-apps).
 
 | App | Notes |
 |-----|-------|
@@ -106,12 +108,12 @@ directly in a repo will be rejected by the push ruleset. See the
 [security-config sync config](https://github.com/opendatahub-io/security-config/blob/main/sync-config.yml)
 for the full list of synced repos.
 
-**Known issue with Renovate:** The file path restriction ruleset can block Renovate's
-`pushFiles` API call even when Renovate isn't modifying protected files. Renovate's
-`POST /git/trees` sends the full tree without `base_tree`, causing GitHub to validate
-all file paths including unchanged protected ones. Workaround: add the Renovate bot/PAT
-as a bypass actor on the ruleset. Upstream bug:
-[renovatebot/renovate#42555](https://github.com/renovatebot/renovate/discussions/42555).
+**Known issue with Renovate:** Renovate's `pushFiles` sends the full tree via
+`POST /git/trees` without `base_tree`, so GitHub validates all file paths -- including
+unchanged protected ones -- and rejects the push with 422 "File path is restricted".
+This broke MintMaker (Konflux's Renovate instance); Ugo added the MintMaker GitHub App
+as a bypass actor on the ruleset to fix it.
+Upstream bug: [renovatebot/renovate#42555](https://github.com/renovatebot/renovate/discussions/42555).
 
 ## Branch protection
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -21,15 +21,15 @@ For authoritative installation state, see [Checking installed apps](#checking-in
 | App | Notes |
 |-----|-------|
 | [GitHub Actions](https://github.com/features/actions) | Primary CI for most repos |
-| [Red Hat Konflux](https://github.com/konflux-ci) | Container image builds (Tekton pipelines); 26 repos |
-| [GitHub Advanced Security](https://github.com/features/security) | Code scanning (CodeQL); 5 repos |
-| [Tide](https://docs.prow.k8s.io/docs/components/core/tide/) (Prow) | Merge automation; see [docs/tide.md](tide.md). Scan undercounts -- Tide only posts status on PR commits. |
-| [Codecov](https://github.com/apps/codecov) | Coverage reporting; 3 repos |
-| [Mergify](https://github.com/apps/mergify) | Auto-merge and auto-backport; 2 repos |
+| [Red Hat Konflux](https://github.com/konflux-ci) | Container image builds (Tekton pipelines) |
+| [GitHub Advanced Security](https://github.com/features/security) | Code scanning (CodeQL) |
+| [Tide](https://docs.prow.k8s.io/docs/components/core/tide/) (Prow) | Merge automation; see [docs/tide.md](tide.md) |
+| [Codecov](https://github.com/apps/codecov) | Coverage reporting |
+| [Mergify](https://github.com/apps/mergify) | Auto-merge and auto-backport |
 | [CodeRabbit](https://github.com/apps/coderabbitai) | AI code review (free plan); org-wide |
-| [pre-commit.ci](https://github.com/apps/pre-commit-ci) | Auto-fix linting; 1 repo |
-| [Dependabot](https://github.com/dependabot) | Dependency updates; 1 repo |
-| [DCO](https://github.com/apps/dco) | Developer Certificate of Origin check; 1 repo |
+| [pre-commit.ci](https://github.com/apps/pre-commit-ci) | Auto-fix linting |
+| [Dependabot](https://github.com/dependabot) | Dependency updates |
+| [DCO](https://github.com/apps/dco) | Developer Certificate of Origin check |
 
 ### Apps on notebooks specifically
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -16,16 +16,16 @@ As of May 2026, these apps are active across the org (detected via check-runs an
 
 | App | Repos | Notes |
 |-----|-------|-------|
-| **GitHub Actions** | 96 | Primary CI for most repos |
-| **Red Hat Konflux** | 26 | Container image builds (Tekton pipelines) |
-| **GitHub Advanced Security** | 5 | Code scanning (CodeQL) |
-| **Tide** (Prow) | 4 | Merge automation via commit status; see [docs/tide.md](tide.md) |
-| **Codecov** | 3 | Coverage reporting (odh-dashboard, opendatahub-operator, spark-operator) |
-| **Mergify** | 2 | Auto-merge and auto-backport (trainer, trustyai-service-operator) |
-| **CodeRabbit** | org-wide | AI code review, installed on free plan across all repos |
-| **pre-commit.ci** | 1 | Auto-fix linting (opendatahub-tests) |
-| **Dependabot** | 1 | Dependency updates (autofix-skills) |
-| **DCO** | 1 | Developer Certificate of Origin check (modelmesh-serving) |
+| **GitHub Actions** | most repos | Primary CI |
+| **Red Hat Konflux** | [notebooks](https://github.com/opendatahub-io/notebooks), [kubeflow](https://github.com/opendatahub-io/kubeflow), [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator), +23 more | Container image builds (Tekton pipelines) |
+| **GitHub Advanced Security** | [kserve](https://github.com/opendatahub-io/kserve), [guardrails-detectors](https://github.com/opendatahub-io/guardrails-detectors), [eval-hub](https://github.com/opendatahub-io/eval-hub), +2 more | Code scanning (CodeQL) |
+| **Tide** (Prow) | [kserve](https://github.com/opendatahub-io/kserve), [model-registry](https://github.com/opendatahub-io/model-registry), [model-registry-operator](https://github.com/opendatahub-io/model-registry-operator), [models-as-a-service](https://github.com/opendatahub-io/models-as-a-service) | Merge automation; see [docs/tide.md](tide.md) |
+| **Codecov** | [odh-dashboard](https://github.com/opendatahub-io/odh-dashboard), [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator), [spark-operator](https://github.com/opendatahub-io/spark-operator) | Coverage reporting |
+| **Mergify** | [trainer](https://github.com/opendatahub-io/trainer), [trustyai-service-operator](https://github.com/opendatahub-io/trustyai-service-operator) | Auto-merge and auto-backport |
+| **CodeRabbit** | org-wide | AI code review (free plan) |
+| **pre-commit.ci** | [opendatahub-tests](https://github.com/opendatahub-io/opendatahub-tests) | Auto-fix linting |
+| **Dependabot** | [autofix-skills](https://github.com/opendatahub-io/autofix-skills) | Dependency updates |
+| **DCO** | [modelmesh-serving](https://github.com/opendatahub-io/modelmesh-serving) | Developer Certificate of Origin check |
 
 ### Apps on notebooks specifically
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5020

## Summary

- Add `docs/github.md` as a reference for GitHub apps, org settings, and tooling for opendatahub-io

Covers:
- Installed apps inventory across all 184 repos (GitHub Actions, Konflux, Mergify, CodeRabbit, Codecov, etc.)
- How to check which apps are installed (API commands, browser URL trick)
- How to request new app installations (Slack channels, DPP Jira tickets)
- Branch protection (Prow branchprotector vs GitHub-native)
- Renovate, CodeRabbit, Qodo configuration details
- Cross-links to `docs/tide.md` and related Jira tickets

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all links are reachable

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a cross-organization GitHub guide covering installed GitHub Apps, how to inspect/enumerate them via CLI/API, org-admin workflows for requesting app installations and licensing, branch-protection differences and Tide gating, org-level push rulesets, Renovate (including self-hosted via Actions) and CodeRabbit behaviors, Qodo enablement, and links to related docs and tracking tickets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->