### PR TITLE
RHAIENG-4797: fix CUDA/ROCm version mismatches in imagestream manifest annotations

### DIFF
--- a/manifests/odh/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -63,7 +63,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "CUDA", "version": "12.9"},
+            {"name": "CUDA", "version": "13.0"},
             {"name": "Python", "version": "v3.12"},
             {"name": "PyTorch", "version": "2.9"},
             {"name": "LLM-Compressor", "version": "0.9"}

--- a/manifests/odh/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "ROCm", "version": "6.4"},
+            {"name": "ROCm", "version": "7.1"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json

--- a/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "ROCm", "version": "6.4"},
+            {"name": "ROCm", "version": "7.1"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -270,6 +270,9 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                             else:
                                 pytest.fail(f"unexpected {s=}")
 
+                with subtests.test(msg="checking accelerator versions for all variants", pyproject=file):
+                    _check_all_accelerator_variants(directory, manifests_directory, subtests)
+
                 with subtests.test(msg="checking the `notebook-python-dependencies` array", pyproject=file):
                     for d in manifest.dep:
                         workbench_only_packages = [
@@ -817,6 +820,39 @@ def get_accelerator_version_for_directory(directory: pathlib.Path, accelerator_n
     return match.group(1)
 
 
+def _check_all_accelerator_variants(
+    directory: pathlib.Path,
+    manifests_directory: pathlib.Path,
+    subtests: pytest_subtests.plugin.SubTests,
+) -> None:
+    """Check accelerator versions for all build-args variants (cuda, rocm) in a directory.
+
+    Some directories (e.g. jupyter/minimal) have both konflux.cuda.conf and
+    konflux.rocm.conf but extract_metadata_from_path only returns one accelerator
+    flavor, so the other manifest never gets validated by the main test loop.
+    """
+    for conf_file in sorted(directory.glob("build-args/konflux.*.conf")):
+        flavor = conf_file.stem.replace("konflux.", "")
+        if flavor not in ("cuda", "rocm"):
+            continue
+        accel_name = "CUDA" if flavor == "cuda" else "ROCm"
+        with subtests.test(msg=f"accelerator variant {flavor}", directory=str(directory)):
+            expected_version = get_accelerator_version_for_directory(directory, accel_name)
+
+            try:
+                manifest = load_manifests_file_for(directory, manifests_directory, accelerator_flavor=flavor)
+            except FileNotFoundError:
+                pytest.skip(f"No manifest file for {directory} with {flavor}")
+
+            accel_entry = next((s for s in manifest.sw if s.get("name") == accel_name), None)
+            assert accel_entry is not None, f"{manifest.filename.name}: missing {accel_name} entry in notebook-software"
+            manifest_version = accel_entry.get("version", "").lstrip("v")
+            assert manifest_version == expected_version, (
+                f"{manifest.filename.name}: {accel_name} version in imagestream "
+                f"({accel_entry.get('version')}) does not match build-args version ({expected_version})"
+            )
+
+
 @dataclasses.dataclass
 class Manifest:
     filename: pathlib.Path
@@ -826,8 +862,14 @@ class Manifest:
     dep: list[dict[str, Any]]
 
 
-def load_manifests_file_for(directory: pathlib.Path, manifests_directory: pathlib.Path) -> Manifest:
+def load_manifests_file_for(
+    directory: pathlib.Path,
+    manifests_directory: pathlib.Path,
+    accelerator_flavor: str | None = None,
+) -> Manifest:
     metadata = manifests.extract_metadata_from_path(directory)
+    if accelerator_flavor is not None:
+        metadata = dataclasses.replace(metadata, accelerator_flavor=accelerator_flavor)
     manifest_file = manifests.get_source_of_truth_filepath(
         manifests_directory=manifests_directory,
         metadata=metadata,


### PR DESCRIPTION
## Summary

Cross-referenced `build-args/konflux.*.conf` `BASE_IMAGE` values against the
`opendatahub.io/notebook-software` annotations in imagestream manifests and
fixed 3 remaining stale entries (4 others were already corrected on main by
prior merges).

### Manifest fixes (commit 1):
- **ODH LLM Compressor CUDA** tag 3.4: 12.9 -> 13.0
- **ODH Minimal ROCm** tag 3.5: 6.4 -> 7.1
- **RHOAI Minimal ROCm** tag 3.5: 6.4 -> 7.1

### Test improvement (commit 2, [RHAIENG-5056](https://redhat.atlassian.net/browse/RHAIENG-5056)):

Directories like `jupyter/minimal` have both `konflux.cuda.conf` and
`konflux.rocm.conf`, but `extract_metadata_from_path` only returns one
accelerator flavor (whichever Dockerfile it finds first in the elif chain).
This meant the ROCm minimal manifest was never validated, allowing the
ROCm 6.4 -> 7.1 drift to go undetected.

- Add `_check_all_accelerator_variants()` that scans for all
  `build-args/konflux.{cuda,rocm}.conf` files in each directory and
  validates each corresponding manifest independently
- Extend `load_manifests_file_for` with an optional `accelerator_flavor`
  parameter to avoid duplicating manifest loading logic
- Assert that the accelerator entry exists in `notebook-software` (fail
  explicitly if missing, instead of silently passing)

## Context

These stale annotations cause GPU test failures in the RC test matrix (the
`ods-ci` `Verify Installed CUDA Version` test reads the expected version from
the manifest annotation). See the [Jenkins GPU test run](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/rhoai/job/3.4/job/selfmanaged/job/cli/job/gcp/job/gpu/job/nvidia/job/rhoai-generalpurpose-gpu/13/).

Fixes https://redhat.atlassian.net/browse/RHAIENG-4797
Fixes https://redhat.atlassian.net/browse/RHAIENG-5056

## Test plan

- `gmake test` passes (267 subtests, including the new accelerator variant checks)
- Verified both CUDA and ROCm variants of `jupyter/minimal` are now validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Jupyter PyTorch LLM-Compressor image stream updated to CUDA 13.0, PyTorch 2.10, and LLM‑Compressor 0.10.
  * Jupyter ROCm minimal notebook image streams updated to ROCm 7.1 (Python 3.12 and JupyterLab 4.5 remain unchanged).

* **Tests**
  * New validation to ensure CUDA/ROCm notebook-software versions in image manifests match the expected accelerator variants across image configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->