### PR TITLE
RHAIENG-5446: Increase pip prefetch download timeouts for both GHA and Konflux

### DIFF
--- a/.tekton/multiarch-odh-main-combined-pipeline.yaml
+++ b/.tekton/multiarch-odh-main-combined-pipeline.yaml
@@ -231,6 +231,7 @@ spec:
       workspace: git-auth
 
   - name: prefetch-dependencies
+    timeout: 3h
     params:
     - name: input
       value: $(params.prefetch-input)
@@ -240,6 +241,16 @@ spec:
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
+    # Hermeto timeouts for large pip wheels (e.g. torch >1GB). See:
+    # https://github.com/konflux-ci/build-definitions/tree/main/task/prefetch-dependencies-oci-ta/0.3
+    # https://github.com/hermetoproject/hermeto#configuration
+    - name: config-file-content
+      value: |
+        http:
+          read_timeout: 900
+        runtime:
+          concurrency_limit: 8
+          subprocess_timeout: 3600
     runAfter:
     - clone-repository
     taskRef:

--- a/scripts/lockfile-generators/helpers/download-pip-packages.py
+++ b/scripts/lockfile-generators/helpers/download-pip-packages.py
@@ -40,6 +40,12 @@ PYPI_JSON = "https://pypi.org/pypi/{name}/{version}/json"
 # uv uses 50 by default (astral-sh/uv#10570 discusses reducing to 20 for stability).
 # At 10: stable 22s, at 20: 13s, at 50: 12s but high variance (Akamai throttling).
 MAX_WORKERS = 20
+# wget --timeout sets dns/connect/read idle timeouts (not total transfer time).
+# Large wheels (e.g. torch >1GB) need a generous read idle window on slow links.
+WGET_NETWORK_TIMEOUT_SECONDS = 300
+# Per-file wall-clock cap for subprocess.run(); must cover multi-GB wheels when
+# MAX_WORKERS parallel downloads share CI bandwidth (~1GB at ~1 MB/s ≈ 17 min).
+DOWNLOAD_PROCESS_TIMEOUT_SECONDS = 3600
 
 ARCH_ALIASES: dict[str, list[str]] = {
     "amd64": ["x86_64", "amd64"],
@@ -252,8 +258,13 @@ def download_one(args: tuple) -> tuple[bool, str]:
     url, dest_path, expected_hash = args
     try:
         subprocess.run(
-            ["wget", "-q", "-O", str(dest_path), "--tries=3", "--waitretry=2", "--timeout=30", url],
-            check=True, timeout=120,
+            [
+                "wget", "-q", "-O", str(dest_path),
+                "--tries=3", "--waitretry=2",
+                f"--timeout={WGET_NETWORK_TIMEOUT_SECONDS}",
+                url,
+            ],
+            check=True, timeout=DOWNLOAD_PROCESS_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
         Path(dest_path).unlink(missing_ok=True)


### PR DESCRIPTION
[RHAIENG-5446](https://redhat.atlassian.net/browse/RHAIENG-5446): Increase pip prefetch download timeouts for both GHA and Konflux

## Description
- Increase pip download timeouts in scripts/lockfile-generators/helpers/download-pip-packages.py
- Increase timeouts in .tekton/multiarch-odh-main-combined-pipeline.yaml

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended timeout settings in the build pipeline for dependency prefetching, including longer read and subprocess timeouts and a runtime concurrency limit.
  * Updated package download process to use configurable network and subprocess timeouts for individual downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->