### PR TITLE
[RHAIENG-4894] Derive Konflux RHOAI index URLs from BASE_IMAGE instead of hard-coding

### DIFF
--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -116,9 +116,9 @@ project: `rhoai-tenant`
 Each notebook image (workbench or pipeline runtime) has:
 - A `Dockerfile.<variant>` (e.g., `Dockerfile.cpu`, `Dockerfile.cuda`, `Dockerfile.rocm`)
 - A `Dockerfile.konflux.<variant>` twin that currently differs only in LABEL metadata
-- Build-args conf files in `build-args/` (e.g., `cpu.conf`, `konflux.cpu.conf`) containing `BASE_IMAGE`, `INDEX_URL`, `PYLOCK_FLAVOR`
+- Build-args conf files in `build-args/` (e.g., `cpu.conf`, `konflux.cpu.conf`) containing `BASE_IMAGE`, `PYLOCK_FLAVOR`, and related metadata. For `konflux.*.conf`, the effective `INDEX_URL` is derived dynamically from `BASE_IMAGE`.
 
-The Makefile selects which Dockerfile and conf file to use based on the `KONFLUX` environment variable. The conf file is parsed by awk into quoted `--build-arg 'KEY=VALUE'` flags (see the `build_image` function in the Makefile). In Tekton pipelines, the same conf file is passed to buildah via `--build-arg-file`.
+The Makefile selects which Dockerfile and conf file to use based on the `KONFLUX` environment variable. The conf file is parsed by awk into quoted `--build-arg 'KEY=VALUE'` flags (see the `build_image` function in the Makefile), and Konflux builds inject a computed `INDEX_URL` alongside the checked-in args. Downstream Tekton/buildah flows that use `konflux.*.conf` via `--build-arg-file` must mirror that `INDEX_URL` injection instead of assuming the file alone is sufficient.
 
 For hermetic build internals (cachi2.env injection, RPM prefetch paths, module_hotfixes pattern), see [`docs/hermetic-guide.md`](hermetic-guide.md).
 

--- a/docs/subscribed-builds.md
+++ b/docs/subscribed-builds.md
@@ -92,7 +92,8 @@ This will fail with a 403 error if the entitlement is missing or does not includ
 ## Step 3: Build
 
 Build with the Konflux Dockerfile and the AIPCC base image. The build-args config files in
-`build-args/konflux.*.conf` specify the correct base image and index URLs.
+`build-args/konflux.*.conf` specify the correct base image, and the build derives the matching
+Python index URL from that `BASE_IMAGE`.
 
 ```bash
 # Example: runtime-minimal CPU

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -5,8 +5,8 @@ requires-python = "==3.12.*"
 
 dependencies = [
     # Hermetic cpu-base: prefetched with the rest of the stack (see repo-root prefetch-input/ and jupyter/minimal pyproject)
-    "uv==0.11.0",
-    "micropipenv[toml]==1.10.0",
+    "uv",
+    "micropipenv[toml]",
 
     # Datascience and useful extensions
     "skl2onnx",

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1778760737
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1778760737
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1778760737
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.2-1778760744
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/rstudio/rhel9-python-3.12/build-args/konflux.cpu.conf
+++ b/rstudio/rhel9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,2 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777398804
 PYLOCK_FLAVOR=cpu

--- a/rstudio/rhel9-python-3.12/build-args/konflux.cuda.conf
+++ b/rstudio/rhel9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,2 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.1-1777398846
 PYLOCK_FLAVOR=cuda

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cpu-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1778760737
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1778760737
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,4 +1,3 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.2-1778760744
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/scripts/index_url_resolver.py
+++ b/scripts/index_url_resolver.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Annotated
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+import typer
+
+RHOAI_INDEX_ROOT = "https://console.redhat.com/api/pypi/public-rhai/rhoai"
+INDEX_CHECK_TIMEOUT_SECONDS = 5.0
+
+
+class IndexResolutionError(ValueError):
+    """Raised when a build-args config cannot be resolved into an index URL."""
+
+
+@dataclass(frozen=True)
+class ResolvedIndexConfig:
+    conf_file: Path
+    product: str
+    index_profile: str
+    flavor: str
+    base_image: str
+    accelerator: str
+    release: str
+    index_url: str
+
+
+_BASE_IMAGE_RE = re.compile(
+    r"^quay\.io/aipcc/base-images/(?P<image>[^:]+):(?P<tag>[^:]+)$",
+)
+_ACCELERATOR_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^cpu$"), "cpu"),
+    (re.compile(r"^cuda-(?P<version>\d+\.\d+)-el\d+(?:\.\d+)?$"), "cuda"),
+    (re.compile(r"^rocm-(?P<version>\d+\.\d+)-el\d+(?:\.\d+)?$"), "rocm"),
+)
+_TAG_RE = re.compile(r"^(?P<minor>\d+\.\d+)\.\d+(?:-ea\.(?P<ea>\d+))?(?:[-.].+)?$")
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+def read_conf_file(conf_file: Path) -> dict[str, str]:
+    entries: dict[str, str] = {}
+    for line in conf_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        entries[key.strip()] = value.strip()
+    return entries
+
+
+def is_konflux_conf(conf_file: Path) -> bool:
+    return conf_file.name.startswith("konflux.")
+
+
+def resolve_product(conf_file: Path, entries: dict[str, str]) -> str:
+    product = entries.get("PRODUCT")
+    if product:
+        return product
+    if is_konflux_conf(conf_file):
+        return "rhoai"
+    raise IndexResolutionError(f"PRODUCT is missing in {conf_file}")
+
+
+def resolve_flavor(conf_file: Path, entries: dict[str, str]) -> str:
+    if flavor := entries.get("PYLOCK_FLAVOR"):
+        return flavor
+
+    stem = conf_file.stem
+    if stem.startswith("konflux."):
+        return stem.removeprefix("konflux.")
+    return stem
+
+
+def parse_accelerator(image_name: str, conf_file: Path) -> str:
+    for pattern, prefix in _ACCELERATOR_PATTERNS:
+        match = pattern.fullmatch(image_name)
+        if not match:
+            continue
+        version = match.groupdict().get("version")
+        return prefix if version is None else f"{prefix}{version}"
+    raise IndexResolutionError(f"Unsupported BASE_IMAGE accelerator in {conf_file}: {image_name}")
+
+
+def parse_release(tag: str, conf_file: Path) -> str:
+    match = _TAG_RE.fullmatch(tag)
+    if match is None:
+        raise IndexResolutionError(f"Unsupported BASE_IMAGE tag in {conf_file}: {tag}")
+    release = match.group("minor")
+    ea = match.group("ea")
+    return release if ea is None else f"{release}-EA{int(ea)}"
+
+
+def build_rhoai_index_url(*, release: str, accelerator: str) -> str:
+    return f"{RHOAI_INDEX_ROOT}/{release}/{accelerator}-ubi9/simple/"
+
+
+def build_rhoai_test_index_url(*, release: str, accelerator: str) -> str:
+    return f"{RHOAI_INDEX_ROOT}/{release}/{accelerator}-ubi9-test/simple/"
+
+
+def index_url_candidates(*, release: str, accelerator: str) -> tuple[str, str]:
+    return (
+        build_rhoai_index_url(release=release, accelerator=accelerator),
+        build_rhoai_test_index_url(release=release, accelerator=accelerator),
+    )
+
+
+def ensure_json_format_param(url: str) -> str:
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    query["format"] = ["json"]
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
+def validated_index_probe_url(index_url: str) -> str:
+    probe_url = ensure_json_format_param(index_url)
+    parsed = urlparse(probe_url)
+    expected_prefix = urlparse(RHOAI_INDEX_ROOT)
+    if parsed.scheme != "https":
+        raise IndexResolutionError(f"Unsupported index URL scheme for availability probe: {index_url}")
+    if parsed.netloc != expected_prefix.netloc:
+        raise IndexResolutionError(f"Unsupported index URL host for availability probe: {index_url}")
+    if not parsed.path.startswith(expected_prefix.path):
+        raise IndexResolutionError(f"Unsupported index URL path for availability probe: {index_url}")
+    return probe_url
+
+
+@cache
+def index_url_exists(index_url: str) -> bool:
+    request = Request(validated_index_probe_url(index_url), method="HEAD")  # noqa: S310
+    try:
+        with urlopen(request, timeout=INDEX_CHECK_TIMEOUT_SECONDS) as response:  # noqa: S310
+            return 200 <= response.status < 400
+    except HTTPError:
+        return False
+    except URLError:
+        return False
+
+
+def resolve_index_config(
+    conf_file: Path,
+    *,
+    require_konflux: bool = False,
+) -> ResolvedIndexConfig:
+    if not conf_file.is_file():
+        raise IndexResolutionError(f"Config file not found: {conf_file}")
+    if require_konflux and not is_konflux_conf(conf_file):
+        raise IndexResolutionError(f"RH index resolution currently supports only konflux.*.conf files: {conf_file}")
+
+    entries = read_conf_file(conf_file)
+    product = resolve_product(conf_file, entries)
+    if product != "rhoai":
+        raise IndexResolutionError(f"Unsupported PRODUCT for dynamic RH index resolution in {conf_file}: {product}")
+
+    base_image = entries.get("BASE_IMAGE")
+    if not base_image:
+        raise IndexResolutionError(f"BASE_IMAGE is missing in {conf_file}")
+
+    match = _BASE_IMAGE_RE.fullmatch(base_image)
+    if match is None:
+        raise IndexResolutionError(f"Unsupported BASE_IMAGE format in {conf_file}: {base_image}")
+
+    accelerator = parse_accelerator(match.group("image"), conf_file)
+    release = parse_release(match.group("tag"), conf_file)
+    flavor = resolve_flavor(conf_file, entries)
+    production_url, test_url = index_url_candidates(release=release, accelerator=accelerator)
+
+    if index_url_exists(production_url):
+        selected_index_url = production_url
+    elif index_url_exists(test_url):
+        selected_index_url = test_url
+    else:
+        raise IndexResolutionError(
+            f"Neither production nor -test RH index is available for {conf_file}: "
+            f"{production_url} / {test_url}"
+        )
+
+    return ResolvedIndexConfig(
+        conf_file=conf_file,
+        product=product,
+        index_profile="rhoai",
+        flavor=flavor,
+        base_image=base_image,
+        accelerator=accelerator,
+        release=release,
+        index_url=selected_index_url,
+    )
+
+
+@app.command("index-url")
+def print_index_url(
+    conf_file: Annotated[str, typer.Argument(help="Path to build-args config file")],
+) -> None:
+    typer.echo(resolve_index_config(Path(conf_file)).index_url)
+
+
+@app.callback()
+def main() -> None:
+    """Resolve dynamic index URLs from build-args config files."""
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/lockfile-generators/create-requirements-lockfile.sh
+++ b/scripts/lockfile-generators/create-requirements-lockfile.sh
@@ -49,7 +49,7 @@ Options:
                          (e.g. codeserver/ubi9-python-3.12/pyproject.toml)
   --flavor NAME          Lock file flavor (default: cpu).
                          Must match a Dockerfile.<flavor> and
-                         build-args/<flavor>.conf in the project directory.
+                         build-args/konflux.<flavor>.conf for the RH-index flow.
   --download             After generating, download all wheels into
                          cachi2/output/deps/pip/ for offline builds.
   -h, --help             Show this help message and exit
@@ -93,14 +93,6 @@ done
 PROJECT_DIR="$(dirname "$PYPROJECT")"
 REQUIREMENTS_FILE="${PROJECT_DIR}/requirements.${FLAVOR}.txt"
 
-# Read build args from build-args/<flavor>.conf (same source as pylocks_generator.py)
-CONF_FILE="${PROJECT_DIR}/build-args/${FLAVOR}.conf"
-INDEX_URL=""
-if [[ -f "$CONF_FILE" ]]; then
-  # shellcheck source=/dev/null
-  source "$CONF_FILE"
-fi
-
 # Use public-index when PROJECT_DIR equals a listed path or is a subdirectory (e.g. .../ubi9-python-3.12).
 # Produces root pylock.toml (not uv.lock.d/pylock.<flavor>.toml) — same layout as jupyter/rocm/tensorflow.
 PUBLIC_INDEX_PROJECTS=(
@@ -117,10 +109,13 @@ for _d in "${PUBLIC_INDEX_PROJECTS[@]}"; do
 done
 
 PYLOCK_FILE="${PROJECT_DIR}/uv.lock.d/pylock.${FLAVOR}.toml"
-REQUIREMENTS_INDEX_URL="$INDEX_URL"
+REQUIREMENTS_INDEX_URL=""
 if [[ "$PYLOCKS_MODE" == "public-index" ]]; then
   PYLOCK_FILE="${PROJECT_DIR}/pylock.toml"
-  REQUIREMENTS_INDEX_URL=""
+else
+  KONFLUX_CONF_FILE="${PROJECT_DIR}/build-args/konflux.${FLAVOR}.conf"
+  [[ -f "$KONFLUX_CONF_FILE" ]] || error_exit "Konflux config not found: $KONFLUX_CONF_FILE"
+  REQUIREMENTS_INDEX_URL="$(./uv run python scripts/index_url_resolver.py index-url "$KONFLUX_CONF_FILE")"
 fi
 
 # =========================================================================

--- a/scripts/lockfile-generators/helpers/pylock-to-requirements.py
+++ b/scripts/lockfile-generators/helpers/pylock-to-requirements.py
@@ -41,10 +41,22 @@ import re
 import sys
 import tomllib
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 # uv pip compile records its index in the first-line comment, e.g.
 #   --default-index=https://pypi.org/simple
 _DEFAULT_INDEX_RE = re.compile(r"--default-index=(https?://\S+)")
+
+
+def strip_format_json_param(index_url: str) -> str:
+    parsed = urlparse(index_url)
+    query_items = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not (key == "format" and value == "json")
+    ]
+    normalized_query = urlencode(query_items, doseq=True)
+    return urlunparse(parsed._replace(query=normalized_query))
 
 
 def extract_default_index_from_pylock(pylock_path: Path) -> str:
@@ -54,7 +66,7 @@ def extract_default_index_from_pylock(pylock_path: Path) -> str:
     except OSError:
         return ""
     m = _DEFAULT_INDEX_RE.search(head)
-    return m.group(1).rstrip("'\"") if m else ""
+    return strip_format_json_param(m.group(1).rstrip("'\"")) if m else ""
 
 
 def main():

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -64,15 +64,17 @@ import os
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import typer
+
+from scripts.index_url_resolver import IndexResolutionError, ResolvedIndexConfig, resolve_index_config
 
 # region Configuration
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -264,7 +266,7 @@ _EXCLUDE_NEWER_HEADER_RE = re.compile(r"--exclude-newer(?:=|\s+)(\S+)")
 
 def utc_now_iso() -> str:
     """Return current UTC time as ISO-8601 with Z suffix (uv --exclude-newer)."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def parse_exclude_newer_from_lockfile(path: Path) -> str | None:
@@ -302,25 +304,33 @@ def resolve_exclude_newer(
 
 
 # region Lock generation
+def get_rh_index_conf_file(project_dir: Path, flavor: str) -> Path:
+    return project_dir / "build-args" / f"konflux.{flavor}.conf"
+
+
+def resolve_rh_index_config(
+    project_dir: Path,
+    flavor: str,
+    log: LogBuffer,
+) -> ResolvedIndexConfig | None:
+    conf_file = get_rh_index_conf_file(project_dir, flavor)
+    try:
+        return resolve_index_config(conf_file, require_konflux=True)
+    except IndexResolutionError as exc:
+        log.warning(str(exc))
+        return None
+
+
 def get_index_flags(project_dir: Path, flavor: str, log: LogBuffer) -> list[str] | None:
-    """Build uv index flags from build-args/<flavor>.conf.
+    """Build uv index flags from build-args/konflux.<flavor>.conf.
 
-    Returns None on failure (missing conf or INDEX_URL).
+    Returns None on failure.
     """
-    conf_file = project_dir / "build-args" / f"{flavor}.conf"
-    if not conf_file.is_file():
-        log.warning(f"Missing build-args config for {flavor}: {conf_file}")
+    resolved = resolve_rh_index_config(project_dir, flavor, log)
+    if resolved is None:
         return None
 
-    index_url = read_conf_value(conf_file, "INDEX_URL")
-    if not index_url:
-        log.warning(f"INDEX_URL not found in {conf_file}")
-        return None
-
-    index_url = ensure_json_format_param(index_url)
-    flags = [f"--default-index={index_url}"]
-
-    return flags
+    return [f"--default-index={ensure_json_format_param(resolved.index_url)}"]
 
 
 def lock_extra_index_flags_from_env() -> list[str]:
@@ -413,6 +423,12 @@ def run_lock(
     cmd.append(f"--exclude-newer={exclude_newer}")
 
     cmd.extend(index_flags)
+    default_index = next(
+        (flag.removeprefix("--default-index=") for flag in index_flags if flag.startswith("--default-index=")),
+        None,
+    )
+    if default_index is not None:
+        log.print(f"  🌐 Lock INDEX_URL: {default_index}")
     extra_idx = lock_extra_index_flags_from_env()
     if extra_idx:
         cmd.extend(extra_idx)
@@ -463,12 +479,12 @@ def generate_requirements_txt(
     """Convert pylock.<flavor>.toml → requirements.<flavor>.txt via helper script."""
     pylock_path = project_dir / "uv.lock.d" / f"pylock.{flavor}.toml"
     requirements_path = project_dir / f"requirements.{flavor}.txt"
-
-    index_url = read_conf_value(project_dir / "build-args" / f"{flavor}.conf", "INDEX_URL") or ""
+    resolved = resolve_rh_index_config(project_dir, flavor, log)
+    if resolved is None:
+        return False
 
     cmd = [sys.executable, str(PYLOCK_TO_REQUIREMENTS), str(pylock_path), str(requirements_path)]
-    if index_url:
-        cmd.append(index_url)
+    cmd.append(resolved.index_url)
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.stdout:

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -480,11 +480,14 @@ def generate_requirements_txt(
     pylock_path = project_dir / "uv.lock.d" / f"pylock.{flavor}.toml"
     requirements_path = project_dir / f"requirements.{flavor}.txt"
     resolved = resolve_rh_index_config(project_dir, flavor, log)
-    if resolved is None:
-        return False
 
     cmd = [sys.executable, str(PYLOCK_TO_REQUIREMENTS), str(pylock_path), str(requirements_path)]
-    cmd.append(resolved.index_url)
+    if resolved is None:
+        log.warning(
+            f"Falling back to --default-index recorded in {pylock_path} for requirements generation."
+        )
+    else:
+        cmd.append(resolved.index_url)
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.stdout:

--- a/tests/unit/scripts/test_index_url_resolver.py
+++ b/tests/unit/scripts/test_index_url_resolver.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import scripts.index_url_resolver as resolver
+
+
+def write_conf(
+    tmp_path: Path,
+    name: str,
+    lines: list[str],
+) -> Path:
+    conf_file = Path(tmp_path) / name
+    conf_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return conf_file
+
+
+def prod_index_url(*, release: str, accelerator: str) -> str:
+    return f"https://console.redhat.com/api/pypi/public-rhai/rhoai/{release}/{accelerator}-ubi9/simple/"
+
+
+def test_index_url_candidates_use_prod_then_test_suffix() -> None:
+    assert resolver.index_url_candidates(release="3.5-EA2", accelerator="cpu") == (
+        "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/",
+        "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/",
+    )
+
+
+def test_resolve_rhoai_cpu_index_from_konflux_conf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cpu.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488",
+            "PYLOCK_FLAVOR=cpu",
+            "PRODUCT=rhoai",
+        ],
+    )
+    monkeypatch.setattr(
+        resolver,
+        "index_url_exists",
+        lambda url: url == prod_index_url(release="3.5-EA2", accelerator="cpu"),
+    )
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.product == "rhoai"
+    assert resolved.index_profile == "rhoai"
+    assert resolved.flavor == "cpu"
+    assert resolved.accelerator == "cpu"
+    assert resolved.release == "3.5-EA2"
+    assert resolved.index_url == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/"
+
+
+def test_resolve_rhoai_cuda_index_from_konflux_conf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cuda.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1778760737",
+            "PYLOCK_FLAVOR=cuda",
+            "PRODUCT=rhoai",
+        ],
+    )
+    monkeypatch.setattr(
+        resolver,
+        "index_url_exists",
+        lambda url: url == prod_index_url(release="3.5-EA2", accelerator="cuda13.0"),
+    )
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.flavor == "cuda"
+    assert resolved.accelerator == "cuda13.0"
+    assert resolved.release == "3.5-EA2"
+    assert resolved.index_url == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda13.0-ubi9/simple/"
+
+
+def test_resolve_rhoai_rocm_index_from_konflux_conf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.rocm.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581",
+            "PYLOCK_FLAVOR=rocm",
+            "PRODUCT=rhoai",
+        ],
+    )
+    monkeypatch.setattr(
+        resolver,
+        "index_url_exists",
+        lambda url: url == prod_index_url(release="3.5-EA2", accelerator="rocm7.1"),
+    )
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.flavor == "rocm"
+    assert resolved.accelerator == "rocm7.1"
+    assert resolved.release == "3.5-EA2"
+    assert resolved.index_url == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/rocm7.1-ubi9/simple/"
+
+
+def test_reject_non_konflux_conf_when_required(tmp_path: Path) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "cpu.conf",
+        [
+            "BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest",
+            "PYLOCK_FLAVOR=cpu",
+            "PRODUCT=odh",
+        ],
+    )
+
+    with pytest.raises(resolver.IndexResolutionError, match="konflux"):
+        resolver.resolve_index_config(conf_file, require_konflux=True)
+
+
+def test_resolve_rhoai_falls_back_to_test_index_when_prod_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cpu.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488",
+            "PYLOCK_FLAVOR=cpu",
+            "PRODUCT=rhoai",
+        ],
+    )
+
+    checked_urls: list[str] = []
+
+    def fake_index_url_exists(url: str) -> bool:
+        checked_urls.append(url)
+        return url.endswith("/cpu-ubi9-test/simple/")
+
+    monkeypatch.setattr(resolver, "index_url_exists", fake_index_url_exists)
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.index_url == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/"
+    assert checked_urls == [
+        "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/",
+        "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/",
+    ]
+
+
+def test_resolve_rhoai_does_not_check_test_when_prod_is_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cpu.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488",
+            "PYLOCK_FLAVOR=cpu",
+            "PRODUCT=rhoai",
+        ],
+    )
+
+    checked_urls: list[str] = []
+
+    def fake_index_url_exists(url: str) -> bool:
+        checked_urls.append(url)
+        return url.endswith("/cpu-ubi9/simple/")
+
+    monkeypatch.setattr(resolver, "index_url_exists", fake_index_url_exists)
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.index_url == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/"
+    assert checked_urls == [
+        "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/",
+    ]
+
+
+def test_cli_prints_plain_index_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.rocm.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1778760581",
+            "PYLOCK_FLAVOR=rocm",
+            "PRODUCT=rhoai",
+        ],
+    )
+    monkeypatch.setattr(
+        resolver,
+        "index_url_exists",
+        lambda url: url == prod_index_url(release="3.5-EA2", accelerator="rocm7.1"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(resolver.app, ["index-url", str(conf_file)])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/rocm7.1-ubi9/simple/"

--- a/tests/unit/scripts/test_pylock_to_requirements.py
+++ b/tests/unit/scripts/test_pylock_to_requirements.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "lockfile-generators" / "helpers" / "pylock-to-requirements.py"
+_SPEC = importlib.util.spec_from_file_location("pylock_to_requirements", _MODULE_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+helper = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(helper)
+
+
+def test_extract_default_index_from_pylock_strips_format_json(tmp_path: Path) -> None:
+    pylock_path = tmp_path / "pylock.toml"
+    pylock_path.write_text(
+        "# uv pip compile --default-index=https://example.invalid/simple/?format=json\n",
+        encoding="utf-8",
+    )
+
+    assert helper.extract_default_index_from_pylock(pylock_path) == "https://example.invalid/simple/"

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -213,3 +213,30 @@ def test_run_lock_logs_index_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
     assert success is True
     assert any("Lock INDEX_URL: https://example.invalid/simple/?format=json" in line for line in log._lines)
+
+
+def test_generate_requirements_txt_falls_back_to_pylock_header_when_index_resolution_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    log = pg.LogBuffer()
+    captured_cmd: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd[:] = cmd
+        return pg.subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pg, "resolve_rh_index_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pg.subprocess, "run", fake_run)
+
+    success = pg.generate_requirements_txt(project_dir, "cpu", log)
+
+    assert success is True
+    assert captured_cmd == [
+        pg.sys.executable,
+        str(pg.PYLOCK_TO_REQUIREMENTS),
+        str(project_dir / "uv.lock.d" / "pylock.cpu.toml"),
+        str(project_dir / "requirements.cpu.txt"),
+    ]

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -11,6 +11,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 # if str(_SCRIPTS) not in sys.path:
 #     sys.path.insert(0, str(_SCRIPTS))
 
+import scripts.index_url_resolver as resolver  # noqa: E402
 import scripts.pylocks_generator as pg  # noqa: E402
 
 
@@ -135,3 +136,80 @@ class TestEnsureJsonFormatParam:
         result = pg.ensure_json_format_param(url)
         assert result == url + "?format=json"
         assert pg.ensure_json_format_param(result) == result
+
+
+def test_get_index_flags_uses_konflux_conf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = tmp_path / "project"
+    build_args = project_dir / "build-args"
+    build_args.mkdir(parents=True)
+    (build_args / "konflux.cpu.conf").write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488\nPYLOCK_FLAVOR=cpu\nPRODUCT=rhoai\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        resolver,
+        "index_url_exists",
+        lambda url: url == "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/",
+    )
+
+    flags = pg.get_index_flags(project_dir, "cpu", pg.LogBuffer())
+
+    assert flags == [
+        "--default-index=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/?format=json",
+    ]
+
+
+def test_get_index_flags_falls_back_to_test_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = tmp_path / "project"
+    build_args = project_dir / "build-args"
+    build_args.mkdir(parents=True)
+    (build_args / "konflux.cpu.conf").write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488\nPYLOCK_FLAVOR=cpu\nPRODUCT=rhoai\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        resolver,
+        "index_url_exists",
+        lambda url: url.endswith("/cpu-ubi9-test/simple/"),
+    )
+
+    flags = pg.get_index_flags(project_dir, "cpu", pg.LogBuffer())
+
+    assert flags == [
+        "--default-index=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/?format=json",
+    ]
+
+
+def test_run_lock_logs_index_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    log = pg.LogBuffer()
+    completed = pg.subprocess.CompletedProcess(args=["uv"], returncode=0, stdout="", stderr="")
+
+    def fake_run(*args, **kwargs):
+        return completed
+
+    monkeypatch.setattr(pg.subprocess, "run", fake_run)
+
+    success = pg.run_lock(
+        project_dir,
+        "cpu",
+        ["--default-index=https://example.invalid/simple/?format=json"],
+        pg.IndexMode.rh_index,
+        "3.12",
+        False,
+        False,
+        "2026-05-18T00:00:00Z",
+        log,
+    )
+
+    assert success is True
+    assert any("Lock INDEX_URL: https://example.invalid/simple/?format=json" in line for line in log._lines)


### PR DESCRIPTION
Related to: https://redhat.atlassian.net/browse/RHAIENG-4894
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Derive Konflux RHOAI index URLs from BASE_IMAGE instead of hard-coding INDEX_URL in konflux.*.conf files, and fall back to the matching -test index only when production is unavailable.

### Summary by CodeRabbit

* **New Features**
  * Added dynamic Python package index URL resolution based on image configuration.

* **Chores**
  * Removed hardcoded package index URLs from build configuration files across all image types.
  * Updated build scripts to resolve index URLs dynamically instead of using static values.

* **Documentation**
  * Updated build documentation to clarify that package index URLs are now derived dynamically.

* **Tests**
  * Added unit tests for index URL resolution logic.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run ` gmake refresh-lock-files` and inspect if the new generated lock file locked from the proper index
or check the logs: https://github.com/opendatahub-io/notebooks/actions/runs/26030696362/job/76515785982?pr=3658#step:20:199


Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic resolution CLI for selecting the appropriate Python package index at build time.

* **Chores**
  * Removed hardcoded package index URLs from image build configurations.
  * Build and lockfile generation scripts now compute/inject index URLs when needed.
  * Relaxed exact pins for a couple of build-time Python dependencies.

* **Documentation**
  * Clarified how index URLs are derived and how build-args are handled.

* **Tests**
  * Added unit tests for index resolution and lockfile conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->