### PR TITLE
fix(.github/workflows): upload kernel logs and test JUnit XML as CI artifacts

### DIFF
--- a/.github/actions/playwright-test/action.yml
+++ b/.github/actions/playwright-test/action.yml
@@ -31,17 +31,29 @@ inputs:
     required: false
     default: 'tests/browser'
   upload-report:
-    description: 'Whether to upload the Playwright report as an artifact'
+    description: 'Whether to upload the Playwright HTML report as an artifact'
     required: false
     default: 'false'
+  upload-junit:
+    description: 'Whether to upload the Playwright JUnit XML report as an uncompressed artifact'
+    required: false
+    default: 'true'
   artifact-name:
-    description: 'Name for the uploaded artifact (required if upload-report is true)'
+    description: 'Name for the uploaded HTML report artifact (required if upload-report is true)'
     required: false
     default: 'playwright-report'
+  junit-artifact-file:
+    description: 'Filename for the uploaded JUnit XML (upload-artifact v7 archive:false uses the filename as the artifact name)'
+    required: false
+    default: ''
   artifact-retention-days:
-    description: 'Number of days to retain the artifact'
+    description: 'Number of days to retain the HTML report artifact'
     required: false
     default: '30'
+  junit-retention-days:
+    description: 'Number of days to retain the JUnit XML artifact'
+    required: false
+    default: '14'
   grep-pattern:
     description: 'Grep pattern passed to --grep to filter tests (e.g. "@codeserver", "@smoke"). Empty string runs all tests.'
     required: false
@@ -129,6 +141,44 @@ runs:
         PLAYWRIGHT_VERSION: ${{ steps.playwright-version.outputs.version }}
         PNPM_VERSION: ${{ steps.pnpm-version.outputs.version }}
         GREP_PATTERN: ${{ inputs.grep-pattern }}
+
+    - name: Stage Playwright JUnit XML
+      id: stage-junit
+      if: ${{ !cancelled() && inputs.upload-junit == 'true' }}
+      shell: bash
+      run: |
+        set -Eeuxo pipefail
+        src="${WORKING_DIRECTORY}/results/junit.xml"
+        if [[ -n "${JUNIT_ARTIFACT_FILE}" ]]; then
+          artifact_file="${JUNIT_ARTIFACT_FILE}"
+        else
+          artifact_file="${ARTIFACT_NAME/_playwright-report/_playwright-junit.xml}"
+          if [[ "${artifact_file}" == "${ARTIFACT_NAME}" ]]; then
+            artifact_file="${ARTIFACT_NAME}-junit.xml"
+          fi
+        fi
+        dest="${RUNNER_TEMP}/playwright-reports/${artifact_file}"
+        mkdir -p "$(dirname "${dest}")"
+        if [[ -f "${src}" ]]; then
+          cp "${src}" "${dest}"
+          echo "path=${dest}" >> "${GITHUB_OUTPUT}"
+          echo "Staged Playwright JUnit XML at ${dest}"
+        else
+          echo "::warning::Playwright JUnit XML not found at ${src}"
+        fi
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        JUNIT_ARTIFACT_FILE: ${{ inputs.junit-artifact-file }}
+
+    - name: Upload Playwright JUnit XML
+      if: ${{ always() && !cancelled() && inputs.upload-junit == 'true' && steps.stage-junit.outputs.path != '' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        path: ${{ steps.stage-junit.outputs.path }}
+        archive: false
+        retention-days: ${{ inputs.junit-retention-days }}
+        if-no-files-found: warn
 
     - name: Upload Playwright report
       if: ${{ !cancelled() && inputs.upload-report == 'true' }}

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -666,10 +666,33 @@ jobs:
           fi
         if: "${{ !cancelled() && steps.install-compsize.outcome == 'success' }}"
 
-      # print system logs, useful when hunting for OOM kills
-
-      - run: sudo dmesg
+      # Capture kernel logs on failure (OOM debugging); upload as uncompressed artifacts instead of flooding job logs
+      - name: Capture kernel logs
         if: "${{ failure() }}"
+        env:
+          LOG_PREFIX: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}"
+        run: |
+          set -euo pipefail
+          log_dir="${RUNNER_TEMP}/kernel-logs"
+          mkdir -p "${log_dir}"
+          sudo dmesg > "${log_dir}/${LOG_PREFIX}_dmesg.log"
+          sudo journalctl --no-pager -k > "${log_dir}/${LOG_PREFIX}_journalctl-k.log"
+          echo "Kernel logs captured in ${log_dir}/"
 
-      - run: journalctl --no-pager -k
+      - name: Upload dmesg log
         if: "${{ failure() }}"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: "${{ runner.temp }}/kernel-logs/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_dmesg.log"
+          archive: false
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload journalctl kernel log
+        if: "${{ failure() }}"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: "${{ runner.temp }}/kernel-logs/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_journalctl-k.log"
+          archive: false
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -465,14 +465,25 @@ jobs:
       - name: Run Testcontainers container tests (in PyTest)
         id: pytest-testcontainers
         if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
-        run: |
-          set -Eeuxo pipefail
-          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
           # pulling the Ryuk container from docker.io introduces CI flakiness
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_testcontainers-junit.xml"
+        run: |
+          set -Eeuxo pipefail
+          mkdir -p "$(dirname "${JUNIT_XML}")"
+          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}" --junitxml="${JUNIT_XML}"
+
+      - name: Upload Testcontainers pytest JUnit XML
+        if: ${{ always() && steps.pytest-testcontainers.conclusion != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_testcontainers-junit.xml"
+          archive: false
+          retention-days: 14
+          if-no-files-found: warn
 
       # endregion Pytest image tests
 
@@ -526,15 +537,26 @@ jobs:
       - name: Run OpenShift container tests (in PyTest)
         id: pytest-openshift
         if: ${{ !cancelled() && steps.make-target.outcome == 'success' && steps.provision-k8s.outcome == 'success' && steps.have-tests.outputs.tests == 'true' }}
-        run: |
-          set -Eeuxo pipefail
-          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
         env:
           # TODO(jdanek): this Testcontainers stuff should not be necessary but currently it has to be there
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
           # pulling the Ryuk container from docker.io introduces CI flakiness
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_openshift-junit.xml"
+        run: |
+          set -Eeuxo pipefail
+          mkdir -p "$(dirname "${JUNIT_XML}")"
+          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}" --junitxml="${JUNIT_XML}"
+
+      - name: Upload OpenShift pytest JUnit XML
+        if: ${{ always() && steps.pytest-openshift.conclusion != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_openshift-junit.xml"
+          archive: false
+          retention-days: 14
+          if-no-files-found: warn
 
       # region Trivy vulnerability scan
 
@@ -651,6 +673,7 @@ jobs:
           podman-socket: /var/run/podman/podman.sock
           upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
           artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
+          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
           grep-pattern: '@codeserver'
 
       # endregion

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -470,11 +470,12 @@ jobs:
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
           # pulling the Ryuk container from docker.io introduces CI flakiness
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          OUTPUT_IMAGE: "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
           JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_testcontainers-junit.xml"
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}" --junitxml="${JUNIT_XML}"
+          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
 
       - name: Upload Testcontainers pytest JUnit XML
         if: ${{ always() && steps.pytest-testcontainers.conclusion != 'skipped' }}
@@ -543,11 +544,12 @@ jobs:
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
           # pulling the Ryuk container from docker.io introduces CI flakiness
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          OUTPUT_IMAGE: "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
           JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_openshift-junit.xml"
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}" --junitxml="${JUNIT_XML}"
+          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
 
       - name: Upload OpenShift pytest JUnit XML
         if: ${{ always() && steps.pytest-openshift.conclusion != 'skipped' }}

--- a/.github/workflows/test-playwright-action.yaml
+++ b/.github/workflows/test-playwright-action.yaml
@@ -127,4 +127,5 @@ jobs:
           podman-socket: /var/run/podman/podman.sock
           upload-report: 'true'
           artifact-name: playwright-action-test-report
+          junit-artifact-file: playwright-action-test-junit.xml
           grep-pattern: '@codeserver'


### PR DESCRIPTION
## Summary

- On matrix build failure, capture `dmesg` and `journalctl -k` to per-job files and upload them with `upload-artifact` v7 `archive: false` instead of dumping kernel logs into the job log tail
- Emit matrix-scoped pytest JUnit XML for Testcontainers and OpenShift container test steps, uploaded uncompressed on `always()`
- Stage and upload Playwright JUnit XML from the composite `playwright-test` action (`archive: false`); HTML Playwright report upload behavior unchanged

These changes make CI failures easier to inspect without downloading zipped HTML reports or wading through post-failure kernel cleanup noise in job logs.

## Test plan

- [x] Trigger a matrix PR build and confirm artifacts appear for pytest JUnit XML when test steps run — verified in [Test Build Notebooks Template run](https://github.com/opendatahub-io/notebooks/actions/runs/27063980937): uploaded `jupyter-minimal-ubi9-python-3.12_odh_linux_amd64_testcontainers-junit.xml` (38 707 B) and `…_openshift-junit.xml` (511 B); upload steps succeeded
- [x] On a codeserver matrix cell, confirm Playwright JUnit XML artifact is uploaded — verified via the same composite action in [Test Playwright Action run](https://github.com/opendatahub-io/notebooks/actions/runs/27063980895): uploaded `playwright-action-test-junit.xml` (2 189 107 B, `archive: false`); codeserver matrix cell not in this PR’s path-filtered CI, but action code path matches
- [x] On a forced matrix failure, confirm kernel log artifacts upload without dmesg/journalctl spam in the main job log — success-path verified in [template run](https://github.com/opendatahub-io/notebooks/actions/runs/27063980937): `Capture kernel logs` / upload steps correctly **skipped** on success and job log contains no `dmesg`/`journalctl` output; steps are gated on `failure()` and redirect to `${RUNNER_TEMP}/kernel-logs/*.log` before upload

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playwright and container-based tests now produce JUnit XML which is staged and uploaded as artifacts with configurable filenames and retention.
  * Workflows pass JUnit output through the test action so Playwright results are saved alongside pytest results.

* **Chores**
  * CI workflows and the test action inputs were updated to standardize JUnit artifact handling and conditional upload behavior.
* **Bug Fixes**
  * Failure logging now archives system/kernel logs as artifacts for post-mortem debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->