### PR TITLE
RHAIENG-5321: test: remove stale _KNOWN_EVR_MISMATCHES entries

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -871,13 +871,7 @@ def _collect_rpms_lock_files() -> list[pathlib.Path]:
     return files
 
 
-# RHOAIENG-45152: these packages have arch-specific builds upstream
-_KNOWN_EVR_MISMATCHES: frozenset[str] = frozenset(
-    {
-        "iptables-libs",
-        "openshift-clients",
-    }
-)
+_KNOWN_EVR_MISMATCHES: frozenset[str] = frozenset()
 
 
 @pytest.mark.parametrize("lockfile", _collect_rpms_lock_files(), ids=lambda p: str(p.relative_to(PROJECT_ROOT)))


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5321

## Summary

- Clear the `_KNOWN_EVR_MISMATCHES` frozenset (was `iptables-libs`, `openshift-clients`)
- `iptables-libs` is no longer present in any RHDS `rpms.lock.yaml`
- `openshift-clients` currently has identical EVR across all four arches in both lockfiles
- The xfail mechanism is preserved for future use if legitimate arch-specific EVR differences arise

Both entries were bootstrapping workarounds from when the test was first introduced ([RHAIENG-5012](https://redhat.atlassian.net/browse/RHAIENG-5012)). Clearing them makes the test strictly enforce EVR consistency without silent xfails.

## Test plan

- [x] `make test` passes (no xfails triggered since both packages are already consistent)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated package consistency validation to enforce stricter testing requirements for package versions across different architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->