### PR TITLE
[RHAIENG-4791] Update 3.4 image references

### DIFF
--- a/manifests/rhoai/base/commit.env
+++ b/manifests/rhoai/base/commit.env
@@ -1,16 +1,14 @@
-# Git short hashes for 3.4 GA images (align with product build when available)
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-3-4=1e60d9c
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-3-4=1e60d9c
-odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-3-4=1e60d9c
+odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-3-4=3a2ec4a
+odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-3-4=3a2ec4a
+odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-3-4=b1396fc
+odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-3-4=b1396fc
+odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-3-4=3a2ec4a
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-3-4=3a2ec4a
+odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-3-4=3a2ec4a
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-3-4=3a2ec4a
-odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-3-4=1e60d9c
-
+odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-3-4=3a2ec4a
 
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-2025-2=a2a3d89
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-2025-2=a2a3d89

--- a/manifests/rhoai/base/params.env
+++ b/manifests/rhoai/base/params.env
@@ -1,17 +1,14 @@
-# Temporary: using quay.io 3.4 GA (v3.4.0, tag rhoai-3.4) digests until
-# official registry.redhat.io images are available (RHAIENG-4791).
-# TODO: https://redhat.atlassian.net/browse/RHAIENG-4791
-odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:71b6aee897c14a0e8392e1fdd30a182adc86067d9bdf3a2c5605699c7cec261d
-odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:767f9d39b79c8d2d0613716349606926a43ee038eca689ab28ac67caa9d3224e
-odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:c7bf1787326be2763b1812e64cf521e2487bac1f3985ba6f3ee79c97da06f61f
-odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:5f9ed295bed88d5e0422fe8df58ef83e0fba7432da5dbef65ea0324c60938285
-odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:b1d1ff462e3969907f9b2c8755570ecd49e057a799537ab0c3a1377ec858ecc0
-odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:35351c8ff07e41679d32d7576bfce76d9c922707dc3281f6a322ae6fb58178be
-odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:5c0725e708a9173f506312954663c302863ed65c03ac54884c5703d930862211
-odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:054feaad634145fd50a2ce7ec65cec834390e40398ebf7e6dc5bb1e37c13b47e
-odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:27225b17f8e37f90b64db3118f42b1e9d636366229cac301c2a68ea87bb39b4e
-odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:05bf03b4b7858cfd60f46f8b58206bba20d95b5b16e99443417fef7425b1bb04
-odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4=quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:e9c0c48dfba0b7d89c143dac0a49a80a4ea79ae383afe1e75264eab60dfd4a09
+odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
+odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9
+odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:496b9ff80594d486f594bba69652c3ae4445265b94a44995b25f5ebd1e5767b3
+odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:19e62e604a6b74ded1c5df88112e5be44424fb1752df46dc1587447fe024865f
+odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:6ccdf5e6cf1cbd46c5f844738889e671130c513de6bd64a48029fd4d177c0a82
+odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:1fafb4f2f909b13d7dbdc03cb865469a7feb2ceadc2ca0995b2d2933e9b0d027
+odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:9180767bd0ff3bae9827c1e584036cdfb442467252328b8b89058b2b907f996a
+odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:c8be5cfe590e3a08c2515b3224826aaf125fc3e7a26d1018d78dfd316ef8640d
+odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:cada04c9bd1c8ad4e167dfbbde3b3b955b6a6d322726602c8b109a986d62ac73
+odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:05bf03b4b7858cfd60f46f8b58206bba20d95b5b16e99443417fef7425b1bb04
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:3fe23bc6e7689dc4d825a1d44f05d226009caebcf9602ec1ec7529f855af067b
 
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:792c7c809440655e19da5d50e4b7568f39b403e61eeacd9e0fa095fc01a5e167
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:bd15088088dd6258da62e6658fa66790036acc6bb9af43bdcc240b389ef52f47


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://redhat.atlassian.net/browse/RHAIENG-4791
## Description
<!--- Describe your changes in detail -->
Update 3.4 image references
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions and references for workbench components across multiple deployment variants to ensure infrastructure consistency.
  * Transitioned image registry endpoints to new infrastructure targets for improved deployment management.
  * Cleaned up obsolete configuration comments and documentation headers from deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->