### PR TITLE
RHAIENG-3646, RHAIENG-3644: fix(deps): add nltk>=3.9.3 CVE constraint to prevent version downgrade

### DIFF
--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -21,3 +21,5 @@ jupyterlab>=4.5.7
 
 # Pin librt to 0.10 as the 0.11 has not have wheels for all architectures
 librt==0.10.0
+# RHAIENG-3644: CVE-2026-0846 NLTK: Arbitrary file read via improper path validation in `filestring()` function
+nltk>=3.9.3


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-3644

## Description
<!--- Describe your changes in detail -->
add nltk to cve-constraints.txt to safeguard from downgrade

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to add a constraint for the natural language toolkit package while retaining the existing constraint for the JupyterLab package.
  * These changes adjust how dependency versions are resolved during constraint compilation used by the build and packaging tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->