### PR TITLE
RHAIENG-5137: unify LABEL blocks across ODH and Konflux Dockerfiles

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -129,7 +129,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=1258
             ;;
         odh-workbench-jupyter-minimal-cpu-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=1017
@@ -166,7 +166,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=3399
             ;;
         odh-workbench-jupyter-minimal-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -207,7 +207,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=7015
             ;;
         odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -273,7 +273,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=1708
             ;;
         odh-workbench-jupyter-datascience-cpu-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=1592
@@ -310,7 +310,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=6429
             ;;
         odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -351,7 +351,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=5058
             ;;
         odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -392,7 +392,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=1017
             ;;
         odh-workbench-codeserver-datascience-cpu-py312-ubi9-n)
-            expected_name="odh-notebook-code-server-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -427,7 +427,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_build_name="konflux"
             ;;
         odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -468,7 +468,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=6519
             ;;
         odh-workbench-jupyter-minimal-rocm-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -484,7 +484,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=8177
             ;;
         odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=6519
@@ -521,7 +521,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_img_size=7473
             ;;
         odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-n)
-            expected_name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12"
+            expected_name="opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -557,19 +557,19 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             ;;
         # The following are pipeline runtime images
         odh-pipeline-runtime-minimal-cpu-py312-ubi9-n)
-            expected_name="odh-notebook-runtime-minimal-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=692
             ;;
         odh-pipeline-runtime-datascience-cpu-py312-ubi9-n)
-            expected_name="odh-notebook-runtime-datascience-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=1461
             ;;
         odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-runtime-pytorch-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             if [ "${_MANIFESTS_VARIANT}" = "rhoai" ]; then
@@ -579,25 +579,25 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             fi
             ;;
         odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n)
-            expected_name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=6117
             ;;
         odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=8793
             ;;
         odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n)
-            expected_name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=10217
             ;;
         odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-n)
-            expected_name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12"
+            expected_name="opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9"
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=5859

--- a/ci/expected-image-metadata.yaml
+++ b/ci/expected-image-metadata.yaml
@@ -15,7 +15,7 @@ odh-workbench-jupyter-minimal-cpu-py311-ubi9-2025-1:
   variants:
     - rhoai
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-n:
-  name: odh-notebook-jupyter-minimal-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 1169
@@ -50,7 +50,7 @@ odh-workbench-jupyter-datascience-cpu-py311-ubi9-2025-1:
   variants:
     - rhoai
 odh-workbench-jupyter-datascience-cpu-py312-ubi9-n:
-  name: odh-notebook-jupyter-datascience-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 1731
@@ -97,7 +97,7 @@ odh-workbench-jupyter-pytorch-rocm-py311-ubi9-2025-1:
   variants:
     - rhoai
 odh-workbench-jupyter-pytorch-rocm-py312-ubi9-n:
-  name: odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 6409
@@ -112,7 +112,7 @@ odh-workbench-jupyter-tensorflow-rocm-py311-ubi9-2025-1:
   variants:
     - rhoai
 odh-pipeline-runtime-minimal-cpu-py312-ubi9-n:
-  name: odh-notebook-runtime-minimal-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 692
@@ -120,7 +120,7 @@ odh-pipeline-runtime-minimal-cpu-py312-ubi9-n:
     - odh
     - rhoai
 odh-pipeline-runtime-datascience-cpu-py312-ubi9-n:
-  name: odh-notebook-runtime-datascience-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 1330
@@ -128,7 +128,7 @@ odh-pipeline-runtime-datascience-cpu-py312-ubi9-n:
     - odh
     - rhoai
 odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n:
-  name: odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 5999
@@ -136,7 +136,7 @@ odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n:
     - odh
     - rhoai
 odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n:
-  name: odh-notebook-runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 8794
@@ -144,7 +144,7 @@ odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-n:
     - odh
     - rhoai
 odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n:
-  name: odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 10169
@@ -152,7 +152,7 @@ odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n:
     - odh
     - rhoai
 odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-n:
-  name: odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb: 5953
@@ -175,7 +175,7 @@ odh-workbench-jupyter-minimal-cpu-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-n:
-  name: odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -197,7 +197,7 @@ odh-workbench-jupyter-minimal-cuda-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-pytorch-cuda-py312-ubi9-n:
-  name: odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -219,7 +219,7 @@ odh-workbench-jupyter-pytorch-cuda-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-n:
-  name: odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -253,7 +253,7 @@ odh-workbench-jupyter-datascience-cpu-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n:
-  name: odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -275,7 +275,7 @@ odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n:
-  name: odh-notebook-jupyter-trustyai-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -297,7 +297,7 @@ odh-workbench-jupyter-trustyai-cpu-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-n:
-  name: odh-notebook-code-server-ubi9-python-3.12
+  name: opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -319,7 +319,7 @@ odh-workbench-codeserver-datascience-cpu-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-n:
-  name: odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -353,7 +353,7 @@ odh-workbench-jupyter-pytorch-rocm-py312-ubi9-2025-2:
     - odh
     - rhoai
 odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-n:
-  name: odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12
+  name: opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:
@@ -378,7 +378,7 @@ odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-2025-2:
 # --- Missing pipeline runtime entries ---
 
 odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n:
-  name: odh-notebook-runtime-pytorch-ubi9-python-3.12
+  name: opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9
   commitref: main
   build_name: konflux
   size_mb:

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -265,10 +265,10 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="code-server image with python 3.12 based on UBI 9" \

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -265,15 +265,16 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-code-server-ubi9-python-3.12" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="code-server image with python 3.12 based on UBI 9" \
       description="code-server image with python 3.12 based on UBI9" \
-      io.k8s.display-name="code-server image with python 3.12 based on UBI9" \
       io.k8s.description="code-server image with python 3.12 based on UBI9" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-      io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/ubi9-python-3.12" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-ubi9-python-3.12"
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 USER 0
 

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -264,9 +264,12 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="code-server image with python 3.12 based on UBI 9" \
       description="code-server image with python 3.12 based on UBI9" \
       io.k8s.description="code-server image with python 3.12 based on UBI9" \

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -264,10 +264,10 @@ ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 ARG CODESERVER_VERSION=v4.106.3
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="code-server image with python 3.12 based on UBI 9" \

--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-ubi9

--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-ubi9
+PRODUCT=odh

--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-rhel9

--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -110,10 +110,10 @@ FROM jupyter-minimal AS jupyter-datascience
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter data science notebook image for ODH notebooks" \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -110,15 +110,16 @@ FROM jupyter-minimal AS jupyter-datascience
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-datascience-ubi9-python-3.12" \
-    summary="Jupyter data science notebook image for ODH notebooks" \
-    description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter data science notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter data science notebook image for ODH notebooks" \
+      description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -110,10 +110,10 @@ FROM jupyter-minimal AS jupyter-datascience
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter data science notebook image for ODH notebooks" \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -110,9 +110,12 @@ FROM jupyter-minimal AS jupyter-datascience
 ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-datascience-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-datascience-cpu-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter data science notebook image for ODH notebooks" \
       description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-ubi9
+PRODUCT=odh

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-ubi9

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -41,15 +41,16 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-minimal-ubi9-python-3.12" \
-    summary="Minimal Jupyter notebook image for ODH notebooks" \
-    description="Minimal Jupyter notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Minimal Jupyter notebook image for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+    com.redhat.component="${LABEL_COMPONENT}" \
+    io.k8s.display-name="${LABEL_COMPONENT}" \
+    summary="Minimal Jupyter CPU notebook image for ODH notebooks" \
+    description="Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+    io.k8s.description="Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+    com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -41,10 +41,10 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
     com.redhat.component="${LABEL_COMPONENT}" \
     io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CPU notebook image for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -40,15 +40,16 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-cuda-minimal-ubi9-python-3.12" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+    com.redhat.component="${LABEL_COMPONENT}" \
+    io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \
     description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Minimal Jupyter CUDA notebook image for ODH notebooks" \
     io.k8s.description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-minimal-ubi9-python-3.12"
+    com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -40,10 +40,10 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
     com.redhat.component="${LABEL_COMPONENT}" \
     io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -41,9 +41,12 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9" \
-    com.redhat.component="odh-workbench-jupyter-minimal-cpu-py312-rhel9" \
-    io.k8s.display-name="odh-workbench-jupyter-minimal-cpu-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+    com.redhat.component="${LABEL_COMPONENT}" \
+    io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CPU notebook image for ODH notebooks" \
     description="Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
     io.k8s.description="Minimal Jupyter CPU notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -41,10 +41,10 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
     com.redhat.component="${LABEL_COMPONENT}" \
     io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CPU notebook image for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -40,13 +40,16 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9" \
-    com.redhat.component="odh-workbench-jupyter-minimal-cuda-py312-rhel9" \
-    io.k8s.display-name="odh-workbench-jupyter-minimal-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+    com.redhat.component="${LABEL_COMPONENT}" \
+    io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \
     description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
     io.k8s.description="Minimal Jupyter CUDA notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+    com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -40,10 +40,10 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
     com.redhat.component="${LABEL_COMPONENT}" \
     io.k8s.display-name="${LABEL_COMPONENT}" \
     summary="Minimal Jupyter CUDA notebook image for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -42,10 +42,10 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -42,9 +42,12 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-minimal-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-minimal-rocm-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \
       description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -42,10 +42,10 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -42,15 +42,16 @@ ARG JUPYTER_REUSABLE_UTILS=jupyter/utils
 ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-rocm-minimal-ubi9-python-3.12" \
-    summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \
-    description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Minimal Jupyter ROCm notebook image for ODH notebooks" \
-    io.k8s.description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-minimal-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Minimal Jupyter ROCm notebook image for ODH notebooks" \
+      description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Minimal Jupyter ROCm notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-ubi9
+PRODUCT=odh

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-ubi9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-ubi9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-ubi9
+PRODUCT=odh

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-ubi9
+PRODUCT=odh

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-ubi9

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -148,10 +148,10 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -148,15 +148,16 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="odh-notebook-jupyter-cuda-pytorch-llmcompressor-ubi9-python-3.12" \
-    summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch+llmcompressor/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
+      description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 # Install Python packages and Jupyterlab extensions from lockfile (requirements.cuda.txt used only for Cachi2 prefetch)
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -148,9 +148,12 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
       description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -148,10 +148,10 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA pytorch-llmcompressor notebook image for ODH notebooks" \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9
+PRODUCT=odh

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -130,10 +130,10 @@ WORKDIR /opt/app-root/bin
 
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -130,15 +130,16 @@ WORKDIR /opt/app-root/bin
 
 USER root
 
-LABEL name="odh-notebook-jupyter-cuda-pytorch-ubi9-python-3.12" \
-    summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \
-    description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter CUDA pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-pytorch-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \
+      description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 # pylock.toml documents the graph; requirements.cuda.txt drives Cachi2 prefetch and hermetic uv install
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -130,10 +130,10 @@ WORKDIR /opt/app-root/bin
 
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -130,9 +130,12 @@ WORKDIR /opt/app-root/bin
 
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-pytorch-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-pytorch-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA pytorch notebook image for ODH notebooks" \
       description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter CUDA pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-ubi9
+PRODUCT=odh

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-ubi9

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-rhel9

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -129,9 +129,12 @@ ARG PYLOCK_FLAVOR
 
 WORKDIR /opt/app-root/bin
 
-LABEL name="rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \
       description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -129,10 +129,10 @@ ARG PYLOCK_FLAVOR
 
 WORKDIR /opt/app-root/bin
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -129,15 +129,16 @@ ARG PYLOCK_FLAVOR
 
 WORKDIR /opt/app-root/bin
 
-LABEL name="odh-notebook-jupyter-rocm-pytorch-ubi9-python-3.12" \
-    summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \
-    description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter ROCm pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-pytorch-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \
+      description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -129,10 +129,10 @@ ARG PYLOCK_FLAVOR
 
 WORKDIR /opt/app-root/bin
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter ROCm pytorch notebook image for ODH notebooks" \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-rhel9

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-ubi9

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-ubi9
+PRODUCT=odh

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -148,9 +148,12 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-tensorflow-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-tensorflow-rocm-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
       description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -148,10 +148,10 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -148,15 +148,16 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12" \
-    summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
-    description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter AMD tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/rocm/tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-jupyter-tensorflow-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
+      description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 # Install Python packages from lockfile (requirements.rocm.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -148,10 +148,10 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-rhel9

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-ubi9

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-ubi9
+PRODUCT=odh

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -147,10 +147,10 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -147,15 +147,16 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
-    summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
-    description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
+      description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 # Install Python packages and Jupyterlab extensions from lockfile (requirements.cuda.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -147,10 +147,10 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -147,9 +147,12 @@ WORKDIR /opt/app-root/bin
 # hadolint ignore=DL3002
 USER root
 
-LABEL name="rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
       description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-ubi9

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
+PRODUCT=odh

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1778521475
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1778521475
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-rhel9

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -136,15 +136,16 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-jupyter-trustyai-ubi9-python-3.12" \
-    summary="Jupyter trustyai notebook image for ODH notebooks" \
-    description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Jupyter trustyai notebook image for ODH notebooks" \
-    io.k8s.description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/jupyter/trustyai/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi9-python-3.12"
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Jupyter trustyai notebook image for ODH notebooks" \
+      description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -136,10 +136,10 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter trustyai notebook image for ODH notebooks" \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -136,9 +136,12 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter trustyai notebook image for ODH notebooks" \
       description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -136,10 +136,10 @@ FROM jupyter-datascience AS jupyter-trustyai
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Jupyter trustyai notebook image for ODH notebooks" \

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-ubi9
+PRODUCT=odh

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-ubi9

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-rhel9
+PRODUCT=rhoai

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-rhel9

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -47,16 +47,6 @@ ARG TARGETARCH
 ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-datascience-ubi9-python-3.12" \
-    summary="Runtime data science notebook image for ODH notebooks" \
-    description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime data science notebook image for ODH notebooks" \
-    io.k8s.description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/datascience/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 USER 0
@@ -95,3 +85,14 @@ EOF
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime data science notebook image for ODH notebooks" \
+      description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -86,10 +86,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime data science notebook image for ODH notebooks" \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -85,10 +85,13 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
-      io.k8s.description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-      description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime data science notebook image for ODH notebooks" \
+      description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -85,10 +85,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime data science notebook image for ODH notebooks" \

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-ubi9
+PRODUCT=odh

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-ubi9

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-rhel9

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -46,16 +46,6 @@ FROM cpu-base AS runtime-minimal
 ARG MINIMAL_SOURCE_CODE=runtimes/minimal/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-minimal-ubi9-python-3.12" \
-    summary="Runtime minimal image for ODH notebooks" \
-    description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime minimal image for ODH notebooks" \
-    io.k8s.description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/minimal/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-minimal-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
@@ -86,3 +76,14 @@ EOF
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime minimal image for ODH notebooks" \
+      description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -77,10 +77,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime minimal image for ODH notebooks" \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -74,9 +74,12 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-minimal-cpu-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-minimal-cpu-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime minimal image for ODH notebooks" \
       description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Runtime minimal image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -74,10 +74,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime minimal image for ODH notebooks" \

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-ubi9

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-ubi9
+PRODUCT=odh

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1778521486
 PYLOCK_FLAVOR=cpu
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-rhel9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -36,16 +36,6 @@ FROM cuda-base AS cuda-runtime-pytorch
 ARG PYTORCH_SOURCE_CODE=runtimes/pytorch+llmcompressor/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12" \
-    summary="Runtime CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    description="Runtime CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime CUDA pytorch-llmcompressor notebook image for ODH notebooks" \
-    io.k8s.description="Runtime CUDA pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch+llmcompressor/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-llmcompressor-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 COPY --chown=1001:0 ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
@@ -76,3 +66,14 @@ EOF
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime pytorch-llmcompressor notebook image for ODH notebooks" \
+      description="Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -67,10 +67,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime pytorch-llmcompressor notebook image for ODH notebooks" \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,9 +67,12 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime pytorch-llmcompressor notebook image for ODH notebooks" \
       description="Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Runtime pytorch-llmcompressor notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,10 +67,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime pytorch-llmcompressor notebook image for ODH notebooks" \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -2,4 +2,4 @@ INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 PRODUCT=opendatahub
-LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-ubi9
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9
+PRODUCT=odh

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-ubi9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -2,4 +2,4 @@ INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
 PRODUCT=rhoai
-LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -38,16 +38,6 @@ FROM cuda-base AS cuda-runtime-pytorch
 ARG PYTORCH_SOURCE_CODE=runtimes/pytorch/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-pytorch-ubi9-python-3.12" \
-    summary="Runtime pytorch notebook image for ODH notebooks" \
-    description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 COPY --chown=1001:0 ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
@@ -78,3 +68,14 @@ EOF
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime pytorch notebook image for ODH notebooks" \
+      description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -69,10 +69,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime pytorch notebook image for ODH notebooks" \

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,9 +67,12 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-pytorch-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime pytorch notebook image for ODH notebooks" \
       description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Runtime pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,10 +67,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime pytorch notebook image for ODH notebooks" \

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-ubi9

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-ubi9
+PRODUCT=odh

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1778521489
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -75,10 +75,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime ROCm pytorch notebook image for ODH notebooks" \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -75,9 +75,12 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-pytorch-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-pytorch-rocm-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
       description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -75,10 +75,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime ROCm pytorch notebook image for ODH notebooks" \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -34,16 +34,6 @@ FROM rocm-base AS rocm-runtime-pytorch
 ARG PYTORCH_SOURCE_CODE=runtimes/rocm-pytorch/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-runtime-rocm-pytorch-ubi9-python-3.12" \
-    summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
-    description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime ROCm pytorch notebook image for ODH notebooks" \
-    io.k8s.description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/rocm-pytorch/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-runtime-pytorch-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 COPY --chown=1001:0 ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
@@ -84,3 +74,14 @@ ENV ROCM_PATH=/opt/rocm
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime ROCm pytorch notebook image for ODH notebooks" \
+      description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-rhel9

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-ubi9
+PRODUCT=odh

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-ubi9

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -70,10 +70,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -70,9 +70,12 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-tensorflow-rocm-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-tensorflow-rocm-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
       description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -70,10 +70,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -34,16 +34,6 @@ FROM rocm-base AS rocm-runtime-tensorflow
 ARG TENSORFLOW_SOURCE_CODE=runtimes/rocm-tensorflow/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-rocm-runtime-tensorflow-ubi9-python-3.12" \
-    summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
-    description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime ROCm tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/rocm-tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:rocm-runtime-tensorflow-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 COPY --chown=1001:0 ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
@@ -79,3 +69,14 @@ ENV ROCM_PATH=/opt/rocm
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime ROCm tensorflow notebook image for ODH notebooks" \
+      description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime ROCm tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-rhel9

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.1-1778521387
 PYLOCK_FLAVOR=rocm
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-ubi9
+PRODUCT=odh

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-ubi9

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -67,10 +67,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -36,16 +36,6 @@ FROM cuda-base AS cuda-runtime-tensorflow
 ARG TENSORFLOW_SOURCE_CODE=runtimes/tensorflow/ubi9-python-3.12
 ARG PYLOCK_FLAVOR
 
-LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12" \
-    summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
-    description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    io.k8s.display-name="Runtime CUDA tensorflow notebook image for ODH notebooks" \
-    io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
-    authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
-    io.openshift.build.commit.ref="main" \
-    io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/runtimes/tensorflow/ubi9-python-3.12" \
-    io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-runtime-tensorflow-ubi9-python-3.12"
-
 WORKDIR /opt/app-root/bin
 
 COPY --chown=1001:0 ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
@@ -76,3 +66,14 @@ EOF
 USER 1001
 
 WORKDIR /opt/app-root/src
+
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
+      summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
+      description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,10 +67,10 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-ARG PRODUCT
+ARG LABEL_REGISTRY_PREFIX
 ARG LABEL_COMPONENT
 
-LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
       com.redhat.component="${LABEL_COMPONENT}" \
       io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -67,9 +67,12 @@ USER 1001
 
 WORKDIR /opt/app-root/src
 
-LABEL name="rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9" \
-      com.redhat.component="odh-pipeline-runtime-tensorflow-cuda-py312-rhel9" \
-      io.k8s.display-name="odh-pipeline-runtime-tensorflow-cuda-py312-rhel9" \
+ARG PRODUCT
+ARG LABEL_COMPONENT
+
+LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
+      com.redhat.component="${LABEL_COMPONENT}" \
+      io.k8s.display-name="${LABEL_COMPONENT}" \
       summary="Runtime CUDA tensorflow notebook image for ODH notebooks" \
       description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Runtime CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
-PRODUCT=opendatahub
+LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-ubi9
+PRODUCT=odh

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
+PRODUCT=opendatahub
+LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-ubi9

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,5 +1,6 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1778521475
 PYLOCK_FLAVOR=cuda
-PRODUCT=rhoai
+LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+PRODUCT=rhoai

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1778521475
 PYLOCK_FLAVOR=cuda
+PRODUCT=rhoai
+LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-rhel9

--- a/scripts/check_dockerfile_alignment.sh
+++ b/scripts/check_dockerfile_alignment.sh
@@ -3,7 +3,7 @@
 # Script: dockerfile_diff_checker.sh
 # Purpose: Scan a directory tree for Dockerfile.konflux.*
 #          and compare each with its original Dockerfile,
-#          ignoring comments and multi-line LABEL instructions.
+#          ignoring comments.
 #=========================================================
 
 set -euo pipefail
@@ -16,7 +16,7 @@ main() {
     # Define multiple starting directories
     local start_dirs=("./jupyter" "./codeserver" "./runtimes")
     echo "Scanning ${start_dirs[*]} for directories containing Dockerfile.konflux.*"
-    echo "Comparing Dockerfiles, ignoring comments and LABEL blocks..."
+    echo "Comparing Dockerfiles, ignoring comments..."
 
     # Populate array of directories (while-read is portable; mapfile requires Bash 4+)
     local docker_dirs=()
@@ -56,8 +56,9 @@ find_docker_dirs() {
 #---------------------------------------------------------
 # Function: strip
 # Description:
-#   Remove comments and ignore LABEL blocks from a Dockerfile.
-#   Useful for comparing Dockerfiles while ignoring cosmetic differences.
+#   Remove comments from a Dockerfile.
+#   LABEL blocks are now compared directly (they should be byte-identical
+#   since RHAIENG-5137 unified them via PRODUCT/LABEL_COMPONENT ARGs).
 # Arguments:
 #   Reads from standard input
 # Returns:
@@ -65,26 +66,10 @@ find_docker_dirs() {
 #---------------------------------------------------------
 strip() {
     awk '
-        BEGIN { in_label = 0 }
-
         # Skip full-line comments
         /^[[:space:]]*#/ { next }
 
-        # Skip lines inside multi-line LABEL blocks
-        in_label {
-            # End LABEL block if line does not end with backslash
-            if ($0 !~ /\\$/) in_label = 0
-            next
-        }
-
-        # Detect start of LABEL instruction
-        /^[[:space:]]*LABEL([ \t]|$)/ {
-            # Multi-line LABEL block
-            if ($0 ~ /\\$/) in_label = 1
-            next
-        }
-
-        # Print all other lines (trimmed)
+        # Print all non-comment lines (trimmed)
         {
             # Trim leading and trailing whitespace
             gsub(/^[ \t]+|[ \t]+$/, "", $0)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-5137

## Summary

- Introduce `PRODUCT` and `LABEL_COMPONENT` build-args to replace divergent hardcoded LABEL blocks
- LABEL blocks are now **byte-identical** between `Dockerfile.*` and `Dockerfile.konflux.*` for all 18 image pairs
- Reduces label ARGs from 11 (PR #3497 approach) to 2, with no empty-string labels
- Supersedes #3497

## What changed

**Dockerfiles (36 files)**: Replace hardcoded LABEL blocks with unified template:
```dockerfile
ARG PRODUCT
ARG LABEL_COMPONENT

LABEL name="${PRODUCT}/${LABEL_COMPONENT}" \
      com.redhat.component="${LABEL_COMPONENT}" \
      io.k8s.display-name="${LABEL_COMPONENT}" \
      summary="..." \
      description="..." \
      io.k8s.description="..." \
      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
```

**Conf files (36 files)**: Each conf provides `PRODUCT` and `LABEL_COMPONENT`:
- ODH: `PRODUCT=opendatahub`, `LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-ubi9`
- Konflux: `PRODUCT=rhoai`, `LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-rhel9`

**Naming standardization**: `odh-notebook-*` → `odh-workbench-*` (jupyter/codeserver) / `odh-pipeline-*` (runtimes)

**Labels removed from Dockerfiles** (auto-injected by Konflux buildah task):
- `authoritative-source-url`, `io.openshift.build.commit.ref`, `io.openshift.build.source-location`, `io.openshift.build.image`

**Labels added as shared constants**:
- `com.redhat.license_terms` — ODH is midstream Red Hat (UBI base, Red Hat Python index)
- `com.redhat.component` — harmless in ODH, required by Conforma in RHOAI

**Alignment script**: Removed LABEL-block skipping from `check_dockerfile_alignment.sh` — LABEL blocks are now identical, enabling direct comparison

**CI scripts**: Updated `-n` entries only in `check-params-env.sh` and `expected-image-metadata.yaml`; historical version entries keep old names

## How Has This Been Tested?

- `gmake test` passes (69 passed, 22 skipped, 34 xfailed)
- `check_dockerfile_alignment.sh` reports all 18 pairs in sync
- Verified no external repos reference dropped labels (searched operator, dashboard, tests, ods-ci)

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized container image naming for py312-ubi9 workbench and pipeline runtime variants to use opendatahub paths.
  * Parameterized image metadata labels across many builds for consistent, component-driven labeling.
  * Updated CI validation and Dockerfile comparison behavior to match the new naming and label scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->