### PR TITLE
fix: use --password-stdin for skopeo login in pr-merge-image-delete (CWE-214)

### DIFF
--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -48,7 +48,7 @@ jobs:
           QUAY_ROBOT_USERNAME: ${{ secrets.QUAY_ROBOT_USERNAME }}
           QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
         run: |
-         skopeo login quay.io -u ${QUAY_ROBOT_USERNAME} -p ${QUAY_ROBOT_TOKEN}
+         printf '%s' "${QUAY_ROBOT_TOKEN}" | skopeo login --username "${QUAY_ROBOT_USERNAME}" --password-stdin quay.io
       - name: Delete PR image
         shell: bash
         continue-on-error: true


### PR DESCRIPTION
## Summary

Use `--password-stdin` instead of `-p` flag for `skopeo login` in
`pr-merge-image-delete.yml` to avoid exposing the password in process
arguments (CWE-214).

PR #3588 fixed this in `params-env.yaml` and `software-versions.yaml`
but missed `pr-merge-image-delete.yml` which had the same pattern.

## Test plan

- [ ] Verify the `pr-merge-image-delete` workflow still authenticates successfully on next PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security for internal container image management workflows by improving credential handling practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->