### PR TITLE
RHAIENG-4342: fix Apache directives to proper serve culling API

### DIFF
--- a/codeserver/ubi9-python-3.12/httpd/httpd.conf
+++ b/codeserver/ubi9-python-3.12/httpd/httpd.conf
@@ -4,6 +4,7 @@ Listen 8080
 
 # Load modules
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule unixd_module modules/mod_unixd.so
 LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule dir_module modules/mod_dir.so
@@ -11,8 +12,8 @@ LoadModule cgi_module modules/mod_cgi.so
 LoadModule rewrite_module modules/mod_rewrite.so
 
 # User and Group - run as the container user (OpenShift assigns random UIDs)
-# User 1001
-# Group 0
+User 1001
+Group 0
 
 # Server configuration
 ServerAdmin root@localhost
@@ -32,10 +33,11 @@ DocumentRoot "/opt/app-root"
     Options +ExecCGI
     Require all granted
     AddHandler cgi-script .cgi
+    DirectoryIndex access.cgi
 </Directory>
 
 # Error and access logs
-ErrorLog "/var/log/httpd/error_log"
+ErrorLog "/dev/stderr"
 LogLevel warn
 
 # Include additional configurations

--- a/codeserver/ubi9-python-3.12/httpd/httpd.conf
+++ b/codeserver/ubi9-python-3.12/httpd/httpd.conf
@@ -32,10 +32,11 @@ DocumentRoot "/opt/app-root"
     Options +ExecCGI
     Require all granted
     AddHandler cgi-script .cgi
+    DirectoryIndex access.cgi
 </Directory>
 
 # Error and access logs
-ErrorLog "/var/log/httpd/error_log"
+ErrorLog "/dev/stderr"
 LogLevel warn
 
 # Include additional configurations


### PR DESCRIPTION
Multiple work has been done to improve the Apache configuration to serve the culling API, which has led to some confusion and undesirable states.

This PR aims to unify and fix all issues together.

## Description
OpenShift provides a functionality to stop automatically notebooks that are not being actively used by its users, which is calling **[culling](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_resources/managing-basic-workbenches_notebook-mgmt)**. This will 

For this to work, we rely in the heartbeat provided by both Jupyter and CodeServer applications:

- CodeServer exposes a /healthz endpoint that reports the last recorded user activity as a heartbeat. The format is different from Jupyter provided culling, but we are work with this data another way that will be explained below.
    ```json
    {
        "status": "alive",
        "lastHeartbeat": 1599166210566
    }
    ```
    Here is the official documentation about the heartbeat and its structure:
      - [coder/code-server/docs/FAQ.md#what-is-the-healthz-endpoint](https://github.com/coder/code-server/blob/359b40d422aa257ee5a7db8534cbcd5f9c1eb373/docs/FAQ.md#what-is-the-healthz-endpoint)

- Jupyter exposes a native culling API that tracks each running kernel individually, giving the culler precise visibility into the activity state of every open notebook.
    
    The format of the culling API endpoint comes as a JSON, representing each kernel available and their last heartbeat:
    ```json
    [
        {
            "id": "22c58c17-bc9d-4141-aac0-06d86d4dff3b",
            "name": "python3",
            "last_activity": "2026-05-20T13:51:54.960378Z",
            "execution_state": "idle",
            "connections": 1
        }
    ]
    ```
    
    Be aware that for the culling API to work on Jupyter Lab, you need to explicitly spawn up a new notebook, not only open the Jupyter UI. After that the culling will return the kernel's latest heartbeat.

    Example:

    | Page | URL |
    |------|-----|
    | JupyterLab | [https://{mycluster}/notebook/{project}/{workbench}/lab/](https://{mycluster}/notebook/{project}/{workbench}/lab/) |
    | Jupyter Lab with a Notebook open: | [https://{mycluster}/notebook/{project}/{workbench}/lab/tree/Untitled.ipynb](https://{mycluster}/notebook/{project}/{workbench}/lab/tree/Untitled.ipynb) |
    | Culling API for the JupyterLab above | [https://{mycluster}/notebook/{project}/{workbench}/api/kernels](https://{mycluster}/notebook/{project}/{workbench}/api/kernels) |

- We have a small documentation inside the repository that explains our structure and how it currently works, like how we read both applications heartbeat, how we provide that to the odh-notebooks controller, etc:
    > The notebook controller's culler expects a Jupyter-compatible API at /api/kernels/ that reports last_activity timestamps and execution_state (busy/idle). JupyterLab provides this natively.
    > 
    > Code-Server does not have a Jupyter-compatible API, so this repo fakes it using a three-process stack per workbench container:
    > 
    >   - nginx (port 80) — reverse proxy with custom JSON access logging for activity tracking
    >   - httpd (port 8080) — Apache acting as a CGI gateway
    >   - bash CGI scripts — access.cgi implements the /api/kernels/ endpoint by polling the IDE's heartbeat (Code-Server)

    Read the entire documentation in the [ARCHITECTURE.md#idle-culling](https://github.com/opendatahub-io/notebooks/blob/b3803ad4e49d09613f01f8362d5455fd70da204b/ARCHITECTURE.md#idle-culling)

- As @jiridanek have commented out, the unixd module addition for the chroot operation is not necessary, as OpenShift already assigns random user ID and group ID to every container automatically, and we are never running any command or operation as root, so this change is not necessary at all
  Comparing to PR #3092 , we are not going to add the unixd module for this reason

```diff
LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
- LoadModule unixd_module modules/mod_unixd.so
LoadModule authz_core_module modules/mod_authz_core.so
LoadModule mime_module modules/mod_mime.so
LoadModule dir_module modules/mod_dir.so
LoadModule cgi_module modules/mod_cgi.so
LoadModule rewrite_module modules/mod_rewrite.so

[...]

# User and Group - run as the container user (OpenShift assigns random UIDs)
+ # User 1001
+ # Group 0
- User 1001
- Group 0
```

References:

- [Red Hat OpenShift AI Self-Managed > 3.4 > Configure user access, storage, and telemetry in OpenShift AI > Chapter 8. Managing basic workbenches](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_resources/managing-basic-workbenches_notebook-mgmt#stopping-idle-workbenches_notebook-mgmt)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Set `access.cgi` as the default directory index for the application root, so directory requests load the CGI entry point.
  * Redirect the web server’s error log output to the container’s standard error stream to ensure runtime errors are visible in container logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->