### PR TITLE
chore: update Tekton pipeline tags 3.5_ea1-v1.44 → 3.5_ea2-v1.45 (Step 1/2)

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -46,7 +46,7 @@ spec:
       requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -46,7 +46,7 @@ spec:
       requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: .
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   - name: build-platforms
     value:
     - linux-d160-m4xlarge/amd64

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -50,7 +50,7 @@ spec:
       requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -46,7 +46,7 @@ spec:
       requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -46,7 +46,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -50,7 +50,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -50,7 +50,7 @@ spec:
       requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -48,7 +48,7 @@ spec:
       requirements_files: [requirements.cuda.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -50,7 +50,7 @@ spec:
       requirements_files: [requirements.rocm.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -50,7 +50,7 @@ spec:
       requirements_files: [requirements.cpu.txt]
   - name: additional-tags
     value:
-    - 3.5_ea1-v1.44
+    - 3.5_ea2-v1.45
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
**Step 1 of 2** for post-release tag update ([RHAIENG-4291](https://redhat.atlassian.net/browse/RHAIENG-4291))

Updates Tekton pipelines to build images with the new `3.5_ea2-v1.44` tag.

## Changes
- 18 Tekton pipeline files updated
- `params-latest.env` intentionally NOT updated in this PR

## Next Steps
1. Merge this PR
2. Wait for Konflux to build images with the new `3.5_ea2-v1.44` tag
3. Create follow-up PR to update `params-latest.env` to reference the new images

## Why two PRs?
Lesson from 3.4 GA: If we update `params-latest.env` before images exist, it will point to non-existent images. So we first build, then update references.

Jira: [RHAIENG-4291](https://redhat.atlassian.net/browse/RHAIENG-4291)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image tagging configuration across 18 CI/CD pipeline definitions to use version tag `3.5_ea2-v1.44` instead of `3.5_ea1-v1.44`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->