### PR TITLE
fix(deps): pin uv environments to Python 3.12.* for cp312 images

### DIFF
--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 override-dependencies = [

--- a/dependencies/odh-notebooks-meta-db-connectors-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-db-connectors-deps/pyproject.toml
@@ -14,5 +14,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/dependencies/odh-notebooks-meta-jupyterlab-datascience-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-jupyterlab-datascience-deps/pyproject.toml
@@ -15,5 +15,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/dependencies/odh-notebooks-meta-jupyterlab-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-jupyterlab-deps/pyproject.toml
@@ -18,5 +18,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/dependencies/odh-notebooks-meta-llmcompressor-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-llmcompressor-deps/pyproject.toml
@@ -27,5 +27,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/dependencies/odh-notebooks-meta-runtime-datascience-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-runtime-datascience-deps/pyproject.toml
@@ -32,5 +32,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/dependencies/odh-notebooks-meta-runtime-elyra-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-runtime-elyra-deps/pyproject.toml
@@ -29,5 +29,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/dependencies/odh-notebooks-meta-workbench-datascience-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-workbench-datascience-deps/pyproject.toml
@@ -34,5 +34,5 @@ dependencies = [
 package = false
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 override-dependencies = [

--- a/jupyter/minimal/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pyproject.toml
@@ -19,5 +19,5 @@ odh-notebooks-meta-jupyterlab-deps = { path = "../../../dependencies/odh-noteboo
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -57,7 +57,7 @@ odh-notebooks-meta-jupyterlab-datascience-deps = { path = "../../../dependencies
 [tool.uv]
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 # May at some point these or some of these dependencies need to be remove as they will autoheal

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 override-dependencies = [

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -35,7 +35,7 @@ odh-notebooks-meta-jupyterlab-datascience-deps = { path = "../../../../dependenc
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 override-dependencies = [
     # RHAIENG-2458: urllib3>=2.7.0 — CVE-2026-44431, CVE-2026-44432 (2.7.0); CVE-2025-66418 (2.6.0)

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -35,9 +35,7 @@ override-dependencies = [
 ]
 
 environments = [
-    # Keep this explicit upper bound: with `uv pip compile --universal`, transitive
-    # markers can still create a >=3.13 split, and tensorflow-rocm is cp312-only.
-    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version < '3.13'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 [tool.uv.sources]

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -42,5 +42,5 @@ override-dependencies = [
 ]
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 override-dependencies = [
     # RHAIENG-2458: urllib3>=2.7.0 — CVE-2026-44431, CVE-2026-44432 (2.7.0); CVE-2025-66418 (2.6.0)

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 override-dependencies = [
     # AIPCC-13675: protobuf 6.33.6+ UPB C extension segfaults on s390x

--- a/runtimes/minimal/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/minimal/ubi9-python-3.12/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 [tool.uv.sources]

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -40,7 +40,7 @@ odh-notebooks-meta-db-connectors-deps = { path = "../../../dependencies/odh-note
 [tool.uv]
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 # May at some point these or some of these dependencies need to be remove as they will autoheal

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 override-dependencies = [
     # AIPCC-13675: protobuf 6.33.6+ UPB C extension segfaults on s390x

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -32,7 +32,7 @@ odh-notebooks-meta-db-connectors-deps = { path = "../../../dependencies/odh-note
 
 [tool.uv]
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 override-dependencies = [
     # RHAIENG-2458: urllib3>=2.7.0 — CVE-2026-44431, CVE-2026-44432 (2.7.0); CVE-2025-66418 (2.6.0)

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -34,7 +34,7 @@ constraint-dependencies = [
 ]
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 [tool.uv.sources]

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -33,7 +33,7 @@ override-dependencies = [
 ]
 
 environments = [
-    "sys_platform == 'linux' and implementation_name == 'cpython'",
+    "sys_platform == 'linux' and implementation_name == 'cpython' and python_full_version == '3.12.*'",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary

- Add `python_full_version == '3.12.*'` to `[tool.uv] environments` in all 23 cp312 image and meta-package `pyproject.toml` files (jupyter, runtimes, codeserver, dependencies).
- Aligns uv lock resolution with `[project] requires-python = "==3.12.*"` so `uv pip compile --universal` no longer forks on hypothetical Python 3.13+ environments from open-ended transitive metadata.
- Replaces the ad-hoc `python_full_version < '3.13'` workaround in `jupyter/rocm/tensorflow` with the same standard marker.

## Test plan

- [x] `uv pip compile --universal` succeeds with the new marker (tested on `jupyter/minimal`)
- [x] `make test`
- [ ] `make refresh-lock-files` (optional follow-up to refresh pylock markers)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment markers in project configuration files across 25+ dependencies and runtime environments to specifically target Python 3.12, ensuring correct environment selection for Python 3.12 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->