### PR TITLE
RHAIENG-5321: test: document why RPM lockfile check is RHDS-only

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -866,6 +866,7 @@ class Manifest:
 
 
 def _collect_rpms_lock_files() -> list[pathlib.Path]:
+    # RHDS only: ODH images are not subject to Conforma rpm_packages.unique_version policy (47517e5ca).
     files = sorted(PROJECT_ROOT.glob("**/prefetch-input/rhds/rpms.lock.yaml"))
     assert files, "No RHDS rpms.lock.yaml files found under PROJECT_ROOT"
     return files


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5321

## Summary

- Add a one-line comment to `_collect_rpms_lock_files` explaining that the RHDS-only scope is intentional
- The restriction was introduced in `47517e5ca` without rationale in the commit message
- ODH images are not subject to Conforma's `rpm_packages.unique_version` policy, so checking their lockfiles adds no value

## Test plan

- [x] No functional change -- comment only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added clarification in test infrastructure documentation.

---

**Note:** This release contains internal documentation updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->