### PR TITLE
RHAIENG-5173: build: parallel arch-aware pip and npm prefetch downloads

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -397,7 +397,7 @@ jobs:
               PREFETCH_ROOT="prefetch-input"
             fi
             echo "Hermetic build detected — prefetching dependencies for $COMPONENT_DIR (prefetch root $PREFETCH_ROOT, flavor=$FLAVOR)"
-            pip3 install --quiet --break-system-packages pyyaml
+            pip3 install --quiet --break-system-packages pyyaml packaging
             command -v uv &>/dev/null || pip3 install --quiet --break-system-packages uv
 
             PREFETCH_ARGS="--component-dir $COMPONENT_DIR --flavor $FLAVOR"
@@ -423,6 +423,7 @@ jobs:
           fi
         env:
           MAKE_TARGET: ${{ inputs.target }}
+          BUILD_ARCH: ${{ inputs.platform }}
           SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
           SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 

--- a/scripts/lockfile-generators/download-npm.sh
+++ b/scripts/lockfile-generators/download-npm.sh
@@ -241,38 +241,40 @@ if [[ -z "$refs" ]]; then
     exit 0
 fi
 
-# --- Download ---
+# --- Download (parallel) ---
 mkdir -p "$DEST_DIR"
 
 total=$(echo "$refs" | wc -l | tr -d ' ')
-count=0
-downloaded=0
-skipped=0
-failed=0
 
 echo ""
-echo "Found $total unique packages to download."
+# 20 parallel workers (npm registry doesn't have the Akamai rate-limiting
+# that the AIPCC pip index has; could go higher, but 20 is a safe default).
+echo "Found $total unique packages to download (20 parallel workers)."
 echo ""
 
-while IFS=$'\t' read -r filename download_url; do
-    count=$((count + 1))
-
+export DEST_DIR
+download_file() {
+    local filename="$1"
+    local download_url="$2"
     if [[ -f "$DEST_DIR/$filename" ]]; then
-        echo "[$count/$total] SKIP  Already exists: $filename"
-        skipped=$((skipped + 1))
+        echo "SKIP  Already exists: $filename"
     else
-        if wget -q -O "$DEST_DIR/$filename" "$download_url"; then
-            echo "[$count/$total] OK    Downloaded: $filename"
-            downloaded=$((downloaded + 1))
+        if wget -q -O "$DEST_DIR/$filename" --tries=3 --waitretry=2 --timeout=30 "$download_url"; then
+            echo "OK    Downloaded: $filename"
         else
-            echo "[$count/$total] FAIL  Failed: $download_url" >&2
-            failed=$((failed + 1))
-            # Clean up partial download
+            echo "FAIL  Failed: $download_url" >&2
             rm -f "$DEST_DIR/$filename"
+            return 1
         fi
     fi
-done <<< "$refs"
+}
+export -f download_file
+
+if ! echo "$refs" | xargs -n 2 -P 20 bash -c 'download_file "$1" "$2"' _; then
+    echo "" >&2
+    echo "ERROR: Some npm downloads failed." >&2
+    exit 1
+fi
 
 echo ""
-echo "Finished! Total: $total  Downloaded: $downloaded  Skipped: $skipped  Failed: $failed"
-echo "Location: $DEST_DIR"
+echo "Finished! Location: $DEST_DIR"

--- a/scripts/lockfile-generators/helpers/download-pip-packages.py
+++ b/scripts/lockfile-generators/helpers/download-pip-packages.py
@@ -1,66 +1,86 @@
 #!/usr/bin/env python3
-"""download-pip-packages.py — Prefetch pip wheels/sdists for offline builds.
+"""download-pip-packages.py — Parallel arch-aware pip wheel prefetch.
 
-Downloads all packages listed in a requirements.txt (with --hash=sha256:…
-lines) into cachi2/output/deps/pip/.  This is the local-development equivalent
-of what cachi2 does automatically in Konflux CI — it populates the same
-directory so that `podman build` can install
-packages with --no-index --find-links /cachi2/output/deps/pip.
+Downloads wheels listed in a requirements.txt (with --hash=sha256:… lines)
+into cachi2/output/deps/pip/ for hermetic offline builds.
+
+Architecture:
+  Phase 1: Parse requirements.txt for (name, version, hashes, marker)
+  Phase 2: Skip packages whose markers exclude the target arch
+  Phase 3: Resolve URLs from index (10 parallel HTTP requests)
+  Phase 4: Filter: skip sdists (AIPCC), keep target-arch + pure-python wheels
+  Phase 5: Download (10 parallel wget)
 
 Supports two index backends:
-  • PyPI (default) — uses the JSON API (https://pypi.org/pypi/{name}/{ver}/json)
-    to resolve download URLs for each hash.
-  • PEP 503 simple indexes — auto-detected when the requirements file contains
-    an --index-url that is not pypi.org (e.g. the RHOAI index).  Parses the
-    simple HTML page to match hashes to download URLs.
-
-Steps:
-  1. Parse the requirements file for (name, version, sha256 hashes).
-  2. Detect --index-url (if present) to choose PyPI JSON vs. simple index.
-  3. For each package, resolve download URLs that match the requested hashes.
-  4. Skip files that already exist locally; download missing ones with wget.
-  5. Verify every file's sha256 checksum (whether freshly downloaded or cached).
+  - PEP 503 simple indexes (AIPCC/RHOAI) — auto-detected from --index-url
+  - PyPI JSON API (fallback for pypi.org)
 
 Usage:
-  python3 scripts/lockfile-generators/download-pip-packages.py \\
-      [-o OUTPUT_DIR] <requirements.txt>
-
-Can be invoked standalone or by create-requirements-lockfile.sh (which has
-its own inline download step for pylock.toml-based workflows).
+  python3 download-pip-packages.py [--arch ARCH] [-o OUTPUT_DIR] requirements.txt
 """
+from __future__ import annotations
+
 import argparse
+import concurrent.futures
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from urllib.parse import urljoin
 
-import packaging.utils
+from packaging.markers import Marker
 
 OUT_DIR = Path("cachi2/output/deps/pip")
 PYPI_JSON = "https://pypi.org/pypi/{name}/{version}/json"
+# 20 workers balances throughput vs Akamai burst rate-limiting on console.redhat.com.
+# uv uses 50 by default (astral-sh/uv#10570 discusses reducing to 20 for stability).
+# At 10: stable 22s, at 20: 13s, at 50: 12s but high variance (Akamai throttling).
+MAX_WORKERS = 20
+
+ARCH_ALIASES: dict[str, list[str]] = {
+    "amd64": ["x86_64", "amd64"],
+    "x86_64": ["x86_64", "amd64"],
+    "arm64": ["aarch64", "arm64"],
+    "aarch64": ["aarch64", "arm64"],
+    "ppc64le": ["ppc64le"],
+    "s390x": ["s390x"],
+}
 
 
-def get_and_validate_args():
-    parser = argparse.ArgumentParser(description=__doc__)
+def get_args():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("requirements", type=Path, help="Path to requirements.txt")
-    parser.add_argument(
-        "-o", "--output-dir", type=Path, default=OUT_DIR, help=f"Output directory (default: {OUT_DIR})",
-    )
+    parser.add_argument("-o", "--output-dir", type=Path, default=OUT_DIR, help=f"Output directory (default: {OUT_DIR})")
+    parser.add_argument("--arch", type=str, default=None, help="Target architecture (default: from BUILD_ARCH env or uname -m)")
+    parser.add_argument("--python-version", type=str, default=None,
+                        help="Target Python version, e.g. 3.12 (default: from RELEASE_PYTHON_VERSION env or current)")
     args = parser.parse_args()
+
+    if args.arch is None:
+        build_arch = os.environ.get("BUILD_ARCH", "")
+        if build_arch:
+            raw = build_arch.split("/")[-1]
+            args.arch = {"amd64": "x86_64", "arm64": "aarch64"}.get(raw, raw)
+        else:
+            import platform
+            args.arch = platform.machine()
+
+    if args.python_version is None:
+        args.python_version = os.environ.get("RELEASE_PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}")
+
     req_path = args.requirements.resolve()
-    out_dir = args.output_dir.resolve()
     if not req_path.is_file():
         print(f"Error: not a file: {req_path}", file=sys.stderr)
         sys.exit(1)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    return req_path, out_dir
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    return req_path, args.output_dir.resolve(), args.arch, args.python_version
 
 
-def detect_index_url(req_path: Path):
-    """Return the --index-url value from the requirements file, or None."""
+def detect_index_url(req_path: Path) -> str | None:
     for line in req_path.read_text().splitlines():
         m = re.match(r"^\s*--index-url\s+(\S+)", line)
         if m:
@@ -68,88 +88,185 @@ def detect_index_url(req_path: Path):
     return None
 
 
-def get_packages_and_checksums(req_path: Path):
-    """Parse requirements.txt; yield (name, version, list of sha256 hashes)."""
+def parse_requirements(req_path: Path) -> list[tuple[str, str, set[str], str]]:
+    """Return list of (name, version, hashes, marker_string)."""
     text = req_path.read_text()
     text = re.sub(r" \\\n\s*", " ", text)
-    lines = text.split("\n")
-    block = None
-    for line in lines:
-        s = line.strip()
-        if not s or s.startswith("#") or s.startswith("--index-url ") or s.startswith("--extra-index-url "):
+    packages = []
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("--"):
             continue
-        if "==" in s and not line.startswith((" ", "\t")):
-            if block:
-                yield block
-            block = [s]
-        elif block is not None and "--hash=" in s:
-            block.append(s)
-    if block:
-        yield block
+        hash_parts = line.split("--hash=")
+        name_ver_marker = hash_parts[0].strip()
 
+        marker = ""
+        if ";" in name_ver_marker:
+            name_ver, marker = name_ver_marker.split(";", 1)
+            name_ver = name_ver.strip()
+            marker = marker.strip()
+        else:
+            name_ver = name_ver_marker.strip()
 
-def block_to_name_version_hashes(block):
-    """(name, version, [sha256, ...])."""
-    first = block[0].split("--hash=")[0].strip().rstrip(";").strip()
-    # "name==version" or "name==version ; markers"
-    name_ver = first.split(";")[0].strip()
-    if "==" not in name_ver:
-        return None, None, []
-    name, version = name_ver.split("==", 1)
-    hashes = []
-    for line in block:
-        hashes.extend(re.findall(r"--hash=sha256:([a-f0-9]+)", line, re.I))
-    return name, version, list(dict.fromkeys(hashes))
-
-
-def fetch_pypi_urls(name: str, version: str, wanted_hashes: set):
-    """Return list of (url, filename, sha256) for urls whose sha256 is in wanted_hashes."""
-    url = PYPI_JSON.format(name=name, version=version)
-    try:
-        with urllib.request.urlopen(url, timeout=30) as r:
-            data = json.load(r)
-    except Exception as e:
-        print(f"Error fetching {url}: {e}", file=sys.stderr)
-        return []
-    
-    out = []
-    for entry in data.get("urls", []):
-        filename = entry["url"].split("/")[-1].split("?")[0]
-        
-        # Skip Windows, MacOS, iOS
-        if any(x in filename for x in ["macosx", "win_amd64", "win32", "win_arm64", "ios_"]):
+        if "==" not in name_ver:
             continue
-
-        digests = entry.get("digests") or {}
-        h = digests.get("sha256")
-        if h and h in wanted_hashes:
-            u = entry["url"]
-            out.append((u, filename, h))
-    return out
+        name, version = name_ver.split("==", 1)
+        hashes = set(re.findall(r"sha256:([a-f0-9]+)", line, re.I))
+        packages.append((name.strip(), version.strip(), hashes, marker))
+    return packages
 
 
-def fetch_simple_index_urls(index_url: str, name: str, version: str, wanted_hashes: set):
-    """Return list of (url, filename, sha256) from a PEP 503 simple index page.
+class _PoisonString(str):
+    """Sentinel that detonates if marker evaluation touches an uncontrolled key."""
 
-    Used for RHOAI and other custom indexes that don't provide a JSON API.
+    def __new__(cls, key_name: str):
+        obj = super().__new__(cls, "POISON")
+        obj._key_name = key_name
+        return obj
+
+    def _boom(self, *args, **kwargs):
+        raise _UnexpectedKeyAccess(super().__getattribute__("_key_name"))
+
+
+class _UnexpectedKeyAccess(Exception):
+    pass
+
+
+# Poison all comparison/operator dunders so any use in marker evaluation explodes
+for _op in ("__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__",
+            "__contains__", "__hash__"):
+    setattr(_PoisonString, _op, _PoisonString._boom)
+
+
+def should_skip_for_marker(marker: str, arch: str, python_version: str) -> bool:
+    """Return True when the marker excludes this architecture/python.
+
+    Only evaluates markers that reference platform_machine (our purpose is
+    arch filtering). Keys we control are set to target values; all other
+    keys are filled with poison sentinels that explode if touched, ensuring
+    no host values silently leak into the evaluation.
     """
-    # Normalize name for URL: PEP 503 uses lowercase with hyphens
-    normalized = packaging.utils.canonicalize_name(name)
+    if not marker:
+        return False
+    if "platform_machine" not in marker:
+        return False
+    full_version = python_version if python_version.count(".") >= 2 else f"{python_version}.0"
+    short_version = ".".join(full_version.split(".")[:2])
+    controlled_env = {
+        "implementation_name": "cpython",
+        "platform_machine": arch,
+        "platform_python_implementation": "CPython",
+        "python_full_version": full_version,
+        "python_version": short_version,
+        "sys_platform": "linux",
+    }
+    # Poison any key from default_environment() that we don't explicitly control
+    from packaging.markers import default_environment
+    env = {k: _PoisonString(k) for k in default_environment()}
+    env.update(controlled_env)
+    try:
+        return not Marker(marker).evaluate(env)
+    except _UnexpectedKeyAccess as e:
+        print(f"  WARN: marker touches uncontrolled key '{e}', not skipping: {marker}", file=sys.stderr)
+        return False
+    except Exception:
+        return False
+
+
+def should_keep_for_arch(filename: str, arch: str, skip_sdists: bool) -> bool:
+    """Filter files by architecture and type."""
+    if not filename.endswith(".whl"):
+        return not skip_sdists
+
+    stem = filename[:-4]
+    parts = stem.split("-")
+    if len(parts) < 3:
+        return True
+    platform_tag = parts[-1]
+
+    if platform_tag in ("any", "none") or "any" in platform_tag.split("_"):
+        return True
+
+    return any(a in platform_tag for a in ARCH_ALIASES.get(arch, [arch]))
+
+
+def fetch_simple_index_urls(index_url: str, name: str, version: str, wanted_hashes: set[str]) -> list[tuple[str, str, str]]:
+    normalized = re.sub(r"[-_.]+", "-", name).lower()
     page_url = f"{index_url.rstrip('/')}/{normalized}/"
     try:
-        req = urllib.request.Request(page_url, headers={"Accept": "text/html"})
+        req = urllib.request.Request(page_url, headers={"Accept": "text/html", "User-Agent": "prefetch/1.0"})
         with urllib.request.urlopen(req, timeout=30) as r:
             html = r.read().decode()
     except Exception as e:
-        print(f"Error fetching {page_url}: {e}", file=sys.stderr)
+        print(f"  WARN: failed to fetch index page for {name}: {e}", file=sys.stderr)
         return []
 
     out = []
     for m in re.finditer(r'<a\s+href="([^"]*?)#sha256=([a-f0-9]+)"[^>]*>([^<]+)</a>', html):
         download_url, sha, filename = m.group(1), m.group(2), m.group(3).strip()
+        download_url = urljoin(page_url, download_url)
+        filename = PurePosixPath(filename).name
+        if not filename or filename in (".", ".."):
+            continue
         if sha in wanted_hashes:
             out.append((download_url, filename, sha))
     return out
+
+
+def fetch_pypi_urls(name: str, version: str, wanted_hashes: set[str]) -> list[tuple[str, str, str]]:
+    url = PYPI_JSON.format(name=name, version=version)
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "prefetch/1.0"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            data = json.loads(r.read().decode())
+    except Exception as e:
+        print(f"  WARN: failed to fetch PyPI metadata for {name}: {e}", file=sys.stderr)
+        return []
+
+    out = []
+    for entry in data.get("urls", []):
+        raw_filename = entry["url"].split("/")[-1].split("?")[0]
+        filename = PurePosixPath(raw_filename).name
+        if not filename:
+            continue
+        if any(x in filename for x in ["macosx", "win_amd64", "win32", "win_arm64", "ios_"]):
+            continue
+        digests = entry.get("digests") or {}
+        h = digests.get("sha256")
+        if h and h in wanted_hashes:
+            out.append((entry["url"], filename, h))
+    return out
+
+
+def resolve_one(args: tuple) -> list[tuple[str, str, str]]:
+    """Resolve URLs for one package. Called in parallel."""
+    name, version, wanted_hashes, index_url, use_simple = args
+    if use_simple:
+        return fetch_simple_index_urls(index_url, name, version, wanted_hashes)
+    else:
+        return fetch_pypi_urls(name, version, wanted_hashes)
+
+
+def download_one(args: tuple) -> tuple[bool, str]:
+    """Download one file. Called in parallel."""
+    url, dest_path, expected_hash = args
+    try:
+        subprocess.run(
+            ["wget", "-q", "-O", str(dest_path), "--tries=3", "--waitretry=2", "--timeout=30", url],
+            check=True, timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        Path(dest_path).unlink(missing_ok=True)
+        return False, f"TIMEOUT {Path(dest_path).name}"
+    except subprocess.CalledProcessError:
+        Path(dest_path).unlink(missing_ok=True)
+        return False, f"FAIL {Path(dest_path).name}: wget error"
+
+    actual = file_sha256(Path(dest_path))
+    if actual != expected_hash:
+        Path(dest_path).unlink(missing_ok=True)
+        return False, f"HASH MISMATCH {Path(dest_path).name}: got {actual[:16]}..., expected {expected_hash[:16]}..."
+    return True, f"OK {Path(dest_path).name}"
 
 
 def file_sha256(path: Path) -> str:
@@ -160,49 +277,91 @@ def file_sha256(path: Path) -> str:
     return h.hexdigest()
 
 
-def wget(url: str, path: Path):
-    subprocess.run(["wget", "-q", "-O", str(path), url], check=True)
-
-
 def main():
-    req_path, out_dir = get_and_validate_args()
+    req_path, out_dir, arch, python_version = get_args()
 
-    # Detect --index-url in requirements file (e.g. RHOAI)
     index_url = detect_index_url(req_path)
-    use_simple_index = index_url is not None and "pypi.org" not in index_url
-    if use_simple_index:
-        print(f"Detected custom index: {index_url}")
-        print(f"Using PEP 503 simple index for downloads.\n")
+    use_simple = index_url is not None and "pypi.org" not in index_url
+    is_aipcc = index_url is not None and "console.redhat.com/api/pypi/" in index_url
+    skip_sdists = is_aipcc
 
-    # Build list of (path, expected_sha256, url, name, version, filename) per file to have
-    to_fetch = []
-    for block in get_packages_and_checksums(req_path):
-        name, version, hashes = block_to_name_version_hashes(block)
-        if not name or not version or not hashes:
-            continue
+    print(f"=== download-pip-packages.py ===")
+    print(f"  requirements: {req_path}")
+    print(f"  output:       {out_dir}")
+    print(f"  arch:         {arch}")
+    print(f"  python:       {python_version}")
+    print(f"  index:        {index_url or 'PyPI (default)'}")
+    print(f"  skip sdists:  {skip_sdists} (AIPCC={is_aipcc})")
+    print()
 
-        if use_simple_index:
-            results = fetch_simple_index_urls(index_url, name, version, set(hashes))
+    packages = parse_requirements(req_path)
+    print(f"Parsed {len(packages)} packages from requirements.txt")
+
+    # Phase 2: skip packages excluded by marker
+    skipped_marker = []
+    to_resolve = []
+    for name, version, hashes, marker in packages:
+        if should_skip_for_marker(marker, arch, python_version):
+            skipped_marker.append(f"{name}=={version}")
         else:
-            results = fetch_pypi_urls(name, version, set(hashes))
+            to_resolve.append((name, version, hashes, index_url, use_simple))
 
-        for url, filename, expected_hash in results:
-            to_fetch.append((out_dir / filename, expected_hash, url, name, version, filename))
+    if skipped_marker:
+        print(f"\nSkipped by marker (platform_machine != '{arch}'): {len(skipped_marker)}")
+        for pkg in skipped_marker:
+            print(f"  - {pkg}")
 
-    total = len(to_fetch)
-    for idx, (path, expected_hash, url, name, version, filename) in enumerate(to_fetch, 1):
-        print(f"[{idx}/{total}] {name}=={version}  {filename}")
-        if not path.exists():
-            print(f"  Downloading: {url}")
-            wget(url, path)
-        else:
-            print(f"  Already exists, skipping download.")
-        actual = file_sha256(path)
-        if actual != expected_hash:
-            print(f"Error: {path.name} checksum mismatch (got {actual}, expected {expected_hash})", file=sys.stderr)
-            sys.exit(1)
-        print(f"  Checksum OK (sha256:{actual[:16]}...)")
-    print(f"Done: {total} file(s) present and validated.")
+    print(f"\nPhase 3: Resolving URLs for {len(to_resolve)} packages ({MAX_WORKERS} parallel)...")
+
+    # Phase 3: parallel resolve
+    all_files: list[tuple[str, str, str]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        for urls in executor.map(resolve_one, to_resolve):
+            all_files.extend(urls)
+
+    # Phase 4: filter by arch and type
+    to_download = []
+    for url, filename, sha in all_files:
+        if should_keep_for_arch(filename, arch, skip_sdists):
+            dest = out_dir / filename
+            if dest.exists():
+                actual = file_sha256(dest)
+                if actual == sha:
+                    continue
+                else:
+                    dest.unlink()
+            to_download.append((url, dest, sha))
+
+    print(f"  Resolved {len(all_files)} total files from index")
+    print(f"  After arch filter: {len(to_download)} to download ({len(all_files) - len(to_download)} skipped/cached)")
+
+    if not to_download:
+        print("\nNothing to download.")
+        return
+
+    # Phase 5: parallel download
+    print(f"\nPhase 5: Downloading {len(to_download)} files ({MAX_WORKERS} parallel)...")
+    failures = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        results = list(executor.map(download_one, to_download))
+
+    for ok, msg in results:
+        if not ok:
+            failures.append(msg)
+            print(f"  ERROR: {msg}", file=sys.stderr)
+
+    downloaded = sum(1 for ok, _ in results if ok)
+    print(f"\n  Downloaded: {downloaded}, Failed: {len(failures)}")
+
+    if failures:
+        print(f"\nERROR: {len(failures)} download(s) failed:", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        sys.exit(1)
+
+    total_files = len(list(out_dir.iterdir()))
+    total_size_mb = sum(f.stat().st_size for f in out_dir.iterdir()) / (1024 * 1024)
+    print(f"\nDone: {total_files} files in {out_dir} ({total_size_mb:.0f} MB)")
 
 
 if __name__ == "__main__":

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -235,8 +235,27 @@ fi
 PYPROJECT="$COMPONENT_DIR/pyproject.toml"
 if [[ -f "$PYPROJECT" ]]; then
   echo "=== [2/5] Pip wheels ==="
+  # Generate lockfile + requirements.txt (no download)
   "$SCRIPTS_PATH/create-requirements-lockfile.sh" \
-      --pyproject-toml "$PYPROJECT" --flavor "$FLAVOR" --download
+      --pyproject-toml "$PYPROJECT" --flavor "$FLAVOR"
+
+  REQUIREMENTS_FILE="$COMPONENT_DIR/requirements.${FLAVOR}.txt"
+  if [[ -f "$REQUIREMENTS_FILE" ]]; then
+    # Derive target arch from BUILD_ARCH (GHA cross-build via QEMU) or host
+    if [[ -n "${BUILD_ARCH:-}" ]]; then
+      case "${BUILD_ARCH##*/}" in
+        amd64) ARCH="x86_64" ;;
+        arm64) ARCH="aarch64" ;;
+        *) ARCH="${BUILD_ARCH##*/}" ;;
+      esac
+    else
+      ARCH=$(uname -m)
+    fi
+
+    # Download wheels (parallel, arch-filtered)
+    python3 "$SCRIPTS_PATH/helpers/download-pip-packages.py" \
+        --arch "$ARCH" "$REQUIREMENTS_FILE"
+  fi
   STEPS_RUN=$((STEPS_RUN + 1))
   echo ""
 else
@@ -258,13 +277,13 @@ echo "=== [3/5] NPM packages ==="
 npm_done=false
 tekton_file=""
 
-# Find the Tekton PipelineRun YAML: RHDS first (dockerfile COMPONENT_DIR/Dockerfile.konflux.*),
-# then ODH (dockerfile COMPONENT_DIR/Dockerfile.*). The file lists npm prefetch-input
-# paths for download-npm.sh to process in one go.
+# Find the Tekton PipelineRun YAML for this component. Prefer the active
+# variant (matches --rhds flag), fall back to the other variant.
 if [[ -d ".tekton" ]] && command -v yq &>/dev/null; then
-  tekton_file=$(find_tekton_yaml "$COMPONENT_DIR" "rhds" 2>/dev/null | head -1) || true
+  tekton_file=$(find_tekton_yaml "$COMPONENT_DIR" "$VARIANT" 2>/dev/null | head -1) || true
   if [[ -z "$tekton_file" ]]; then
-    tekton_file=$(find_tekton_yaml "$COMPONENT_DIR" "odh" 2>/dev/null | head -1) || true
+    fallback_variant=$([[ "$VARIANT" == "rhds" ]] && echo "odh" || echo "rhds")
+    tekton_file=$(find_tekton_yaml "$COMPONENT_DIR" "$fallback_variant" 2>/dev/null | head -1) || true
   fi
   if [[ -n "$tekton_file" ]]; then
     echo "  Auto-detected tekton file: $tekton_file"


### PR DESCRIPTION
## Summary

- Replace serial pip wheel downloads (3m37s) with custom parallel downloader (23s) — 9x faster
- Replace serial npm tarball downloads with `xargs -P 20`
- Fix cross-platform arch detection (BUILD_ARCH for QEMU builds)
- Fix Tekton variant lookup order (prefer active `$VARIANT`)

## Benchmarks (msg-qe-11, AIPCC index)

| Scenario | Current (serial wget from pylock) | pip download --platform | This PR (10x parallel) |
|----------|----------------------------------|------------------------|------------------------|
| jupyter/minimal x86_64 | 3m37s, 162 files (all arches) | 1m52s, 113 files | **23s**, 114 files |
| jupyter/datascience ppc64le | 3m37s+ (all arches, no filtering) | FAILED (hash mismatch) | **1m09s**, 285 files |

The current code downloads wheels for ALL architectures (162 files / 175MB) because pylock.toml has URLs for every platform. This PR downloads only the target arch (114 files / 77MB for x86_64).

## Changes

1. `download-pip-packages.py` (rewritten): parallel resolve + download via ThreadPoolExecutor(10), arch filtering, skip sdists for AIPCC, skip marker-excluded packages
2. `prefetch-all.sh`: wire parallel pip downloader, BUILD_ARCH derivation, Tekton variant fix
3. `download-npm.sh`: `xargs -P 20` with failure propagation (2241 tarballs for codeserver)
4. `build-notebooks-TEMPLATE.yaml`: pass `BUILD_ARCH=${{ inputs.platform }}`

## Why not pip/pex/hermeto?

- `pip download --platform`: serial, **fails** with hash mismatch on marker-excluded packages (bcrypt on ppc64le)
- `pex3 download`: doesn't pick up `--index-url` from requirements.txt, marker evaluation failures
- hermeto single invocation (PR #3653): blocked by [hermeto #1570](https://github.com/hermetoproject/hermeto/issues/1570) (pip binary filter ignores env markers)

## Test plan

- [x] pip prefetch jupyter/minimal x86_64: 23s, 114 files, no wrong-arch leaks
- [x] pip prefetch jupyter/datascience ppc64le: 1m09s, 285 files, 24 marker-excluded packages correctly skipped
- [x] BUILD_ARCH=linux/s390x correctly maps to s390x (16 s390x wheels, 0 x86_64 leaks)
- [ ] GHA CI passes on all architectures (x86_64, aarch64, ppc64le, s390x)
- [ ] npm prefetch for codeserver uses parallel downloads

Supersedes: #3352, #3653
Jira: [RHAIENG-5173](https://redhat.atlassian.net/browse/RHAIENG-5173)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency prefetching: added platform-aware env and faster parallel downloads for npm and pip
  * Made downloads more reliable with retries, integrity (checksum) checks, and failures surfaced as errors
  * Prefetch logic now favors the active variant for pipeline selection and gates wheel downloads on generated lockfiles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->