### PR TITLE
fix(ci): fix setup-go cache path in Lock Files Renewal workflow

### DIFF
--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: scripts/buildinputs/go.mod
+          cache-dependency-path: scripts/buildinputs/go.mod
 
       - name: Run make refresh-lock-files
         run: |


### PR DESCRIPTION
## Summary

Fixes a recurring workflow annotation on **Lock Files Renewal Action** (`refresh-lock-files` job):

> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/notebooks/notebooks. Supported file pattern: go.mod

Example run: https://github.com/opendatahub-io/notebooks/actions/runs/26467279687/job/77930860995

### Problem

The `refresh-lock-files` job installs Go so `make refresh-lock-files` can build `bin/buildinputs` (the Dockerfile dependency parser under `scripts/buildinputs/`). The workflow already sets:

```yaml
go-version-file: scripts/buildinputs/go.mod
```

That correctly selects the Go toolchain version, but **`actions/setup-go` still defaults module-cache restore to a `go.mod` at the repository root**. This repo has no root `go.mod`—only module roots such as `scripts/buildinputs/go.mod` and `scripts/check-payload/go.mod`—so cache restore fails and GitHub surfaces a warning on every run. The job still succeeded; this was noise, not a functional failure.

### Fix

Set `cache-dependency-path: scripts/buildinputs/go.mod`, matching other workflows that use the same Go module (e.g. `codeql.yaml`, `build-notebooks-pr.yaml`).

## Test plan

- [ ] Merge and confirm the next **Lock Files Renewal Action** run (or a manual `workflow_dispatch` with `update-lockfiles`) no longer shows the setup-go cache warning on the **Set up Go** step.

Made with [Cursor](https://cursor.com)