### PR TITLE
fix(ci): set pylock downgrade baseline on push to github.event.before

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -59,8 +59,9 @@ jobs:
         run: make test
         if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
         env:
-          # Prefer the PR base commit so fork PRs compare pylocks to upstream main, not the fork's main.
-          NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
+          # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).
+          NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
 
       - name: Upload Python coverage to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}


### PR DESCRIPTION
## Summary

- On **push**, `NOTEBOOKS_DOWNGRADE_BASE_REF` was unset, so `tests/test_pylock_downgrade.py` fell back to `origin/main`.
- That is wrong for non-`main` branches (`stable`, `rhoai-*`, etc.): pylocks are compared to ODH main instead of the previous commit on the same branch, causing false “downgrade” failures after merges.
- Set the baseline to `github.event.before` on push; keep `pull_request.base.sha` for PRs (fork PRs still compare to the upstream PR base).

## Test plan

- [ ] Code static analysis / `pytest-tests` passes on this PR (PR path unchanged).
- [ ] After merge, a push to `stable` or a release branch should compare pylocks to the pre-push tip, not `origin/main`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality workflow configuration to dynamically determine the base commit reference for pull request events, with fallback behavior for other event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->