### PR TITLE
NO-JIRA: docs: add CI systems overview and fix /retest docs

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,91 @@
+# CI Systems Overview
+
+This repo uses three CI systems simultaneously. Each handles a different concern:
+
+| System | What it does | Config location |
+|--------|-------------|-----------------|
+| **GitHub Actions** | Code quality, static analysis, security scans, docs, notifications | `.github/workflows/` |
+| **Konflux / Pipelines-as-Code** | Container image builds, integration testing | `.tekton/` |
+| **Prow / Tide** | Merge automation, label management (`/lgtm`, `/approve`, `/hold`) | [openshift/release](https://github.com/openshift/release) |
+
+Detailed docs for each:
+- [docs/tide.md](tide.md) -- Prow/Tide merge automation, OWNERS file, Prow commands
+- [docs/konflux.md](konflux.md) -- Konflux build system, pipeline triggers, Renovate/MintMaker
+- [docs/konflux-integration.md](konflux-integration.md) -- Konflux group testing, ephemeral clusters
+
+## Slash commands
+
+All three systems use PR comment commands, and some commands are consumed by multiple
+systems simultaneously. Prow and PaC both watch for `/retest` and `/test`, responding
+independently based on their own job/pipeline registries.
+
+### Common commands (shared between Prow and PaC)
+
+| Command | Prow response | PaC/Konflux response |
+|---------|--------------|---------------------|
+| `/retest` (bare) | Retriggers all failed Prow presubmit jobs | Retriggers all failed PaC pipelines. Ignores successful and in-progress ones. |
+| `/retest <name>` | Retriggers the named Prow job if it failed | Triggers the named PaC pipeline regardless of previous outcome — even if it never ran on this PR |
+| `/test <name>` | Same as `/retest <name>` for Prow | Same as `/retest <name>` for PaC |
+| `/ok-to-test` | Trusts a fork PR for Prow CI | Trusts a fork PR for PaC pipelines |
+
+Since Prow presubmit jobs are no longer configured for `main`, Prow responds to `/test`
+and `/retest` with *"No presubmit jobs available"* while PaC proceeds to trigger the
+matching pipeline.
+
+### Prow-only commands (merge automation)
+
+These commands are handled exclusively by Prow. See [docs/tide.md](tide.md) for details.
+
+| Command | Effect |
+|---------|--------|
+| `/lgtm` | Adds `lgtm` label (required for merge) |
+| `/approve` | Adds `approved` label (required for merge) |
+| `/hold` | Adds `do-not-merge/hold` to block merge |
+| `/override <context>` | Forces a failing check to pass |
+
+Clicking the GitHub "Approve" review button triggers `/lgtm` and `/approve` automatically
+for OWNERS approvers. See the [review mapping table](tide.md#github-review-approval-vs-prow-lgtm-and-approve).
+
+### Konflux-only commands (build triggers)
+
+These commands are handled exclusively by PaC. See [docs/konflux.md](konflux.md#triggering-builds)
+for the full list.
+
+**ODH (`opendatahub-io/notebooks`):**
+
+| Command | Effect |
+|---------|--------|
+| `/kfbuild all` | Triggers all PR build pipelines |
+| `/kfbuild <component>` | Triggers a single component build |
+| `/kfbuild <source-path>` | Triggers by source directory |
+| `/group-test` | Triggers the integration test pipeline |
+
+**RHDS (`red-hat-data-services/notebooks`):**
+
+| Command | Effect |
+|---------|--------|
+| `/build-konflux` | Triggers all RHDS PR build pipelines |
+| `/build-<image-type>` | Triggers a specific image build |
+
+RHDS also supports label-based triggers (`kfbuild-all`, `kfbuild-cuda`, etc.).
+
+### GitHub Actions
+
+GitHub Actions workflows are **not** triggered by slash commands. They run automatically
+on PR events based on `on:` triggers in `.github/workflows/*.yaml`. To re-run a failed
+GHA workflow, use the GitHub UI "Re-run" button on the Actions or Checks tab.
+
+## How the systems interact
+
+```
+PR opened/updated
+  ├── GitHub Actions: runs automatically (code-quality, security, etc.)
+  ├── Konflux/PaC: runs if pathChanged() matches .tekton/ CEL expressions
+  │                 or triggered manually via /kfbuild, /test, /retest
+  └── Prow/Tide: watches for label state
+                  └── When lgtm + approved + all checks green → auto-merge
+```
+
+Tide considers checks from **all** systems when deciding to merge. A failing GitHub
+Actions workflow or a failing Konflux pipeline will both block Tide from merging,
+unless overridden with `/override <context-name>`.

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -45,7 +45,7 @@ List your contexts with `oc config get-contexts -o name | grep stone`.
 
 ## ODH-io (Open Data Hub)
 
-This section covers the Konflux setup for the upstream **Open Data Hub** community project.
+This section covers the Konflux setup for the midstream **Open Data Hub** community project.
 
 project: `open-data-hub-tenant`
 
@@ -242,7 +242,42 @@ oc annotate components/<component-name> \
 
 This requires `oc` access to the respective cluster and namespace. The annotation is consumed immediately, but the PipelineRun takes ~2 minutes to appear. The component must have PaC `state: enabled` in its build status annotation. The same action is available as the "Start new build" button in the Konflux UI.
 
-See also: [Running Build Pipelines (Konflux docs)](https://konflux-ci.dev/docs/building/running/)
+#### Retrying a push build via GitHub commit comment
+
+You can trigger push pipelines by commenting on a **commit** page (not on a PR).
+The most reliable command is `/test <pipelinerun-name>`, which uses the PipelineRun's
+`metadata.name` from `.tekton/` (e.g., `odh-base-image-cpu-py312-ubi9-on-push` -- note
+this is the PipelineRun name, not the component name or filename).
+
+1. Navigate to the **latest commit on the branch** on GitHub
+2. Scroll to the Comments section at the bottom of the commit page
+3. To trigger a specific push pipeline:
+   `/test <pipelinerun-name>` (always works, even if the pipeline never ran)
+4. To retrigger all failed push pipelines:
+   `/retest` (only retriggers previously failed runs -- does nothing if no prior failures)
+5. For non-default branches:
+   `/test <pipelinerun-name> branch:<branch-name>` (pipeline name first, then `branch:`)
+
+**Constraints** ([source: PaC `handleCommitCommentEvent`](https://github.com/tektoncd/pipelines-as-code/blob/main/pkg/provider/github/parse_payload.go)):
+- Only works on the **latest commit (HEAD)** of the branch -- PaC calls `isHeadCommitOfBranch`
+  and rejects comments on older commits ([source](https://github.com/tektoncd/pipelines-as-code/blob/main/pkg/provider/github/github.go))
+- Without `branch:`, defaults to the **default branch** (`main`). For `stable` or `rhoai-*`
+  branches, you must specify `branch:<name>`
+- Does **not** trigger nudging PRs (use `trigger-pac-build` annotation when you need nudge propagation)
+
+**Verified** on `opendatahub-io/notebooks` (May 10, 2026):
+`/test odh-base-image-cpu-py312-ubi9-on-push` on commit `22d8b92` (HEAD of `main`)
+successfully triggered a push pipeline. Also confirmed working in
+[ACS](https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1771841918073429) and
+[AAP Hub](https://redhat-internal.slack.com/archives/C07BMJL2X42/p1771333521169669).
+
+**Warning:** Custom `on-comment` triggers (like `/kfbuild`) also work on commit comments,
+but they match **all** pipelines with a matching regex -- including PR pipelines. Commenting
+`/kfbuild all` on a commit triggers all PR build pipelines, not push pipelines. Use the
+built-in `/test <name>` for commit comments instead.
+
+See also: [Running Build Pipelines (Konflux docs)](https://konflux-ci.dev/docs/building/running/),
+[RHAIENG-5020](https://redhat.atlassian.net/browse/RHAIENG-5020)
 
 ## Build trigger internals
 

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -183,7 +183,7 @@ All PipelineRuns in `.tekton/` override compute resources for several tasks that
 
 ### PR builds
 
-Comment `/retest` on the pull request to retrigger all **failed** PR pipelines (successful ones are skipped). To retrigger a specific pipeline regardless of its previous outcome, use `/test <pipelinerun-name>` or `/retest <pipelinerun-name>`. See [PaC GitOps Commands](https://pipelinesascode.com/docs/guides/gitops-commands/).
+Comment `/retest` on the pull request to retrigger all **failed** PR pipelines (successful and in-progress ones are skipped). To trigger a specific pipeline regardless of its previous outcome -- including pipelines that never ran on the PR -- use `/test <pipelinerun-name>` or `/retest <pipelinerun-name>`. See [PaC GitOps Commands](https://pipelinesascode.com/docs/guides/gitops-commands/).
 
 The GitHub Checks tab "Re-run" button restarts **all** Konflux pipelines in the check suite, including those still running or already succeeded (it can cancel in-progress checks, causing them to fail). There is no way to re-run a single check from the UI. The GitHub API endpoints `POST /check-runs/{id}/rerequest` and `POST /check-suites/{id}/rerequest` do not work with user tokens — classic OAuth returns 404, fine-grained PATs return 403 ("Resource not accessible by personal access token"). Checks API write access is [limited to GitHub Apps](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens); the API reference pages incorrectly list fine-grained PATs as supported ([doc bug](https://github.com/github/rest-api-description/issues/4290)).
 


### PR DESCRIPTION
## Summary

- Add `docs/ci.md` -- unified overview of all three CI systems (GitHub Actions, Konflux/PaC, Prow/Tide)
- Fix `/retest` documentation in `docs/konflux.md`

### docs/ci.md

Cross-reference doc that explains how the three CI systems coexist:
- Slash command comparison table showing which system handles what
- Documents that `/retest` and `/test` are consumed by both Prow and PaC simultaneously
- ASCII flow diagram of how PR events reach each system
- Links to detailed docs (tide.md, konflux.md, konflux-integration.md)

### docs/konflux.md fix

Updated `/retest` behavior based on testing on PR #3590:
- Bare `/retest` skips **in-progress** pipelines too (not just successful ones)
- `/retest <name>` and `/test <name>` trigger pipelines that **never ran** on the PR (not just failed ones)

### Verification

Tested on PR #3590 (docs-only PR with no Konflux pipelines auto-triggered):
1. `/retest` (bare) -- Prow: no response (no jobs). PaC: no response (nothing failed).
2. `/test odh-base-image-cpu-py312-ubi9-on-pull-request` -- Prow: "No presubmit jobs available". PaC: started the pipeline.
3. `/retest odh-base-image-cpu-py312-c9s-on-pull-request` -- Prow: "No presubmit jobs available". PaC: started the pipeline.
4. `/retest` (bare, with 2 pipelines in-progress) -- Neither system triggered anything new.

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Verify cross-links to tide.md, konflux.md, konflux-integration.md resolve

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CI docs describing GitHub Actions, Pipelines-as-Code, and Prow/Tide and how each interacts with PR slash commands (note: GitHub Actions are not triggered via slash commands) and how auto-merge considers checks across systems.
  * Clarified `/retest` behavior: reruns skip successful and in-progress pipelines when targeting failed pipelines.
  * Added guidance for retrying push pipelines via commit comments and a warning about custom comment triggers matching PR pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->