### PR TITLE
ISSUE#3729: chore(uv): adjust uv version range to >=0.10,<0.12 in scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Note: To ensure the GitHub Action runs successfully, users must add a `GH_ACCESS
 
 #### Prepare Python + uv + pytest env
 
-Root dev tooling uses `[tool.uv] required-version` in `pyproject.toml` (currently `>=0.11,<0.12`).
+Root dev tooling uses `[tool.uv] required-version` in `pyproject.toml` (currently `>=0.10,<0.12`).
 Install any uv in that range and use it directly for sync, tests, and pre-commit:
 
 ```shell
 # Linux
 sudo dnf install python3.14
-pip install --user 'uv>=0.11,<0.12'
+pip install --user 'uv>=0.10,<0.12'
 # macOS
 brew install python@3.14 uv
 

--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
-uv --version || pip install 'uv>=0.11,<0.12'
+uv --version || pip install 'uv>=0.10,<0.12'
 
 uv run scripts/dockerfile_fragments.py
 uv run manifests/tools/generate_kustomization.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.11,<0.12"
+required-version = ">=0.10,<0.12"
 # Supply-chain hardening: only resolve package versions published ≥3 days ago.
 # See https://docs.astral.sh/uv/concepts/resolution/#time-restricted-reproducible-resolutions
 exclude-newer = "3 days"


### PR DESCRIPTION
This way the workbenches pyproject.toml version will be within the allowed interval, meaning there won't be weird problems in CI.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to reflect expanded `uv` version compatibility.

* **Chores**
  * Extended support for earlier `uv` package manager versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->