### PR TITLE
DO NOT MERGE: PyPI-configured minimal workbench images (RHAIENG-5334 spike)

### DIFF
--- a/codeserver/ubi9-python-3.12-pypi/Dockerfile
+++ b/codeserver/ubi9-python-3.12-pypi/Dockerfile
@@ -16,8 +16,9 @@ RUN curl -fOL https://github.com/coder/code-server/releases/download/v${CODESERV
  && rpm -U code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm \
  && rm -f code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm
 
-# Install nginx for reverse proxy (handles NB_PREFIX path rewriting for OpenShift)
-RUN dnf install -y nginx \
+# libatomic: required by ROCm PyTorch (user pip installs torch with rocm index)
+# nginx: reverse proxy for NB_PREFIX path rewriting on OpenShift
+RUN dnf install -y libatomic nginx \
  && dnf clean all
 
 # Install Python kernel support for VS Code

--- a/codeserver/ubi9-python-3.12-pypi/Dockerfile
+++ b/codeserver/ubi9-python-3.12-pypi/Dockerfile
@@ -16,22 +16,27 @@ RUN curl -fOL https://github.com/coder/code-server/releases/download/v${CODESERV
  && rpm -U code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm \
  && rm -f code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm
 
+# Install nginx for reverse proxy (handles NB_PREFIX path rewriting for OpenShift)
+RUN dnf install -y nginx \
+ && dnf clean all
+
 # Install Python kernel support for VS Code
 RUN pip install --no-cache-dir jupyter ipykernel
 
-# Ensure writable dirs for code-server data
+# Create nginx config template that rewrites NB_PREFIX to code-server on 8787
+RUN mkdir -p /opt/app-root/etc/nginx.default.d
+COPY codeserver/ubi9-python-3.12-pypi/start-codeserver.sh ${APP_ROOT}/bin/
+
+# Ensure writable dirs
 RUN mkdir -p ${APP_ROOT}/src/.local/share/code-server \
+    /var/log/nginx /var/lib/nginx /run \
+ && chown -R 1001:0 /var/log/nginx /var/lib/nginx /run /etc/nginx \
+ && chmod -R ug+rwX /var/log/nginx /var/lib/nginx /run /etc/nginx \
  && fix-permissions ${APP_ROOT} -P
 
 USER 1001
 WORKDIR ${APP_ROOT}/src
 
-EXPOSE 8080
+EXPOSE 8888
 
-CMD ["code-server", \
-     "--bind-addr", "0.0.0.0:8080", \
-     "--auth", "none", \
-     "--disable-telemetry", \
-     "--disable-update-check", \
-     "--disable-getting-started-override", \
-     "/opt/app-root/src"]
+CMD ["/opt/app-root/bin/start-codeserver.sh"]

--- a/codeserver/ubi9-python-3.12-pypi/Dockerfile
+++ b/codeserver/ubi9-python-3.12-pypi/Dockerfile
@@ -33,6 +33,10 @@ RUN mkdir -p /opt/app-root/src/.local/share/code-server \
  && chmod +x /opt/app-root/bin/start-codeserver.sh \
  && fix-permissions /opt/app-root -P
 
+# OpenShift runs containers with a random UID whose /etc/passwd entry has
+# /sbin/nologin as the shell. code-server's integrated terminal uses $SHELL.
+ENV SHELL=/bin/bash
+
 USER 1001
 WORKDIR /opt/app-root/src
 

--- a/codeserver/ubi9-python-3.12-pypi/Dockerfile
+++ b/codeserver/ubi9-python-3.12-pypi/Dockerfile
@@ -1,0 +1,37 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER 0
+
+ARG APP_ROOT=/opt/app-root
+
+# Override pip/uv config to use PyPI instead of AIPCC index
+RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > ${APP_ROOT}/pip.conf \
+ && printf 'index-url = "https://pypi.org/simple/"\n' > ${APP_ROOT}/uv.toml
+
+# Install code-server from upstream GitHub RPM (nonhermetic)
+ARG CODESERVER_VERSION=4.106.3
+ARG TARGETARCH=amd64
+RUN curl -fOL https://github.com/coder/code-server/releases/download/v${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm \
+ && rpm -U code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm \
+ && rm -f code-server-${CODESERVER_VERSION}-${TARGETARCH}.rpm
+
+# Install Python kernel support for VS Code
+RUN pip install --no-cache-dir jupyter ipykernel
+
+# Ensure writable dirs for code-server data
+RUN mkdir -p ${APP_ROOT}/src/.local/share/code-server \
+ && fix-permissions ${APP_ROOT} -P
+
+USER 1001
+WORKDIR ${APP_ROOT}/src
+
+EXPOSE 8080
+
+CMD ["code-server", \
+     "--bind-addr", "0.0.0.0:8080", \
+     "--auth", "none", \
+     "--disable-telemetry", \
+     "--disable-update-check", \
+     "--disable-getting-started-override", \
+     "/opt/app-root/src"]

--- a/codeserver/ubi9-python-3.12-pypi/Dockerfile
+++ b/codeserver/ubi9-python-3.12-pypi/Dockerfile
@@ -1,13 +1,13 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
 FROM ${BASE_IMAGE}
 
 USER 0
 
-ARG APP_ROOT=/opt/app-root
-
 # Override pip/uv config to use PyPI instead of AIPCC index
-RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > ${APP_ROOT}/pip.conf \
- && printf 'index-url = "https://pypi.org/simple/"\n' > ${APP_ROOT}/uv.toml
+RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > /opt/app-root/pip.conf \
+ && printf 'index-url = "https://pypi.org/simple/"\n' > /opt/app-root/uv.toml
+
+ENV PIP_CONFIG_FILE=/opt/app-root/pip.conf
 
 # Install code-server from upstream GitHub RPM (nonhermetic)
 ARG CODESERVER_VERSION=4.106.3
@@ -23,19 +23,18 @@ RUN dnf install -y nginx \
 # Install Python kernel support for VS Code
 RUN pip install --no-cache-dir jupyter ipykernel
 
-# Create nginx config template that rewrites NB_PREFIX to code-server on 8787
-RUN mkdir -p /opt/app-root/etc/nginx.default.d
-COPY codeserver/ubi9-python-3.12-pypi/start-codeserver.sh ${APP_ROOT}/bin/
+COPY codeserver/ubi9-python-3.12-pypi/start-codeserver.sh /opt/app-root/bin/
 
 # Ensure writable dirs
-RUN mkdir -p ${APP_ROOT}/src/.local/share/code-server \
+RUN mkdir -p /opt/app-root/src/.local/share/code-server \
     /var/log/nginx /var/lib/nginx /run \
  && chown -R 1001:0 /var/log/nginx /var/lib/nginx /run /etc/nginx \
  && chmod -R ug+rwX /var/log/nginx /var/lib/nginx /run /etc/nginx \
- && fix-permissions ${APP_ROOT} -P
+ && chmod +x /opt/app-root/bin/start-codeserver.sh \
+ && fix-permissions /opt/app-root -P
 
 USER 1001
-WORKDIR ${APP_ROOT}/src
+WORKDIR /opt/app-root/src
 
 EXPOSE 8888
 

--- a/codeserver/ubi9-python-3.12-pypi/start-codeserver.sh
+++ b/codeserver/ubi9-python-3.12-pypi/start-codeserver.sh
@@ -40,7 +40,7 @@ http {
         listen 8888;
         server_name _;
 
-        location ${NB_PREFIX:-/} {
+        location ${NB_PREFIX:-/}/ {
             proxy_pass http://127.0.0.1:8787/;
             proxy_set_header Host \$host;
             proxy_set_header Upgrade \$http_upgrade;
@@ -53,8 +53,13 @@ http {
             proxy_send_timeout 3600s;
         }
 
+        # Redirect /notebook/ns/name to /notebook/ns/name/ (trailing slash)
+        location = ${NB_PREFIX:-} {
+            return 302 \$scheme://\$host${NB_PREFIX:-/}/;
+        }
+
         # Health check endpoint for readiness probe
-        location ${NB_PREFIX:-/}api {
+        location ${NB_PREFIX:-/}/api {
             proxy_pass http://127.0.0.1:8787/healthz;
             proxy_set_header Host \$host;
         }

--- a/codeserver/ubi9-python-3.12-pypi/start-codeserver.sh
+++ b/codeserver/ubi9-python-3.12-pypi/start-codeserver.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eu
 
+# OpenShift assigns a random UID with /sbin/nologin as shell.
+# /etc/passwd is read-only, so we can't sed it. Set SHELL env var instead;
+# code-server respects SHELL for its integrated terminal.
+export SHELL=/bin/bash
+
 NB_PREFIX="${NB_PREFIX:-}"
 CODE_SERVER_DATA_DIR="/opt/app-root/src/.local/share/code-server"
 mkdir -p "${CODE_SERVER_DATA_DIR}/User"

--- a/codeserver/ubi9-python-3.12-pypi/start-codeserver.sh
+++ b/codeserver/ubi9-python-3.12-pypi/start-codeserver.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -eu
+
+NB_PREFIX="${NB_PREFIX:-}"
+CODE_SERVER_DATA_DIR="/opt/app-root/src/.local/share/code-server"
+mkdir -p "${CODE_SERVER_DATA_DIR}/User"
+
+# Write VS Code settings
+cat > "${CODE_SERVER_DATA_DIR}/User/settings.json" << 'SETTINGS'
+{
+  "python.defaultInterpreterPath": "/opt/app-root/bin/python3",
+  "telemetry.telemetryLevel": "off",
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "security.workspace.trust.enabled": false,
+  "security.workspace.trust.startupPrompt": "never"
+}
+SETTINGS
+
+# Generate nginx config that proxies 8888 -> code-server on 8787
+# and handles the NB_PREFIX path rewriting
+cat > /etc/nginx/nginx.conf << NGINX_EOF
+worker_processes auto;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    access_log /var/log/nginx/access.log;
+
+    map \$http_upgrade \$connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    server {
+        listen 8888;
+        server_name _;
+
+        location ${NB_PREFIX:-/} {
+            proxy_pass http://127.0.0.1:8787/;
+            proxy_set_header Host \$host;
+            proxy_set_header Upgrade \$http_upgrade;
+            proxy_set_header Connection \$connection_upgrade;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto \$scheme;
+            proxy_http_version 1.1;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
+        # Health check endpoint for readiness probe
+        location ${NB_PREFIX:-/}api {
+            proxy_pass http://127.0.0.1:8787/healthz;
+            proxy_set_header Host \$host;
+        }
+    }
+}
+NGINX_EOF
+
+# Start nginx in background
+nginx &
+
+# IPv6 support for code-server
+if [ -f /proc/net/if_inet6 ]; then
+    BIND_ADDR="[::]:8787"
+else
+    BIND_ADDR="0.0.0.0:8787"
+fi
+
+# Start code-server
+exec code-server \
+    --bind-addr "${BIND_ADDR}" \
+    --user-data-dir "${CODE_SERVER_DATA_DIR}" \
+    --extensions-dir "${CODE_SERVER_DATA_DIR}/extensions" \
+    --disable-telemetry \
+    --auth none \
+    --disable-update-check \
+    --disable-getting-started-override \
+    /opt/app-root/src

--- a/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
@@ -1,0 +1,153 @@
+# PyPI-Enabled Minimal Workbench Images — BU Demo Cheatsheet
+
+## What these images are
+
+Minimal workbench images (Jupyter + CodeServer) on RHEL 9 / UBI9 base, configured
+to use **PyPI** as the default pip index instead of the AIPCC/Red Hat Python index.
+
+No ML frameworks pre-installed. Users `pip install` what they need at runtime.
+
+## Available images
+
+| Image | quay.io | Use for |
+|-------|---------|---------|
+| JupyterLab | `quay.io/jdanek/jupyter-minimal-cpu-pypi:spike` | Notebook workflows |
+| CodeServer | `quay.io/jdanek/codeserver-cpu-pypi:spike3` | VS Code in browser |
+
+Both are CPU-only base images. GPU frameworks (PyTorch, TensorFlow) bundle their
+own CUDA/ROCm runtime and work without CUDA RPMs in the image.
+
+## Quick start on OpenShift
+
+1. Import as custom workbench image in RHOAI dashboard (Settings → Workbench Images)
+2. Create a workbench, optionally request a GPU
+3. Open terminal, install what you need
+
+## Installing PyTorch (CUDA)
+
+```bash
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
+```
+
+Verify GPU:
+
+```python
+import torch
+print(torch.__version__)          # should be 2.6+
+print(torch.cuda.is_available())  # True if GPU allocated
+print(torch.cuda.get_device_name(0))
+```
+
+**Note:** If using PyTorch < 2.6, the `torch.accelerator` API doesn't exist yet.
+Use the legacy device detection:
+
+```python
+device = "cuda" if torch.cuda.is_available() else "cpu"
+```
+
+If you get `AttributeError: module 'torch' has no attribute 'accelerator'`,
+either upgrade torch (`pip install --upgrade torch`) or use the legacy pattern above.
+
+## Installing PyTorch (ROCm)
+
+ROCm wheels are hosted on PyTorch's custom index (not on default PyPI):
+
+```bash
+pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm6.2
+```
+
+Unlike CUDA, there are no granular `nvidia-*` style ROCm PyPI packages.
+The ROCm runtime is bundled inside the torch wheel itself.
+
+## Installing TensorFlow (CUDA)
+
+```bash
+pip install "tensorflow[and-cuda]"
+```
+
+The `[and-cuda]` extra pulls NVIDIA CUDA libraries from PyPI automatically.
+
+Verify GPU:
+
+```python
+import tensorflow as tf
+gpus = tf.config.list_physical_devices('GPU')
+print("GPUs:", gpus)
+```
+
+## Installing TensorFlow (ROCm)
+
+TensorFlow ROCm support requires system-level ROCm installation — it cannot
+be installed purely from PyPI like the CUDA variant. The `tensorflow-rocm`
+package on PyPI expects ROCm to be pre-installed on the host.
+
+For ROCm + TensorFlow, use AIPCC-based (secure) images instead.
+
+## CUDA compiler (nvcc) from PyPI
+
+If you need to compile custom CUDA kernels (e.g., for vLLM's FlashInfer JIT,
+custom torch extensions):
+
+```bash
+pip install nvidia-cuda-nvcc
+```
+
+Most users don't need this — `torch.compile` uses Triton (Python-based, no nvcc).
+
+## Known issues and workarounds
+
+### TensorBoard fails with `No module named 'pkg_resources'`
+
+Python 3.12 dropped bundled `setuptools`. TensorBoard still depends on it.
+
+```bash
+pip install "setuptools<70.0.0"
+```
+
+Versions 70.0+ removed `pkg_resources`. Upgrading TensorBoard alone doesn't
+fix it because TensorFlow pins the TensorBoard version.
+
+### pip installs don't survive pod restarts
+
+Packages installed at runtime are lost when the OpenShift pod restarts (node
+drain, scale-down, OOM kill). Options:
+
+- Mount a PVC on `/opt/app-root` for persistence
+- Save `requirements.txt` to PVC, re-run `pip install -r` after restart
+- Build a custom image with your packages baked in
+
+### torch.accelerator not found
+
+PyTorch < 2.6 doesn't have `torch.accelerator`. Use:
+
+```python
+device = "cuda" if torch.cuda.is_available() else "cpu"
+```
+
+## What's NOT in these images
+
+- No torch, numpy, pandas, scipy, scikit-learn
+- No CUDA/ROCm RPMs (torch bundles its own)
+- No Red Hat supply chain guarantees on user-installed packages
+- This is the "community" tier — user accepts responsibility
+
+## What IS in these images
+
+- Python 3.12 (UBI9)
+- JupyterLab 4.5.x or CodeServer 4.106.3
+- pip configured to use `https://pypi.org/simple/`
+- Standard RHEL 9 system libraries
+- `gcc`, `make` (for building C extensions from source if needed)
+
+## CUDA ABI — why CPU base is fine
+
+PyTorch and TensorFlow wheels from PyPI bundle their own CUDA runtime
+libraries. They don't depend on system-installed CUDA RPMs. This is the
+same configuration that worked in RHOAI through 3.3.
+
+RPM-installed CUDA and PyPI-bundled CUDA coexist without conflicts.
+
+## Architecture support
+
+Currently amd64 only. arm64 is feasible (UBI9 and code-server RPMs both
+support it). IBM ppc64le/s390x would need investigation.

--- a/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
@@ -44,7 +44,8 @@ print("torch version:", torch.__version__)
 print("CUDA available:", torch.cuda.is_available())
 if torch.cuda.is_available():
     props = torch.cuda.get_device_properties(0)
-    print(f"Device: {props.name} ({props.gcnArchName if hasattr(props, 'gcnArchName') else 'CUDA'})")
+    arch = getattr(props, 'gcnArchName', f"SM {props.major}.{props.minor}")
+    print(f"Device: {props.name} ({arch})")
     print(f"Memory: {props.total_memory // 1024**2} MB, CUs/SMs: {props.multi_processor_count}")
 ```
 

--- a/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
@@ -127,6 +127,14 @@ pip install "setuptools<70.0.0"
 Versions 70.0+ removed `pkg_resources`. Upgrading TensorBoard alone doesn't
 fix it because TensorFlow pins the TensorBoard version.
 
+### No `rocm-smi` / `rocminfo` on ROCm clusters
+
+The PyTorch ROCm wheel bundles only runtime libs, not the AMD diagnostic CLI tools
+(`rocm-smi`, `rocminfo`). These come from AMD's ROCm RPM repos, not UBI9 or PyPI.
+Use `torch.cuda.get_device_properties(0)` to get GPU arch, memory, and CU count.
+For full GPU monitoring, the tools need to be pre-installed in the image or
+available on the host node.
+
 ### pip installs don't survive pod restarts
 
 Packages installed at runtime are lost when the OpenShift pod restarts (node

--- a/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
@@ -33,9 +33,10 @@ Verify GPU:
 
 ```python
 import torch
-print(torch.__version__)          # should be 2.6+
-print(torch.cuda.is_available())  # True if GPU allocated
-print(torch.cuda.get_device_name(0))
+print("torch version:", torch.__version__)
+print("CUDA available:", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("Device:", torch.cuda.get_device_name(0))
 ```
 
 **Note:** If using PyTorch < 2.6, the `torch.accelerator` API doesn't exist yet.
@@ -53,11 +54,21 @@ either upgrade torch (`pip install --upgrade torch`) or use the legacy pattern a
 ROCm wheels are hosted on PyTorch's custom index (not on default PyPI):
 
 ```bash
-pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm6.2
+pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.1/
 ```
 
 Unlike CUDA, there are no granular `nvidia-*` style ROCm PyPI packages.
-The ROCm runtime is bundled inside the torch wheel itself.
+The ROCm runtime is bundled inside the torch wheel itself (~3GB download).
+
+Verify GPU (same commands as CUDA -- ROCm uses the CUDA API):
+
+```python
+import torch
+print("torch version:", torch.__version__)
+print("CUDA available:", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("Device:", torch.cuda.get_device_name(0))
+```
 
 ## Installing TensorFlow (CUDA)
 
@@ -71,8 +82,12 @@ Verify GPU:
 
 ```python
 import tensorflow as tf
+print("TF version:", tf.__version__)
+print("Built with CUDA:", tf.test.is_built_with_cuda())
 gpus = tf.config.list_physical_devices('GPU')
 print("GPUs:", gpus)
+if gpus:
+    print("GPU name:", gpus[0].name)
 ```
 
 ## Installing TensorFlow (ROCm)

--- a/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
@@ -36,7 +36,9 @@ import torch
 print("torch version:", torch.__version__)
 print("CUDA available:", torch.cuda.is_available())
 if torch.cuda.is_available():
-    print("Device:", torch.cuda.get_device_name(0))
+    props = torch.cuda.get_device_properties(0)
+    print(f"Device: {props.name} ({props.gcnArchName if hasattr(props, 'gcnArchName') else 'CUDA'})")
+    print(f"Memory: {props.total_memory // 1024**2} MB, CUs/SMs: {props.multi_processor_count}")
 ```
 
 **Note:** If using PyTorch < 2.6, the `torch.accelerator` API doesn't exist yet.
@@ -67,7 +69,10 @@ import torch
 print("torch version:", torch.__version__)
 print("CUDA available:", torch.cuda.is_available())
 if torch.cuda.is_available():
-    print("Device:", torch.cuda.get_device_name(0))
+    props = torch.cuda.get_device_properties(0)
+    # ROCm reports "AMD Radeon Graphics" as name; gcnArchName shows the real arch (e.g. gfx942 = MI300X)
+    print(f"Device: {props.name} ({props.gcnArchName})")
+    print(f"Memory: {props.total_memory // 1024**2} MB, CUs: {props.multi_processor_count}")
 ```
 
 ## Installing TensorFlow (CUDA)

--- a/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md
@@ -19,8 +19,15 @@ own CUDA/ROCm runtime and work without CUDA RPMs in the image.
 
 ## Quick start on OpenShift
 
-1. Import as custom workbench image in RHOAI dashboard (Settings → Workbench Images)
-2. Create a workbench, optionally request a GPU
+Deploy imagestreams into your namespace (one command):
+
+```bash
+oc apply -n <your-namespace> -f jupyter/minimal/ubi9-python-3.12-pypi/imagestreams.yaml
+```
+
+Then in the RHOAI dashboard:
+1. Create a workbench using "Jupyter Minimal PyPI (CPU)" or "CodeServer PyPI (CPU)"
+2. Optionally request a GPU
 3. Open terminal, install what you need
 
 ## Installing PyTorch (CUDA)

--- a/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
@@ -1,13 +1,13 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
 FROM ${BASE_IMAGE}
 
 USER 0
 
-ARG APP_ROOT=/opt/app-root
-
 # Override pip/uv config to use PyPI instead of AIPCC index
-RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > ${APP_ROOT}/pip.conf \
- && printf 'index-url = "https://pypi.org/simple/"\n' > ${APP_ROOT}/uv.toml
+RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > /opt/app-root/pip.conf \
+ && printf 'index-url = "https://pypi.org/simple/"\n' > /opt/app-root/uv.toml
+
+ENV PIP_CONFIG_FILE=/opt/app-root/pip.conf
 
 # Install JupyterLab and friends from PyPI (nonhermetic -- downloads at build time)
 RUN pip install --no-cache-dir \
@@ -19,15 +19,15 @@ RUN pip install --no-cache-dir \
     nbdime \
     nbgitpuller
 
-COPY jupyter/minimal/ubi9-python-3.12/start-notebook.sh ${APP_ROOT}/bin/
-COPY jupyter/utils/ ${APP_ROOT}/bin/utils/
+COPY jupyter/minimal/ubi9-python-3.12/start-notebook.sh /opt/app-root/bin/
+COPY jupyter/utils/ /opt/app-root/bin/utils/
 
-RUN mkdir -p ${APP_ROOT}/etc/jupyter \
- && cp ${APP_ROOT}/bin/utils/jupyter_server_config.py ${APP_ROOT}/etc/jupyter/ \
- && chmod +x ${APP_ROOT}/bin/start-notebook.sh \
- && fix-permissions ${APP_ROOT} -P
+RUN mkdir -p /opt/app-root/etc/jupyter \
+ && cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter/ \
+ && chmod +x /opt/app-root/bin/start-notebook.sh \
+ && fix-permissions /opt/app-root -P
 
 USER 1001
-WORKDIR ${APP_ROOT}/src
+WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]

--- a/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
@@ -9,6 +9,9 @@ RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > /opt/app-root/pi
 
 ENV PIP_CONFIG_FILE=/opt/app-root/pip.conf
 
+# libatomic: required by ROCm PyTorch (user pip installs torch with rocm index)
+RUN dnf install -y libatomic && dnf clean all
+
 # Install JupyterLab and friends from PyPI (nonhermetic -- downloads at build time)
 RUN pip install --no-cache-dir \
     jupyterlab \

--- a/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
@@ -1,0 +1,33 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER 0
+
+ARG APP_ROOT=/opt/app-root
+
+# Override pip/uv config to use PyPI instead of AIPCC index
+RUN printf '[global]\nindex-url = https://pypi.org/simple/\n' > ${APP_ROOT}/pip.conf \
+ && printf 'index-url = "https://pypi.org/simple/"\n' > ${APP_ROOT}/uv.toml
+
+# Install JupyterLab and friends from PyPI (nonhermetic -- downloads at build time)
+RUN pip install --no-cache-dir \
+    jupyterlab \
+    jupyter-server \
+    jupyter-server-proxy \
+    jupyter-server-terminals \
+    jupyterlab-git \
+    nbdime \
+    nbgitpuller
+
+COPY jupyter/minimal/ubi9-python-3.12/start-notebook.sh ${APP_ROOT}/bin/
+COPY jupyter/utils/ ${APP_ROOT}/bin/utils/
+
+RUN mkdir -p ${APP_ROOT}/etc/jupyter \
+ && cp ${APP_ROOT}/bin/utils/jupyter_server_config.py ${APP_ROOT}/etc/jupyter/ \
+ && chmod +x ${APP_ROOT}/bin/start-notebook.sh \
+ && fix-permissions ${APP_ROOT} -P
+
+USER 1001
+WORKDIR ${APP_ROOT}/src
+
+ENTRYPOINT ["start-notebook.sh"]

--- a/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile
@@ -33,4 +33,6 @@ RUN mkdir -p /opt/app-root/etc/jupyter \
 USER 1001
 WORKDIR /opt/app-root/src
 
+EXPOSE 8888
+
 ENTRYPOINT ["start-notebook.sh"]

--- a/jupyter/minimal/ubi9-python-3.12-pypi/imagestreams.yaml
+++ b/jupyter/minimal/ubi9-python-3.12-pypi/imagestreams.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: jupyter-minimal-cpu-pypi
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-name: "Jupyter Minimal PyPI (CPU)"
+    opendatahub.io/notebook-image-desc: "Minimal JupyterLab with PyPI index. pip install torch/tensorflow at runtime."
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: spike
+      from:
+        kind: DockerImage
+        name: quay.io/jdanek/jupyter-minimal-cpu-pypi:spike
+      importPolicy:
+        importMode: PreserveOriginal
+      referencePolicy:
+        type: Source
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: codeserver-cpu-pypi
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-name: "CodeServer PyPI (CPU)"
+    opendatahub.io/notebook-image-desc: "VS Code (code-server) with PyPI index. pip install torch/tensorflow at runtime."
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: spike3
+      from:
+        kind: DockerImage
+        name: quay.io/jdanek/codeserver-cpu-pypi:spike3
+      importPolicy:
+        importMode: PreserveOriginal
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
## DO NOT MERGE — spike / proof of concept

This PR contains the nonhermetic PyPI-configured minimal workbench images for BU evaluation, as part of [RHAIENG-5334](https://redhat.atlassian.net/browse/RHAIENG-5334) under the [RHAIENG-4960](https://redhat.atlassian.net/browse/RHAIENG-4960) epic (Alternative 1 from [RHAISTRAT-1482](https://redhat.atlassian.net/browse/RHAISTRAT-1482)).

## What's here

Two Dockerfiles producing 2 images (Jupyter + CodeServer), both on UBI9 base with PyPI as default pip index:

| Image | quay.io |
|-------|---------|
| JupyterLab | `quay.io/jdanek/jupyter-minimal-cpu-pypi:spike` |
| CodeServer | `quay.io/jdanek/codeserver-cpu-pypi:spike3` |

### Files added (no existing files modified)

- `jupyter/minimal/ubi9-python-3.12-pypi/Dockerfile` — JupyterLab on UBI9, pip→PyPI
- `jupyter/minimal/ubi9-python-3.12-pypi/BU-DEMO-README.md` — User-facing cheatsheet
- `jupyter/minimal/ubi9-python-3.12-pypi/imagestreams.yaml` — One-command deploy on OpenShift
- `codeserver/ubi9-python-3.12-pypi/Dockerfile` — CodeServer on UBI9, pip→PyPI, nginx proxy
- `codeserver/ubi9-python-3.12-pypi/start-codeserver.sh` — Entrypoint with nginx + NB_PREFIX

### Validated on

- **NVIDIA L40S** (ntbcudashrd cluster): PyTorch CUDA — full quickstart + GPU ops passed
- **AMD MI300X** (ods-az-amd-02 cluster): PyTorch ROCm — GPU detected, torch ops working

### Key findings

- CPU-only base image is sufficient for GPU workloads (torch bundles its own CUDA/ROCm)
- No AIPCC base image needed (plain UBI9 python-312 works)
- `libatomic` system package required for ROCm PyTorch
- TensorFlow CUDA works (`tensorflow[and-cuda]`), TensorFlow ROCm does NOT (needs system ROCm)
- CodeServer needs nginx reverse proxy for OpenShift NB_PREFIX path rewriting
- `ENV SHELL=/bin/bash` needed for code-server terminal with OpenShift random UIDs

### Related

- Epic: [RHAIENG-4960](https://redhat.atlassian.net/browse/RHAIENG-4960)
- Spike: [RHAIENG-5334](https://redhat.atlassian.net/browse/RHAIENG-5334)
- ADR: [Build PyPI-configured minimal workbench images for RHOAI](https://docs.google.com/document/d/1_qM5Ud0N0f-jFa2HnsKdm2GhRRp-c6WLl1qVlHR8jh4/edit)
- Feature: [RHAISTRAT-1482](https://redhat.atlassian.net/browse/RHAISTRAT-1482)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CodeServer container image with Python 3.12 and PyPI package configuration.
  * Added JupyterLab container image with Python 3.12 and PyPI package configuration.
  * Both images include integrated nginx proxy support with telemetry disabled by default.

* **Documentation**
  * Added configuration guide for minimal workbench images with deployment and runtime installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHAIENG-5334]: https://redhat.atlassian.net/browse/RHAIENG-5334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4960]: https://redhat.atlassian.net/browse/RHAIENG-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAISTRAT-1482]: https://redhat.atlassian.net/browse/RHAISTRAT-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4960]: https://redhat.atlassian.net/browse/RHAIENG-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ