### PR TITLE
fix(renovate): compare EA seq before timestamp for base-image tags

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -116,9 +116,12 @@
       // reconstruct the BASE_IMAGE=… line correctly.
       "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}",
       "datasourceTemplate": "docker",
-      // Parses 3.4.0-ea.1-1773428606 as major=3, minor=4, patch=0, prerelease=ea.x, build=1773428606
-      // so Renovate can correctly classify update types and block cross-version upgrades.
-      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?:-ea\\.(?<prerelease>\\d+))?-(?<build>\\d+)$",
+      // Stable tags become [major, minor, patch, timestamp].
+      // EA tags become [major, minor, patch, ea_version, timestamp] while still
+      // keeping prerelease=ea_version so ignoreUnstable can gate EA proposals.
+      // That makes Renovate compare EA sequence before timestamp and stops
+      // invalid downgrades like 3.5.0-ea.2-* -> 3.5.0-ea.1-*.
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?:-ea\\.(?<prerelease>(?<build>\\d+))-(?<revision>\\d+)|-(?<build>\\d+))$",
     },
   ],
 
@@ -156,7 +159,8 @@
     },
     {
       // Block major/minor upgrades by default on all branches.
-      // Only patch/build updates (e.g. 3.4.0-1773428606 -> 3.4.0-1774635932) are allowed.
+      // Patch-like updates within the same base version stay allowed, including
+      // timestamp bumps, EA sequence bumps, and EA -> stable promotions.
       "description": "Block major/minor base image version upgrades (default)",
       "matchManagers": ["custom.regex"],
       "matchUpdateTypes": ["major", "minor"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://github.com/opendatahub-io/notebooks/pull/3666#issuecomment-4485957142
## Description
<!--- Describe your changes in detail -->
fix(renovate): compare EA seq before timestamp for base-image tags
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced base image version parsing to better distinguish between stable and early-access versions
  * Improved classification of version updates and safeguards against invalid downgrade scenarios
  * Clarified update policies to allow patch-level updates and version promotions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->