### PR TITLE
ci: pick most recent SHA in test image discovery

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -37,6 +37,11 @@ jobs:
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Find images for test matrix
         id: find
         env:
@@ -46,8 +51,9 @@ jobs:
         # language=python
         run: |
           import json, os, subprocess, sys
+          sys.path.insert(0, "ci")
 
-          from ci.find_images_for_test_matrix import find_suitable_sha
+          from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
           suffix = "_odh_linux_amd64"

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -70,7 +70,7 @@ jobs:
           matrix = {"include": [
               {"name": img, "image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
           ]}
-          print(f"Using SHA {sha} ({len(common)+1} candidates)")
+          print(f"Using SHA {sha}")
           print(json.dumps(matrix, indent=2))
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -47,6 +47,8 @@ jobs:
         run: |
           import json, os, subprocess, sys
 
+          from ci.find_images_for_test_matrix import find_suitable_sha
+
           registry = os.environ["IMAGE_REGISTRY"]
           suffix = "_odh_linux_amd64"
           required = [
@@ -64,21 +66,7 @@ jobs:
               print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
               sys.exit(1)
 
-          tags = set(json.loads(result.stdout)["Tags"])
-
-          sha_sets = []
-          for img in required:
-              prefix = f"{img}-main_"
-              shas = {t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)}
-              print(f"  {img}: {len(shas)} builds")
-              sha_sets.append(shas)
-
-          common = set.intersection(*sha_sets)
-          if not common:
-              print(f"::error::No SHA has all required images: {required}", file=sys.stderr)
-              sys.exit(1)
-
-          sha = common.pop()
+          sha = find_suitable_sha(suffix, required, result.stdout)
           matrix = {"include": [
               {"name": img, "image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
           ]}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          submodules: false
           persist-credentials: false
 
       - name: Find images for test matrix

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from collections import defaultdict
+
 
 def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> str:
     """Skopeo lists tags oldest to newest."""
@@ -9,7 +9,9 @@ def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> s
     sha_list: list[list[str]] = []
     for img in required:
         prefix = f"{img}-main_"
-        shas = [t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)]
+        shas = [
+            t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)
+        ]
         print(f"  {img}: {len(shas)} builds")
         sha_list.append(shas)
 
@@ -30,16 +32,22 @@ def test_find_suitable_sha__single():
     skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_suffix"]})
     assert find_suitable_sha(suffix, required, skopeo_output) == "abdcef"
 
+
 def test_find_suitable_sha__multiple():
     suffix = "_suffix"
     required = ["img-a", "img-b"]
-    skopeo_output = json.dumps({"Tags": [
-        "img-a-main_old111_suffix",
-        "img-b-main_old111_suffix",
-        "img-a-main_new222_suffix",
-        "img-b-main_new222_suffix",
-    ]})
+    skopeo_output = json.dumps(
+        {
+            "Tags": [
+                "img-a-main_old111_suffix",
+                "img-b-main_old111_suffix",
+                "img-a-main_new222_suffix",
+                "img-b-main_new222_suffix",
+            ]
+        }
+    )
     assert find_suitable_sha(suffix, required, skopeo_output) == "new222"
+
 
 if __name__ == "__main__":
     test_find_suitable_sha__single()

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -1,0 +1,47 @@
+import json
+import sys
+from collections import defaultdict
+
+def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> str:
+    """Skopeo lists tags oldest to newest."""
+    tags = list(json.loads(skopeo_output)["Tags"])
+
+    sha_list: list[list[str]] = []
+    for img in required:
+        prefix = f"{img}-main_"
+        shas = [t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)]
+        print(f"  {img}: {len(shas)} builds")
+        sha_list.append(shas)
+
+    common = set.intersection(*map(set, sha_list))
+    if not common:
+        print(f"::error::No SHA has all required images: {required}", file=sys.stderr)
+        sys.exit(1)
+
+    for sha in reversed(sha_list[0]):
+        if sha in common:
+            return sha
+    raise RuntimeError("unreachable")
+
+
+def test_find_suitable_sha__single():
+    suffix = "_suffix"
+    required = ["codeserver-ubi9-python-3.12"]
+    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_suffix"]})
+    assert find_suitable_sha(suffix, required, skopeo_output) == "abdcef"
+
+def test_find_suitable_sha__multiple():
+    suffix = "_suffix"
+    required = ["img-a", "img-b"]
+    skopeo_output = json.dumps({"Tags": [
+        "img-a-main_old111_suffix",
+        "img-b-main_old111_suffix",
+        "img-a-main_new222_suffix",
+        "img-b-main_new222_suffix",
+    ]})
+    assert find_suitable_sha(suffix, required, skopeo_output) == "new222"
+
+if __name__ == "__main__":
+    test_find_suitable_sha__single()
+    test_find_suitable_sha__multiple()
+    print("OK")


### PR DESCRIPTION
## Summary
- Extract SHA resolution logic to `ci/find_images_for_test_matrix.py` with tests
- Walk tags in reverse (most recent first) instead of using `set.pop()` which is non-deterministic
- Fix stale `common` variable reference in `test-containers.yaml`

## Problem
`set.pop()` picked an arbitrary SHA from 119 candidates. It happened to pick commit `9e9998f` (pre-PR #3650) instead of the latest, causing test failures because the old images didn't have `PIP_INDEX_URL` set.

## Test plan
- [x] `pytest ci/find_images_for_test_matrix.py` passes (2 tests)
- [ ] CI: "Find test images" picks a recent SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Docker image selection process in test container workflows by consolidating image selection logic into a dedicated utility function
  * Enhanced continuous integration infrastructure to ensure consistent test execution across multiple image versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->