### PR TITLE
RHAIENG-5352: fix(scripts/cve): tracker script for embargoed RHOAIENG children

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,6 +120,9 @@ Each new tracker is created with:
 - **Labels:** `CVE`, the CVE id (e.g. `CVE-2026-28498`), and `security`, so CVE work is distinguishable from other Bugs.
 - **Team:** Jira field `customfield_10001` set to the **AAIET Notebooks** team id as a **plain string** (required by the [REST create API](https://developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api/); default id from RHAIENG-3752). Override with **`JIRA_RHAIENG_TEAM_OPTION_ID`** if your site differs.
 - **Component:** `Notebooks` (unchanged).
+- **Security level:** `Red Hat Employee` by default; **`Embargoed Security Issue`** when any child is embargoed (security level or `EMBARGOED` summary prefix).
+- **Summary:** includes an `EMBARGOED` prefix when children are embargoed (so automation such as jira-autofix can detect embargoed work).
+- **Contributors** (`customfield_10466`): union of Contributors from all blocked RHOAIENG children, plus the authenticated user and optional **`JIRA_RHAIENG_EXTRA_CONTRIBUTORS`** (comma-separated Atlassian accountIds). Required for visibility under embargo ACL (changelog comments may say “involved users” but the field is Contributors).
 
 Requires Jira auth (e.g. `JIRA_EMAIL` + `JIRA_API_TOKEN`, or `JIRA_TOKEN` / OAuth per [`scripts/cve/jira_auth.py`](cve/jira_auth.py)). `JIRA_URL` defaults to `https://redhat.atlassian.net` in code; some docs still mention `issues.redhat.com` for legacy flows.
 

--- a/scripts/cve/create_cve_trackers.py
+++ b/scripts/cve/create_cve_trackers.py
@@ -10,6 +10,10 @@ New trackers always get the literal label ``CVE`` (plus the CVE id and ``securit
 so they are distinguishable from other Bugs, and the Jira **Team** field set to
 **AAIET Notebooks** (``customfield_10001``), matching RHAIENG process.
 
+When any child issue is embargoed, the tracker uses security level
+``Embargoed Security Issue``, keeps an ``EMBARGOED`` summary prefix, and copies
+**Contributors** (``customfield_10466``) from children so the team can view it.
+
 Usage:
     # Dry run - show what would be created
     python scripts/cve/create_cve_trackers.py --dry-run
@@ -44,6 +48,17 @@ RHAIENG_TEAM_CUSTOM_FIELD = "customfield_10001"
 # Option id for team name "AAIET Notebooks" (override if Jira admin changes teams).
 RHAIENG_TEAM_OPTION_ID_DEFAULT = "ec74d716-af36-4b3c-950f-f79213d08f71-62"
 
+# Contributors multi-user picker (changelog text may say "involved users").
+RHAIENG_CONTRIBUTORS_FIELD = "customfield_10466"
+
+EMBARGOED_SECURITY_LEVEL = "Embargoed Security Issue"
+DEFAULT_SECURITY_LEVEL = "Red Hat Employee"
+
+SEARCH_FIELDS = (
+    f"key,summary,status,labels,security,issuelinks,"
+    f"{RHAIENG_TEAM_CUSTOM_FIELD},{RHAIENG_CONTRIBUTORS_FIELD}"
+)
+
 
 def build_tracker_labels(cve_id: str) -> list[str]:
     """Labels for new CVE trackers: keep literal ``CVE`` first (team Jira hygiene)."""
@@ -69,6 +84,8 @@ class CVEInfo:
     issues: list = field(default_factory=list)
     has_tracker: bool = False
     tracker_key: str | None = None
+    is_embargoed: bool = False
+    contributor_account_ids: set[str] = field(default_factory=set)
 
     @property
     def version_suffix(self) -> str:
@@ -97,8 +114,7 @@ def extract_version(summary: str) -> str | None:
 
 
 def extract_description(summary: str, cve_id: str) -> str:
-    """Extract the CVE description from the summary."""
-    # Remove CVE ID prefix
+    """Extract the CVE description from the summary (without EMBARGOED prefix)."""
     desc = summary
     if cve_id in desc:
         desc = desc.split(cve_id, 1)[1].strip()
@@ -113,6 +129,65 @@ def extract_description(summary: str, cve_id: str) -> str:
     desc = re.sub(r"\s*\[rhoai-[\d.]+]\s*$", "", desc)
 
     return desc.strip()
+
+
+def child_is_embargoed(fields: dict) -> bool:
+    """True if a RHOAIENG child issue is under embargo."""
+    security = (fields.get("security") or {}).get("name", "")
+    if security == EMBARGOED_SECURITY_LEVEL:
+        return True
+    return fields.get("summary", "").startswith("EMBARGOED ")
+
+
+def extract_contributor_account_ids(fields: dict) -> set[str]:
+    """Collect accountIds from the Contributors field on an issue."""
+    contributors = fields.get(RHAIENG_CONTRIBUTORS_FIELD) or []
+    ids: set[str] = set()
+    for user in contributors:
+        if isinstance(user, dict):
+            account_id = user.get("accountId")
+            if account_id:
+                ids.add(account_id)
+    return ids
+
+
+def contributors_field_value(account_ids: set[str]) -> list[dict[str, str]]:
+    """Format account ids for Jira multi-user picker REST create/update."""
+    return [{"accountId": aid} for aid in sorted(account_ids)]
+
+
+def parse_extra_contributor_ids() -> set[str]:
+    """Optional extra Contributors from ``JIRA_RHAIENG_EXTRA_CONTRIBUTORS`` (comma-separated accountIds)."""
+    raw = os.environ.get("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", "").strip()
+    if not raw:
+        return set()
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def get_runner_account_id(client: JiraClient) -> str | None:
+    """Account id for the authenticated user (or ``JIRA_RUNNER_ACCOUNT_ID`` override)."""
+    explicit = os.environ.get("JIRA_RUNNER_ACCOUNT_ID", "").strip()
+    if explicit:
+        return explicit
+    try:
+        return client.get_current_user().get("accountId")
+    except Exception:
+        return None
+
+
+def build_tracker_summary(cve_info: CVEInfo) -> str:
+    """Build tracker summary, preserving EMBARGOED prefix when children are embargoed."""
+    prefix = "EMBARGOED " if cve_info.is_embargoed else ""
+    summary = f"{prefix}{cve_info.cve_id} {cve_info.description} {cve_info.version_suffix}".strip()
+
+    if len(summary) > 250:
+        max_desc_len = 250 - len(prefix) - len(cve_info.cve_id) - len(cve_info.version_suffix) - 5
+        summary = (
+            f"{prefix}{cve_info.cve_id} {cve_info.description[:max_desc_len]}... "
+            f"{cve_info.version_suffix}"
+        ).strip()
+
+    return summary
 
 
 def get_blocking_issues(issue: dict) -> list[str]:
@@ -222,8 +297,12 @@ def find_orphan_cves(client: JiraClient, max_results: int = 1000) -> OrphanCVEsR
     # This ensures we only create parent trackers for Notebooks-related CVEs.
 
     # Get all RHOAIENG CVE issues
-    jql = 'project = RHOAIENG AND issuetype in (Bug, Vulnerability, Weakness) AND resolution = Unresolved AND labels = SecurityTracking AND component = "Notebooks Images" ORDER BY created DESC'
-    issues = client.search_issues(jql, fields=f"key,summary,status,labels,issuelinks,{RHAIENG_TEAM_CUSTOM_FIELD}", max_results=max_results)
+    jql = (
+        'project = RHOAIENG AND issuetype in (Bug, Vulnerability, Weakness) '
+        'AND resolution = Unresolved AND labels = SecurityTracking '
+        'AND component = "Notebooks Images" ORDER BY created DESC'
+    )
+    issues = client.search_issues(jql, fields=SEARCH_FIELDS, max_results=max_results)
     print(f"Found {len(issues)} RHOAIENG CVE issues")
 
     # Group by (CVE ID, version)
@@ -269,10 +348,15 @@ def find_orphan_cves(client: JiraClient, max_results: int = 1000) -> OrphanCVEsR
             if desc:
                 info.description = desc
 
+        if child_is_embargoed(fields):
+            info.is_embargoed = True
+
+        info.contributor_account_ids |= extract_contributor_account_ids(fields)
+
         info.issues.append({
             "key": key,
             "summary": summary,
-            "has_parent": has_rhaieng_blocker
+            "has_parent": has_rhaieng_blocker,
         })
 
         if has_rhaieng_blocker:
@@ -288,26 +372,51 @@ def find_orphan_cves(client: JiraClient, max_results: int = 1000) -> OrphanCVEsR
     return OrphanCVEsResult(orphans=orphans, issues=issues)
 
 
-def create_tracker_issue(client: JiraClient, cve_info: CVEInfo, jira_url: str = JIRA_DEFAULT_URL, dry_run: bool = False) -> str | None:
+def resolve_tracker_contributors(client: JiraClient, cve_info: CVEInfo) -> set[str]:
+    """Union of child Contributors, extras, and the script runner."""
+    contributor_ids = set(cve_info.contributor_account_ids)
+    contributor_ids |= parse_extra_contributor_ids()
+    runner_id = get_runner_account_id(client)
+    if runner_id:
+        contributor_ids.add(runner_id)
+    return contributor_ids
+
+
+def format_contributor_labels(contributor_ids: set[str]) -> str:
+    """Short display for dry-run output."""
+    if not contributor_ids:
+        return "(none)"
+    return ", ".join(sorted(contributor_ids))
+
+
+def create_tracker_issue(
+    client: JiraClient,
+    cve_info: CVEInfo,
+    jira_url: str = JIRA_DEFAULT_URL,
+    dry_run: bool = False,
+) -> str | None:
     """Create a tracker issue for a CVE."""
-    summary = f"{cve_info.cve_id} {cve_info.description} {cve_info.version_suffix}"
-
-    # Truncate summary if too long (Jira limit is 255 chars)
-    if len(summary) > 250:
-        max_desc_len = 250 - len(cve_info.cve_id) - len(cve_info.version_suffix) - 5
-        summary = f"{cve_info.cve_id} {cve_info.description[:max_desc_len]}... {cve_info.version_suffix}"
-
+    summary = build_tracker_summary(cve_info)
     description = build_description(cve_info, base_url=jira_url)
 
     labels = build_tracker_labels(cve_info.cve_id)
     team_extra = build_tracker_team_extra_fields()
+    security_level = EMBARGOED_SECURITY_LEVEL if cve_info.is_embargoed else DEFAULT_SECURITY_LEVEL
+
+    contributor_ids = resolve_tracker_contributors(client, cve_info)
+    extra_fields: dict[str, Any] = dict(team_extra)
+    if contributor_ids:
+        extra_fields[RHAIENG_CONTRIBUTORS_FIELD] = contributors_field_value(contributor_ids)
 
     print(f"\n{'[DRY RUN] ' if dry_run else ''}Creating tracker for {cve_info.cve_id}:")
     print(f"  Summary: {summary}")
     print(f"  Version: {cve_info.version}")
+    print(f"  Embargoed: {cve_info.is_embargoed}")
+    print(f"  Security level: {security_level}")
     print(f"  Child issues: {cve_info.issue_count}")
     print(f"  Labels: {' '.join(labels)}")
     print(f"  Team field ({RHAIENG_TEAM_CUSTOM_FIELD}): {team_extra[RHAIENG_TEAM_CUSTOM_FIELD]!r}")
+    print(f"  Contributors ({len(contributor_ids)}): {format_contributor_labels(contributor_ids)}")
 
     if dry_run:
         return None
@@ -320,8 +429,8 @@ def create_tracker_issue(client: JiraClient, cve_info: CVEInfo, jira_url: str = 
             description=description,
             labels=labels,
             components=["Notebooks"],
-            security_level="Red Hat Employee",
-            extra_fields=team_extra,
+            security_level=security_level,
+            extra_fields=extra_fields,
         )
         tracker_key = result.get("key")
         print(f"  Created: {tracker_key}")
@@ -399,16 +508,16 @@ def parse_args():
         epilog="""
 Examples:
   # Dry run - show what would be created
-  python scripts/create_cve_trackers.py --dry-run
+  python scripts/cve/create_cve_trackers.py --dry-run
 
   # Create trackers for all orphan CVEs
-  python scripts/create_cve_trackers.py
+  python scripts/cve/create_cve_trackers.py
 
   # Create tracker for specific CVE
-  python scripts/create_cve_trackers.py --cve CVE-2025-12345
+  python scripts/cve/create_cve_trackers.py --cve CVE-2025-12345
 
   # List orphans without creating
-  python scripts/create_cve_trackers.py --list-only
+  python scripts/cve/create_cve_trackers.py --list-only
 
 Environment variables:
   JIRA_URL                  Jira server URL (default: https://redhat.atlassian.net)
@@ -418,6 +527,10 @@ Environment variables:
   JIRA_TOKEN                Legacy Bearer token (issues.redhat.com PAT)
   JIRA_RHAIENG_TEAM_OPTION_ID  Optional. Jira Team option id for AAIET Notebooks
                             (default: RHAIENG value verified on RHAIENG-3752)
+  JIRA_RHAIENG_EXTRA_CONTRIBUTORS  Optional. Comma-separated Atlassian accountIds
+                            added to tracker Contributors (union with children)
+  JIRA_RUNNER_ACCOUNT_ID    Optional. Override accountId for authenticated user
+                            (default: resolved via /rest/api/3/myself)
 """
     )
     parser.add_argument("--dry-run", action="store_true",
@@ -472,10 +585,13 @@ def main():
 
     for (cve_id, version), info in sorted(orphans.items()):
         version_label = version or "(no version)"
-        print(f"  {cve_id} {version_label}: {info.issue_count} issues")
+        embargo_label = " [EMBARGOED]" if info.is_embargoed else ""
+        print(f"  {cve_id} {version_label}{embargo_label}: {info.issue_count} issues")
         if info.description:
             desc = info.description[:60] + "..." if len(info.description) > 60 else info.description
             print(f"    Description: {desc}")
+        if info.contributor_account_ids:
+            print(f"    Contributors from children: {len(info.contributor_account_ids)}")
 
     if args.list_only:
         return

--- a/scripts/cve/jira_client.py
+++ b/scripts/cve/jira_client.py
@@ -189,3 +189,7 @@ class JiraClient:
     def update_issue(self, issue_key: str, fields: dict) -> None:
         """Update fields on an existing issue."""
         self._request("PUT", f"/rest/api/3/issue/{issue_key}", data={"fields": fields})
+
+    def get_current_user(self) -> dict:
+        """Return the authenticated user (``accountId``, ``displayName``, etc.)."""
+        return self._request("GET", "/rest/api/3/myself")

--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.cve import create_cve_trackers as cct
+
+
+def test_extract_cve_id_from_label_and_summary() -> None:
+    assert cct.extract_cve_id("CVE-2026-8643") == "CVE-2026-8643"
+    assert cct.extract_cve_id("EMBARGOED CVE-2026-8643 foo") == "CVE-2026-8643"
+    assert cct.extract_cve_id("no cve here") is None
+
+
+def test_extract_version() -> None:
+    summary = (
+        "EMBARGOED CVE-2026-8643 rhoai/odh-workbench: flaw [rhoai-2.25]"
+    )
+    assert cct.extract_version(summary) == "rhoai-2.25"
+    assert cct.extract_version("no version suffix") is None
+
+
+def test_extract_description_strips_embargo_and_component() -> None:
+    summary = (
+        "EMBARGOED CVE-2026-8643 rhoai/odh-workbench-jupyter-trustyai: "
+        "Path traversal flaw [rhoai-2.25]"
+    )
+    desc = cct.extract_description(summary, "CVE-2026-8643")
+    assert desc == "Path traversal flaw"
+    assert "EMBARGOED" not in desc
+
+
+def test_child_is_embargoed_security_level() -> None:
+    fields = {"security": {"name": cct.EMBARGOED_SECURITY_LEVEL}, "summary": "CVE-2026-8643 foo"}
+    assert cct.child_is_embargoed(fields) is True
+
+
+def test_child_is_embargoed_summary_prefix() -> None:
+    fields = {"security": {"name": "Red Hat Employee"}, "summary": "EMBARGOED CVE-2026-8643 foo"}
+    assert cct.child_is_embargoed(fields) is True
+
+
+def test_child_is_not_embargoed() -> None:
+    fields = {"security": {"name": "Red Hat Employee"}, "summary": "CVE-2026-8643 foo"}
+    assert cct.child_is_embargoed(fields) is False
+
+
+def test_extract_contributor_account_ids() -> None:
+    fields = {
+        cct.RHAIENG_CONTRIBUTORS_FIELD: [
+            {"accountId": "557058:abc", "displayName": "Jiri Danek"},
+            {"accountId": "606b693110a0a9006fd7ca32", "displayName": "Jay Koehler"},
+        ]
+    }
+    assert cct.extract_contributor_account_ids(fields) == {
+        "557058:abc",
+        "606b693110a0a9006fd7ca32",
+    }
+
+
+def test_contributors_field_value_sorted() -> None:
+    value = cct.contributors_field_value({"b-id", "a-id"})
+    assert value == [{"accountId": "a-id"}, {"accountId": "b-id"}]
+
+
+def test_build_tracker_summary_embargoed() -> None:
+    info = cct.CVEInfo(
+        cve_id="CVE-2026-8643",
+        version="rhoai-2.25",
+        description="Path traversal flaw",
+        is_embargoed=True,
+    )
+    summary = cct.build_tracker_summary(info)
+    assert summary.startswith("EMBARGOED CVE-2026-8643")
+    assert summary.endswith("[rhoai-2.25]")
+
+
+def test_build_tracker_summary_not_embargoed() -> None:
+    info = cct.CVEInfo(
+        cve_id="CVE-2026-8643",
+        version="rhoai-2.25",
+        description="Path traversal flaw",
+        is_embargoed=False,
+    )
+    summary = cct.build_tracker_summary(info)
+    assert not summary.startswith("EMBARGOED")
+    assert summary.startswith("CVE-2026-8643")
+
+
+def test_get_blocking_issues() -> None:
+    issue = {
+        "fields": {
+            "issuelinks": [
+                {
+                    "type": {"name": "Blocks"},
+                    "inwardIssue": {"key": "RHAIENG-5306"},
+                },
+                {
+                    "type": {"name": "Relates"},
+                    "inwardIssue": {"key": "RHAIENG-9999"},
+                },
+            ]
+        }
+    }
+    assert cct.get_blocking_issues(issue) == ["RHAIENG-5306"]
+
+
+def test_parse_extra_contributor_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", " id-one , id-two ")
+    assert cct.parse_extra_contributor_ids() == {"id-one", "id-two"}
+    monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
+    assert cct.parse_extra_contributor_ids() == set()
+
+
+def test_find_orphan_cves_groups_embargo_and_contributors() -> None:
+    class FakeClient:
+        def search_issues(self, jql: str, fields: str, max_results: int = 500) -> list[dict]:
+            return [
+                {
+                    "key": "RHOAIENG-64025",
+                    "fields": {
+                        "summary": (
+                            "EMBARGOED CVE-2026-8643 rhoai/odh-trustyai: flaw [rhoai-2.25]"
+                        ),
+                        "labels": ["SecurityTracking", "CVE-2026-8643"],
+                        "security": {"name": cct.EMBARGOED_SECURITY_LEVEL},
+                        cct.RHAIENG_CONTRIBUTORS_FIELD: [
+                            {"accountId": "user-a"},
+                        ],
+                        "issuelinks": [],
+                    },
+                },
+            ]
+
+    result = cct.find_orphan_cves(FakeClient(), max_results=10)
+    assert len(result.orphans) == 1
+    info = next(iter(result.orphans.values()))
+    assert info.is_embargoed is True
+    assert info.contributor_account_ids == {"user-a"}
+    assert info.cve_id == "CVE-2026-8643"
+    assert info.version == "rhoai-2.25"

--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from scripts.cve import create_cve_trackers as cct
 
 if TYPE_CHECKING:
-    from pytest import MonkeyPatch
+    from pytest import MonkeyPatch, Subtests
+
+    from scripts.cve.jira_client import JiraClient
 
 
-def test_extract_cve_id_from_label_and_summary() -> None:
-    assert cct.extract_cve_id("CVE-2026-8643") == "CVE-2026-8643"
-    assert cct.extract_cve_id("EMBARGOED CVE-2026-8643 foo") == "CVE-2026-8643"
-    assert cct.extract_cve_id("no cve here") is None
+def test_extract_cve_id_from_label_and_summary(subtests: Subtests) -> None:
+    cases = [
+        ("CVE-2026-8643", "CVE-2026-8643"),
+        ("EMBARGOED CVE-2026-8643 foo", "CVE-2026-8643"),
+        ("no cve here", None),
+    ]
+    for raw, expected in cases:
+        with subtests.test(msg=f"extract_cve_id({raw!r})"):
+            assert cct.extract_cve_id(raw) == expected
 
 
-def test_extract_version() -> None:
-    summary = "EMBARGOED CVE-2026-8643 rhoai/odh-workbench: flaw [rhoai-2.25]"
-    assert cct.extract_version(summary) == "rhoai-2.25"
-    assert cct.extract_version("no version suffix") is None
+def test_extract_version(subtests: Subtests) -> None:
+    cases = [
+        ("EMBARGOED CVE-2026-8643 rhoai/odh-workbench: flaw [rhoai-2.25]", "rhoai-2.25"),
+        ("no version suffix", None),
+    ]
+    for summary, expected in cases:
+        with subtests.test(msg=f"extract_version({summary!r})"):
+            assert cct.extract_version(summary) == expected
 
 
 def test_extract_description_strips_embargo_and_component() -> None:
@@ -127,7 +138,7 @@ def test_find_orphan_cves_groups_embargo_and_contributors() -> None:
                 },
             ]
 
-    result = cct.find_orphan_cves(FakeClient(), max_results=10)
+    result = cct.find_orphan_cves(cast("JiraClient", FakeClient()), max_results=10)
     assert len(result.orphans) == 1
     info = next(iter(result.orphans.values()))
     assert info.is_embargoed is True

--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
 from scripts.cve import create_cve_trackers as cct
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
 
 
 def test_extract_cve_id_from_label_and_summary() -> None:
@@ -12,18 +15,13 @@ def test_extract_cve_id_from_label_and_summary() -> None:
 
 
 def test_extract_version() -> None:
-    summary = (
-        "EMBARGOED CVE-2026-8643 rhoai/odh-workbench: flaw [rhoai-2.25]"
-    )
+    summary = "EMBARGOED CVE-2026-8643 rhoai/odh-workbench: flaw [rhoai-2.25]"
     assert cct.extract_version(summary) == "rhoai-2.25"
     assert cct.extract_version("no version suffix") is None
 
 
 def test_extract_description_strips_embargo_and_component() -> None:
-    summary = (
-        "EMBARGOED CVE-2026-8643 rhoai/odh-workbench-jupyter-trustyai: "
-        "Path traversal flaw [rhoai-2.25]"
-    )
+    summary = "EMBARGOED CVE-2026-8643 rhoai/odh-workbench-jupyter-trustyai: Path traversal flaw [rhoai-2.25]"
     desc = cct.extract_description(summary, "CVE-2026-8643")
     assert desc == "Path traversal flaw"
     assert "EMBARGOED" not in desc
@@ -104,7 +102,7 @@ def test_get_blocking_issues() -> None:
     assert cct.get_blocking_issues(issue) == ["RHAIENG-5306"]
 
 
-def test_parse_extra_contributor_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_parse_extra_contributor_ids(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", " id-one , id-two ")
     assert cct.parse_extra_contributor_ids() == {"id-one", "id-two"}
     monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
@@ -118,9 +116,7 @@ def test_find_orphan_cves_groups_embargo_and_contributors() -> None:
                 {
                     "key": "RHOAIENG-64025",
                     "fields": {
-                        "summary": (
-                            "EMBARGOED CVE-2026-8643 rhoai/odh-trustyai: flaw [rhoai-2.25]"
-                        ),
+                        "summary": ("EMBARGOED CVE-2026-8643 rhoai/odh-trustyai: flaw [rhoai-2.25]"),
                         "labels": ["SecurityTracking", "CVE-2026-8643"],
                         "security": {"name": cct.EMBARGOED_SECURITY_LEVEL},
                         cct.RHAIENG_CONTRIBUTORS_FIELD: [


### PR DESCRIPTION
Fixes [RHAIENG-5352](https://redhat.atlassian.net/browse/RHAIENG-5352): Create embargoed trackers for embargoed issues

## Summary

- When creating RHAIENG parent trackers from RHOAIENG CVE children, detect embargoed children (`Embargoed Security Issue` or `EMBARGOED` summary prefix) and set the tracker security level and summary accordingly so **jira-autofix** and similar automation skip the work.
- Copy **Contributors** (`customfield_10466`) from all children onto the new tracker (plus the authenticated user and optional `JIRA_RHAIENG_EXTRA_CONTRIBUTORS`) so engineers can view embargoed trackers under the PSIRT ACL.
- Add unit tests for parsing, embargo detection, contributor union, and orphan grouping; document behavior in `scripts/README.md`.

## Context

Follow-up to CVE-2026-8643 handling: RHAIENG trackers created without embargo metadata or Contributors were visible to autofix and inaccessible to the Notebooks team until fixed manually (see [RHAIENG-5306](https://redhat.atlassian.net/browse/RHAIENG-5306) / child pattern [RHOAIENG-64025](https://redhat.atlassian.net/browse/RHOAIENG-64025)).

## Test plan

- [x] `uv run pytest tests/unit/scripts/cve/test_create_cve_trackers.py`
- [x] `uv run ruff check scripts/cve/create_cve_trackers.py tests/unit/scripts/cve/test_create_cve_trackers.py`
- [x] `uv run python scripts/cve/create_cve_trackers.py --dry-run` (with Jira credentials) and verify embargo groups show correct security level and Contributors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CVE trackers now detect embargoed children (via security level or summary prefix), set appropriate security level, and preserve an "EMBARGOED" summary prefix.
  * Tracker issues now aggregate and set contributor accounts (including optional extra and runner accounts) and show contributor counts.

* **Documentation**
  * Updated script CLI docs and README to describe embargo behavior, contributor handling, env vars, and dry-run output.

* **Tests**
  * Added tests covering embargo detection, contributor extraction, summary formatting, and orphan grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->