### PR TITLE
RHAIENG-5297: scope MintMaker to ODH main and RHDS support branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,7 +136,7 @@
 
   "packageRules": [
     {
-      description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL branches)",
+      description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL, rhoai-2.24 — release-data may still list 2.24 until ops MR)",
       matchRepositories: ["red-hat-data-services/notebooks"],
       enabled: false,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,12 @@
-// Renovate / MintMaker configuration for opendatahub-io/notebooks (RHAIENG-5297).
+// Renovate / MintMaker configuration (RHAIENG-5297). Shared renovate.json5 on
+// opendatahub-io/notebooks and red-hat-data-services/notebooks support branches.
+// Do not add .github/renovate.json — it shadows this file.
 //
-// Repo layout:
-//   - Development: opendatahub-io/notebooks#main (MintMaker ON — this repo).
-//   - Downstream: red-hat-data-services/notebooks#main autosyncs from ODH main (MintMaker OFF).
-//   - RHDS support branches rhoai-2.25, rhoai-3.3, rhoai-3.4 are maintained separately;
-//     use this same renovate.json5 there and do NOT keep a legacy renovate.json (it shadows json5).
+// MintMaker ON (remote @ base branch):
+//   - opendatahub-io/notebooks @ main
+//   - red-hat-data-services/notebooks @ rhoai-2.25, rhoai-3.3, rhoai-3.4
+// MintMaker OFF:
+//   - red-hat-data-services/notebooks @ main (autosync from ODH main), EA, EOL branches
 //
 // This file is ignored if `.github/renovate.json` is also present —
 // see https://docs.renovatebot.com/configuration-options/ and https://json5.org.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,12 @@
-// Renovate bot configuration for opendatahub-io/notebooks
-// This file is ignored if `.github/renovate.json` is also present,
+// Renovate / MintMaker configuration for opendatahub-io/notebooks (RHAIENG-5297).
+//
+// Repo layout:
+//   - Development: opendatahub-io/notebooks#main (MintMaker ON — this repo).
+//   - Downstream: red-hat-data-services/notebooks#main autosyncs from ODH main (MintMaker OFF).
+//   - RHDS support branches rhoai-2.25, rhoai-3.3, rhoai-3.4 are maintained separately;
+//     use this same renovate.json5 there and do NOT keep a legacy renovate.json (it shadows json5).
+//
+// This file is ignored if `.github/renovate.json` is also present —
 // see https://docs.renovatebot.com/configuration-options/ and https://json5.org.
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -127,10 +134,21 @@
 
   "packageRules": [
     {
-      "description": "Group GitHub Actions digest updates into a single PR",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "pinDigests": true,
+      description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL branches)",
+      matchRepositories: ["red-hat-data-services/notebooks"],
+      enabled: false,
+    },
+    {
+      description: "RHDS supported release branches only (rhoai-2.25, rhoai-3.3, rhoai-3.4)",
+      matchRepositories: ["red-hat-data-services/notebooks"],
+      matchBaseBranches: ["rhoai-2.25", "rhoai-3.3", "rhoai-3.4"],
+      enabled: true,
+    },
+    {
+      description: "Group GitHub Actions digest updates into a single PR",
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+      pinDigests: true,
     },
     {
       // astral-sh/setup-uv uses exact version tags (v8.0.0), not major tags (v8).

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -379,11 +379,13 @@ The integration test pipeline uses a `volumeClaimTemplate` (not `emptyDir`) to s
 
 Dependency updates are managed by [Renovate](https://docs.renovatebot.com/) through two mechanisms. Configuration lives in [`.github/renovate.json5`](../.github/renovate.json5).
 
-**Where MintMaker runs:** `opendatahub-io/notebooks#main` (development) and supported RHDS release branches `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4` on `red-hat-data-services/notebooks`. It does **not** run on RHDS `main` (autosync mirror of ODH) or end-of-life RHDS branches. RHDS support branches must use `renovate.json5` only — a legacy `.github/renovate.json` disables `github-actions` and other managers.
+**Where MintMaker runs:** `opendatahub-io/notebooks#main` (development) and supported RHDS release branches `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4` on `red-hat-data-services/notebooks`. It does **not** run on RHDS `main` (autosync mirror of ODH), `rhoai-2.24`, or end-of-life RHDS branches (`rhoai-2.21`–`2.23`). Konflux **release-data** may still register `rhoai-2.24` streams until an ops MR freezes them — repo `renovate.json5` and release-data must align (ADR 0013). RHDS support branches must use `renovate.json5` only — a legacy `.github/renovate.json` disables `github-actions` and other managers.
 
 **MintMaker** (Konflux-managed Renovate) runs automatically and creates branches named `konflux/mintmaker/<base-branch>/<image-ref>` for base image updates detected via the `customManagers` regex rules in `renovate.json5` (for example `main`, `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4`). GitHub Actions pins use `konflux/mintmaker/<base-branch>/github-actions`. It uses `platformCommit: "enabled"` (GitHub API commits instead of git push).
 
 **Self-hosted Renovate** runs via the `renovate-self-hosted.yaml` workflow with `renovate_run.py` as a wrapper. It creates branches named `konflux/references/main` for Tekton bundle digest updates.
+
+**Local dry-run:** With RHDS `matchRepositories` in `renovate.json5`, use `scripts/ci/renovate_run.py lookup` (remote/GitHub), not `local-lookup` — the latter fails with `repositories list not supported when platform=local`. Set `RENOVATE_TOKEN=$(gh auth token)` and optionally `RENOVATE_REPOSITORIES` / `RENOVATE_BASE_BRANCHES`.
 
 **Known issues:**
 - **"Cannot find replaceString"** — MintMaker fails when a `build-args/*.conf` file was already updated (e.g., by another PR) before MintMaker's branch is rebased. The old value it searches for no longer exists. Workaround: close the stale MintMaker PR and let it re-create.

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -381,7 +381,7 @@ Dependency updates are managed by [Renovate](https://docs.renovatebot.com/) thro
 
 **Where MintMaker runs:** `opendatahub-io/notebooks#main` (development) and supported RHDS release branches `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4` on `red-hat-data-services/notebooks`. It does **not** run on RHDS `main` (autosync mirror of ODH) or end-of-life RHDS branches. RHDS support branches must use `renovate.json5` only — a legacy `.github/renovate.json` disables `github-actions` and other managers.
 
-**MintMaker** (Konflux-managed Renovate) runs automatically and creates branches named `konflux/mintmaker/main/<image-ref>` for base image updates detected via the `customManagers` regex rules in `renovate.json5`. GitHub Actions pins use `konflux/mintmaker/<branch>/github-actions`. It uses `platformCommit: "enabled"` (GitHub API commits instead of git push).
+**MintMaker** (Konflux-managed Renovate) runs automatically and creates branches named `konflux/mintmaker/<base-branch>/<image-ref>` for base image updates detected via the `customManagers` regex rules in `renovate.json5` (for example `main`, `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4`). GitHub Actions pins use `konflux/mintmaker/<base-branch>/github-actions`. It uses `platformCommit: "enabled"` (GitHub API commits instead of git push).
 
 **Self-hosted Renovate** runs via the `renovate-self-hosted.yaml` workflow with `renovate_run.py` as a wrapper. It creates branches named `konflux/references/main` for Tekton bundle digest updates.
 

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -379,7 +379,9 @@ The integration test pipeline uses a `volumeClaimTemplate` (not `emptyDir`) to s
 
 Dependency updates are managed by [Renovate](https://docs.renovatebot.com/) through two mechanisms. Configuration lives in [`.github/renovate.json5`](../.github/renovate.json5).
 
-**MintMaker** (Konflux-managed Renovate) runs automatically and creates branches named `konflux/mintmaker/main/<image-ref>` for base image updates detected via the `customManagers` regex rules in `renovate.json5`. It uses `platformCommit: "enabled"` (GitHub API commits instead of git push).
+**Where MintMaker runs:** `opendatahub-io/notebooks#main` (development) and supported RHDS release branches `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4` on `red-hat-data-services/notebooks`. It does **not** run on RHDS `main` (autosync mirror of ODH) or end-of-life RHDS branches. RHDS support branches must use `renovate.json5` only — a legacy `.github/renovate.json` disables `github-actions` and other managers.
+
+**MintMaker** (Konflux-managed Renovate) runs automatically and creates branches named `konflux/mintmaker/main/<image-ref>` for base image updates detected via the `customManagers` regex rules in `renovate.json5`. GitHub Actions pins use `konflux/mintmaker/<branch>/github-actions`. It uses `platformCommit: "enabled"` (GitHub API commits instead of git push).
 
 **Self-hosted Renovate** runs via the `renovate-self-hosted.yaml` workflow with `renovate_run.py` as a wrapper. It creates branches named `konflux/references/main` for Tekton bundle digest updates.
 

--- a/scripts/ci/renovate_run.py
+++ b/scripts/ci/renovate_run.py
@@ -9,8 +9,14 @@ found on PATH, else docker. Override with CONTAINER_ENGINE=podman|docker.
   export GITHUB_MCP_PAT=ghp_...  # or RENOVATE_TOKEN (required for local/remote/lookup)
   python3 scripts/ci/renovate_run.py            # platform=local, current tree
   python3 scripts/ci/renovate_run.py remote    # clone from GitHub
-  python3 scripts/ci/renovate_run.py lookup    # remote + --dry-run=lookup, branch-aware JSON logs
-  python3 scripts/ci/renovate_run.py local-lookup  # local + --dry-run=lookup, JSON logs on stdout
+  export RENOVATE_TOKEN=$(gh auth token)
+  export CONTAINER_ENGINE=docker   # if podman machine is not running
+
+  python3 scripts/ci/renovate_run.py lookup    # remote + --dry-run=lookup (preferred for RHDS allowlist)
+  python3 scripts/ci/renovate_run.py local-lookup  # unsupported when renovate.json5 uses matchRepositories
+
+  RENOVATE_REPOSITORIES=opendatahub-io/notebooks RENOVATE_BASE_BRANCHES=main \\
+    python3 scripts/ci/renovate_run.py lookup
 
 Registry auth: DOCKER_CONFIG (default ~/.docker); sets RENOVATE_HOST_RULES from
 config.json unless RENOVATE_HOST_RULES is already set (e.g. from GITHUB_ENV in CI).
@@ -171,12 +177,27 @@ def main(argv: list[str] | None = None) -> int:
         choices=("local", "remote", "lookup", "local-lookup"),
         help=(
             "local: current tree; remote: clone repo; "
-            "lookup: remote dry-run lookup + JSON logs; "
-            "local-lookup: local dry-run lookup + JSON logs"
+            "lookup: remote dry-run lookup (use with RENOVATE_REPOSITORIES / RENOVATE_BASE_BRANCHES); "
+            "local-lookup: unsupported with matchRepositories in renovate.json5 — use lookup"
         ),
     )
     args = parser.parse_args(argv)
     mode = args.mode
+
+    if mode == "local-lookup":
+        print(
+            "error: local-lookup is not supported when .github/renovate.json5 uses "
+            "matchRepositories (Renovate: repositories list not supported when platform=local)",
+            file=sys.stderr,
+        )
+        print(
+            "Use remote lookup instead:\n"
+            "  export RENOVATE_TOKEN=$(gh auth token)\n"
+            "  RENOVATE_REPOSITORIES=opendatahub-io/notebooks RENOVATE_BASE_BRANCHES=main \\\n"
+            "    ./uv run python scripts/ci/renovate_run.py lookup",
+            file=sys.stderr,
+        )
+        return 1
 
     engine = detect_engine()
 

--- a/tests/unit/scripts/ci/test_renovate_run.py
+++ b/tests/unit/scripts/ci/test_renovate_run.py
@@ -78,26 +78,22 @@ def test_main_lookup_requires_token(
     assert "set RENOVATE_TOKEN (required for lookup)" in captured.err
 
 
-def test_main_local_lookup_runs_without_token(
+def test_main_local_lookup_exits_before_container(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     clear_renovate_env(monkeypatch)
     monkeypatch.setenv("DOCKER_CONFIG", str(tmp_path))
-    monkeypatch.setattr(renovate_run, "detect_engine", lambda: "docker")
-    monkeypatch.setattr(renovate_run, "maybe_load_host_rules", lambda _: None)
 
-    observed: dict[str, list[str]] = {}
+    def fail_if_run(cmd: list[str], check: bool) -> SimpleNamespace:
+        raise AssertionError("subprocess.run should not be called for local-lookup")
 
-    def fake_run(cmd: list[str], check: bool) -> SimpleNamespace:
-        observed["cmd"] = cmd
-        assert check is False
-        return SimpleNamespace(returncode=0)
-
-    monkeypatch.setattr(renovate_run.subprocess, "run", fake_run)
+    monkeypatch.setattr(renovate_run.subprocess, "run", fail_if_run)
 
     exit_code = renovate_run.main(["local-lookup"])
 
-    assert exit_code == 0
-    assert "--platform=local" in observed["cmd"]
-    assert "--dry-run=lookup" in observed["cmd"]
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "matchRepositories" in captured.err
+    assert "renovate_run.py lookup" in captured.err


### PR DESCRIPTION
## Summary

Scopes MintMaker/Renovate for the ODH → RHDS autosync model ([RHAIENG-5297](https://redhat.atlassian.net/browse/RHAIENG-5297)).

- **MintMaker on:** `opendatahub-io/notebooks#main` and RHDS `rhoai-2.25`, `rhoai-3.3`, `rhoai-3.4` (via packageRules on the fork).
- **MintMaker off:** `red-hat-data-services/notebooks#main` (autosync mirror) and all other RHDS branches (EA, EOL `rhoai-2.21`–`2.23`).
- Rename GitHub Actions pin group to `github-actions` (matches `konflux/mintmaker/<base-branch>/github-actions` branches).
- Document branch targeting in `renovate.json5` and `docs/konflux.md`.

After merge and autosync to RHDS `main`, MintMaker should not open PRs against RHDS `main`.

## RHDS follow-up (separate PRs on red-hat-data-services/notebooks)

- [#2271](https://github.com/red-hat-data-services/notebooks/pull/2271) `rhoai-2.25`, [#2272](https://github.com/red-hat-data-services/notebooks/pull/2272) `rhoai-3.3`: remove legacy `.github/renovate.json`, add `renovate.json5`.
- [#2273](https://github.com/red-hat-data-services/notebooks/pull/2273) `rhoai-3.4`: [RHAIENG-5297](https://redhat.atlassian.net/browse/RHAIENG-5297) delta on existing json5.
- EOL pin PRs #2212, #2214, #2219 — already merged on `rhoai-2.21`–`2.23` (not closable).

## Test plan

- [x] **`renovate_run.py lookup` (ODH `main`)** — PR branch `29695602a`, config mounted from workspace:
  ```bash
  export RENOVATE_TOKEN=$(gh auth token) CONTAINER_ENGINE=docker
  RENOVATE_REPOSITORIES=opendatahub-io/notebooks RENOVATE_BASE_BRANCHES=main \
    ./uv run python scripts/ci/renovate_run.py lookup
  ```
  Exit 0; `github-actions` 154 deps / 40 files; `regex` 36; expected `matchBaseBranches` config warnings in dry-run.

- [x] **RHDS `main` lookup with this PR’s `renovate.json5` mounted** (pre-autosync simulation):
  ```bash
  RENOVATE_REPOSITORIES=red-hat-data-services/notebooks RENOVATE_BASE_BRANCHES=main \
    ./uv run python scripts/ci/renovate_run.py lookup
  ```
  Exit 0; dependency extraction completes. Repo-level `packageRules` disable `red-hat-data-services/notebooks` except `rhoai-2.25` / `3.3` / `3.4` — **re-run after merge + autosync** when json5 is on live RHDS `main`.

- [ ] **Konflux release-data** — ops: confirm MintMaker components target ODH `main` + RHDS `rhoai-2.25` / `3.3` / `3.4` only; deregister `2.21`–`2.23` in [`konflux-release-data`](https://gitlab.cee.redhat.com/releng/konflux-release-data) (not verifiable from this repo).

- [x] **`gmake test`** — static/manifest checks passed (2026-05-25).

**Note:** `local-lookup` fails with `repositories list not supported when platform=local` because `matchRepositories` in json5 requires remote/GitHub mode; use `lookup` (remote) instead.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified where MintMaker runs, which branches are covered or excluded, branch-naming conventions, and note that the alternate renovate config is ignored when the primary exists.

* **Chores**
  * Adjusted dependency automation configuration: added repo-scoped rules to disable MintMaker by default and re-enable it for specific release branches, and normalized the GitHub Actions grouping label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->