### PR TITLE
RHAIENG-4654: remove dead AIPCC migration phase 1.5 index override

### DIFF
--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -204,13 +204,6 @@ def main():
                 LANG=en_US.UTF-8 \
                 LC_ALL=en_US.UTF-8 \
                 PS1="(app-root) \w\$ "'''),
-        "RHAIENG-2189: this is AIPCC migration phase 1.5": textwrap.dedent(r"""
-            ENV PIP_INDEX_URL=https://pypi.org/simple
-            # UV_INDEX_URL is deprecated in favor of UV_DEFAULT_INDEX
-            ENV UV_INDEX_URL=https://pypi.org/simple
-            # https://docs.astral.sh/uv/reference/environment/#uv_default_index
-            ENV UV_DEFAULT_INDEX=https://pypi.org/simple"""),
-
         "Subscribe with subscription manager": textwrap.dedent(subscription_manager_register_refresh),
         "upgrade first to avoid fixable vulnerabilities": textwrap.dedent(ntb.process_template_with_indents(rt"""
             {subscription_manager_register_refresh}


### PR DESCRIPTION
## Summary
- Remove unused fragment `"[RHAIENG-2189](https://redhat.atlassian.net/browse/RHAIENG-2189): this is AIPCC migration phase 1.5"` from `dockerfile_fragments.py`
- No Dockerfile has the corresponding `### BEGIN/END` markers — the replacement was never applied
- Base images now set `PIP_INDEX_URL`/`UV_INDEX_URL` directly from `INDEX_URL` (PR #3650)

## Test plan
- [x] `./uv run python scripts/dockerfile_fragments.py` succeeds
- [x] 7-line deletion, no Dockerfiles affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Docker image build process by replacing hardcoded package index configuration with parameterized settings, enabling more flexible build-time customization of Python and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->