### PR TITLE
RHAIENG-3348: trial: use AIPCC base image for jupyter-minimal ODH build

### DIFF
--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -35,7 +35,7 @@ spec:
     value: 'true'
   - name: prefetch-input
     value:
-    - path: prefetch-input/odh
+    - path: prefetch-input/rhds
       type: rpm
     - path: prefetch-input/odh
       type: generic

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
     value: 'true'
   - name: prefetch-input
     value:
-    - path: prefetch-input/odh
+    - path: prefetch-input/rhds
       type: rpm
     - path: prefetch-input/odh
       type: generic

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -49,7 +49,7 @@ spec:
     value: 'true'
   - name: prefetch-input
     value:
-    - path: prefetch-input/odh
+    - path: prefetch-input/rhds
       type: rpm
     - path: prefetch-input/odh
       type: generic

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,4 +1,4 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-ubi9


### PR DESCRIPTION
## Summary

- Test whether GitHub Actions CI can pull from `quay.io/aipcc/base-images` by replacing the ODH base image (`quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest`) with the AIPCC one (`quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1778762488`) in `jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf`.
- This is a **trial PR** to verify registry access. See [RHAIENG-3348](https://redhat.atlassian.net/browse/RHAIENG-3348) for context.

## What we're testing

1. Can the CI runner pull from `quay.io/aipcc/base-images`? (The `AIPCC_QUAY_BOT_USERNAME`/`AIPCC_QUAY_BOT_PASSWORD` secrets must be configured)
2. Is the AIPCC RHEL-based base image compatible with the ODH `Dockerfile.cpu`?

## Expected outcome

- If the `build-odh` job succeeds: CI has AIPCC registry access and the base image is compatible
- If it fails at image pull: CI lacks AIPCC credentials
- If it fails during build: the AIPCC (RHEL) base image isn't directly compatible with the c9s-targeted ODH Dockerfile

> **Do not merge** — this is an exploratory PR.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image configuration for the Jupyter minimal environment to ensure optimal system performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->