### PR TITLE
RHAIENG-5340: fix(AGENTS.md): add CVE autofix agent instructions for jira-autofix bot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ and follow linked documents for topic-specific detail.
 | [docs/subscribed-builds.md](docs/subscribed-builds.md) | You need local AIPCC / subscribed builds |
 | [docs/uv-guide.md](docs/uv-guide.md) | You are changing Python dependencies beyond the quick path in `CONTRIBUTING.md` |
 | [docs/cves/python.md](docs/cves/python.md) / [docs/cves/nodejs.md](docs/cves/nodejs.md) | You are fixing CVEs or lockfile-driven security updates |
+| [docs/cves/agents-cve-autofix.md](docs/cves/agents-cve-autofix.md) | You are an automated CVE fix agent (jira-autofix) |
 | [`.github/AGENTS.md`](.github/AGENTS.md) | You are editing GitHub Actions or action metadata |
 | [`tests/browser/AGENTS.md`](tests/browser/AGENTS.md) | You are editing Playwright tests or browser tooling |
 | [docs/agents/testing.md](docs/agents/testing.md) | You need the test catalog: types, markers, commands, CI parity |
@@ -109,6 +110,15 @@ Use formatting: bold, italics and code blocks.
 - Python 3.14: `except ExcA, ExcB:` (no parentheses) is valid when there is no
   `as` clause (PEP 758). Ruff format enforces this style. Parentheses are still
   required when binding: `except (ExcA, ExcB) as e:`.
+
+## Commit and PR title style
+
+Preferred format: `TICKET: scope: description in imperative mood`
+
+Scope follows [Conventional Commits](https://www.conventionalcommits.org/)
+(`chore`, `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, etc.), optionally
+with a directory hint like `chore(.tekton/)` or `fix(jupyter/trustyai)`.
+Most dependency/CVE work is `chore`. See `.coderabbit.yaml` for validation rules.
 
 ## Repo-specific reminders
 

--- a/docs/cves/agents-cve-autofix.md
+++ b/docs/cves/agents-cve-autofix.md
@@ -1,0 +1,119 @@
+# CVE Autofix Agent Instructions
+
+Instructions for the AIPCC jira-autofix bot (triage and fix agents).
+
+## Jira project glossary
+
+- **RHOAIENG** — per-image downstream vulnerability trackers filed by Product Security
+  (one issue per container image per release branch)
+- **RHAIENG** — aggregate upstream tracker that groups all images for a single CVE
+  and release; this is the ticket that should be fixed
+
+## Triage: when to reject (verdict: `not_fixable`)
+
+RHOAIENG Vulnerability tickets are per-image trackers. They should NOT be
+fixed individually.
+
+A parent RHAIENG tracker issue is created (or will be shortly) that groups
+all affected images for that CVE and release. The fix is best applied once
+in `dependencies/cve-constraints.txt` which covers all images, rather than
+piecemeal per-image changes to individual `pyproject.toml` files.
+
+Verdict: `not_fixable` with reason:
+"Per-image RHOAIENG CVE tracker — fix is applied via the parent RHAIENG
+tracker which covers all images at once through cve-constraints.txt."
+
+## RHAIENG CVE trackers: fix on downstream release branch
+
+RHAIENG Bug/tracker tickets for CVEs must be fixed on the **downstream**
+repository and the release branch indicated in the title:
+
+- **Repo**: `https://github.com/red-hat-data-services/notebooks`
+- **Branch**: `rhoai-X.Y` (extract from the `[rhoai-X.Y]` suffix in the title)
+
+Do NOT fix these on `opendatahub-io/notebooks` `main`. The release branch
+on the downstream repo is where the vulnerable pinned dependency lives.
+Dependencies on `main` are regularly updated to latest and CVEs are
+typically already resolved there.
+
+**Gather context from linked issues:** The RHAIENG tracker blocks multiple
+RHOAIENG per-image child tickets. Fetch those linked issues and read their
+comments — they often contain useful details about which specific packages
+are affected, which images have the vulnerability, version constraints from
+Product Security, or notes from engineers who investigated earlier.
+
+## Before creating a PR: dedup checks
+
+1. Check `dependencies/cve-constraints.txt` on the target branch — if the
+   package constraint already exists at the required version, the fix is
+   already present. Verdict: `already_fixed`.
+
+2. Search open PRs for the same CVE ID **on the same target branch**:
+   `gh pr list --repo red-hat-data-services/notebooks --search "CVE-YYYY-NNNNN" --base rhoai-X.Y --state open`
+   If a PR already exists for this CVE on the same branch, do not create another.
+   A PR targeting a different branch does NOT count as a duplicate.
+   Verdict: `already_fixed`.
+
+## Fix pattern
+
+CVE Python dependency fixes use a **single centralized file**. Do NOT add
+`override-dependencies` entries to individual `pyproject.toml` files.
+
+1. Add one line to `dependencies/cve-constraints.txt`:
+   ```text
+   # RHAIENG-NNNN: CVE-YYYY-XXXXX <description>
+   package>=fixed_version
+   ```
+2. Run `make refresh-lock-files` to regenerate all image lock files.
+3. Commit both the constraint file and the regenerated locks.
+
+One PR per CVE. Never combine multiple CVEs in one PR.
+See existing entries in `dependencies/cve-constraints.txt` for format examples.
+
+## Iteration: when to stop
+
+If the fix is already present on the target branch (constraint exists in
+`cve-constraints.txt` at the required version), produce verdict: `no_changes`.
+Do not push commits, do not modify files.
+
+## Operator reference: bot labels and states
+
+The jira-autofix bot uses Jira labels as its state machine:
+
+| Label | Meaning |
+|-------|---------|
+| `jira-autofix` | Ticket ready for bot pickup |
+| `jira-autofix-review` | PR created, bot is iterating on feedback |
+| `jira-autofix-merged` | PR merged (terminal) |
+| `jira-autofix-rejected` | PR closed without merge (terminal) |
+| `jira-autofix-max-retries` | Bot hit iteration limit (terminal) |
+| `jira-autofix-blocked` | Bot needs human input (terminal) |
+| `no-autofix` | **Opt-out** — bot will never process this ticket |
+
+To immediately stop the bot from iterating on a ticket, add the
+`no-autofix` label. This is the fastest escape hatch and requires no
+code changes or PR closures.
+
+## Operator reference: verdict values
+
+The bot produces a verdict JSON at the end of each run. Valid verdicts:
+
+**Triage verdicts** (written to `.triage-verdict.json`):
+
+| Verdict | Effect |
+|---------|--------|
+| `ready` | Ticket gets `jira-autofix` label, enters fix pipeline |
+| `needs_info` | Bot comments asking for clarification |
+| `not_fixable` | Ticket labeled unsuitable for automated fixing |
+
+**Autofix verdicts** (written to `autofix-output/.autofix-verdict.json`):
+
+| Verdict | Effect |
+|---------|--------|
+| `committed` | Changes pushed, PR created or updated |
+| `already_fixed` | Fix already present on target branch; no PR created |
+| `no_changes` | Nothing to do (iteration: silently skips) |
+| `not_a_bug` | Ticket describes expected behavior |
+| `insufficient_info` | Not enough context to proceed → `jira-autofix-blocked` |
+| `blocked` | Cannot proceed (e.g., missing repo URL) → `jira-autofix-blocked` |
+| `research` | Findings posted as Jira comment, no PR |


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5340

## Summary

- Add `docs/cves/agents-cve-autofix.md` with instructions the jira-autofix bot reads during triage and fix phases
- Add pointer row in `AGENTS.md` "Start here" table

The AIPCC jira-autofix bot (powered by Claude Code) reads `AGENTS.md` from the cloned repo when triaging and fixing tickets. These instructions tell it to:

1. **Reject RHOAIENG per-image CVE tickets** targeting release branches — they are not fixable on `main` (verdict: `not_fixable`)
2. **Direct RHAIENG CVE trackers** with `[rhoai-X.Y]` to the downstream repo (`red-hat-data-services/notebooks`) on the correct release branch
3. **Check for duplicates** before creating PRs (existing constraints, open PRs, Jira blocker links)
4. **Use the centralized `cve-constraints.txt` pattern** — never scatter `override-dependencies` across per-image `pyproject.toml` files

## Context

CVE-2026-48710 generated 25 duplicate PRs from the bot, 21 still open, costing an estimated $500-800+ in Claude API. Root cause analysis posted to #wg-rhai-ai-first-code-autofix. This PR addresses the repo-level preventive layer while upstream fixes are discussed with the bot team.

## Test plan

- [ ] Verify `docs/cves/agents-cve-autofix.md` renders correctly
- [ ] Verify AGENTS.md table row links correctly
- [ ] Monitor next bot triage run for RHOAIENG tickets — should produce `not_fixable` verdicts

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Start here” entry for the automated CVE autofix agent.
  * Added detailed agent docs describing triage rules, standardized constraint-based fix workflow, pre-PR deduplication checks, stop conditions when no changes are needed, downstream routing guidance, and operator reference including bot labels and opt-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->