### PR TITLE
[No jira] Fix container index checks

### DIFF
--- a/base-images/build-args/cuda12.9.conf
+++ b/base-images/build-args/cuda12.9.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda12.9-ubi9/simple/
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda12.9-ubi9-test/simple/

--- a/base-images/build-args/cuda13.0.conf
+++ b/base-images/build-args/cuda13.0.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/cuda13.0-ubi9/simple/
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda13.0-ubi9-test/simple/

--- a/base-images/build-args/rocm7.1.conf
+++ b/base-images/build-args/rocm7.1.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA1/rocm7.1-ubi9/simple/
+INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/rocm7.1-ubi9-test/simple/

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -16,6 +16,7 @@ import pytest
 import testcontainers.core.container
 
 import ntb
+from tests import index_config_utils
 from tests.containers import docker_utils
 
 logging.basicConfig(level=logging.DEBUG)
@@ -272,13 +273,17 @@ class TestBaseImage:
 
     @allure.issue("RHAIENG-2189")
     def test_python_package_index(self, image: str, subtests: pytest_subtests.SubTests):
-        """Verify all images have AIPCC index config and env vars.
+        """Verify all images have AIPCC index config.
 
         All images (both ODH and RHOAI) use AIPCC wheels and must point pip/uv
         to the AIPCC index. Mixing AIPCC wheels with PyPI wheels causes ABI
         incompatibility — especially for CUDA/torch-dependent packages (flash-attn,
         vllm, xformers, etc.) which link against the exact torch C++ ABI that
         AIPCC builds. Crashes range from core dumps to random garbage results.
+
+        ODH-derived images usually also export PIP_INDEX_URL / UV_INDEX_URL.
+        RHOAI/AIPCC base images configure the index via pip.conf and uv.toml,
+        without exporting those env vars in the final image.
 
         References:
         - Christian Heimes (AIPCC): "you cannot mix our wheels with upstream PyPI"
@@ -288,6 +293,20 @@ class TestBaseImage:
         - Customer docs: https://access.redhat.com/articles/7137881
         """
         with docker_utils.running_container(image=image) as container:
+
+            def read_container_file(path: str) -> str:
+                ecode, output = container.exec(
+                    [
+                        "python3",
+                        "-c",
+                        "from pathlib import Path; import sys; print(Path(sys.argv[1]).read_text())",
+                        path,
+                    ]
+                )
+                output_str = output.decode()
+                assert ecode == 0, f"Failed to read {path}: {output_str}"
+                return output_str
+
             _, output = container.exec(["env"])
             actual = dict(line.split("=", maxsplit=1) for line in output.decode().strip().splitlines())
 
@@ -299,16 +318,35 @@ class TestBaseImage:
             with subtests.test("Images have AIPCC config file env vars"):
                 ntb.assert_subdict(aipcc_config_vars, actual)
 
-            # PIP_INDEX_URL and UV_INDEX_URL are set by base-images (aipcc.sh)
-            # to the AIPCC index. They must NOT point to pypi.org.
-            with subtests.test("Index URL env vars do not point to PyPI"):
-                for key in ("PIP_INDEX_URL", "UV_INDEX_URL"):
-                    assert key in actual, f"{key} must be set in image environment"
-                    normalized = actual[key].rstrip("/")
-                    assert normalized != "https://pypi.org/simple", (
-                        f"{key} must not point to PyPI — AIPCC wheels have ABI "
-                        f"incompatibility with PyPI wheels (torch, CUDA extensions). "
-                        f"Got: {actual[key]}"
+            pip_index_url = index_config_utils.pip_index_url_from_config(read_container_file(actual["PIP_CONFIG_FILE"]))
+            uv_index_url = index_config_utils.uv_index_url_from_config(read_container_file(actual["UV_CONFIG_FILE"]))
+
+            with subtests.test("pip.conf points to a non-PyPI index"):
+                assert pip_index_url is not None, "pip.conf must define global.index-url"
+                assert not index_config_utils.is_pypi_index_url(pip_index_url), (
+                    "pip.conf must not point to PyPI — AIPCC wheels have ABI "
+                    f"incompatibility with PyPI wheels. Got: {pip_index_url}"
+                )
+
+            with subtests.test("uv.toml points to a non-PyPI index"):
+                assert uv_index_url is not None, 'uv.toml must define "index-url"'
+                assert not index_config_utils.is_pypi_index_url(uv_index_url), (
+                    "uv.toml must not point to PyPI — AIPCC wheels have ABI "
+                    f"incompatibility with PyPI wheels. Got: {uv_index_url}"
+                )
+
+            with subtests.test("PIP_INDEX_URL env var, if present, does not point to PyPI"):
+                if "PIP_INDEX_URL" in actual:
+                    assert not index_config_utils.is_pypi_index_url(actual["PIP_INDEX_URL"]), (
+                        "PIP_INDEX_URL must not point to PyPI — AIPCC wheels have ABI "
+                        f"incompatibility with PyPI wheels. Got: {actual['PIP_INDEX_URL']}"
+                    )
+
+            with subtests.test("UV_INDEX_URL env var, if present, does not point to PyPI"):
+                if "UV_INDEX_URL" in actual:
+                    assert not index_config_utils.is_pypi_index_url(actual["UV_INDEX_URL"]), (
+                        "UV_INDEX_URL must not point to PyPI — AIPCC wheels have ABI "
+                        f"incompatibility with PyPI wheels. Got: {actual['UV_INDEX_URL']}"
                     )
 
 

--- a/tests/index_config_utils.py
+++ b/tests/index_config_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import configparser
+import tomllib
+
+PYPI_SIMPLE_INDEX = "https://pypi.org/simple"
+
+
+def normalize_index_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def is_pypi_index_url(url: str) -> bool:
+    return normalize_index_url(url) == PYPI_SIMPLE_INDEX
+
+
+def pip_index_url_from_config(config_text: str) -> str | None:
+    parser = configparser.ConfigParser()
+    parser.read_string(config_text)
+    value = parser.get("global", "index-url", fallback=None)
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def uv_index_url_from_config(config_text: str) -> str | None:
+    data = tomllib.loads(config_text)
+    value = data.get("index-url")
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/tests/unit/test_index_config_utils.py
+++ b/tests/unit/test_index_config_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from tests.index_config_utils import is_pypi_index_url, pip_index_url_from_config, uv_index_url_from_config
+
+
+def test_pip_index_url_from_config_reads_global_index_url():
+    config_text = """# pip.conf
+[global]
+index-url = https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/
+"""
+
+    assert (
+        pip_index_url_from_config(config_text)
+        == "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/"
+    )
+
+
+def test_uv_index_url_from_config_reads_index_url():
+    config_text = """# uv.toml
+index-url = "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/"
+native-tls = true
+"""
+
+    assert (
+        uv_index_url_from_config(config_text)
+        == "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/"
+    )
+
+
+def test_is_pypi_index_url_normalizes_trailing_slash():
+    assert is_pypi_index_url("https://pypi.org/simple")
+    assert is_pypi_index_url("https://pypi.org/simple/")
+    assert not is_pypi_index_url("https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix container index checks

## Description
<!--- Describe your changes in detail -->
- update the CUDA 12.9, CUDA 13.0, and ROCm 7.1 base-image `INDEX_URL`s to the current 3.5-EA2 `-test` endpoints
- fix `test_python_package_index` to validate the effective pip/uv index from `pip.conf` and `uv.toml` instead of requiring `PIP_INDEX_URL` and `UV_INDEX_URL` to be exported
- add small parsing helpers and unit tests to keep the container assertion focused and maintainable
## Why 
This is a current failed test on main https://github.com/opendatahub-io/notebooks/actions/runs/26042646191/job/76558656393?pr=3660
The current test assumes every image exposes Python index URLs through environment variables. That is not true for published AIPCC base images, which configure pip and uv through config files in the final image. As a result, valid RHOAI/AIPCC images fail the test even when they point to the correct RH index.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package index endpoints from 3.5-EA1 to 3.5-EA2 for CUDA 12.9, CUDA 13.0, and ROCm 7.1 build configurations
  * Enhanced test infrastructure to validate package index configuration settings in container environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->