### PR TITLE
RHAIENG-5032: test+fix(manifests): detect installed workbench packages missing from manifest annotations

### DIFF
--- a/manifests/odh/base/code-server-notebook-imagestream.yaml
+++ b/manifests/odh/base/code-server-notebook-imagestream.yaml
@@ -35,7 +35,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.2"},
             {"name": "Kubeflow-Training", "version": "1.9"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Feast", "version": "0.62"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -89,7 +89,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -85,7 +85,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -43,7 +43,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Feast", "version": "0.62"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -82,7 +82,8 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.35"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
-            {"name": "MySQL Connector/Python", "version": "9.6"}
+            {"name": "MySQL Connector/Python", "version": "9.6"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -89,7 +89,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/odh/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -89,7 +89,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -65,7 +65,8 @@ spec:
             {"name": "Scipy", "version": "1.17"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.2"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -35,7 +35,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.2"},
             {"name": "Kubeflow-Training", "version": "1.9"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Feast", "version": "0.62"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
@@ -80,7 +80,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -88,7 +88,9 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Codeflare-SDK", "version": "0.36"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -87,7 +87,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -83,7 +83,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -80,7 +80,8 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.36"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
-            {"name": "MySQL Connector/Python", "version": "9.6"}
+            {"name": "MySQL Connector/Python", "version": "9.6"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -43,7 +43,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "MLflow", "version": "3.10"}
+            {"name": "MLflow", "version": "3.10"},
+            {"name": "Feast", "version": "0.62"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -87,7 +87,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -87,7 +87,8 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "Kubeflow-Training", "version": "1.9"},
+            {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/tools/package_names.py
+++ b/manifests/tools/package_names.py
@@ -60,3 +60,10 @@ def manifest_name_to_pip(name: str) -> str:
     if name in MANIFEST_LOWER_NAMES:
         return name.lower()
     return name
+
+
+def all_workbench_pip_names() -> frozenset[str]:
+    """Return the set of pip package names that should appear in imagestream annotations."""
+    names = {v.lower() for v in MANIFEST_TO_PIP.values()}
+    names |= {n.lower() for n in MANIFEST_LOWER_NAMES}
+    return frozenset(names)

--- a/tests/containers/manifest_validation_test.py
+++ b/tests/containers/manifest_validation_test.py
@@ -512,6 +512,22 @@ def _compare_manifest_vs_actual(
             ):
                 pytest.fail(f"Manifest says {manifest_name}=={manifest_version}, but image has {actual_version_str}")
 
+    # Pre-existing gaps in older tag manifests — packages installed in images
+    # but historically never listed in annotations. xfail to surface them
+    # without blocking CI. New omissions will hard-fail.
+    REVERSE_CHECK_XFAIL: frozenset[str] = frozenset(
+        {
+            "nvidia-cuda-runtime-cu12",  # never listed in older manifests
+            "boto3",  # ROCm images historically didn't list it
+            "kfp",  # ROCm and code-server historically didn't list it
+            "kubeflow-training",  # rocm-tensorflow omission
+            "accelerate",  # transitive dep of llmcompressor
+            "datasets",  # transitive dep of llmcompressor
+            "transformers",  # transitive dep of llmcompressor
+            "feast",  # pre-existing gap in code-server and rocm-tensorflow old tags
+        }
+    )
+
     if not is_software:
         known_pip_names = all_workbench_pip_names()
         manifest_pip_names = {_normalize_pip_name(manifest_name_to_pip(d["name"])) for d in expected_deps}
@@ -521,7 +537,10 @@ def _compare_manifest_vs_actual(
                 continue
             if normalized not in manifest_pip_names:
                 with subtests.test(msg=f"{is_name} tag {tag_name}: {pip_name} installed but not in manifest"):
-                    pytest.fail(f"{pip_name} found in image but not listed in manifest annotations")
+                    if normalized in REVERSE_CHECK_XFAIL:
+                        pytest.xfail(f"{pip_name} found in image but not listed in manifest annotations (known gap)")
+                    else:
+                        pytest.fail(f"{pip_name} found in image but not listed in manifest annotations")
 
 
 @dataclasses.dataclass

--- a/tests/containers/manifest_validation_test.py
+++ b/tests/containers/manifest_validation_test.py
@@ -46,7 +46,7 @@ import pytest
 import yaml
 
 from manifests.tools.commit_env_refs import parse_env_file
-from manifests.tools.package_names import manifest_name_to_pip
+from manifests.tools.package_names import all_workbench_pip_names, manifest_name_to_pip
 from tests import PROJECT_ROOT
 
 if TYPE_CHECKING:
@@ -511,6 +511,17 @@ def _compare_manifest_vs_actual(
                 msg=f"{is_name} tag {tag_name}: {manifest_name} {manifest_version} != {actual_version_str}"
             ):
                 pytest.fail(f"Manifest says {manifest_name}=={manifest_version}, but image has {actual_version_str}")
+
+    if not is_software:
+        known_pip_names = all_workbench_pip_names()
+        manifest_pip_names = {_normalize_pip_name(manifest_name_to_pip(d["name"])) for d in expected_deps}
+        for pip_name in actual_packages:
+            normalized = _normalize_pip_name(pip_name)
+            if normalized not in known_pip_names:
+                continue
+            if normalized not in manifest_pip_names:
+                with subtests.test(msg=f"{is_name} tag {tag_name}: {pip_name} installed but not in manifest"):
+                    pytest.fail(f"{pip_name} found in image but not listed in manifest annotations")
 
 
 @dataclasses.dataclass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,7 +23,7 @@ import pytest
 import yaml
 
 from manifests.tools.commit_env_refs import parse_env_file
-from manifests.tools.package_names import manifest_name_to_pip
+from manifests.tools.package_names import all_workbench_pip_names, manifest_name_to_pip
 from tests import PROJECT_ROOT, manifests
 
 if TYPE_CHECKING:
@@ -311,6 +311,30 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                         ), (
                             f"{name}: manifest {manifest.filename} declares {manifest_version}, but pylock.toml pins {locked_version}"
                         )
+
+                with subtests.test(msg="checking pylock workbench packages are listed in manifest", pyproject=file):
+                    known_pip_names = all_workbench_pip_names()
+                    manifest_pip_names = {manifest_name_to_pip(d["name"]).lower() for d in manifest.dep}
+                    workbench_only_pip = {manifest_name_to_pip(n).lower() for n in workbench_only_packages}
+                    direct_deps = set()
+                    for d in pyproject["project"]["dependencies"]:
+                        req = packaging.requirements.Requirement(d)
+                        if not is_subproject_metapackage(req.name):
+                            direct_deps.add(req.name.lower())
+                    for pip_name in pylock_packages:
+                        if pip_name.lower() not in known_pip_names:
+                            continue
+                        if pip_name.lower() not in direct_deps:
+                            continue
+                        if (
+                            manifest.metadata.type == manifests.NotebookType.RUNTIME
+                            and pip_name.lower() in workbench_only_pip
+                        ):
+                            continue
+                        if pip_name.lower() not in manifest_pip_names:
+                            pytest.fail(
+                                f"{pip_name} is in pylock.toml (direct dep) but missing from manifest {manifest.filename}"
+                            )
 
 
 @pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -324,17 +324,20 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                     for pip_name in pylock_packages:
                         if pip_name.lower() not in known_pip_names:
                             continue
-                        if pip_name.lower() not in direct_deps:
-                            continue
                         if (
                             manifest.metadata.type == manifests.NotebookType.RUNTIME
                             and pip_name.lower() in workbench_only_pip
                         ):
                             continue
                         if pip_name.lower() not in manifest_pip_names:
-                            pytest.fail(
-                                f"{pip_name} is in pylock.toml (direct dep) but missing from manifest {manifest.filename}"
-                            )
+                            if pip_name.lower() in direct_deps:
+                                pytest.fail(
+                                    f"{pip_name} is in pylock.toml (direct dep) but missing from manifest {manifest.filename}"
+                                )
+                            else:
+                                pytest.xfail(
+                                    f"{pip_name} is in pylock.toml (transitive) but missing from manifest {manifest.filename}"
+                                )
 
 
 @pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5032

## Summary

The manifest validation tests only checked one direction: _"is every manifest entry present in the image?"_ This missed the reverse: _"is every installed workbench package listed in the manifest?"_

PR #3588 exposed this gap — Codeflare-SDK and MLflow were removed from the llmcompressor 3.4 tag manifest because the EA2 image didn't have them, but when the same PR switched to GA digests (which DO have them), no test caught the now-stale removal.

## Changes

- **`manifests/tools/package_names.py`**: Add `all_workbench_pip_names()` helper that returns the canonical set of packages belonging in imagestream annotations (derived from existing `MANIFEST_TO_PIP` + `MANIFEST_LOWER_NAMES`)

- **`tests/test_main.py`** (runs in `gmake test`, no network): For the N (recommended) tag, verify every workbench package in pylock.toml that is a **direct** pyproject.toml dependency appears in the manifest. Transitive workbench packages (e.g. Accelerate pulled in by llmcompressor) xfail instead of hard-failing — this surfaces the inconsistency without blocking CI.

- **`tests/containers/manifest_validation_test.py`** (marker-gated, uses Quay/SBOM): For old tags, verify every workbench package found in the actual image appears in the manifest annotations.

- **Manifest fixes**: Add missing Feast entries to code-server and rocm-tensorflow N tag manifests in both ODH and RHOAI (caught by the new test).

## Test plan

- [x] `gmake test` — 41 passed, 22 skipped, 14 xfailed, 796 subtests passed
- [x] `./uv run pre-commit run --all-files` — all checks pass
- [x] Verified the test catches the exact scenario from #3588 (removing Codeflare-SDK from a manifest triggers a failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated notebook environment dependency lists to add MLflow 3.10, Feast 0.62, and Codeflare‑SDK 0.36 where applicable; one older Codeflare‑SDK entry removed.

* **Tests**
  * Strengthened validations to ensure image packages and manifest-listed workbench packages are mutually consistent; missing entries now fail or use predefined expected-failure handling.

* **Chores**
  * Improved generation/normalization of known workbench package names used by validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->