### PR TITLE
RHAIENG-5321: docs: document base-image RPM drift gap

### DIFF
--- a/docs/conforma.md
+++ b/docs/conforma.md
@@ -149,9 +149,34 @@ The ones most relevant to notebook images:
 | `slsa_provenance_available` | SLSA provenance attestation must exist. |
 | `hermetic_task` / `trusted_task` | Build must run in a hermetic, trusted Tekton task. |
 | `labels` | Required container labels (see above). |
+| `rpm_packages.unique_version` | Every RPM in a multi-arch image index must have the same version across all architectures. |
 
 Policy data (allowed RPM keys, disallowed attributes, CVE windows) is configured in
 [`rhtap-ec-policy/data/rule_data.yml`](https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/rule_data.yml).
+
+## Base-image RPM drift across architectures
+
+The repo's `test_rpms_lock_nvr_consistency_across_arches` test validates that
+RPMs pinned in `rpms.lock.yaml` have the same EVR across all architectures. It
+**does not** cover RPMs inherited from the base image (`FROM ${BASE_IMAGE}`).
+
+System packages like `openssl`, `python3`, etc. are baked into the UBI9 base
+image. If one architecture's base image has not been rebuilt with the latest
+RPMs (e.g. s390x repos lagging behind), the final multi-arch image index will
+have different versions per arch — even though the lockfile is consistent.
+
+Conforma's `rpm_packages.unique_version` policy catches this class of issue
+post-build. There is no pre-build defense in this repo.
+
+**Fix:** rebuild once the base image is updated for the affected architecture.
+Regenerating `rpms.lock.yaml` will not help because the mismatch comes from the
+base image, not from lockfile-installed RPMs.
+
+Historical example:
+[RHAIENG-5321](https://redhat.atlassian.net/browse/RHAIENG-5321) — s390x UBI9
+had older `openssl` (3.2.2-6.el9\_5.1 vs 3.2.2-7.el9\_6.2) and `python3`
+(3.9.21-2.el9\_6.2 vs 3.9.21-2.el9\_6.5) while the lockfile had matching
+versions across all arches.
 
 ## Policy exceptions
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -882,7 +882,13 @@ _KNOWN_EVR_MISMATCHES: frozenset[str] = frozenset(
 
 @pytest.mark.parametrize("lockfile", _collect_rpms_lock_files(), ids=lambda p: str(p.relative_to(PROJECT_ROOT)))
 def test_rpms_lock_nvr_consistency_across_arches(subtests: pytest_subtests.plugin.SubTests, lockfile: pathlib.Path):
-    """Assert that every RPM name pinned in RHDS rpms.lock.yaml has the same EVR across all architectures."""
+    """Assert that every RPM name pinned in RHDS rpms.lock.yaml has the same EVR across all architectures.
+
+    This only validates lockfile-installed RPMs. Packages inherited from the base
+    image (e.g. openssl, python3) are not covered here; cross-arch consistency for
+    those is enforced by Conforma's rpm_packages.unique_version policy post-build.
+    See RHAIENG-5321.
+    """
     data = yaml.safe_load(lockfile.read_text())
     arches = data.get("arches", [])
     if len(arches) <= 1:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5321

## Summary

- Add `rpm_packages.unique_version` to the Conforma policy checks table in `docs/conforma.md`
- Add a new "Base-image RPM drift across architectures" section explaining:
  - The lockfile consistency test only covers lockfile-installed RPMs
  - System packages from the base image (openssl, python3, etc.) are not covered
  - Conforma is the only defense against cross-arch base-image RPM drift
  - Fix is to rebuild after the base image is updated, not to regenerate the lockfile
  - References [RHAIENG-5321](https://redhat.atlassian.net/browse/RHAIENG-5321) as historical example
- Extend `test_rpms_lock_nvr_consistency_across_arches` docstring with a scope note

## Test plan

- [x] Documentation and docstring change only -- no functional impact

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended policy checks documentation with new `rpm_packages.unique_version` entry.
  * Added section explaining base-image RPM drift detection across architectures with remediation guidance and historical example.

* **Tests**
  * Clarified test documentation for RPM consistency validation scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->