### PR TITLE
RHAIENG-5016: prefix Renovate PR titles on non-main branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,6 +136,11 @@
 
   "packageRules": [
     {
+      "description": "Prefix PR titles with branch name for non-main branches",
+      "matchBaseBranches": ["!/^main$/"],
+      "commitMessagePrefix": "[{{{baseBranch}}}]",
+    },
+    {
       description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL, rhoai-2.24 — release-data may still list 2.24 until ops MR)",
       matchRepositories: ["red-hat-data-services/notebooks"],
       enabled: false,


### PR DESCRIPTION
## Summary

- Add a Renovate `packageRule` that prefixes commit messages and PR titles with `[baseBranch]` for all non-`main` branches (e.g. `[rhoai-2.22] chore(deps): update github actions (major)`).
- Ensures MintMaker PRs to release branches follow the required naming convention in both `opendatahub-io/notebooks` and `red-hat-data-services/notebooks` (via automerge propagation).

Closes [RHAIENG-5016](https://redhat.atlassian.net/browse/RHAIENG-5016)

## Test plan

- [x] Verify `.github/renovate.json5` parses as valid JSON5 — `npx json5 -c .github/renovate.json5`
- [x] Confirm MintMaker/Renovate dry-run on a release branch produces PR titles prefixed with `[branch-name]` — `scripts/ci/renovate_run.py remote` with `RENOVATE_REPOSITORIES=red-hat-data-services/notebooks`, `RENOVATE_BASE_BRANCHES=rhoai-3.4`; sample titles: `[rhoai-3.4] Update github-actions (major)`, `[rhoai-3.4] Update Konflux references`
- [x] Confirm PRs to `main` remain unprefixed — same dry-run with `RENOVATE_REPOSITORIES=opendatahub-io/notebooks`, `RENOVATE_BASE_BRANCHES=main`; sample titles: `Update github-actions`, `Update Konflux references` (no `[main]` prefix)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development automation configuration for improved workflow management on non-main branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->