### PR TITLE
fix: add missing base images to params-latest.env [RHAIENG-4291]

### DIFF
--- a/manifests/odh/base/params-latest.env
+++ b/manifests/odh/base/params-latest.env
@@ -1,3 +1,6 @@
+odh-base-image-cpu-py312-ubi9-n=quay.io/opendatahub/odh-base-image-cpu-py312-ubi9:3.5_ea1-v1.44
+odh-base-image-cuda-12-9-py312-ubi9-n=quay.io/opendatahub/odh-base-image-cuda-12-9-py312-ubi9:3.5_ea1-v1.44
+odh-base-image-rocm-6-4-py312-ubi9-n=quay.io/opendatahub/odh-base-image-rocm-6-4-py312-ubi9:3.5_ea1-v1.44
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:3.5_ea1-v1.44
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:3.5_ea1-v1.44
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9:3.5_ea1-v1.44

--- a/manifests/rhoai/base/params-latest.env
+++ b/manifests/rhoai/base/params-latest.env
@@ -1,3 +1,6 @@
+odh-base-image-cpu-py312-ubi9-n=dummy
+odh-base-image-cuda-12-9-py312-ubi9-n=dummy
+odh-base-image-rocm-6-4-py312-ubi9-n=dummy
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-n=dummy
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-n=dummy
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-n=dummy


### PR DESCRIPTION
## Summary
The params-latest.env files were missing entries for base images for the ODH 3.5 EA1 release.

## Changes
Added the following base images to both `manifests/odh/base/params-latest.env` and `manifests/rhoai/base/params-latest.env`:
- `odh-base-image-cpu-py312-ubi9`
- `odh-base-image-cuda-12-9-py312-ubi9`
- `odh-base-image-rocm-6-4-py312-ubi9`

## Test Plan
- [ ] Verify the base image entries are correctly formatted
- [ ] Verify images exist on quay.io with the 3.5_ea1-v1.44 tag

Fixes: [RHAIENG-4291](https://redhat.atlassian.net/browse/RHAIENG-4291)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image configurations for ODH and RHOAI environments, including version pinning and placeholder value assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->