### PR TITLE
fix(renovate): raise hourly PR cap for self-hosted runs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,6 +29,7 @@
   "autodiscover": false,
   "pruneStaleBranches": false,
   "branchConcurrentLimit": 0,
+  "prHourlyLimit": 6,
   "customEnvVariables": {
     "GOTOOLCHAIN": "auto",
   },


### PR DESCRIPTION
Related to: https://redhat.atlassian.net/browse/RHAIENG-4906

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow Renovate to open up to five PRs per hour so a single self-hosted run can surface eligible image updates instead of deferring some to a later rerun.

The ROCm 7.1 update was not missed by detection. The more likely root cause is Renovate’s PR creation pacing.

Evidence:

Scheduled self-hosted Renovate run #80 started at 06:22:46Z
It created two PRs immediately:
CPU PR #3764 at 06:24:19Z
CUDA 12.9 PR #3765 at 06:24:24Z
The ROCm tag 3.5.0-ea.2-1779922162 was already available before that run; its timestamp suffix decodes to 2026-05-27T22:49:22Z
Manual rerun #81 started at 08:07:35Z
That rerun then created ROCm PR #3767 at 08:08:55Z
This pattern is consistent with Renovate hitting its hourly PR creation limit during the scheduled run: it opened the first two eligible PRs, then deferred the next one until a later run. In other words, the second trigger was needed to open the ROCm PR, not to discover the update.

This also matches Renovate’s built-in pacing defaults, where prHourlyLimit is effectively 2 unless explicitly overridden. branchConcurrentLimit: 0 does not help here, because it controls concurrent branches, not hourly PR creation.

Conclusion

ROCm required the second trigger because the scheduled run likely exhausted Renovate’s hourly PR budget after creating the CPU and CUDA 12.9 PRs.
CUDA 13.0 is a separate issue: that update was blocked by the stale PR Edited (Blocked) state in Dependency Dashboard #3357, so it was not eligible for normal PR creation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration: adjusted the automated pull-request rate limit to allow up to 6 PRs per hour. This reduces sprawl of renovate PRs while keeping automation active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->