### PR TITLE
RHAIENG-5000: add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,54 @@
+---
+name: Gitleaks
+
+"on":
+  push:
+    branches:
+      - main
+      - stable
+      - 'rhoai-*'
+  pull_request:
+  schedule:
+    - cron: '0 4 * * 3'
+  workflow_dispatch:
+
+concurrency:
+  group: gitleaks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  scan:
+    name: Gitleaks secret scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
+        with:
+          # mise_toml (not install_args) so the tool is both installed and
+          # activated; install_args only runs `mise install` which leaves the
+          # shim unresolved ("No version is set for shim: gitleaks").
+
+          # language=TOML
+          mise_toml: |
+            [tools]
+            "github:gitleaks/gitleaks" = "8.30.1"
+
+      - name: Run Gitleaks
+        # Exit code 0: no leaks, 1: leaks found. Don't fail the job on
+        # findings -- the SARIF upload feeds GitHub code scanning which
+        # handles baseline comparison and only alerts on net-new leaks.
+        run: gitleaks git --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif --no-banner --exit-code 0
+
+      - name: Upload SARIF
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        with:
+          sarif_file: gitleaks.sarif

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,11 @@ repos:
       - id: ruff-format
         types_or: [python, pyi]
         files: '^(ci|tests|ntb|base-images)/.*\.(py|pyi)$'
+  # https://github.com/gitleaks/gitleaks
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
   # https://pre-commit.com/#new-hooks
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

- Add gitleaks v8.30.1 as a pre-commit hook, enforced in CI via the existing `prek` job
- Add a dedicated `gitleaks.yaml` GitHub Actions workflow with full git history scanning, SARIF upload to the Security tab, and weekly scheduled baseline scans
- Uses `jdx/mise-action` for clean binary installation (no `curl | tar | sudo mv`)

The repo already had `.gitleaks.toml` (org-wide allowlists) and `.gitleaksignore` but nothing was actually running gitleaks.

Closes [RHAIENG-5000](https://redhat.atlassian.net/browse/RHAIENG-5000)

## Test plan

- [x] `prek` job in `code-quality` workflow passes -- gitleaks hook shows `Detect hardcoded secrets...Passed` ([run](https://github.com/opendatahub-io/notebooks/actions/runs/26045623118))
- [x] `gitleaks.yaml` workflow runs green, scans 3973 commits, and uploads SARIF to the Security tab ([run](https://github.com/opendatahub-io/notebooks/actions/runs/26045623616))
- [x] 93 historical findings reported via SARIF -- all pre-existing in git history, none in current working tree. GitHub code scanning handles baseline comparison and will only flag net-new leaks on future PRs (same pattern as Trivy `exit-code: '0'`).