### PR TITLE
RHAIENG-5139: fix(ci): add symlink-aware change detection for GHA builds

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -8,6 +8,7 @@ import platform
 import re
 import shutil
 import subprocess
+import tempfile
 import unittest
 from typing import Literal
 
@@ -35,7 +36,7 @@ def _symlink_reverse_map() -> dict[str, list[str]]:
         try:
             logical = str(symlink.relative_to(PROJECT_ROOT))
             resolved = str(symlink.resolve().relative_to(PROJECT_ROOT))
-        except ValueError, OSError, RuntimeError:
+        except (ValueError, OSError, RuntimeError):  # fmt: skip  # parens needed for Python <3.14 (GHA runners)
             # RuntimeError: symlink loops (a→b→a) cause infinite resolution
             continue
         # symlink resolving to itself is not useful
@@ -67,7 +68,7 @@ def _resolve_symlinks(paths: list[str]) -> list[str]:
             if path == resolved:
                 expanded.update(symlinks)
             elif path.startswith(resolved + "/"):
-                suffix = path[len(resolved):]
+                suffix = path[len(resolved) :]
                 expanded.update(f"{symlink}{suffix}" for symlink in symlinks)
             elif resolved.startswith(path + "/"):
                 expanded.update(symlinks)
@@ -264,8 +265,6 @@ class TestSelf(unittest.TestCase):
     def test_resolve_symlinks_preserves_suffix_for_directory_symlink(self):
         """When real_dir/sub/file changes and link_dir → real_dir, we should
         get link_dir/sub/file in the expanded list, not just link_dir."""
-        import tempfile
-
         _symlink_reverse_map.cache_clear()
         with tempfile.TemporaryDirectory(dir=PROJECT_ROOT) as tmpdir:
             tmpdir = pathlib.Path(tmpdir)
@@ -280,15 +279,11 @@ class TestSelf(unittest.TestCase):
             rel_link_expected = str((link_dir / "sub" / "file.txt").relative_to(PROJECT_ROOT))
 
             result = _resolve_symlinks([rel_real])
-            assert rel_link_expected in result, (
-                f"Expected {rel_link_expected} in result, got {result}"
-            )
+            assert rel_link_expected in result, f"Expected {rel_link_expected} in result, got {result}"
         _symlink_reverse_map.cache_clear()
 
     def test_symlink_loop_does_not_crash(self):
         """A symlink loop should be skipped, not crash the scan."""
-        import tempfile
-
         _symlink_reverse_map.cache_clear()
         with tempfile.TemporaryDirectory(dir=PROJECT_ROOT) as tmpdir:
             tmpdir = pathlib.Path(tmpdir)

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -1,4 +1,5 @@
 import fnmatch
+import functools
 import json
 import logging
 import os
@@ -19,6 +20,59 @@ def get_github_token() -> str:
     return github_token
 
 
+@functools.cache
+def _symlink_reverse_map() -> dict[str, list[str]]:
+    """Build a map from resolved real path to symlink logical paths.
+
+    Git reports changes to real files only, not to symlinks pointing at them.
+    This map lets us expand a list of changed real paths to include the logical
+    symlink paths that are affected. Built once per process and cached.
+    """
+    result: dict[str, list[str]] = {}
+    for symlink in PROJECT_ROOT.rglob("*"):
+        if not symlink.is_symlink():
+            continue
+        try:
+            logical = str(symlink.relative_to(PROJECT_ROOT))
+            resolved = str(symlink.resolve().relative_to(PROJECT_ROOT))
+        except ValueError, OSError:
+            continue
+        # symlink resolving to itself is not useful
+        if logical != resolved:
+            result.setdefault(resolved, []).append(logical)
+    if result:
+        logging.debug(f"Symlink reverse map: {len(result)} targets with symlinks")
+    return result
+
+
+def _resolve_symlinks(paths: list[str]) -> list[str]:
+    """Expand paths to include symlinks whose resolved targets match.
+
+    Git reports changes to real files only, not to symlinks pointing at them.
+    This adds logical symlink paths when their resolved targets appear in the
+    input list.
+    """
+    if not paths:
+        return paths
+
+    reverse = _symlink_reverse_map()
+    if not reverse:
+        return paths
+
+    original = set(paths)
+    expanded = set(original)
+    for path in paths:
+        for resolved, symlinks in reverse.items():
+            if path == resolved or path.startswith(resolved + "/"):
+                expanded.update(symlinks)
+            elif resolved.startswith(path + "/"):
+                expanded.update(symlinks)
+
+    if added := expanded - original:
+        logging.info(f"Symlink resolution added {len(added)} paths: {sorted(added)}")
+    return sorted(expanded)
+
+
 def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     logging.debug("Getting list of changed files from git diff")
 
@@ -29,6 +83,7 @@ def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     files = subprocess.check_output(
         ["git", "diff", "--name-only", f"{from_ref}...{to_ref}", "--"], encoding="utf-8"
     ).splitlines()
+    files = _resolve_symlinks(files)
 
     logging.debug(f"Determined {len(files)} changed files: {files[:100]} (..., printing up to 100 files)")
     return files
@@ -114,6 +169,7 @@ def should_build_target(changed_files: list[str], target_directory: str) -> str:
             # no dependencies
             continue
         dependencies: list[str] = json.loads(stdout)
+        dependencies = _resolve_symlinks(dependencies)
         for dependency in dependencies:
             for changed_file in changed_files:
                 if _is_file_in_directory(changed_file, dependency):
@@ -176,3 +232,27 @@ class TestSelf(unittest.TestCase):
 
     def test_should_build_target(self):
         assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.12")
+
+    def test_resolve_symlinks_no_symlinks(self):
+        """No symlinks in input paths -> returned unchanged."""
+        assert _resolve_symlinks(["README.md"]) == ["README.md"]
+
+    def test_resolve_symlinks_empty(self):
+        assert _resolve_symlinks([]) == []
+
+    def test_resolve_symlinks_expands_target(self):
+        """Editing a symlink target adds the symlink path."""
+        result = _resolve_symlinks(["jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu"])
+        assert "jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu" in result
+        assert "jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu" in result
+
+    def test_resolve_symlinks_pointer_change(self):
+        """Editing the symlink itself needs no expansion — already in list."""
+        result = _resolve_symlinks(["jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu"])
+        assert result == ["jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu"]
+
+    def test_should_build_with_symlinked_dockerfile_target_change(self):
+        """Changing Dockerfile.konflux.cpu triggers build for target using Dockerfile.cpu."""
+        changed = _resolve_symlinks(["jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu"])
+        result = should_build_target(changed, "jupyter/minimal/ubi9-python-3.12")
+        assert result

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -64,8 +64,11 @@ def _resolve_symlinks(paths: list[str]) -> list[str]:
     expanded = set(original)
     for path in paths:
         for resolved, symlinks in reverse.items():
-            if path == resolved or path.startswith(resolved + "/"):
+            if path == resolved:
                 expanded.update(symlinks)
+            elif path.startswith(resolved + "/"):
+                suffix = path[len(resolved):]
+                expanded.update(f"{symlink}{suffix}" for symlink in symlinks)
             elif resolved.startswith(path + "/"):
                 expanded.update(symlinks)
 
@@ -257,6 +260,30 @@ class TestSelf(unittest.TestCase):
         changed = _resolve_symlinks(["jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu"])
         result = should_build_target(changed, "jupyter/minimal/ubi9-python-3.12")
         assert result
+
+    def test_resolve_symlinks_preserves_suffix_for_directory_symlink(self):
+        """When real_dir/sub/file changes and link_dir → real_dir, we should
+        get link_dir/sub/file in the expanded list, not just link_dir."""
+        import tempfile
+
+        _symlink_reverse_map.cache_clear()
+        with tempfile.TemporaryDirectory(dir=PROJECT_ROOT) as tmpdir:
+            tmpdir = pathlib.Path(tmpdir)
+            real_dir = tmpdir / "real_dir"
+            real_dir.mkdir()
+            (real_dir / "sub").mkdir()
+            (real_dir / "sub" / "file.txt").write_text("content")
+            link_dir = tmpdir / "link_dir"
+            link_dir.symlink_to("real_dir")
+
+            rel_real = str((real_dir / "sub" / "file.txt").relative_to(PROJECT_ROOT))
+            rel_link_expected = str((link_dir / "sub" / "file.txt").relative_to(PROJECT_ROOT))
+
+            result = _resolve_symlinks([rel_real])
+            assert rel_link_expected in result, (
+                f"Expected {rel_link_expected} in result, got {result}"
+            )
+        _symlink_reverse_map.cache_clear()
 
     def test_symlink_loop_does_not_crash(self):
         """A symlink loop should be skipped, not crash the scan."""

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -35,7 +35,8 @@ def _symlink_reverse_map() -> dict[str, list[str]]:
         try:
             logical = str(symlink.relative_to(PROJECT_ROOT))
             resolved = str(symlink.resolve().relative_to(PROJECT_ROOT))
-        except ValueError, OSError:
+        except ValueError, OSError, RuntimeError:
+            # RuntimeError: symlink loops (a→b→a) cause infinite resolution
             continue
         # symlink resolving to itself is not useful
         if logical != resolved:
@@ -256,3 +257,19 @@ class TestSelf(unittest.TestCase):
         changed = _resolve_symlinks(["jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu"])
         result = should_build_target(changed, "jupyter/minimal/ubi9-python-3.12")
         assert result
+
+    def test_symlink_loop_does_not_crash(self):
+        """A symlink loop should be skipped, not crash the scan."""
+        import tempfile
+
+        _symlink_reverse_map.cache_clear()
+        with tempfile.TemporaryDirectory(dir=PROJECT_ROOT) as tmpdir:
+            tmpdir = pathlib.Path(tmpdir)
+            link_a = tmpdir / "a"
+            link_b = tmpdir / "b"
+            link_a.symlink_to("b")
+            link_b.symlink_to("a")
+
+            result = _resolve_symlinks(["README.md"])
+            assert "README.md" in result
+        _symlink_reverse_map.cache_clear()


### PR DESCRIPTION
## Summary
- Add `_resolve_symlinks()` to expand git-reported paths to include symlinks pointing at them
- Build a cached reverse map (`real_path → [symlink_paths]`) once per process via `@functools.cache`
- Integrate into `list_changed_files()` (git diff output) and `should_build_target()` (buildinputs dependency paths)

## Why

Git tracks symlinks as pointer files. When a symlink target changes, `git diff --name-only` reports only the real path, not the symlink. After #3633 symlinked `Dockerfile.*` → `Dockerfile.konflux.*`, editing the real file (`Dockerfile.konflux.cpu`) would not show the symlink (`Dockerfile.cpu`) in the diff. This could cause GHA builds to miss changes that go through symlinks.

Currently this works by accident because the directory-level check in `should_build_target()` catches any change inside the build directory. But this is fragile and would break if symlinks ever pointed outside the build directory.

Closes [RHAIENG-5139](https://redhat.atlassian.net/browse/RHAIENG-5139) (partially — this is the change detection piece)

## Test plan
- [x] `./uv run python -m pytest ci/cached-builds/gha_pr_changed_files.py -v` — 5 new tests pass
- [x] CodeRabbit CLI review: no findings
- [ ] GHA CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Build-trigger detection now recognizes and follows repository symlinks, expanding changed paths to include logical symlink locations for more accurate automatic build decisions.

* **Tests**
  * CI coverage expanded for symlink scenarios (empty inputs, target changes, directory symlinks, loop handling and preservation of subpaths) to ensure reliable build decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->