### PR TITLE
RHAIENG-4654: test: fix assert_subdict diff display and update AIPCC index URL test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,16 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
+# Enable pytest assertion introspection for the ntb helper module.
+# Without this, assert failures in ntb.asserts (e.g. assert_subdict) show a
+# bare "AssertionError" with no diff — pytest only rewrites assertions in
+# modules it discovers as test files, not in imported utility modules.
+# https://github.com/pytest-dev/pytest/issues/1871
+# https://github.com/pytest-dev/pytest/issues/3454
+pytest.register_assert_rewrite("ntb.asserts")
+
 logging.basicConfig(level=logging.DEBUG)
 
 # Exclude tests/containers from default collection (see pytest.ini near testpaths).

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -16,7 +16,7 @@ import pytest
 import testcontainers.core.container
 
 import ntb
-from tests.containers import conftest, docker_utils, skopeo_utils
+from tests.containers import docker_utils
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
@@ -29,31 +29,6 @@ if TYPE_CHECKING:
 
 class TestBaseImage:
     """Tests that are applicable for all images we have in this repository."""
-
-    def _has_uv_lock_d(self, image: str) -> bool:
-        """Check if the image is AIPCC-enabled by looking for uv.lock.d in source directory."""
-        image_metadata = conftest.get_image_metadata(image)
-        source_location = image_metadata.labels.get("io.openshift.build.source-location", "")
-
-        # Dockerfile.konflux does not have source-location label. Use skopeo or local image env.
-        if not source_location:
-            image_info = skopeo_utils.get_image_info(image)
-            # When skopeo fails (e.g. "manifest unknown" for ephemeral tags), use env from
-            # local image inspect (image is already pulled earlier in the test run).
-            env = image_info.env if image_info is not None else image_metadata.env
-            if not env:
-                # No env from skopeo or local inspect; assume non-AIPCC so PyPI checks run.
-                return False
-            return "PIP_INDEX_URL" not in env
-
-        # Extract relative path from URL (after /tree/main/)
-        source_dir = None
-        if "/tree/main/" in source_location:
-            source_dir = source_location.split("/tree/main/")[1]
-
-        # Check if uv.lock.d directory exists in source
-        workspace_root = pathlib.Path(__file__).parent.parent.parent
-        return source_dir is not None and (workspace_root / source_dir / "uv.lock.d").is_dir()
 
     def _run_test(self, image: str, test_fn: Callable[[testcontainers.core.container.DockerContainer], None]) -> None:
         with docker_utils.running_container(image) as container:
@@ -295,54 +270,46 @@ class TestBaseImage:
 
         self._run_test(image=image, test_fn=test_fn)
 
-    @staticmethod
-    @allure.step("Verify AIPCC image has config file env vars and no index URL env vars")
-    def _check_aipcc_env_vars(actual: dict[str, str], subtests: pytest_subtests.SubTests) -> None:
-        """AIPCC images use pip.conf and uv.toml config files instead of index URL env vars."""
-        aipcc_config_vars = {
-            "PIP_CONFIG_FILE": "/opt/app-root/pip.conf",
-            "UV_CONFIG_FILE": "/opt/app-root/uv.toml",
-        }
-        pypi_index_vars = ("PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX")
-
-        with subtests.test("AIPCC images have config file env vars"):
-            ntb.assert_subdict(aipcc_config_vars, actual)
-        with subtests.test("AIPCC images do not have index URL env vars"):
-            for key in pypi_index_vars:
-                assert key not in actual, f"Expected {key} to NOT be present (image uses uv.lock.d)"
-
-    @staticmethod
-    @allure.step("Verify non-AIPCC image has PyPI index URL env vars")
-    def _check_pypi_env_vars(actual: dict[str, str], subtests: pytest_subtests.SubTests) -> None:
-        """Non-AIPCC images set PIP_INDEX_URL, UV_INDEX_URL, and UV_DEFAULT_INDEX to pypi.org."""
-        pypi_env_vars = {
-            "PIP_INDEX_URL": "https://pypi.org/simple",
-            "UV_INDEX_URL": "https://pypi.org/simple",
-            # https://docs.astral.sh/uv/reference/environment/#uv_default_index
-            "UV_DEFAULT_INDEX": "https://pypi.org/simple",
-        }
-        with subtests.test("Non-AIPCC images have index URL env vars"):
-            ntb.assert_subdict(pypi_env_vars, actual)
-
     @allure.issue("RHAIENG-2189")
     def test_python_package_index(self, image: str, subtests: pytest_subtests.SubTests):
-        """Checks that we use the Python Package Index we mean to use.
-        https://redhat-internal.slack.com/archives/C05TTTYG599/p1764240587118899?thread_ts=1764234802.564119&cid=C05TTTYG599
+        """Verify all images have AIPCC index config and env vars.
 
-        Images with uv.lock.d directory do not need these env vars since dependencies
-        are pinned with exact sources in the lockfile (RHAIENG-3056).
+        All images (both ODH and RHOAI) use AIPCC wheels and must point pip/uv
+        to the AIPCC index. Mixing AIPCC wheels with PyPI wheels causes ABI
+        incompatibility — especially for CUDA/torch-dependent packages (flash-attn,
+        vllm, xformers, etc.) which link against the exact torch C++ ABI that
+        AIPCC builds. Crashes range from core dumps to random garbage results.
+
+        References:
+        - Christian Heimes (AIPCC): "you cannot mix our wheels with upstream PyPI"
+          https://redhat-internal.slack.com/archives/C07JX0EMKCZ/p1762148168064779
+        - Doug Hellmann (AIPCC): "too many ways for ABI issues to come up"
+          https://redhat-internal.slack.com/archives/C0987K24BNV/p1761159166691689
+        - Customer docs: https://access.redhat.com/articles/7137881
         """
-
-        has_uv_lock_d = self._has_uv_lock_d(image)
-
         with docker_utils.running_container(image=image) as container:
             _, output = container.exec(["env"])
             actual = dict(line.split("=", maxsplit=1) for line in output.decode().strip().splitlines())
 
-            if has_uv_lock_d:
-                self._check_aipcc_env_vars(actual, subtests)
-            else:
-                self._check_pypi_env_vars(actual, subtests)
+            # All images have pip.conf and uv.toml pointing to the AIPCC index
+            aipcc_config_vars = {
+                "PIP_CONFIG_FILE": "/opt/app-root/pip.conf",
+                "UV_CONFIG_FILE": "/opt/app-root/uv.toml",
+            }
+            with subtests.test("Images have AIPCC config file env vars"):
+                ntb.assert_subdict(aipcc_config_vars, actual)
+
+            # PIP_INDEX_URL and UV_INDEX_URL are set by base-images (aipcc.sh)
+            # to the AIPCC index. They must NOT point to pypi.org.
+            with subtests.test("Index URL env vars do not point to PyPI"):
+                for key in ("PIP_INDEX_URL", "UV_INDEX_URL"):
+                    assert key in actual, f"{key} must be set in image environment"
+                    normalized = actual[key].rstrip("/")
+                    assert normalized != "https://pypi.org/simple", (
+                        f"{key} must not point to PyPI — AIPCC wheels have ABI "
+                        f"incompatibility with PyPI wheels (torch, CUDA extensions). "
+                        f"Got: {actual[key]}"
+                    )
 
 
 def encode_python_function_execution_command_interpreter(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4654

## Summary
- Register `ntb.asserts` for pytest assertion rewriting so `assert_subdict` shows diffs instead of bare `AssertionError`
- Update `test_python_package_index` to verify images use the AIPCC index (not PyPI)
- Remove dead `_has_uv_lock_d` / `_check_pypi_env_vars` / `_check_aipcc_env_vars` methods

## Why

**Assertion rewriting**: `ntb.asserts` is a utility module, not a test file. Pytest only rewrites assertions in modules it discovers as test files. Without `register_assert_rewrite`, failures show `E   AssertionError` with no diff — making CI debugging impossible.
- https://github.com/pytest-dev/pytest/issues/1871
- https://github.com/pytest-dev/pytest/issues/3454

**Index URL test**: After PR #3650 added `PIP_INDEX_URL` to base-images, all images now have the AIPCC index set. The old test expected `PIP_INDEX_URL=https://pypi.org/simple` which was set by the dead "AIPCC migration phase 1.5" block. This caused test failures on every PR.

AIPCC wheels must not be mixed with PyPI wheels — the AIPCC team builds wheels against RHEL-specific toolchains and torch ABI. Mixing causes crashes in CUDA-dependent packages (flash-attn, vllm, xformers, etc.):
- Christian Heimes: "you cannot mix our wheels with upstream PyPI" ([Slack](https://redhat-internal.slack.com/archives/C07JX0EMKCZ/p1762148168064779))
- Doug Hellmann: "too many ways for ABI issues to come up... core dumps to random garbage" ([Slack](https://redhat-internal.slack.com/archives/C0987K24BNV/p1761159166691689))
- Customer docs: https://access.redhat.com/articles/7137881

## Test plan
- [x] `prek --all-files` passes
- [ ] CI: `test_python_package_index` passes with AIPCC index check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test assertion reporting for clearer, more informative failure diffs.
  * Revised container image tests to simplify setup and consistently validate package index and config environment variables (ensuring custom indexes/configs are used instead of the public PyPI defaults).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->