### PR TITLE
RHAIENG-4892: chore(build-args): drive base image updates from versions_config.yml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,12 +439,15 @@ refresh-lock-files:
 #   - Registry access for quay.io/aipcc/base-images when syncing RHDS build args
 # ======================================================================================
 SYNC_BUILD_ARGS_ARGS ?=
+SYNC_BUILD_ARGS_ALLOWED := --dry-run --check
+SYNC_BUILD_ARGS_INVALID := $(strip $(filter-out $(SYNC_BUILD_ARGS_ALLOWED),$(value SYNC_BUILD_ARGS_ARGS)))
 .PHONY: sync-build-args-from-versions
 sync-build-args-from-versions:
+	$(if $(SYNC_BUILD_ARGS_INVALID),$(error Invalid SYNC_BUILD_ARGS_ARGS token(s): $(SYNC_BUILD_ARGS_INVALID) (allowed: $(SYNC_BUILD_ARGS_ALLOWED))))
 	@echo "==================================================================="
 	@echo "🔁 Syncing build-args BASE_IMAGE values from versions_config.yml"
 	@echo "==================================================================="
-	@cd $(ROOT_DIR) && ./uv run scripts/update_build_args_from_versions.py $(SYNC_BUILD_ARGS_ARGS)
+	@cd "$(ROOT_DIR)" && ./uv run scripts/update_build_args_from_versions.py $(value SYNC_BUILD_ARGS_ARGS)
 
 # ======================================================================================
 #   gmake update-imagestream-annotations

--- a/Makefile
+++ b/Makefile
@@ -434,12 +434,13 @@ refresh-lock-files:
 #   gmake sync-build-args-from-versions
 #   gmake sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--check
 #   gmake sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--dry-run
+#   gmake sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--rhds-stable-repo-override=cuda=quay.io/<org>/cuda-el9.6
 # Prerequisites:
 #   - skopeo on PATH (RHDS tag resolution uses skopeo list-tags)
 #   - Registry access for quay.io/aipcc/base-images when syncing RHDS build args
 # ======================================================================================
 SYNC_BUILD_ARGS_ARGS ?=
-SYNC_BUILD_ARGS_ALLOWED := --dry-run --check
+SYNC_BUILD_ARGS_ALLOWED := --dry-run --check --rhds-stable-repo-override=%
 SYNC_BUILD_ARGS_INVALID := $(strip $(filter-out $(SYNC_BUILD_ARGS_ALLOWED),$(value SYNC_BUILD_ARGS_ARGS)))
 .PHONY: sync-build-args-from-versions
 sync-build-args-from-versions:

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ endef
 #######################################        Build helpers                 #######################################
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
-skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files sync-commit-env-files update-imagestream-annotations refresh-imagestream-metadata scan-image-vulnerabilities print-release
+skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files sync-build-args-from-versions sync-commit-env-files update-imagestream-annotations refresh-imagestream-metadata scan-image-vulnerabilities print-release
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
 $(SELF): bin/buildinputs
 endif
@@ -427,6 +427,24 @@ refresh-lock-files:
 		export PIP_LOCK_EXTRA_INDEX_URL="$(PIP_EXTRA_INDEX_URL)" && \
 		unset UV_EXTRA_INDEX_URL PIP_EXTRA_INDEX_URL && \
 		uv run scripts/pylocks_generator.py "$(INDEX_MODE)" $(DIR)
+
+# ======================================================================================
+# Sync build-args BASE_IMAGE values from versions_config.yml
+# Usage examples:
+#   gmake sync-build-args-from-versions
+#   gmake sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--check
+#   gmake sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--dry-run
+# Prerequisites:
+#   - skopeo on PATH (RHDS tag resolution uses skopeo list-tags)
+#   - Registry access for quay.io/aipcc/base-images when syncing RHDS build args
+# ======================================================================================
+SYNC_BUILD_ARGS_ARGS ?=
+.PHONY: sync-build-args-from-versions
+sync-build-args-from-versions:
+	@echo "==================================================================="
+	@echo "🔁 Syncing build-args BASE_IMAGE values from versions_config.yml"
+	@echo "==================================================================="
+	@cd $(ROOT_DIR) && ./uv run scripts/update_build_args_from_versions.py $(SYNC_BUILD_ARGS_ARGS)
 
 # ======================================================================================
 #   gmake update-imagestream-annotations

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ Image lock files (`pylock.toml` / `uv.lock.d/`) are regenerated with `make refre
 For details on the dual `uv` version policy (dev vs image locks), see the
 [Deploy & Test](#deploy--test) section below.
 
+### Update base image versions
+
+Use the root [`versions_config.yml`](versions_config.yml) file as the operator
+entry point for base image updates.
+
+The sync flow validates that config, rewrites managed `build-args/*.conf`
+`BASE_IMAGE` and `RELEASE` values, updates root `Makefile` `RELEASE` defaults,
+and resolves RHDS `channel: fast` tags from published Quay tags with `skopeo`.
+
+For the full configuration contract, RHDS and ODH resolution rules, Mermaid flow
+diagram, and worked examples, see
+[`docs/base_image_versions_update_configuration.md`](docs/base_image_versions_update_configuration.md).
+
+Quick commands:
+
+```shell
+make sync-build-args-from-versions
+make sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--dry-run
+make sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--check
+```
+
+If the version update also requires lockfile refreshes, run
+`make refresh-lock-files` after the sync.
+
 ### Deploy & Test
 
 #### Prepare Python + uv + pytest env

--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/docs/base_image_versions_update_configuration.md
+++ b/docs/base_image_versions_update_configuration.md
@@ -138,17 +138,23 @@ RHDS stable targets do not take `version` or nested `acc_version`. The script de
 stable image from `release.full_version`:
 
 - CPU: `quay.io/aipcc/base-image-cpu-stable-ubi9:<major.minor>`
-- CUDA: `quay.io/aipcc/base-image-cuda-stable-ubi9:<major.minor>`
-- ROCm: `quay.io/aipcc/base-image-rocm-stable-ubi9:<major.minor>`
+- CUDA: published `quay.io/aipcc/base-images/cuda-<rhds_os_base>:<full_version>-stable-<build>`
+- ROCm: published `quay.io/aipcc/base-images/rocm-<rhds_os_base>:<full_version>-stable-<build>`
 
-For example, `release.full_version: "3.5.0"` resolves stable targets to `:3.5`.
+CPU remains a direct `major.minor` derivation. For CUDA and ROCm, the script uses
+`skopeo list-tags` to list published stable tags for the configured
+`release.full_version` and `release.rhds_os_base`, then inspects candidate images
+in descending build order until it finds one whose embedded accelerator stream
+matches the shared flavor-level `acc_version`.
 
 When using `channel: stable`, do not set `version` for CPU and do not set
 `acc_version` under `rhds` for CUDA or ROCm. GPU flavors can still define a
-shared flavor-level `acc_version` so ODH stays aligned. For stable CUDA and
-ROCm targets, the script also inspects the resolved RHDS stable image and logs a
-warning if the detected accelerator stream does not match the shared
-`acc_version`.
+shared flavor-level `acc_version` so RHDS and ODH resolve to the same stream
+from their corresponding origins.
+
+If no published stable CUDA or ROCm tag can be proven to match the configured
+shared `acc_version`, the sync fails with an explicit error instead of silently
+falling back to the highest stable build in the repository.
 
 Example:
 
@@ -165,7 +171,10 @@ artifacts:
           channel: stable
 ```
 
-That resolves to `quay.io/aipcc/base-image-cuda-stable-ubi9:3.5`.
+With `release.rhds_os_base: "el9.6"`, that resolves to the latest published
+`3.5.0-stable-*` tag in `quay.io/aipcc/base-images/cuda-el9.6` whose embedded
+CUDA version is `13.0`, for example
+`quay.io/aipcc/base-images/cuda-el9.6:3.5.0-stable-1780598175`.
 
 ### `channel: fast`
 

--- a/docs/base_image_versions_update_configuration.md
+++ b/docs/base_image_versions_update_configuration.md
@@ -103,12 +103,11 @@ artifacts:
 
     cuda:
       minimal:
+        acc_version: "13.0"
         rhds:
           channel: fast
-          acc_version: "13.0"
         odh:
           origin: in-house
-          acc_version: "13.0"
 ```
 
 ### Release Fields
@@ -123,7 +122,7 @@ artifacts:
 ### Policy Keys
 
 - CPU policies use `version`
-- CUDA and ROCm policies use `acc_version`
+- CUDA and ROCm flavors use shared `acc_version`
 - RHDS policies use `channel`
 - ODH policies use `origin`
 
@@ -135,7 +134,7 @@ fail before any file is rewritten.
 
 ### `channel: stable`
 
-RHDS stable targets do not take `version` or `acc_version`. The script derives a
+RHDS stable targets do not take `version` or nested `acc_version`. The script derives a
 stable image from `release.full_version`:
 
 - CPU: `quay.io/aipcc/base-image-cpu-stable-ubi9:<major.minor>`
@@ -145,8 +144,11 @@ stable image from `release.full_version`:
 For example, `release.full_version: "3.5.0"` resolves stable targets to `:3.5`.
 
 When using `channel: stable`, do not set `version` for CPU and do not set
-`acc_version` for CUDA or ROCm. Stable mode derives the repository tag from the
-release only.
+`acc_version` under `rhds` for CUDA or ROCm. GPU flavors can still define a
+shared flavor-level `acc_version` so ODH stays aligned. For stable CUDA and
+ROCm targets, the script also inspects the resolved RHDS stable image and logs a
+warning if the detected accelerator stream does not match the shared
+`acc_version`.
 
 Example:
 
@@ -158,6 +160,7 @@ artifacts:
   base_image:
     cuda:
       minimal:
+        acc_version: "13.0"
         rhds:
           channel: stable
 ```
@@ -166,10 +169,10 @@ That resolves to `quay.io/aipcc/base-image-cuda-stable-ubi9:3.5`.
 
 ### `channel: fast`
 
-RHDS fast targets require `version` for CPU or `acc_version` for CUDA and ROCm.
-The script first builds the correct repository name, then uses `skopeo list-tags`
-to resolve the latest published build within the selected release-and-phase
-family.
+RHDS fast targets require `version` for CPU. CUDA and ROCm use the shared
+flavor-level `acc_version`. The script first builds the correct repository
+name, then uses `skopeo list-tags` to resolve the latest published build within
+the selected release-and-phase family.
 
 Representative repository shapes:
 
@@ -276,9 +279,9 @@ The script rejects any non-`latest` CPU ODH version.
 ```yaml
 rocm:
   minimal:
+    acc_version: "7.1"
     odh:
       origin: midstream
-      acc_version: "7.1"
 ```
 
 That resolves to `quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest`.
@@ -287,7 +290,7 @@ That resolves to `quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest`.
 
 1. Edit `versions_config.yml`.
 2. Review the policy block you changed and confirm the right key is used:
-   `version` for CPU, `acc_version` for CUDA or ROCm.
+   `version` for CPU, shared flavor-level `acc_version` for CUDA or ROCm.
 3. Keep RHDS and ODH rules aligned with the target distribution:
    `channel` is RHDS-only and `origin` is ODH-only.
 4. Run the sync command.
@@ -298,9 +301,9 @@ That resolves to `quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest`.
 ```yaml
 rocm:
   minimal:
+    acc_version: "7.1"
     odh:
       origin: midstream
-      acc_version: "7.1"
 ```
 
 ### Example: change the CPU Python to origin in-house
@@ -320,6 +323,7 @@ cpu:
 ...
     cuda:
       minimal:
+        acc_version: "13.0"
         rhds:
           channel: stable
 ...
@@ -330,9 +334,9 @@ cpu:
 ...
     cuda:
       minimal:
+        acc_version: "13.0"
         rhds:
           channel: fast
-          acc_version: "13.0"
 ...
 ```
 

--- a/docs/base_image_versions_update_configuration.md
+++ b/docs/base_image_versions_update_configuration.md
@@ -1,0 +1,392 @@
+# Base Image Version Update Configuration
+
+## Purpose
+
+This repository uses `versions_config.yml` as the single operator input for base
+image version updates.
+
+The sync flow validates that configuration, resolves the target base image for
+every managed notebook image family, rewrites managed `build-args/*.conf` files,
+and updates the root `Makefile` release defaults. The implementation lives in
+`scripts/update_build_args_from_versions.py`, and the standard entry point is
+`make sync-build-args-from-versions`.
+
+## What This Flow Manages
+
+The sync flow manages:
+
+- `BASE_IMAGE` in image-tree `build-args/*.conf` files under `jupyter/`,
+  `runtimes/`, and `codeserver/`
+- `RELEASE` in managed `build-args/*.conf` files when that key is already present
+- root `Makefile` `RELEASE`
+- root `Makefile` `RELEASE_PYTHON_VERSION`
+
+It does not update unrelated files or regenerate lock files. If the image update
+also requires Python lock refreshes, run `make refresh-lock-files` separately.
+
+The script only manages known build-args filenames:
+
+- `cpu.conf`, `cuda.conf`, `rocm.conf`
+- `konflux.cpu.conf`, `konflux.cuda.conf`, `konflux.rocm.conf`
+
+If an unexpected `build-args` filename appears in a managed tree, the sync fails
+early instead of guessing.
+
+## Prerequisites
+
+- `uv` available through the repo wrapper commands
+- `skopeo` on `PATH` for RHDS `channel: fast` resolution
+- access to the Quay repositories referenced by the configured RHDS and ODH policies
+
+## How the Sync Flow Works
+
+```mermaid
+flowchart TD
+    A[Edit versions_config.yml] --> B[Load and validate config]
+    B --> C[Parse release values and policy blocks]
+    C --> D[Scan managed roots for build-args files]
+    D --> E[Read current BASE_IMAGE values]
+    C --> F[Prepare Makefile replacements]
+
+    E --> G{Target distribution}
+
+    G -->|RHDS stable| H[Build stable repo and major.minor tag]
+    G -->|RHDS fast| I{Current tag already RHDS fast?}
+    I -->|No| J[Seed tag from bundle phase or forward phase]
+    I -->|Yes| K[Reuse bundle phase or discover forward phase]
+    J --> L[skopeo list-tags picks latest published build]
+    K --> L
+
+    G -->|ODH| M{Origin}
+    M -->|in-house| N[Build in-house repo and tag]
+    M -->|midstream| O[Build midstream repo and tag]
+
+    H --> P[Rewrite build-args file]
+    L --> P
+    N --> P
+    O --> P
+    F --> Q[Rewrite Makefile RELEASE defaults]
+```
+
+
+At a high level, the script first validates `versions_config.yml`, then scans the
+managed image trees for known `build-args/*.conf` files. For each target, it
+reads the current `BASE_IMAGE`, chooses the correct RHDS or ODH resolution rule,
+computes the desired image reference, and rewrites only the managed assignments.
+
+For RHDS `channel: fast`, the current repo state matters. The script uses the
+existing RHDS fast peers to infer same-release bundle phase when appropriate, and
+it uses `skopeo list-tags` to resolve the latest published build in the selected
+family.
+
+## Configuration Model
+
+The sync flow expects `schema_version: 1` and the following top-level structure:
+
+```yaml
+schema_version: 1
+
+release:
+  full_version: "3.5.0"
+  rhds_os_base: "el9.6"
+  python_version: "3.12"
+
+artifacts:
+  base_image:
+    cpu:
+      rhds:
+        channel: fast
+        version: "<full_version>"
+      odh:
+        origin: in-house
+        version: "latest"
+
+    cuda:
+      minimal:
+        rhds:
+          channel: fast
+          acc_version: "13.0"
+        odh:
+          origin: in-house
+          acc_version: "13.0"
+```
+
+### Release Fields
+
+- `release.full_version` drives RHDS release selection and the managed
+  `RELEASE` value written to build-args files and the root `Makefile`
+- `release.rhds_os_base` selects the RHDS CUDA and ROCm repository suffix such as
+  `el9.6`
+- `release.python_version` selects the managed `RELEASE_PYTHON_VERSION` value and
+  drives CPU ODH repository naming
+
+### Policy Keys
+
+- CPU policies use `version`
+- CUDA and ROCm policies use `acc_version`
+- RHDS policies use `channel`
+- ODH policies use `origin`
+
+Validation is strict. Unexpected keys, missing required keys, invalid channel or
+origin values, malformed versions, and invalid distribution-specific combinations
+fail before any file is rewritten.
+
+## RHDS Resolution Rules
+
+### `channel: stable`
+
+RHDS stable targets do not take `version` or `acc_version`. The script derives a
+stable image from `release.full_version`:
+
+- CPU: `quay.io/aipcc/base-image-cpu-stable-ubi9:<major.minor>`
+- CUDA: `quay.io/aipcc/base-image-cuda-stable-ubi9:<major.minor>`
+- ROCm: `quay.io/aipcc/base-image-rocm-stable-ubi9:<major.minor>`
+
+For example, `release.full_version: "3.5.0"` resolves stable targets to `:3.5`.
+
+When using `channel: stable`, do not set `version` for CPU and do not set
+`acc_version` for CUDA or ROCm. Stable mode derives the repository tag from the
+release only.
+
+Example:
+
+```yaml
+release:
+  full_version: "3.5.0"
+
+artifacts:
+  base_image:
+    cuda:
+      minimal:
+        rhds:
+          channel: stable
+```
+
+That resolves to `quay.io/aipcc/base-image-cuda-stable-ubi9:3.5`.
+
+### `channel: fast`
+
+RHDS fast targets require `version` for CPU or `acc_version` for CUDA and ROCm.
+The script first builds the correct repository name, then uses `skopeo list-tags`
+to resolve the latest published build within the selected release-and-phase
+family.
+
+Representative repository shapes:
+
+- CPU: `quay.io/aipcc/base-images/cpu`
+- CUDA: `quay.io/aipcc/base-images/cuda-13.0-el9.6`
+- ROCm: `quay.io/aipcc/base-images/rocm-7.1-el9.6`
+
+### Same-Release Bundle Phase Inference
+
+When a target switches from `stable` or another non-fast tag to `fast` on the
+same `release.full_version`, the script inspects the other RHDS fast peers in the
+current repo state.
+
+- If same-release peers already show `ea.1`, `ea.2`, or GA tags, the highest
+  observed phase wins bundle-wide.
+- If no same-release fast-style peer exists yet, the new fast family starts at
+  `ea.1`.
+
+This same-release bundle rule is also used to bring lagging same-release RHDS
+fast targets up to the bundle phase. For example, if CUDA and ROCm are already
+on `ea.2`, a same-release CPU fast target is seeded with `ea.2` rather than
+falling back to `ea.1`.
+
+### Forward Upgrade Phase Discovery
+
+When a target moves to a newer `release.full_version`, the script does not reuse
+the old bundle phase. Instead, it checks the target repository itself and
+selects the highest already-published phase for that new release:
+
+- GA if published
+- otherwise `ea.2` if published
+- otherwise `ea.1`
+
+After choosing the phase, `skopeo` resolves the latest published build in that
+family.
+
+This rule applies to:
+
+- stable or non-fast -> fast transitions that cross into a newer release
+- existing RHDS fast targets moving forward to a newer release
+
+The important distinction is:
+
+- same-release transitions use whole-bundle phase inference
+- forward-release transitions use per-repository phase discovery
+
+### Rollback Behavior
+
+When `release.full_version` moves backward, RHDS fast rollback targets the older
+release in GA first. If that older release has no GA tag, the script falls back
+to the highest published phase available for that older release and then resolves
+the latest build in that family.
+
+Rollback planning ignores newer-release fast peers. It does not reuse the newer
+bundle phase when targeting the older release.
+
+## ODH Resolution Rules
+
+### `origin: in-house`
+
+In-house ODH targets use the normal `quay.io/opendatahub/odh-base-image-*`
+repositories.
+
+- CPU repository naming is derived from `release.python_version`, for example
+  `quay.io/opendatahub/odh-base-image-cpu-py312-c9s`
+- CUDA and ROCm use fixed accelerator family repositories with accelerator stream tags
+
+Examples:
+
+- CPU: `quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest`
+- CUDA: `quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0`
+- ROCm: `quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1`
+
+### `origin: midstream`
+
+Midstream ODH targets use `quay.io/opendatahub/odh-midstream-*` repositories.
+
+- CPU still uses `version: "latest"`
+- CPU repository naming comes from `release.python_version`, for example
+  `quay.io/opendatahub/odh-midstream-python-base-3-12:latest`
+- CUDA and ROCm require numeric `acc_version` values and resolve to `:latest`
+
+Examples:
+
+- CPU: `quay.io/opendatahub/odh-midstream-python-base-3-12:latest`
+- CUDA: `quay.io/opendatahub/odh-midstream-cuda-base-13-0:latest`
+- ROCm: `quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest`
+
+### CPU Version Rule
+
+For CPU ODH, both `origin: in-house` and `origin: midstream` require:
+
+```yaml
+cpu:
+  odh:
+    origin: in-house
+    version: "latest"
+```
+
+The script rejects any non-`latest` CPU ODH version.
+
+### Example: switch ROCm minimal to midstream
+
+```yaml
+rocm:
+  minimal:
+    odh:
+      origin: midstream
+      acc_version: "7.1"
+```
+
+That resolves to `quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest`.
+
+## Updating Versions
+
+1. Edit `versions_config.yml`.
+2. Review the policy block you changed and confirm the right key is used:
+   `version` for CPU, `acc_version` for CUDA or ROCm.
+3. Keep RHDS and ODH rules aligned with the target distribution:
+   `channel` is RHDS-only and `origin` is ODH-only.
+4. Run the sync command.
+5. Review the generated diff before committing anything.
+
+### Example: move a ROCm ODH target to origin midstream
+
+```yaml
+rocm:
+  minimal:
+    odh:
+      origin: midstream
+      acc_version: "7.1"
+```
+
+### Example: change the CPU Python to origin in-house
+
+```yaml
+...
+cpu:
+  odh:
+    origin: in-house
+    version: "latest"
+...
+```
+
+### Example: change the CUDA Python stable channel
+
+```yaml
+...
+    cuda:
+      minimal:
+        rhds:
+          channel: stable
+...
+```
+### Example: change the CUDA Python fast channel
+
+```yaml
+...
+    cuda:
+      minimal:
+        rhds:
+          channel: fast
+          acc_version: "13.0"
+...
+```
+
+That updates CPU ODH repository naming and rewrites the root `Makefile`
+`RELEASE_PYTHON_VERSION`.
+
+## Running the Sync
+
+The normal entry point is the `Makefile` target:
+
+```shell
+make sync-build-args-from-versions
+```
+
+Useful variants:
+
+```shell
+make sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--dry-run
+make sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--check
+```
+
+For direct script usage, the same flags are available through:
+
+```shell
+./uv run scripts/update_build_args_from_versions.py --dry-run
+./uv run scripts/update_build_args_from_versions.py --check
+```
+
+Advanced flags:
+
+- `--config` to point at a different config file
+- `--root` to point at a different repository root
+
+## What to Review After Running
+
+- every changed `build-args/*.conf` still points to the expected repository family
+- `BASE_IMAGE` changed only where the policy or published RHDS tags require it
+- `RELEASE` in managed build-args files matches the new `release.full_version` minor
+- root `Makefile` `RELEASE` and `RELEASE_PYTHON_VERSION` match the new release block
+- RHDS fast targets landed on the expected phase family for the scenario:
+  same-release bundle alignment, forward upgrade discovery, or rollback fallback
+
+For safe review, start with:
+
+```shell
+make sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--dry-run
+```
+
+## Troubleshooting
+
+- `Unsupported schema_version`: set `schema_version: 1`
+- `Missing version` or `Missing acc_version`: check the selected accelerator and policy mode
+- `cpu odh ... requires version latest`: restore CPU ODH `version: "latest"`
+- invalid `channel` or `origin`: check that RHDS blocks use `channel` and ODH blocks use `origin`
+- `skopeo is required to resolve latest RHDS tags`: install `skopeo` and retry
+- `skopeo list-tags failed`: confirm network or registry access to the target RHDS repo
+- `--check` exit code `1`: the repo needs sync updates; rerun without `--check` or inspect `--dry-run`

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1780597719
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1780597719
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1780597719
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1781269697
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1780597719
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1780597719
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,5 @@
+# To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
+# For more information, see `docs/base_image_versions_update_configuration.md`.
 BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1781269697
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -332,7 +332,9 @@ def normalize_gpu_flavor_config(
     release: ReleaseConfig,
 ) -> tuple[dict[str, Any], str]:
     context = f"root.artifacts.base_image.{accelerator}.{flavor}"
-    mapping = validate_expected_mapping_keys(flavor_policy, {"acc_version", "rhds", "odh"}, context, required_keys={"rhds", "odh"})
+    mapping = validate_expected_mapping_keys(
+        flavor_policy, {"acc_version", "rhds", "odh"}, context, required_keys={"rhds", "odh"}
+    )
 
     rhds_policy = mapping["rhds"]
     odh_policy = mapping["odh"]
@@ -367,7 +369,9 @@ def normalize_gpu_flavor_config(
         ]
         if "acc_version" in normalized_rhds:
             shared_versions.append(
-                validate_version_value(normalized_rhds["acc_version"], release, f"{context}.rhds.acc_version", "acc_version")
+                validate_version_value(
+                    normalized_rhds["acc_version"], release, f"{context}.rhds.acc_version", "acc_version"
+                )
             )
 
         normalized_versions = {normalize_stream_version(version) for version in shared_versions}
@@ -390,7 +394,9 @@ def normalize_gpu_flavor_config(
             "acc_version",
         )
         if normalize_stream_version(distribution_version) != shared_version_normalized:
-            raise ValueError(f"Nested {distribution} acc_version at {context}.{distribution} must match shared acc_version")
+            raise ValueError(
+                f"Nested {distribution} acc_version at {context}.{distribution} must match shared acc_version"
+            )
 
     if scalar_to_string(normalized_rhds.get("channel", "")) == "fast":
         normalized_rhds["acc_version"] = shared_version
@@ -594,11 +600,15 @@ def extract_image_labels(config_payload: dict[str, Any]) -> dict[str, str]:
     if isinstance(config, dict):
         config_labels = config.get("Labels")
         if isinstance(config_labels, dict):
-            labels.update({key: value for key, value in config_labels.items() if isinstance(key, str) and isinstance(value, str)})
+            labels.update(
+                {key: value for key, value in config_labels.items() if isinstance(key, str) and isinstance(value, str)}
+            )
 
     root_labels = config_payload.get("Labels")
     if isinstance(root_labels, dict):
-        labels.update({key: value for key, value in root_labels.items() if isinstance(key, str) and isinstance(value, str)})
+        labels.update(
+            {key: value for key, value in root_labels.items() if isinstance(key, str) and isinstance(value, str)}
+        )
     return labels
 
 
@@ -790,13 +800,14 @@ def determine_highest_published_rhds_phase_for_release(
 def select_rhds_forward_phase(
     accelerator: str,
     version: str,
+    release_version: str,
     release: ReleaseConfig,
     tag_cache: dict[str, tuple[str, ...]],
 ) -> str | None:
     repository = build_rhds_pinned_repository(accelerator, version, release)
     return determine_highest_published_rhds_phase_for_release(
         repository,
-        release.full_version,
+        release_version,
         tag_cache,
     )
 
@@ -885,10 +896,10 @@ def rank_rhds_phase(phase: str | None) -> int:
     return int(phase.removeprefix("ea."))
 
 
-def build_rhds_seed_tag(release: ReleaseConfig, phase: str | None) -> str:
+def build_rhds_seed_tag(release_version: str, phase: str | None) -> str:
     if phase is None:
-        return f"{release.full_version}-0"
-    return f"{release.full_version}-{phase}-0"
+        return f"{release_version}-0"
+    return f"{release_version}-{phase}-0"
 
 
 def determine_rhds_fast_bundle_phase(
@@ -923,7 +934,7 @@ def determine_rhds_fast_bundle_phase(
 
 def build_rhds_pinned_tag(
     current_tag: str,
-    release: ReleaseConfig,
+    target_release_version: str,
     *,
     use_bundle_phase: bool = False,
     bundle_phase: str | None = None,
@@ -934,7 +945,7 @@ def build_rhds_pinned_tag(
         raise ValueError(f"Unsupported RHDS BASE_IMAGE tag: {current_tag}")
 
     current_version = parse_release_version(match.group("version"))
-    target_version = parse_release_version(release.full_version)
+    target_version = parse_release_version(target_release_version)
     build = match.group("build")
 
     # Phase precedence: rollback -> same-release bundle -> forward-discovered
@@ -949,14 +960,15 @@ def build_rhds_pinned_tag(
         phase = match.group("phase")
 
     if phase is None:
-        return f"{release.full_version}-{build}"
-    return f"{release.full_version}-{phase}-{build}"
+        return f"{target_release_version}-{build}"
+    return f"{target_release_version}-{phase}-{build}"
 
 
 def build_rhds_pinned_image(
     accelerator: str,
     version: str,
     current_base_image: str,
+    target_release_version: str,
     release: ReleaseConfig,
     *,
     use_bundle_phase: bool = False,
@@ -965,9 +977,7 @@ def build_rhds_pinned_image(
 ) -> str:
     _current_name, current_tag = split_image_ref(current_base_image)
     repository = build_rhds_pinned_repository(accelerator, version, release)
-    return (
-        f"{repository}:{build_rhds_pinned_tag(current_tag, release, use_bundle_phase=use_bundle_phase, bundle_phase=bundle_phase, forward_phase=forward_phase)}"
-    )
+    return f"{repository}:{build_rhds_pinned_tag(current_tag, target_release_version, use_bundle_phase=use_bundle_phase, bundle_phase=bundle_phase, forward_phase=forward_phase)}"
 
 
 def build_rhds_stable_image(accelerator: str, release: ReleaseConfig) -> str:
@@ -997,6 +1007,14 @@ def build_odh_midstream_image(accelerator: str, version: str, release: ReleaseCo
     return f"quay.io/opendatahub/odh-midstream-{accelerator}-base-{normalized_version}:latest"
 
 
+def target_rhds_release_version(target: ConfTarget, policy: BaseImagePolicy, release: ReleaseConfig) -> str:
+    if target.distribution != "rhds":
+        raise ValueError(f"Unsupported distribution in {target.path}: {target.distribution}")
+    if target.accelerator == "cpu" and policy.version is not None:
+        return policy.version
+    return release.full_version
+
+
 def build_target_base_image(
     state: TargetState,
     release: ReleaseConfig,
@@ -1022,35 +1040,39 @@ def build_target_base_image(
         if policy.version is None:
             raise ValueError(f"Missing {policy_version_key(target.accelerator)} for rhds fast channel in {target.path}")
 
+        target_release_version = target_rhds_release_version(target, policy, release)
+        use_release_bundle_phase = target_release_version == release.full_version
         _current_repository, current_tag = split_image_ref(current_base_image)
         if RHDS_TAG_RE.fullmatch(current_tag) is None:
             repository = build_rhds_pinned_repository(target.accelerator, policy.version, release)
             if MIDSTREAM_VERSION_RE.fullmatch(current_tag):
                 current_minor = parse_minor_version(current_tag)
-                target_minor = parse_minor_version(release_minor_version(release.full_version))
+                target_minor = parse_minor_version(release_minor_version(target_release_version))
                 if current_minor > target_minor:
                     seed_phase = None
                 elif current_minor < target_minor:
                     seed_phase = select_rhds_forward_phase(
                         target.accelerator,
                         policy.version,
+                        target_release_version,
                         release,
                         tag_cache,
                     )
                 else:
-                    seed_phase = rhds_bundle_phase if rhds_bundle_phase_known else "ea.1"
+                    seed_phase = rhds_bundle_phase if rhds_bundle_phase_known and use_release_bundle_phase else "ea.1"
             else:
-                seed_phase = rhds_bundle_phase if rhds_bundle_phase_known else "ea.1"
-            candidate = f"{repository}:{build_rhds_seed_tag(release, seed_phase)}"
+                seed_phase = rhds_bundle_phase if rhds_bundle_phase_known and use_release_bundle_phase else "ea.1"
+            candidate = f"{repository}:{build_rhds_seed_tag(target_release_version, seed_phase)}"
         else:
             current_match = RHDS_TAG_RE.fullmatch(current_tag)
             forward_phase: str | None | object = _FORWARD_PHASE_UNSET
             current_version = parse_release_version(current_match.group("version"))
-            target_version = parse_release_version(release.full_version)
+            target_version = parse_release_version(target_release_version)
             if target_version > current_version:
                 forward_phase = select_rhds_forward_phase(
                     target.accelerator,
                     policy.version,
+                    target_release_version,
                     release,
                     tag_cache,
                 )
@@ -1058,8 +1080,11 @@ def build_target_base_image(
                 target.accelerator,
                 policy.version,
                 current_base_image,
+                target_release_version,
                 release,
-                use_bundle_phase=rhds_bundle_phase_known and target_version == current_version,
+                use_bundle_phase=rhds_bundle_phase_known
+                and use_release_bundle_phase
+                and target_version == current_version,
                 bundle_phase=rhds_bundle_phase,
                 forward_phase=forward_phase,
             )
@@ -1119,7 +1144,9 @@ def rewrite_makefile_text(text: str, replacements: dict[str, str]) -> str:
     lines = text.splitlines(keepends=True)
     found_keys: set[str] = set()
     rewritten_lines: list[str] = []
-    assignment_re = re.compile(r"^(?P<leading>\s*)(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?P<separator>\s*\?=\s*)(?P<value>.*)$")
+    assignment_re = re.compile(
+        r"^(?P<leading>\s*)(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?P<separator>\s*\?=\s*)(?P<value>.*)$"
+    )
 
     for line in lines:
         line_ending = "\n" if line.endswith("\n") else ""
@@ -1141,7 +1168,9 @@ def rewrite_makefile_text(text: str, replacements: dict[str, str]) -> str:
     return "".join(rewritten_lines)
 
 
-def build_conf_replacements(assignments: dict[str, str], resolved_base_image: str, release: ReleaseConfig) -> dict[str, str]:
+def build_conf_replacements(
+    assignments: dict[str, str], resolved_base_image: str, release: ReleaseConfig
+) -> dict[str, str]:
     replacements = {"BASE_IMAGE": resolved_base_image}
     if "RELEASE" in assignments:
         replacements["RELEASE"] = release_minor_version(release.full_version)
@@ -1199,7 +1228,9 @@ def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
                 original_text=state.original_text,
                 updated_text=rewrite_conf_text(
                     state.original_text,
-                    build_conf_replacements(read_conf_assignments(state.original_text), resolved_base_image, config.release),
+                    build_conf_replacements(
+                        read_conf_assignments(state.original_text), resolved_base_image, config.release
+                    ),
                 ),
                 target=state.target,
             )

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -67,6 +67,7 @@ MIDSTREAM_VERSION_RE = re.compile(r"^\d+\.\d+$")
 PYTHON_VERSION_RE = re.compile(r"^\d+\.\d+$")
 # Sentinel so callers can omit a forward phase; None means GA, not "unset".
 _FORWARD_PHASE_UNSET = object()
+_STABLE_ACC_VERSION_INSPECT_FAILED = object()
 
 
 @dataclass(frozen=True)
@@ -668,10 +669,10 @@ def inspect_image_config(image: str, *, warning_color: str | None = None) -> dic
     return payload
 
 
-def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | None:
+def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | None | object:
     config_payload = inspect_image_config(image, warning_color="red")
     if config_payload is None:
-        return None
+        return _STABLE_ACC_VERSION_INSPECT_FAILED
 
     env = extract_image_env(config_payload)
     labels = extract_image_labels(config_payload)
@@ -716,7 +717,7 @@ def warn_on_rhds_stable_acc_version_mismatch(
     target: ConfTarget,
     stable_image: str,
     configured_acc_version: str | None,
-    stable_acc_version_cache: dict[tuple[str, str], str | None],
+    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
 ) -> None:
     if target.accelerator == "cpu" or configured_acc_version is None:
         return
@@ -726,6 +727,8 @@ def warn_on_rhds_stable_acc_version_mismatch(
         stable_acc_version_cache[cache_key] = inspect_rhds_stable_acc_version(stable_image, target.accelerator)
 
     detected_acc_version = stable_acc_version_cache[cache_key]
+    if detected_acc_version is _STABLE_ACC_VERSION_INSPECT_FAILED:
+        return
     if detected_acc_version is None:
         log_warning(
             "Could not determine RHDS stable %s acc_version from %s; continuing with configured shared acc_version %s",
@@ -735,6 +738,8 @@ def warn_on_rhds_stable_acc_version_mismatch(
             color="yellow",
         )
         return
+    if not isinstance(detected_acc_version, str):
+        raise TypeError(f"Unexpected cached stable acc_version state for {stable_image}: {detected_acc_version!r}")
 
     configured_normalized = normalize_stream_version(configured_acc_version)
     detected_normalized = normalize_stream_version(detected_acc_version)
@@ -840,9 +845,12 @@ def list_rhds_repository_tags(
             capture_output=True,
             text=True,
             check=False,
+            timeout=60,
         )
     except FileNotFoundError as exc:
         raise ValueError("skopeo is required to resolve latest RHDS tags") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"skopeo list-tags timed out for {repository}") from exc
 
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
@@ -1019,7 +1027,7 @@ def build_target_base_image(
     state: TargetState,
     release: ReleaseConfig,
     tag_cache: dict[str, tuple[str, ...]],
-    stable_acc_version_cache: dict[tuple[str, str], str | None],
+    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
 ) -> str:
@@ -1187,7 +1195,7 @@ def build_makefile_replacements(release: ReleaseConfig) -> dict[str, str]:
 def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
     states: list[TargetState] = []
     tag_cache: dict[str, tuple[str, ...]] = {}
-    stable_acc_version_cache: dict[tuple[str, str], str | None] = {}
+    stable_acc_version_cache: dict[tuple[str, str], str | None | object] = {}
 
     for target in collect_conf_targets(root_dir):
         original_text = target.path.read_text(encoding="utf-8")

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -771,6 +771,8 @@ def resolve_matching_published_rhds_stable_image(
         if detected_acc_version in (_STABLE_ACC_VERSION_INSPECT_FAILED, None):
             unresolved_images.append(image)
             continue
+        if not isinstance(detected_acc_version, str):
+            raise TypeError(f"Unexpected stable acc_version state for {image}: {detected_acc_version!r}")
         if detected_acc_version == configured_normalized:
             return image
         detected_versions.add(detected_acc_version)
@@ -1039,7 +1041,18 @@ def target_rhds_release_version(target: ConfTarget, policy: BaseImagePolicy, rel
     return release.full_version
 
 
-def build_target_base_image(
+def default_rhds_seed_phase(
+    *,
+    rhds_bundle_phase_known: bool,
+    use_release_bundle_phase: bool,
+    rhds_bundle_phase: str | None,
+) -> str | None:
+    if rhds_bundle_phase_known and use_release_bundle_phase:
+        return rhds_bundle_phase
+    return "ea.1"
+
+
+def resolve_rhds_base_image(
     state: TargetState,
     release: ReleaseConfig,
     tag_cache: dict[str, tuple[str, ...]],
@@ -1049,93 +1062,100 @@ def build_target_base_image(
     stable_repo_overrides: dict[str, str] | None = None,
 ) -> str:
     target = state.target
-    current_base_image = state.current_base_image
     policy = state.policy
+    current_base_image = state.current_base_image
 
-    if target.distribution == "rhds":
-        if policy.mode == "stable":
-            if target.accelerator == "cpu":
-                return f"quay.io/aipcc/base-image-cpu-stable-ubi9:{release_minor_version(release.full_version)}"
-            if state.shared_acc_version is None:
-                raise ValueError(f"Missing configured shared acc_version for RHDS stable {target.accelerator}")
-            repository = build_rhds_gpu_stable_repository(
-                target.accelerator,
-                release,
-                stable_repo_overrides,
-            )
-            return resolve_matching_published_rhds_stable_image(
-                repository,
-                release.full_version,
-                target.accelerator,
-                state.shared_acc_version,
-                tag_cache,
-                stable_acc_version_cache,
-            )
-        if policy.version is None:
-            raise ValueError(f"Missing {policy_version_key(target.accelerator)} for rhds fast channel in {target.path}")
+    if policy.mode == "stable":
+        if target.accelerator == "cpu":
+            return f"quay.io/aipcc/base-image-cpu-stable-ubi9:{release_minor_version(release.full_version)}"
+        if state.shared_acc_version is None:
+            raise ValueError(f"Missing configured shared acc_version for RHDS stable {target.accelerator}")
+        repository = build_rhds_gpu_stable_repository(
+            target.accelerator,
+            release,
+            stable_repo_overrides,
+        )
+        return resolve_matching_published_rhds_stable_image(
+            repository,
+            release.full_version,
+            target.accelerator,
+            state.shared_acc_version,
+            tag_cache,
+            stable_acc_version_cache,
+        )
 
-        target_release_version = target_rhds_release_version(target, policy, release)
-        use_release_bundle_phase = target_release_version == release.full_version
-        _current_repository, current_tag = split_image_ref(current_base_image)
-        if RHDS_TAG_RE.fullmatch(current_tag) is None:
-            repository = build_rhds_pinned_repository(target.accelerator, policy.version, release)
-            stable_match = RHDS_STABLE_TAG_RE.fullmatch(current_tag)
-            if MIDSTREAM_VERSION_RE.fullmatch(current_tag):
-                current_minor = parse_minor_version(current_tag)
-                target_minor = parse_minor_version(release_minor_version(target_release_version))
-                if current_minor > target_minor:
-                    seed_phase = None
-                elif current_minor < target_minor:
-                    seed_phase = determine_highest_published_rhds_phase_for_release(
-                        repository,
-                        target_release_version,
-                        tag_cache,
-                    )
-                else:
-                    seed_phase = rhds_bundle_phase if rhds_bundle_phase_known and use_release_bundle_phase else "ea.1"
-            elif stable_match is not None:
-                current_version = parse_release_version(stable_match.group("version"))
-                target_version = parse_release_version(target_release_version)
-                if current_version > target_version:
-                    seed_phase = None
-                elif current_version < target_version:
-                    seed_phase = determine_highest_published_rhds_phase_for_release(
-                        repository,
-                        target_release_version,
-                        tag_cache,
-                    )
-                else:
-                    seed_phase = rhds_bundle_phase if rhds_bundle_phase_known and use_release_bundle_phase else "ea.1"
-            else:
-                seed_phase = rhds_bundle_phase if rhds_bundle_phase_known and use_release_bundle_phase else "ea.1"
-            candidate = f"{repository}:{build_rhds_seed_tag(target_release_version, seed_phase)}"
-        else:
-            current_match = RHDS_TAG_RE.fullmatch(current_tag)
-            forward_phase = "ea.1"
-            current_version = parse_release_version(current_match.group("version"))
-            target_version = parse_release_version(target_release_version)
-            if target_version > current_version:
-                forward_phase = determine_highest_published_rhds_phase_for_release(
-                    build_rhds_pinned_repository(target.accelerator, policy.version, release),
+    if policy.version is None:
+        raise ValueError(f"Missing {policy_version_key(target.accelerator)} for rhds fast channel in {target.path}")
+
+    target_release_version = target_rhds_release_version(target, policy, release)
+    use_release_bundle_phase = target_release_version == release.full_version
+    bundle_seed_phase = default_rhds_seed_phase(
+        rhds_bundle_phase_known=rhds_bundle_phase_known,
+        use_release_bundle_phase=use_release_bundle_phase,
+        rhds_bundle_phase=rhds_bundle_phase,
+    )
+    repository, current_tag = build_rhds_pinned_repository(target.accelerator, policy.version, release), split_image_ref(
+        current_base_image
+    )[1]
+
+    if RHDS_TAG_RE.fullmatch(current_tag) is None:
+        stable_match = RHDS_STABLE_TAG_RE.fullmatch(current_tag)
+        if MIDSTREAM_VERSION_RE.fullmatch(current_tag):
+            current_minor = parse_minor_version(current_tag)
+            target_minor = parse_minor_version(release_minor_version(target_release_version))
+            if current_minor > target_minor:
+                seed_phase = None
+            elif current_minor < target_minor:
+                seed_phase = determine_highest_published_rhds_phase_for_release(
+                    repository,
                     target_release_version,
                     tag_cache,
                 )
-            candidate = build_rhds_pinned_image(
-                target.accelerator,
-                policy.version,
-                current_base_image,
+            else:
+                seed_phase = bundle_seed_phase
+        elif stable_match is not None:
+            current_version = parse_release_version(stable_match.group("version"))
+            target_version = parse_release_version(target_release_version)
+            if current_version > target_version:
+                seed_phase = None
+            elif current_version < target_version:
+                seed_phase = determine_highest_published_rhds_phase_for_release(
+                    repository,
+                    target_release_version,
+                    tag_cache,
+                )
+            else:
+                seed_phase = bundle_seed_phase
+        else:
+            seed_phase = bundle_seed_phase
+        candidate = f"{repository}:{build_rhds_seed_tag(target_release_version, seed_phase)}"
+    else:
+        current_match = RHDS_TAG_RE.fullmatch(current_tag)
+        forward_phase = "ea.1"
+        current_version = parse_release_version(current_match.group("version"))
+        target_version = parse_release_version(target_release_version)
+        if target_version > current_version:
+            forward_phase = determine_highest_published_rhds_phase_for_release(
+                repository,
                 target_release_version,
-                release,
-                use_bundle_phase=rhds_bundle_phase_known
-                and use_release_bundle_phase
-                and target_version == current_version,
-                bundle_phase=rhds_bundle_phase,
-                forward_phase=forward_phase,
+                tag_cache,
             )
-        return resolve_latest_published_rhds_image(candidate, tag_cache)
+        candidate = build_rhds_pinned_image(
+            target.accelerator,
+            policy.version,
+            current_base_image,
+            target_release_version,
+            release,
+            use_bundle_phase=rhds_bundle_phase_known and use_release_bundle_phase and target_version == current_version,
+            bundle_phase=rhds_bundle_phase,
+            forward_phase=forward_phase,
+        )
+    return resolve_latest_published_rhds_image(candidate, tag_cache)
 
-    if target.distribution != "odh":
-        raise ValueError(f"Unsupported distribution in {target.path}: {target.distribution}")
+
+def resolve_odh_base_image(state: TargetState, release: ReleaseConfig) -> str:
+    target = state.target
+    policy = state.policy
 
     if policy.version is None:
         raise ValueError(f"Missing {policy_version_key(target.accelerator)} for odh origin in {target.path}")
@@ -1144,6 +1164,32 @@ def build_target_base_image(
     if policy.mode == "midstream":
         return build_odh_midstream_image(target.accelerator, policy.version, release)
     raise ValueError(f"Unsupported odh origin in {target.path}: {policy.mode}")
+
+
+def build_target_base_image(
+    state: TargetState,
+    release: ReleaseConfig,
+    tag_cache: dict[str, tuple[str, ...]],
+    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
+    rhds_bundle_phase_known: bool,
+    rhds_bundle_phase: str | None,
+    stable_repo_overrides: dict[str, str] | None = None,
+) -> str:
+    match state.target.distribution:
+        case "rhds":
+            return resolve_rhds_base_image(
+                state,
+                release,
+                tag_cache,
+                stable_acc_version_cache,
+                rhds_bundle_phase_known,
+                rhds_bundle_phase,
+                stable_repo_overrides,
+            )
+        case "odh":
+            return resolve_odh_base_image(state, release)
+        case _:
+            raise ValueError(f"Unsupported distribution in {state.target.path}: {state.target.distribution}")
 
 
 def read_conf_assignments(text: str) -> dict[str, str]:

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -32,6 +32,28 @@ GPU_FLAVORS = {
     "cuda": ("minimal", "pytorch", "pytorch-llmcompressor", "tensorflow"),
     "rocm": ("minimal", "pytorch", "tensorflow"),
 }
+ACCELERATOR_DISPLAY_NAMES = {
+    "cuda": "CUDA",
+    "rocm": "ROCm",
+}
+GPU_FLAVOR_PATHS = {
+    "cuda": {
+        ("jupyter", "minimal"): "minimal",
+        ("jupyter", "pytorch"): "pytorch",
+        ("runtimes", "pytorch"): "pytorch",
+        ("jupyter", "pytorch+llmcompressor"): "pytorch-llmcompressor",
+        ("runtimes", "pytorch+llmcompressor"): "pytorch-llmcompressor",
+        ("jupyter", "tensorflow"): "tensorflow",
+        ("runtimes", "tensorflow"): "tensorflow",
+    },
+    "rocm": {
+        ("jupyter", "minimal"): "minimal",
+        ("jupyter", "rocm", "pytorch"): "pytorch",
+        ("runtimes", "rocm-pytorch"): "pytorch",
+        ("jupyter", "rocm", "tensorflow"): "tensorflow",
+        ("runtimes", "rocm-tensorflow"): "tensorflow",
+    },
+}
 CPU_BASE_IMAGE_SCHEMA = {
     "rhds": POLICY_SCHEMA,
     "odh": POLICY_SCHEMA,
@@ -41,6 +63,13 @@ ANSI_GREEN = "\033[32m"
 ANSI_YELLOW = "\033[33m"
 ANSI_RED = "\033[31m"
 ANSI_RESET = "\033[0m"
+WARNING_COLORS = {
+    "green": ANSI_GREEN,
+    "yellow": ANSI_YELLOW,
+    "red": ANSI_RED,
+}
+CONF_ASSIGNMENT_RE = re.compile(r"^(?P<prefix>\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)=).*$")
+MAKEFILE_ASSIGNMENT_RE = re.compile(r"^(?P<prefix>\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?:\s*\?=\s*)).*$")
 
 BASE_IMAGE_SCHEMA = {
     "cpu": CPU_BASE_IMAGE_SCHEMA,
@@ -62,11 +91,11 @@ ROOT_SCHEMA = {
 
 RHDS_CHANNELS = frozenset({"fast", "stable"})
 ODH_ORIGINS = frozenset({"in-house", "midstream"})
+RHDS_STABLE_OVERRIDE_ACCELERATORS = frozenset({"cuda", "rocm"})
 RHDS_TAG_RE = re.compile(r"^(?P<version>\d+\.\d+\.\d+)(?:-(?P<phase>ea\.\d+))?-(?P<build>\d+)$")
+RHDS_STABLE_TAG_RE = re.compile(r"^(?P<version>\d+\.\d+\.\d+)-stable-(?P<build>\d+)$")
 MIDSTREAM_VERSION_RE = re.compile(r"^\d+\.\d+$")
 PYTHON_VERSION_RE = re.compile(r"^\d+\.\d+$")
-# Sentinel so callers can omit a forward phase; None means GA, not "unset".
-_FORWARD_PHASE_UNSET = object()
 _STABLE_ACC_VERSION_INSPECT_FAILED = object()
 
 
@@ -137,6 +166,49 @@ class TargetState:
     shared_acc_version: str | None = None
 
 
+@dataclass(frozen=True)
+class InspectedImageConfig:
+    env: dict[str, str]
+    labels: dict[str, str]
+    history: tuple[str, ...]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> InspectedImageConfig:
+        config = payload.get("config")
+        raw_env = config.get("Env") if isinstance(config, dict) else None
+        raw_history = payload.get("history")
+
+        env: dict[str, str] = {}
+        if isinstance(raw_env, list):
+            for entry in raw_env:
+                if not isinstance(entry, str) or "=" not in entry:
+                    continue
+                key, value = entry.split("=", 1)
+                env[key] = value
+
+        labels: dict[str, str] = {}
+        for raw_labels in (
+            config.get("Labels") if isinstance(config, dict) else None,
+            payload.get("Labels"),
+        ):
+            if not isinstance(raw_labels, dict):
+                continue
+            labels.update(
+                {key: value for key, value in raw_labels.items() if isinstance(key, str) and isinstance(value, str)}
+            )
+
+        history: list[str] = []
+        if isinstance(raw_history, list):
+            for layer in raw_history:
+                if not isinstance(layer, dict):
+                    continue
+                created_by = layer.get("created_by")
+                if isinstance(created_by, str):
+                    history.append(created_by)
+
+        return cls(env=env, labels=labels, history=tuple(history))
+
+
 def scalar_to_string(value: object) -> str:
     if isinstance(value, str):
         return value.strip()
@@ -151,11 +223,7 @@ def log_warning(message: str, *args: object, color: str | None = None) -> None:
         return
 
     rendered_message = message % args if args else message
-    ansi_color = {
-        "green": ANSI_GREEN,
-        "yellow": ANSI_YELLOW,
-        "red": ANSI_RED,
-    }.get(color)
+    ansi_color = WARNING_COLORS.get(color)
     if ansi_color is None:
         raise ValueError(f"Unsupported warning color '{color}'")
     logger.warning(f"{ansi_color}WARNING: {rendered_message}{ANSI_RESET}")
@@ -505,30 +573,17 @@ def classify_flavor(relative_path: Path, accelerator: str) -> str | None:
             return None
         raise ValueError(f"Unsupported CPU build-args path: {relative_path}")
 
-    if accelerator == "cuda":
-        if parts[:2] == ("jupyter", "minimal"):
-            return "minimal"
-        if parts[:2] in {("jupyter", "pytorch"), ("runtimes", "pytorch")}:
-            return "pytorch"
-        if parts[:2] in {
-            ("jupyter", "pytorch+llmcompressor"),
-            ("runtimes", "pytorch+llmcompressor"),
-        }:
-            return "pytorch-llmcompressor"
-        if parts[:2] in {("jupyter", "tensorflow"), ("runtimes", "tensorflow")}:
-            return "tensorflow"
-        raise ValueError(f"Unsupported CUDA build-args path: {relative_path}")
+    mapping = GPU_FLAVOR_PATHS.get(accelerator)
+    if mapping is None:
+        raise ValueError(f"Unsupported accelerator '{accelerator}'")
 
-    if accelerator == "rocm":
-        if parts[:2] == ("jupyter", "minimal"):
-            return "minimal"
-        if parts[:3] == ("jupyter", "rocm", "pytorch") or parts[:2] == ("runtimes", "rocm-pytorch"):
-            return "pytorch"
-        if parts[:3] == ("jupyter", "rocm", "tensorflow") or parts[:2] == ("runtimes", "rocm-tensorflow"):
-            return "tensorflow"
-        raise ValueError(f"Unsupported ROCm build-args path: {relative_path}")
+    for prefix in (parts[:3], parts[:2]):
+        if flavor := mapping.get(prefix):
+            return flavor
 
-    raise ValueError(f"Unsupported accelerator '{accelerator}'")
+    raise ValueError(
+        f"Unsupported {ACCELERATOR_DISPLAY_NAMES.get(accelerator, accelerator)} build-args path: {relative_path}"
+    )
 
 
 def collect_conf_targets(root_dir: Path) -> list[ConfTarget]:
@@ -574,58 +629,6 @@ def major_minor_stream_version(value: str) -> str | None:
     if match is None:
         return None
     return f"{match.group('major')}.{match.group('minor')}"
-
-
-def extract_image_env(config_payload: dict[str, Any]) -> dict[str, str]:
-    config = config_payload.get("config")
-    if not isinstance(config, dict):
-        return {}
-
-    raw_env = config.get("Env")
-    if not isinstance(raw_env, list):
-        return {}
-
-    env: dict[str, str] = {}
-    for entry in raw_env:
-        if not isinstance(entry, str) or "=" not in entry:
-            continue
-        key, value = entry.split("=", 1)
-        env[key] = value
-    return env
-
-
-def extract_image_labels(config_payload: dict[str, Any]) -> dict[str, str]:
-    labels: dict[str, str] = {}
-
-    config = config_payload.get("config")
-    if isinstance(config, dict):
-        config_labels = config.get("Labels")
-        if isinstance(config_labels, dict):
-            labels.update(
-                {key: value for key, value in config_labels.items() if isinstance(key, str) and isinstance(value, str)}
-            )
-
-    root_labels = config_payload.get("Labels")
-    if isinstance(root_labels, dict):
-        labels.update(
-            {key: value for key, value in root_labels.items() if isinstance(key, str) and isinstance(value, str)}
-        )
-    return labels
-
-
-def extract_image_history(config_payload: dict[str, Any]) -> list[str]:
-    history = config_payload.get("history")
-    if not isinstance(history, list):
-        return []
-
-    created_by: list[str] = []
-    for layer in history:
-        if not isinstance(layer, dict):
-            continue
-        value = layer.get("created_by")
-        if isinstance(value, str):
-            created_by.append(value)
-    return created_by
 
 
 def inspect_image_config(image: str, *, warning_color: str | None = None) -> dict[str, Any] | None:
@@ -674,109 +677,133 @@ def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | None 
     if config_payload is None:
         return _STABLE_ACC_VERSION_INSPECT_FAILED
 
-    env = extract_image_env(config_payload)
-    labels = extract_image_labels(config_payload)
-    history = extract_image_history(config_payload)
+    inspected = InspectedImageConfig.from_payload(config_payload)
 
-    if accelerator == "cuda":
-        for value in (env.get("CUDA_VERSION"), labels.get("CUDA_VERSION")):
-            if value is None:
-                continue
-            if version := major_minor_stream_version(value):
+    def first_major_minor(values: tuple[str | None, ...]) -> str | None:
+        for value in values:
+            if value and (version := major_minor_stream_version(value)):
                 return version
+        return None
 
-        requirement = env.get("NVIDIA_REQUIRE_CUDA")
-        if requirement is not None:
-            match = re.search(r"cuda>=(?P<version>\d+\.\d+(?:\.\d+)?)", requirement)
-            if match and (version := major_minor_stream_version(match.group("version"))):
-                return version
-
-        for line in history:
-            match = re.search(r"\bCUDA_VERSION=(?P<version>\d+\.\d+(?:\.\d+)?)\b", line)
+    def version_from_history(pattern: str) -> str | None:
+        for line in inspected.history:
+            match = re.search(pattern, line)
             if match and (version := major_minor_stream_version(match.group("version"))):
                 return version
         return None
 
-    if accelerator == "rocm":
-        for value in (env.get("ROCM_VERSION"), labels.get("ROCM_VERSION")):
-            if value is None:
-                continue
-            if version := major_minor_stream_version(value):
+    match accelerator:
+        case "cuda":
+            if version := first_major_minor((inspected.env.get("CUDA_VERSION"), inspected.labels.get("CUDA_VERSION"))):
                 return version
-
-        for line in history:
-            match = re.search(r"\bROCM_VERSION=(?P<version>\d+\.\d+(?:\.\d+)?)\b", line)
-            if match and (version := major_minor_stream_version(match.group("version"))):
+            requirement = inspected.env.get("NVIDIA_REQUIRE_CUDA")
+            if requirement is not None:
+                match = re.search(r"cuda>=(?P<version>\d+\.\d+(?:\.\d+)?)", requirement)
+                if match and (version := major_minor_stream_version(match.group("version"))):
+                    return version
+            return version_from_history(r"\bCUDA_VERSION=(?P<version>\d+\.\d+(?:\.\d+)?)\b")
+        case "rocm":
+            if version := first_major_minor((inspected.env.get("ROCM_VERSION"), inspected.labels.get("ROCM_VERSION"))):
                 return version
-        return None
+            return version_from_history(r"\bROCM_VERSION=(?P<version>\d+\.\d+(?:\.\d+)?)\b")
+        case _:
+            raise ValueError(f"Unsupported accelerator '{accelerator}'")
 
-    raise ValueError(f"Unsupported accelerator '{accelerator}'")
 
-
-def warn_on_rhds_stable_acc_version_mismatch(
-    target: ConfTarget,
-    stable_image: str,
-    configured_acc_version: str | None,
+def cached_rhds_stable_acc_version(
+    image: str,
+    accelerator: str,
     stable_acc_version_cache: dict[tuple[str, str], str | None | object],
-) -> None:
-    if target.accelerator == "cpu" or configured_acc_version is None:
-        return
-
-    cache_key = (stable_image, target.accelerator)
+) -> str | None | object:
+    cache_key = (image, accelerator)
     if cache_key not in stable_acc_version_cache:
-        stable_acc_version_cache[cache_key] = inspect_rhds_stable_acc_version(stable_image, target.accelerator)
+        stable_acc_version_cache[cache_key] = inspect_rhds_stable_acc_version(image, accelerator)
 
     detected_acc_version = stable_acc_version_cache[cache_key]
-    if detected_acc_version is _STABLE_ACC_VERSION_INSPECT_FAILED:
-        return
-    if detected_acc_version is None:
-        log_warning(
-            "Could not determine RHDS stable %s acc_version from %s; continuing with configured shared acc_version %s",
-            target.accelerator,
-            stable_image,
-            normalize_stream_version(configured_acc_version),
-            color="yellow",
-        )
-        return
+    if detected_acc_version in (_STABLE_ACC_VERSION_INSPECT_FAILED, None):
+        return detected_acc_version
     if not isinstance(detected_acc_version, str):
-        raise TypeError(f"Unexpected cached stable acc_version state for {stable_image}: {detected_acc_version!r}")
+        raise TypeError(f"Unexpected cached stable acc_version state for {image}: {detected_acc_version!r}")
+    return normalize_stream_version(detected_acc_version)
 
+
+def describe_available_rhds_stable_acc_versions(configured_acc_version: str, detected_versions: set[str]) -> str:
+    configured_minor = parse_minor_version(configured_acc_version)
+    sorted_versions = sorted(detected_versions, key=parse_minor_version)
+    older = [version for version in sorted_versions if parse_minor_version(version) < configured_minor]
+    newer = [version for version in sorted_versions if parse_minor_version(version) > configured_minor]
+
+    if older and not newer:
+        label = "older acc_version" if len(older) == 1 else "older acc_versions"
+        return f"{label} {', '.join(older)}"
+    if newer and not older:
+        label = "newer acc_version" if len(newer) == 1 else "newer acc_versions"
+        return f"{label} {', '.join(newer)}"
+    return f"older and newer acc_versions {', '.join(sorted_versions)}"
+
+
+def resolve_matching_published_rhds_stable_image(
+    repository: str,
+    release_version: str,
+    accelerator: str,
+    configured_acc_version: str,
+    tag_cache: dict[str, tuple[str, ...]] | None,
+    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
+) -> str:
     configured_normalized = normalize_stream_version(configured_acc_version)
-    detected_normalized = normalize_stream_version(detected_acc_version)
-    if configured_normalized == detected_normalized:
-        return
+    candidates = sorted(
+        (
+            (int(match.group("build")), tag)
+            for tag in list_rhds_repository_tags(repository, tag_cache)
+            if (match := RHDS_STABLE_TAG_RE.fullmatch(tag)) is not None and match.group("version") == release_version
+        ),
+        reverse=True,
+    )
 
-    log_warning(
-        "Configured shared %s acc_version %s does not match RHDS stable image %s, which appears to use acc_version %s. Consider updating versions_config.yml to use acc_version %s for alignment.",
-        target.accelerator,
-        configured_normalized,
-        stable_image,
-        detected_normalized,
-        detected_normalized,
-        color="green",
+    if not candidates:
+        raise ValueError(f"No published RHDS stable tags found for release '{release_version}'")
+
+    unresolved_images: list[str] = []
+    detected_versions: set[str] = set()
+    for _build, tag in candidates:
+        image = f"{repository}:{tag}"
+        detected_acc_version = cached_rhds_stable_acc_version(image, accelerator, stable_acc_version_cache)
+        if detected_acc_version in (_STABLE_ACC_VERSION_INSPECT_FAILED, None):
+            unresolved_images.append(image)
+            continue
+        if detected_acc_version == configured_normalized:
+            return image
+        detected_versions.add(detected_acc_version)
+
+    if unresolved_images:
+        detail = ""
+        if detected_versions:
+            detail = (
+                " Candidate stable images inspected successfully appear to use "
+                f"{describe_available_rhds_stable_acc_versions(configured_normalized, detected_versions)}."
+            )
+        raise ValueError(
+            f"Could not determine whether any published RHDS stable {accelerator} image in {repository} for "
+            f"release '{release_version}' matches configured shared acc_version {configured_normalized}; one or "
+            f"more candidate stable images could not be inspected or did not expose an acc_version.{detail}"
+        )
+
+    raise ValueError(
+        f"No published RHDS stable {accelerator} image in {repository} for release '{release_version}' matches "
+        f"configured shared acc_version {configured_normalized}; available stable images appear to use "
+        f"{describe_available_rhds_stable_acc_versions(configured_normalized, detected_versions)}."
     )
 
 
-def build_rhds_family_pattern(candidate_tag: str) -> re.Pattern[str]:
+def select_latest_matching_rhds_tag(tags: list[str], candidate_tag: str) -> str:
     match = RHDS_TAG_RE.fullmatch(candidate_tag)
     if match is None:
         raise ValueError(f"Unsupported RHDS candidate tag: {candidate_tag}")
-
     prefix = match.group("version")
     if phase := match.group("phase"):
         prefix = f"{prefix}-{phase}"
-    return re.compile(rf"^{re.escape(prefix)}-(?P<build>\d+)$")
-
-
-def select_latest_matching_rhds_tag(tags: list[str], candidate_tag: str) -> str:
-    family_pattern = build_rhds_family_pattern(candidate_tag)
-    matches: list[tuple[int, str]] = []
-
-    for tag in tags:
-        match = family_pattern.fullmatch(tag)
-        if match is None:
-            continue
-        matches.append((int(match.group("build")), tag))
+    family_pattern = re.compile(rf"^{re.escape(prefix)}-(?P<build>\d+)$")
+    matches = [(int(match.group("build")), tag) for tag in tags if (match := family_pattern.fullmatch(tag)) is not None]
 
     if not matches:
         raise ValueError(f"No matching published RHDS tag found for family '{candidate_tag}'")
@@ -789,42 +816,23 @@ def determine_highest_published_rhds_phase_for_release(
     release_version: str,
     tag_cache: dict[str, tuple[str, ...]] | None = None,
 ) -> str | None:
-    phases: set[str | None] = set()
-
-    for tag in list_rhds_repository_tags(repository, tag_cache):
-        match = RHDS_TAG_RE.fullmatch(tag)
-        if match is None or match.group("version") != release_version:
-            continue
-        phases.add(match.group("phase"))
+    phases = {
+        match.group("phase")
+        for tag in list_rhds_repository_tags(repository, tag_cache)
+        if (match := RHDS_TAG_RE.fullmatch(tag)) is not None and match.group("version") == release_version
+    }
 
     if not phases:
         return "ea.1"
     return max(phases, key=rank_rhds_phase)
 
 
-def select_rhds_forward_phase(
-    accelerator: str,
-    version: str,
-    release_version: str,
-    release: ReleaseConfig,
-    tag_cache: dict[str, tuple[str, ...]],
-) -> str | None:
-    repository = build_rhds_pinned_repository(accelerator, version, release)
-    return determine_highest_published_rhds_phase_for_release(
-        repository,
-        release_version,
-        tag_cache,
-    )
-
-
 def select_highest_published_rhds_tag_for_release(tags: list[str], release_version: str) -> str:
-    matches: list[tuple[int, int, str]] = []
-
-    for tag in tags:
-        match = RHDS_TAG_RE.fullmatch(tag)
-        if match is None or match.group("version") != release_version:
-            continue
-        matches.append((rank_rhds_phase(match.group("phase")), int(match.group("build")), tag))
+    matches = [
+        (rank_rhds_phase(match.group("phase")), int(match.group("build")), tag)
+        for tag in tags
+        if (match := RHDS_TAG_RE.fullmatch(tag)) is not None and match.group("version") == release_version
+    ]
 
     if not matches:
         raise ValueError(f"No published RHDS tags found for release '{release_version}'")
@@ -894,6 +902,18 @@ def build_rhds_pinned_repository(accelerator: str, version: str, release: Releas
     return f"quay.io/aipcc/base-images/{accelerator}-{normalized_version}-{release.rhds_os_base}"
 
 
+def build_rhds_gpu_stable_repository(
+    accelerator: str,
+    release: ReleaseConfig,
+    stable_repo_overrides: dict[str, str] | None = None,
+) -> str:
+    if accelerator not in RHDS_STABLE_OVERRIDE_ACCELERATORS:
+        raise ValueError(f"Unsupported RHDS stable accelerator: {accelerator}")
+    if stable_repo_overrides and accelerator in stable_repo_overrides:
+        return stable_repo_overrides[accelerator]
+    return f"quay.io/aipcc/base-images/{accelerator}-{release.rhds_os_base}"
+
+
 def describe_rhds_phase(phase: str | None) -> str:
     return "GA" if phase is None else phase
 
@@ -946,7 +966,7 @@ def build_rhds_pinned_tag(
     *,
     use_bundle_phase: bool = False,
     bundle_phase: str | None = None,
-    forward_phase: str | None | object = _FORWARD_PHASE_UNSET,
+    forward_phase: str | None = "ea.1",
 ) -> str:
     match = RHDS_TAG_RE.fullmatch(current_tag)
     if match is None:
@@ -963,7 +983,7 @@ def build_rhds_pinned_tag(
     elif use_bundle_phase:
         phase = bundle_phase
     elif target_version > current_version:
-        phase = "ea.1" if forward_phase is _FORWARD_PHASE_UNSET else forward_phase
+        phase = forward_phase
     else:
         phase = match.group("phase")
 
@@ -981,15 +1001,11 @@ def build_rhds_pinned_image(
     *,
     use_bundle_phase: bool = False,
     bundle_phase: str | None = None,
-    forward_phase: str | None | object = _FORWARD_PHASE_UNSET,
+    forward_phase: str | None = "ea.1",
 ) -> str:
     _current_name, current_tag = split_image_ref(current_base_image)
     repository = build_rhds_pinned_repository(accelerator, version, release)
     return f"{repository}:{build_rhds_pinned_tag(current_tag, target_release_version, use_bundle_phase=use_bundle_phase, bundle_phase=bundle_phase, forward_phase=forward_phase)}"
-
-
-def build_rhds_stable_image(accelerator: str, release: ReleaseConfig) -> str:
-    return f"quay.io/aipcc/base-image-{accelerator}-stable-ubi9:{release_minor_version(release.full_version)}"
 
 
 def build_odh_in_house_image(accelerator: str, version: str, release: ReleaseConfig) -> str:
@@ -1030,6 +1046,7 @@ def build_target_base_image(
     stable_acc_version_cache: dict[tuple[str, str], str | None | object],
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
+    stable_repo_overrides: dict[str, str] | None = None,
 ) -> str:
     target = state.target
     current_base_image = state.current_base_image
@@ -1037,14 +1054,23 @@ def build_target_base_image(
 
     if target.distribution == "rhds":
         if policy.mode == "stable":
-            stable_image = build_rhds_stable_image(target.accelerator, release)
-            warn_on_rhds_stable_acc_version_mismatch(
-                target,
-                stable_image,
+            if target.accelerator == "cpu":
+                return f"quay.io/aipcc/base-image-cpu-stable-ubi9:{release_minor_version(release.full_version)}"
+            if state.shared_acc_version is None:
+                raise ValueError(f"Missing configured shared acc_version for RHDS stable {target.accelerator}")
+            repository = build_rhds_gpu_stable_repository(
+                target.accelerator,
+                release,
+                stable_repo_overrides,
+            )
+            return resolve_matching_published_rhds_stable_image(
+                repository,
+                release.full_version,
+                target.accelerator,
                 state.shared_acc_version,
+                tag_cache,
                 stable_acc_version_cache,
             )
-            return stable_image
         if policy.version is None:
             raise ValueError(f"Missing {policy_version_key(target.accelerator)} for rhds fast channel in {target.path}")
 
@@ -1053,17 +1079,29 @@ def build_target_base_image(
         _current_repository, current_tag = split_image_ref(current_base_image)
         if RHDS_TAG_RE.fullmatch(current_tag) is None:
             repository = build_rhds_pinned_repository(target.accelerator, policy.version, release)
+            stable_match = RHDS_STABLE_TAG_RE.fullmatch(current_tag)
             if MIDSTREAM_VERSION_RE.fullmatch(current_tag):
                 current_minor = parse_minor_version(current_tag)
                 target_minor = parse_minor_version(release_minor_version(target_release_version))
                 if current_minor > target_minor:
                     seed_phase = None
                 elif current_minor < target_minor:
-                    seed_phase = select_rhds_forward_phase(
-                        target.accelerator,
-                        policy.version,
+                    seed_phase = determine_highest_published_rhds_phase_for_release(
+                        repository,
                         target_release_version,
-                        release,
+                        tag_cache,
+                    )
+                else:
+                    seed_phase = rhds_bundle_phase if rhds_bundle_phase_known and use_release_bundle_phase else "ea.1"
+            elif stable_match is not None:
+                current_version = parse_release_version(stable_match.group("version"))
+                target_version = parse_release_version(target_release_version)
+                if current_version > target_version:
+                    seed_phase = None
+                elif current_version < target_version:
+                    seed_phase = determine_highest_published_rhds_phase_for_release(
+                        repository,
+                        target_release_version,
                         tag_cache,
                     )
                 else:
@@ -1073,15 +1111,13 @@ def build_target_base_image(
             candidate = f"{repository}:{build_rhds_seed_tag(target_release_version, seed_phase)}"
         else:
             current_match = RHDS_TAG_RE.fullmatch(current_tag)
-            forward_phase: str | None | object = _FORWARD_PHASE_UNSET
+            forward_phase = "ea.1"
             current_version = parse_release_version(current_match.group("version"))
             target_version = parse_release_version(target_release_version)
             if target_version > current_version:
-                forward_phase = select_rhds_forward_phase(
-                    target.accelerator,
-                    policy.version,
+                forward_phase = determine_highest_published_rhds_phase_for_release(
+                    build_rhds_pinned_repository(target.accelerator, policy.version, release),
                     target_release_version,
-                    release,
                     tag_cache,
                 )
             candidate = build_rhds_pinned_image(
@@ -1122,39 +1158,24 @@ def read_conf_assignments(text: str) -> dict[str, str]:
 
 
 def rewrite_conf_text(text: str, replacements: dict[str, str]) -> str:
-    lines = text.splitlines(keepends=True)
-    found_keys: set[str] = set()
-    rewritten_lines: list[str] = []
-
-    for line in lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
-            rewritten_lines.append(line)
-            continue
-
-        key, _, _value = stripped.partition("=")
-        normalized_key = key.strip()
-        if normalized_key not in replacements:
-            rewritten_lines.append(line)
-            continue
-
-        found_keys.add(normalized_key)
-        line_ending = "\n" if line.endswith("\n") else ""
-        rewritten_lines.append(f"{normalized_key}={replacements[normalized_key]}{line_ending}")
-
-    missing_keys = [key for key in replacements if key not in found_keys]
-    if missing_keys:
-        raise ValueError(f"Missing {', '.join(missing_keys)} in build-args content")
-    return "".join(rewritten_lines)
-
-
-def rewrite_makefile_text(text: str, replacements: dict[str, str]) -> str:
-    lines = text.splitlines(keepends=True)
-    found_keys: set[str] = set()
-    rewritten_lines: list[str] = []
-    assignment_re = re.compile(
-        r"^(?P<leading>\s*)(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?P<separator>\s*\?=\s*)(?P<value>.*)$"
+    return rewrite_assignment_text(
+        text,
+        replacements,
+        assignment_re=CONF_ASSIGNMENT_RE,
+        missing_context="build-args content",
     )
+
+
+def rewrite_assignment_text(
+    text: str,
+    replacements: dict[str, str],
+    *,
+    assignment_re: re.Pattern[str],
+    missing_context: str,
+) -> str:
+    lines = text.splitlines(keepends=True)
+    found_keys: set[str] = set()
+    rewritten_lines: list[str] = []
 
     for line in lines:
         line_ending = "\n" if line.endswith("\n") else ""
@@ -1166,14 +1187,21 @@ def rewrite_makefile_text(text: str, replacements: dict[str, str]) -> str:
 
         key = match.group("key")
         found_keys.add(key)
-        rewritten_lines.append(
-            f"{match.group('leading')}{key}{match.group('separator')}{replacements[key]}{line_ending}"
-        )
+        rewritten_lines.append(f"{match.group('prefix')}{replacements[key]}{line_ending}")
 
     missing_keys = [key for key in replacements if key not in found_keys]
     if missing_keys:
-        raise ValueError(f"Missing {', '.join(missing_keys)} in Makefile")
+        raise ValueError(f"Missing {', '.join(missing_keys)} in {missing_context}")
     return "".join(rewritten_lines)
+
+
+def rewrite_makefile_text(text: str, replacements: dict[str, str]) -> str:
+    return rewrite_assignment_text(
+        text,
+        replacements,
+        assignment_re=MAKEFILE_ASSIGNMENT_RE,
+        missing_context="Makefile",
+    )
 
 
 def build_conf_replacements(
@@ -1192,7 +1220,11 @@ def build_makefile_replacements(release: ReleaseConfig) -> dict[str, str]:
     }
 
 
-def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
+def plan_updates(
+    root_dir: Path,
+    config: VersionsConfig,
+    stable_repo_overrides: dict[str, str] | None = None,
+) -> list[PlannedUpdate]:
     states: list[TargetState] = []
     tag_cache: dict[str, tuple[str, ...]] = {}
     stable_acc_version_cache: dict[tuple[str, str], str | None | object] = {}
@@ -1229,6 +1261,7 @@ def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
             stable_acc_version_cache,
             rhds_bundle_phase_known,
             rhds_bundle_phase,
+            stable_repo_overrides,
         )
         updates.append(
             PlannedUpdate(
@@ -1274,19 +1307,46 @@ def print_diff(root_dir: Path, update: PlannedUpdate) -> None:
     print("\n".join(diff))
 
 
+def parse_rhds_stable_repo_override(value: str) -> tuple[str, str]:
+    accelerator, separator, repository = value.partition("=")
+    normalized_accelerator = accelerator.strip().lower()
+    normalized_repository = repository.strip()
+    if separator == "" or not normalized_accelerator or not normalized_repository:
+        raise argparse.ArgumentTypeError("RHDS stable repo override must use ACCELERATOR=REPOSITORY")
+    if normalized_accelerator not in RHDS_STABLE_OVERRIDE_ACCELERATORS:
+        allowed = ", ".join(sorted(RHDS_STABLE_OVERRIDE_ACCELERATORS))
+        raise argparse.ArgumentTypeError(f"RHDS stable repo override accelerator must be one of: {allowed}")
+    return normalized_accelerator, normalized_repository
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=ROOT_DIR, help="Repository root to scan")
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH, help="Path to versions_config.yml")
     parser.add_argument("--dry-run", action="store_true", help="Show changes without writing files")
     parser.add_argument("--check", action="store_true", help="Exit non-zero if files need updates")
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--rhds-stable-repo-override",
+        action="append",
+        default=[],
+        type=parse_rhds_stable_repo_override,
+        metavar="ACCELERATOR=REPOSITORY",
+        help="Override RHDS GPU stable repository for local testing; repeat for cuda/rocm",
+    )
+    args = parser.parse_args(argv)
+    stable_repo_overrides: dict[str, str] = {}
+    for accelerator, repository in args.rhds_stable_repo_override:
+        if accelerator in stable_repo_overrides:
+            parser.error(f"duplicate --rhds-stable-repo-override for accelerator '{accelerator}'")
+        stable_repo_overrides[accelerator] = repository
+    args.rhds_stable_repo_overrides = stable_repo_overrides
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     config = load_versions_config(args.config)
-    updates = plan_updates(args.root, config)
+    updates = plan_updates(args.root, config, args.rhds_stable_repo_overrides)
     changed_updates = [update for update in updates if update.original_text != update.updated_text]
 
     if args.dry_run or args.check:

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -1,0 +1,948 @@
+#!/usr/bin/env python3
+
+"""Sync image-tree build args from ``versions_config.yml``.
+
+This flow validates the root config, scans managed image-tree ``build-args``
+files, rewrites managed ``BASE_IMAGE`` and ``RELEASE`` assignments plus the
+root ``Makefile`` release defaults, resolves newer RHDS ``channel: fast``
+releases to the highest already-published phase per target repository, and
+uses ``skopeo`` to select the latest build in the chosen release-and-phase
+family.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG_PATH = ROOT_DIR / "versions_config.yml"
+MANAGED_ROOTS = ("jupyter", "runtimes", "codeserver")
+POLICY_SCHEMA = object()
+
+BASE_IMAGE_SCHEMA = {
+    "cpu": {
+        "rhds": POLICY_SCHEMA,
+        "odh": POLICY_SCHEMA,
+    },
+    "cuda": {
+        "minimal": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+        "pytorch": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+        "pytorch-llmcompressor": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+        "tensorflow": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+    },
+    "rocm": {
+        "minimal": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+        "pytorch": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+        "tensorflow": {
+            "rhds": POLICY_SCHEMA,
+            "odh": POLICY_SCHEMA,
+        },
+    },
+}
+
+ROOT_SCHEMA = {
+    "schema_version": None,
+    "release": {
+        "full_version": None,
+        "rhds_os_base": None,
+        "python_version": None,
+    },
+    "artifacts": {
+        "base_image": BASE_IMAGE_SCHEMA,
+    },
+}
+
+RHDS_CHANNELS = frozenset({"fast", "stable"})
+ODH_ORIGINS = frozenset({"in-house", "midstream"})
+RHDS_TAG_RE = re.compile(r"^(?P<version>\d+\.\d+\.\d+)(?:-(?P<phase>ea\.\d+))?-(?P<build>\d+)$")
+MIDSTREAM_VERSION_RE = re.compile(r"^\d+\.\d+$")
+PYTHON_VERSION_RE = re.compile(r"^\d+\.\d+$")
+# Sentinel so callers can omit a forward phase; None means GA, not "unset".
+_FORWARD_PHASE_UNSET = object()
+
+
+@dataclass(frozen=True)
+class ReleaseConfig:
+    full_version: str
+    rhds_os_base: str
+    python_version: str
+
+
+@dataclass(frozen=True)
+class BaseImagePolicy:
+    mode: str
+    version: str | None = None
+
+
+@dataclass(frozen=True)
+class VersionsConfig:
+    release: ReleaseConfig
+    base_image: dict[str, Any]
+
+    def policy(self, accelerator: str, distribution: str, flavor: str | None = None) -> BaseImagePolicy:
+        if accelerator == "cpu":
+            raw_policy = self.base_image["cpu"][distribution]
+        else:
+            if flavor is None:
+                raise ValueError(f"Flavor is required for accelerator '{accelerator}'")
+            raw_policy = self.base_image[accelerator][flavor][distribution]
+
+        key = "channel" if distribution == "rhds" else "origin"
+        mode = scalar_to_string(raw_policy[key])
+        version_key = policy_version_key(accelerator)
+        raw_version = raw_policy.get(version_key)
+        version = None if raw_version is None else resolve_version(raw_version, self.release)
+        return BaseImagePolicy(mode=mode, version=version)
+
+
+@dataclass(frozen=True)
+class ConfTarget:
+    path: Path
+    accelerator: str
+    distribution: str
+    flavor: str | None
+
+
+@dataclass(frozen=True)
+class PlannedUpdate:
+    path: Path
+    original_text: str
+    updated_text: str
+    target: ConfTarget | None = None
+
+
+@dataclass(frozen=True)
+class TargetState:
+    target: ConfTarget
+    original_text: str
+    current_base_image: str
+    policy: BaseImagePolicy
+
+
+def scalar_to_string(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, int | float):
+        return str(value)
+    raise TypeError(f"Unsupported scalar value: {value!r}")
+
+
+def policy_version_key(accelerator: str) -> str:
+    return "version" if accelerator == "cpu" else "acc_version"
+
+
+def resolve_version(value: object, release: ReleaseConfig) -> str:
+    resolved = scalar_to_string(value)
+    if resolved == "<full_version>":
+        return release.full_version
+    return resolved
+
+
+def parse_release_version(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"Expected semantic version, got '{version}'")
+    try:
+        return tuple(int(part) for part in parts)  # type: ignore[return-value]
+    except ValueError as exc:
+        raise ValueError(f"Expected semantic version, got '{version}'") from exc
+
+
+def release_minor_version(full_version: str) -> str:
+    major, minor, _patch = parse_release_version(full_version)
+    return f"{major}.{minor}"
+
+
+def parse_minor_version(version: str) -> tuple[int, int]:
+    parts = version.split(".")
+    if len(parts) != 2:
+        raise ValueError(f"Expected major.minor version, got '{version}'")
+    try:
+        return tuple(int(part) for part in parts)  # type: ignore[return-value]
+    except ValueError as exc:
+        raise ValueError(f"Expected major.minor version, got '{version}'") from exc
+
+
+def normalize_python_version(version: str) -> str:
+    if PYTHON_VERSION_RE.fullmatch(version) is None:
+        raise ValueError(f"release.python_version must be in major.minor format, got '{version}'")
+    return version
+
+
+def compact_python_version(version: str) -> str:
+    return normalize_python_version(version).replace(".", "")
+
+
+def hyphenated_python_version(version: str) -> str:
+    return normalize_python_version(version).replace(".", "-")
+
+
+def validate_mapping_schema(data: object, expected: dict[str, Any], context: str) -> None:
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at {context}")
+
+    actual_keys = set(data)
+    expected_keys = set(expected)
+    unexpected_keys = sorted(actual_keys - expected_keys)
+    missing_keys = sorted(expected_keys - actual_keys)
+
+    if unexpected_keys:
+        raise ValueError(f"Unexpected keys under {context}: {', '.join(unexpected_keys)}")
+    if missing_keys:
+        raise ValueError(f"Missing keys under {context}: {', '.join(missing_keys)}")
+
+    for key, child_schema in expected.items():
+        if child_schema is POLICY_SCHEMA:
+            continue
+        if isinstance(child_schema, dict):
+            validate_mapping_schema(data[key], child_schema, f"{context}.{key}")
+
+
+def validate_version_value(value: object, release: ReleaseConfig, context: str, field_name: str) -> str:
+    try:
+        resolved = resolve_version(value, release)
+    except TypeError as exc:
+        raise ValueError(f"Invalid {field_name} at {context}: {exc}") from exc
+    if not resolved:
+        raise ValueError(f"{field_name} at {context} must not be empty")
+    return resolved
+
+
+def validate_distribution_policy(
+    policy: object,
+    *,
+    distribution: str,
+    accelerator: str,
+    context: str,
+    release: ReleaseConfig,
+) -> None:
+    if not isinstance(policy, dict):
+        raise ValueError(f"Expected mapping at {context}")
+
+    if distribution == "rhds":
+        version_key = policy_version_key(accelerator)
+        actual_keys = set(policy)
+        allowed_keys = {"channel", version_key}
+        unexpected_keys = sorted(actual_keys - allowed_keys)
+        if unexpected_keys:
+            raise ValueError(f"Unexpected keys under {context}: {', '.join(unexpected_keys)}")
+        if "channel" not in policy:
+            raise ValueError(f"Missing keys under {context}: channel")
+
+        channel = scalar_to_string(policy["channel"])
+        if channel not in RHDS_CHANNELS:
+            raise ValueError(f"Invalid rhds channel at {context}: {channel}")
+        if channel == "fast":
+            if version_key not in policy:
+                raise ValueError(f"Missing {version_key} for rhds fast channel at {context}")
+            validate_version_value(policy[version_key], release, f"{context}.{version_key}", version_key)
+        elif version_key in policy:
+            raise ValueError(f"rhds stable channel at {context} must not define {version_key}")
+        return
+
+    if distribution != "odh":
+        raise ValueError(f"Unsupported distribution at {context}: {distribution}")
+
+    version_key = policy_version_key(accelerator)
+    actual_keys = set(policy)
+    allowed_keys = {"origin", version_key}
+    unexpected_keys = sorted(actual_keys - allowed_keys)
+    if unexpected_keys:
+        raise ValueError(f"Unexpected keys under {context}: {', '.join(unexpected_keys)}")
+    if "origin" not in policy:
+        raise ValueError(f"Missing keys under {context}: origin")
+
+    origin = scalar_to_string(policy["origin"])
+    if origin not in ODH_ORIGINS:
+        raise ValueError(f"Invalid odh origin at {context}: {origin}")
+    if version_key not in policy:
+        raise ValueError(f"Missing {version_key} for odh {origin} origin at {context}")
+
+    version = validate_version_value(policy[version_key], release, f"{context}.{version_key}", version_key)
+    normalized_version = normalize_stream_version(version)
+    if accelerator == "cpu":
+        if version != "latest":
+            raise ValueError(f"cpu odh {origin} origin at {context} requires version latest")
+        return
+    if origin == "midstream" and MIDSTREAM_VERSION_RE.fullmatch(normalized_version) is None:
+        raise ValueError(f"odh midstream origin at {context} requires a numeric {version_key}")
+    if origin == "in-house" and accelerator != "cpu" and MIDSTREAM_VERSION_RE.fullmatch(normalized_version) is None:
+        raise ValueError(f"odh in-house origin at {context} requires a numeric acc_version")
+
+
+def validate_base_image_config(base_image: dict[str, Any], release: ReleaseConfig) -> None:
+    for distribution in ("rhds", "odh"):
+        validate_distribution_policy(
+            base_image["cpu"][distribution],
+            distribution=distribution,
+            accelerator="cpu",
+            context=f"cpu.{distribution}",
+            release=release,
+        )
+
+    for accelerator, flavors in (
+        ("cuda", ("minimal", "pytorch", "pytorch-llmcompressor", "tensorflow")),
+        ("rocm", ("minimal", "pytorch", "tensorflow")),
+    ):
+        for flavor in flavors:
+            for distribution in ("rhds", "odh"):
+                validate_distribution_policy(
+                    base_image[accelerator][flavor][distribution],
+                    distribution=distribution,
+                    accelerator=accelerator,
+                    context=f"{accelerator}.{flavor}.{distribution}",
+                    release=release,
+                )
+
+
+def load_versions_config(path: Path) -> VersionsConfig:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected top-level mapping in {path}")
+
+    validate_mapping_schema(data, ROOT_SCHEMA, "root")
+
+    if data["schema_version"] != 1:
+        raise ValueError(f"Unsupported schema_version in {path}: {data['schema_version']!r}")
+
+    release_data = data["release"]
+    release = ReleaseConfig(
+        full_version=scalar_to_string(release_data["full_version"]),
+        rhds_os_base=scalar_to_string(release_data["rhds_os_base"]),
+        python_version=scalar_to_string(release_data["python_version"]),
+    )
+    parse_release_version(release.full_version)
+    if not release.rhds_os_base:
+        raise ValueError("release.rhds_os_base must not be empty")
+    normalize_python_version(release.python_version)
+
+    base_image = data["artifacts"]["base_image"]
+    validate_base_image_config(base_image, release)
+    return VersionsConfig(release=release, base_image=base_image)
+
+
+def classify_conf_name(name: str) -> tuple[str, str] | None:
+    mapping = {
+        "cpu.conf": ("cpu", "odh"),
+        "cuda.conf": ("cuda", "odh"),
+        "rocm.conf": ("rocm", "odh"),
+        "konflux.cpu.conf": ("cpu", "rhds"),
+        "konflux.cuda.conf": ("cuda", "rhds"),
+        "konflux.rocm.conf": ("rocm", "rhds"),
+    }
+    return mapping.get(name)
+
+
+def classify_flavor(relative_path: Path, accelerator: str) -> str | None:
+    parts = relative_path.parts
+
+    if accelerator == "cpu":
+        if parts[0] in MANAGED_ROOTS:
+            return None
+        raise ValueError(f"Unsupported CPU build-args path: {relative_path}")
+
+    if accelerator == "cuda":
+        if parts[:2] == ("jupyter", "minimal"):
+            return "minimal"
+        if parts[:2] in {("jupyter", "pytorch"), ("runtimes", "pytorch")}:
+            return "pytorch"
+        if parts[:2] in {
+            ("jupyter", "pytorch+llmcompressor"),
+            ("runtimes", "pytorch+llmcompressor"),
+        }:
+            return "pytorch-llmcompressor"
+        if parts[:2] in {("jupyter", "tensorflow"), ("runtimes", "tensorflow")}:
+            return "tensorflow"
+        raise ValueError(f"Unsupported CUDA build-args path: {relative_path}")
+
+    if accelerator == "rocm":
+        if parts[:2] == ("jupyter", "minimal"):
+            return "minimal"
+        if parts[:3] == ("jupyter", "rocm", "pytorch") or parts[:2] == ("runtimes", "rocm-pytorch"):
+            return "pytorch"
+        if parts[:3] == ("jupyter", "rocm", "tensorflow") or parts[:2] == ("runtimes", "rocm-tensorflow"):
+            return "tensorflow"
+        raise ValueError(f"Unsupported ROCm build-args path: {relative_path}")
+
+    raise ValueError(f"Unsupported accelerator '{accelerator}'")
+
+
+def collect_conf_targets(root_dir: Path) -> list[ConfTarget]:
+    targets: list[ConfTarget] = []
+
+    for managed_root in MANAGED_ROOTS:
+        search_root = root_dir / managed_root
+        if not search_root.is_dir():
+            continue
+
+        for path in sorted(search_root.rglob("build-args/*.conf")):
+            relative_path = path.relative_to(root_dir)
+            classification = classify_conf_name(path.name)
+            if classification is None:
+                raise ValueError(f"Unsupported build-args filename: {relative_path}")
+
+            accelerator, distribution = classification
+            targets.append(
+                ConfTarget(
+                    path=path,
+                    accelerator=accelerator,
+                    distribution=distribution,
+                    flavor=classify_flavor(relative_path, accelerator),
+                )
+            )
+
+    return targets
+
+
+def split_image_ref(image: str) -> tuple[str, str]:
+    name, separator, tag = image.rpartition(":")
+    if not separator:
+        raise ValueError(f"Image reference is missing a tag: {image}")
+    return name, tag
+
+
+def normalize_stream_version(version: str) -> str:
+    return version.removeprefix("v")
+
+
+def build_rhds_family_pattern(candidate_tag: str) -> re.Pattern[str]:
+    match = RHDS_TAG_RE.fullmatch(candidate_tag)
+    if match is None:
+        raise ValueError(f"Unsupported RHDS candidate tag: {candidate_tag}")
+
+    prefix = match.group("version")
+    if phase := match.group("phase"):
+        prefix = f"{prefix}-{phase}"
+    return re.compile(rf"^{re.escape(prefix)}-(?P<build>\d+)$")
+
+
+def select_latest_matching_rhds_tag(tags: list[str], candidate_tag: str) -> str:
+    family_pattern = build_rhds_family_pattern(candidate_tag)
+    matches: list[tuple[int, str]] = []
+
+    for tag in tags:
+        match = family_pattern.fullmatch(tag)
+        if match is None:
+            continue
+        matches.append((int(match.group("build")), tag))
+
+    if not matches:
+        raise ValueError(f"No matching published RHDS tag found for family '{candidate_tag}'")
+
+    return max(matches, key=lambda item: item[0])[1]
+
+
+def determine_highest_published_rhds_phase_for_release(
+    repository: str,
+    release_version: str,
+    tag_cache: dict[str, tuple[str, ...]] | None = None,
+) -> str | None:
+    phases: set[str | None] = set()
+
+    for tag in list_rhds_repository_tags(repository, tag_cache):
+        match = RHDS_TAG_RE.fullmatch(tag)
+        if match is None or match.group("version") != release_version:
+            continue
+        phases.add(match.group("phase"))
+
+    if not phases:
+        return "ea.1"
+    return max(phases, key=rank_rhds_phase)
+
+
+def select_rhds_forward_phase(
+    accelerator: str,
+    version: str,
+    release: ReleaseConfig,
+    tag_cache: dict[str, tuple[str, ...]],
+) -> str | None:
+    repository = build_rhds_pinned_repository(accelerator, version, release)
+    return determine_highest_published_rhds_phase_for_release(
+        repository,
+        release.full_version,
+        tag_cache,
+    )
+
+
+def select_highest_published_rhds_tag_for_release(tags: list[str], release_version: str) -> str:
+    matches: list[tuple[int, int, str]] = []
+
+    for tag in tags:
+        match = RHDS_TAG_RE.fullmatch(tag)
+        if match is None or match.group("version") != release_version:
+            continue
+        matches.append((rank_rhds_phase(match.group("phase")), int(match.group("build")), tag))
+
+    if not matches:
+        raise ValueError(f"No published RHDS tags found for release '{release_version}'")
+
+    return max(matches)[2]
+
+
+def list_rhds_repository_tags(
+    repository: str,
+    tag_cache: dict[str, tuple[str, ...]] | None = None,
+) -> tuple[str, ...]:
+    if tag_cache is not None and repository in tag_cache:
+        return tag_cache[repository]
+
+    try:
+        result = subprocess.run(
+            ["skopeo", "list-tags", "--retry-times", "3", f"docker://{repository}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError("skopeo is required to resolve latest RHDS tags") from exc
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
+        raise ValueError(f"skopeo list-tags failed for {repository}: {detail}")
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"skopeo list-tags returned invalid JSON for {repository}") from exc
+
+    tags = payload.get("Tags")
+    if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+        raise ValueError(f"skopeo list-tags returned invalid tags for {repository}")
+
+    resolved_tags = tuple(tags)
+    if tag_cache is not None:
+        tag_cache[repository] = resolved_tags
+    return resolved_tags
+
+
+def resolve_latest_published_rhds_image(
+    candidate_image: str,
+    tag_cache: dict[str, tuple[str, ...]] | None = None,
+) -> str:
+    repository, candidate_tag = split_image_ref(candidate_image)
+    tags = list(list_rhds_repository_tags(repository, tag_cache))
+    try:
+        latest_tag = select_latest_matching_rhds_tag(tags, candidate_tag)
+    except ValueError:
+        match = RHDS_TAG_RE.fullmatch(candidate_tag)
+        if match is None or match.group("phase") is not None:
+            raise
+        latest_tag = select_highest_published_rhds_tag_for_release(tags, match.group("version"))
+    return f"{repository}:{latest_tag}"
+
+
+def build_rhds_pinned_repository(accelerator: str, version: str, release: ReleaseConfig) -> str:
+    if accelerator == "cpu":
+        return "quay.io/aipcc/base-images/cpu"
+    normalized_version = normalize_stream_version(version)
+    return f"quay.io/aipcc/base-images/{accelerator}-{normalized_version}-{release.rhds_os_base}"
+
+
+def describe_rhds_phase(phase: str | None) -> str:
+    return "GA" if phase is None else phase
+
+
+def rank_rhds_phase(phase: str | None) -> int:
+    if phase is None:
+        return 10_000
+    return int(phase.removeprefix("ea."))
+
+
+def build_rhds_seed_tag(release: ReleaseConfig, phase: str | None) -> str:
+    if phase is None:
+        return f"{release.full_version}-0"
+    return f"{release.full_version}-{phase}-0"
+
+
+def determine_rhds_fast_bundle_phase(
+    states: list[TargetState],
+    release: ReleaseConfig,
+) -> tuple[bool, str | None]:
+    target_version = parse_release_version(release.full_version)
+    same_release_phases: set[str | None] = set()
+
+    for peer_state in states:
+        if peer_state.target.distribution != "rhds":
+            continue
+        if peer_state.policy.mode != "fast":
+            continue
+
+        _peer_repository, peer_tag = split_image_ref(peer_state.current_base_image)
+        match = RHDS_TAG_RE.fullmatch(peer_tag)
+        if match is None:
+            continue
+
+        peer_version = parse_release_version(match.group("version"))
+        if peer_version > target_version:
+            continue
+        if peer_version == target_version:
+            same_release_phases.add(match.group("phase"))
+
+    if not same_release_phases:
+        return False, None
+    highest_phase = max(same_release_phases, key=rank_rhds_phase)
+    return True, highest_phase
+
+
+def build_rhds_pinned_tag(
+    current_tag: str,
+    release: ReleaseConfig,
+    *,
+    use_bundle_phase: bool = False,
+    bundle_phase: str | None = None,
+    forward_phase: str | None | object = _FORWARD_PHASE_UNSET,
+) -> str:
+    match = RHDS_TAG_RE.fullmatch(current_tag)
+    if match is None:
+        raise ValueError(f"Unsupported RHDS BASE_IMAGE tag: {current_tag}")
+
+    current_version = parse_release_version(match.group("version"))
+    target_version = parse_release_version(release.full_version)
+    build = match.group("build")
+
+    # Phase precedence: rollback -> same-release bundle -> forward-discovered
+    # phase -> current tag phase.
+    if target_version < current_version:
+        phase = None
+    elif use_bundle_phase:
+        phase = bundle_phase
+    elif target_version > current_version:
+        phase = "ea.1" if forward_phase is _FORWARD_PHASE_UNSET else forward_phase
+    else:
+        phase = match.group("phase")
+
+    if phase is None:
+        return f"{release.full_version}-{build}"
+    return f"{release.full_version}-{phase}-{build}"
+
+
+def build_rhds_pinned_image(
+    accelerator: str,
+    version: str,
+    current_base_image: str,
+    release: ReleaseConfig,
+    *,
+    use_bundle_phase: bool = False,
+    bundle_phase: str | None = None,
+    forward_phase: str | None | object = _FORWARD_PHASE_UNSET,
+) -> str:
+    _current_name, current_tag = split_image_ref(current_base_image)
+    repository = build_rhds_pinned_repository(accelerator, version, release)
+    return (
+        f"{repository}:{build_rhds_pinned_tag(current_tag, release, use_bundle_phase=use_bundle_phase, bundle_phase=bundle_phase, forward_phase=forward_phase)}"
+    )
+
+
+def build_rhds_stable_image(accelerator: str, release: ReleaseConfig) -> str:
+    return f"quay.io/aipcc/base-image-{accelerator}-stable-ubi9:{release_minor_version(release.full_version)}"
+
+
+def build_odh_in_house_image(accelerator: str, version: str, release: ReleaseConfig) -> str:
+    repositories = {
+        "cpu": f"quay.io/opendatahub/odh-base-image-cpu-py{compact_python_version(release.python_version)}-c9s",
+        "cuda": "quay.io/opendatahub/odh-base-image-cuda-py312-c9s",
+        "rocm": "quay.io/opendatahub/odh-base-image-rocm-py312-c9s",
+    }
+    if accelerator not in repositories:
+        raise ValueError(f"Unsupported ODH in-house accelerator: {accelerator}")
+
+    if accelerator == "cpu":
+        tag = version
+    else:
+        tag = f"v{normalize_stream_version(version)}"
+    return f"{repositories[accelerator]}:{tag}"
+
+
+def build_odh_midstream_image(accelerator: str, version: str, release: ReleaseConfig) -> str:
+    normalized_version = normalize_stream_version(version).replace(".", "-")
+    if accelerator == "cpu":
+        return f"quay.io/opendatahub/odh-midstream-python-base-{hyphenated_python_version(release.python_version)}:{version}"
+    return f"quay.io/opendatahub/odh-midstream-{accelerator}-base-{normalized_version}:latest"
+
+
+def build_target_base_image(
+    state: TargetState,
+    release: ReleaseConfig,
+    tag_cache: dict[str, tuple[str, ...]],
+    rhds_bundle_phase_known: bool,
+    rhds_bundle_phase: str | None,
+) -> str:
+    target = state.target
+    current_base_image = state.current_base_image
+    policy = state.policy
+
+    if target.distribution == "rhds":
+        if policy.mode == "stable":
+            return build_rhds_stable_image(target.accelerator, release)
+        if policy.version is None:
+            raise ValueError(f"Missing {policy_version_key(target.accelerator)} for rhds fast channel in {target.path}")
+
+        _current_repository, current_tag = split_image_ref(current_base_image)
+        if RHDS_TAG_RE.fullmatch(current_tag) is None:
+            repository = build_rhds_pinned_repository(target.accelerator, policy.version, release)
+            if MIDSTREAM_VERSION_RE.fullmatch(current_tag):
+                current_minor = parse_minor_version(current_tag)
+                target_minor = parse_minor_version(release_minor_version(release.full_version))
+                if current_minor > target_minor:
+                    seed_phase = None
+                elif current_minor < target_minor:
+                    seed_phase = select_rhds_forward_phase(
+                        target.accelerator,
+                        policy.version,
+                        release,
+                        tag_cache,
+                    )
+                else:
+                    seed_phase = rhds_bundle_phase if rhds_bundle_phase_known else "ea.1"
+            else:
+                seed_phase = rhds_bundle_phase if rhds_bundle_phase_known else "ea.1"
+            candidate = f"{repository}:{build_rhds_seed_tag(release, seed_phase)}"
+        else:
+            current_match = RHDS_TAG_RE.fullmatch(current_tag)
+            forward_phase: str | None | object = _FORWARD_PHASE_UNSET
+            current_version = parse_release_version(current_match.group("version"))
+            target_version = parse_release_version(release.full_version)
+            if target_version > current_version:
+                forward_phase = select_rhds_forward_phase(
+                    target.accelerator,
+                    policy.version,
+                    release,
+                    tag_cache,
+                )
+            candidate = build_rhds_pinned_image(
+                target.accelerator,
+                policy.version,
+                current_base_image,
+                release,
+                use_bundle_phase=rhds_bundle_phase_known and target_version == current_version,
+                bundle_phase=rhds_bundle_phase,
+                forward_phase=forward_phase,
+            )
+        return resolve_latest_published_rhds_image(candidate, tag_cache)
+
+    if target.distribution != "odh":
+        raise ValueError(f"Unsupported distribution in {target.path}: {target.distribution}")
+
+    if policy.version is None:
+        raise ValueError(f"Missing {policy_version_key(target.accelerator)} for odh origin in {target.path}")
+    if policy.mode == "in-house":
+        return build_odh_in_house_image(target.accelerator, policy.version, release)
+    if policy.mode == "midstream":
+        return build_odh_midstream_image(target.accelerator, policy.version, release)
+    raise ValueError(f"Unsupported odh origin in {target.path}: {policy.mode}")
+
+
+def read_conf_assignments(text: str) -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        assignments[key.strip()] = value.strip()
+    return assignments
+
+
+def rewrite_conf_text(text: str, replacements: dict[str, str]) -> str:
+    lines = text.splitlines(keepends=True)
+    found_keys: set[str] = set()
+    rewritten_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            rewritten_lines.append(line)
+            continue
+
+        key, _, _value = stripped.partition("=")
+        normalized_key = key.strip()
+        if normalized_key not in replacements:
+            rewritten_lines.append(line)
+            continue
+
+        found_keys.add(normalized_key)
+        line_ending = "\n" if line.endswith("\n") else ""
+        rewritten_lines.append(f"{normalized_key}={replacements[normalized_key]}{line_ending}")
+
+    missing_keys = [key for key in replacements if key not in found_keys]
+    if missing_keys:
+        raise ValueError(f"Missing {', '.join(missing_keys)} in build-args content")
+    return "".join(rewritten_lines)
+
+
+def rewrite_makefile_text(text: str, replacements: dict[str, str]) -> str:
+    lines = text.splitlines(keepends=True)
+    found_keys: set[str] = set()
+    rewritten_lines: list[str] = []
+    assignment_re = re.compile(r"^(?P<leading>\s*)(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?P<separator>\s*\?=\s*)(?P<value>.*)$")
+
+    for line in lines:
+        line_ending = "\n" if line.endswith("\n") else ""
+        body = line[:-1] if line_ending else line
+        match = assignment_re.fullmatch(body)
+        if match is None or match.group("key") not in replacements:
+            rewritten_lines.append(line)
+            continue
+
+        key = match.group("key")
+        found_keys.add(key)
+        rewritten_lines.append(
+            f"{match.group('leading')}{key}{match.group('separator')}{replacements[key]}{line_ending}"
+        )
+
+    missing_keys = [key for key in replacements if key not in found_keys]
+    if missing_keys:
+        raise ValueError(f"Missing {', '.join(missing_keys)} in Makefile")
+    return "".join(rewritten_lines)
+
+
+def build_conf_replacements(assignments: dict[str, str], resolved_base_image: str, release: ReleaseConfig) -> dict[str, str]:
+    replacements = {"BASE_IMAGE": resolved_base_image}
+    if "RELEASE" in assignments:
+        replacements["RELEASE"] = release_minor_version(release.full_version)
+    return replacements
+
+
+def build_makefile_replacements(release: ReleaseConfig) -> dict[str, str]:
+    return {
+        "RELEASE": release_minor_version(release.full_version),
+        "RELEASE_PYTHON_VERSION": release.python_version,
+    }
+
+
+def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
+    states: list[TargetState] = []
+    tag_cache: dict[str, tuple[str, ...]] = {}
+
+    for target in collect_conf_targets(root_dir):
+        original_text = target.path.read_text(encoding="utf-8")
+        assignments = read_conf_assignments(original_text)
+        current_base_image = assignments.get("BASE_IMAGE")
+        if current_base_image is None:
+            raise ValueError(f"Missing BASE_IMAGE in {target.path}")
+
+        states.append(
+            TargetState(
+                target=target,
+                original_text=original_text,
+                current_base_image=current_base_image,
+                policy=config.policy(target.accelerator, target.distribution, target.flavor),
+            )
+        )
+
+    rhds_bundle_phase_known, rhds_bundle_phase = determine_rhds_fast_bundle_phase(states, config.release)
+
+    updates: list[PlannedUpdate] = []
+    for state in states:
+        resolved_base_image = build_target_base_image(
+            state,
+            config.release,
+            tag_cache,
+            rhds_bundle_phase_known,
+            rhds_bundle_phase,
+        )
+        updates.append(
+            PlannedUpdate(
+                path=state.target.path,
+                original_text=state.original_text,
+                updated_text=rewrite_conf_text(
+                    state.original_text,
+                    build_conf_replacements(read_conf_assignments(state.original_text), resolved_base_image, config.release),
+                ),
+                target=state.target,
+            )
+        )
+
+    makefile = root_dir / "Makefile"
+    if makefile.is_file():
+        original_text = makefile.read_text(encoding="utf-8")
+        updates.append(
+            PlannedUpdate(
+                path=makefile,
+                original_text=original_text,
+                updated_text=rewrite_makefile_text(original_text, build_makefile_replacements(config.release)),
+            )
+        )
+
+    return updates
+
+
+def relative_display_path(root_dir: Path, path: Path) -> str:
+    return path.relative_to(root_dir).as_posix()
+
+
+def print_diff(root_dir: Path, update: PlannedUpdate) -> None:
+    relative_path = relative_display_path(root_dir, update.path)
+    diff = difflib.unified_diff(
+        update.original_text.splitlines(),
+        update.updated_text.splitlines(),
+        fromfile=relative_path,
+        tofile=relative_path,
+        lineterm="",
+    )
+    print("\n".join(diff))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT_DIR, help="Repository root to scan")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH, help="Path to versions_config.yml")
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without writing files")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero if files need updates")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = load_versions_config(args.config)
+    updates = plan_updates(args.root, config)
+    changed_updates = [update for update in updates if update.original_text != update.updated_text]
+
+    if args.dry_run or args.check:
+        for update in changed_updates:
+            print_diff(args.root, update)
+        if changed_updates:
+            print(f"{len(changed_updates)} build-args file(s) need updates.")
+        else:
+            print("Build-args files already match versions_config.yml.")
+        return 1 if args.check and changed_updates else 0
+
+    for update in changed_updates:
+        update.path.write_text(update.updated_text, encoding="utf-8")
+        print(f"Updated {relative_display_path(args.root, update.path)}")
+
+    if not changed_updates:
+        print("Build-args files already match versions_config.yml.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -813,6 +813,26 @@ def select_latest_matching_rhds_tag(tags: list[str], candidate_tag: str) -> str:
     return max(matches, key=lambda item: item[0])[1]
 
 
+def select_latest_progressing_rhds_tag(tags: list[str], candidate_tag: str) -> str | None:
+    """Return the latest published tag at or above the candidate phase for the same release."""
+    candidate_match = RHDS_TAG_RE.fullmatch(candidate_tag)
+    if candidate_match is None:
+        raise ValueError(f"Unsupported RHDS candidate tag: {candidate_tag}")
+
+    release_version = candidate_match.group("version")
+    minimum_phase_rank = rank_rhds_phase(candidate_match.group("phase"))
+    matches = [
+        (rank_rhds_phase(match.group("phase")), int(match.group("build")), tag)
+        for tag in tags
+        if (match := RHDS_TAG_RE.fullmatch(tag)) is not None
+        and match.group("version") == release_version
+        and rank_rhds_phase(match.group("phase")) >= minimum_phase_rank
+    ]
+    if not matches:
+        return None
+    return max(matches)[2]
+
+
 def determine_highest_published_rhds_phase_for_release(
     repository: str,
     release_version: str,
@@ -887,13 +907,18 @@ def resolve_latest_published_rhds_image(
 ) -> str:
     repository, candidate_tag = split_image_ref(candidate_image)
     tags = list(list_rhds_repository_tags(repository, tag_cache))
-    try:
-        latest_tag = select_latest_matching_rhds_tag(tags, candidate_tag)
-    except ValueError:
-        match = RHDS_TAG_RE.fullmatch(candidate_tag)
-        if match is None or match.group("phase") is not None:
-            raise
-        latest_tag = select_highest_published_rhds_tag_for_release(tags, match.group("version"))
+    candidate_match = RHDS_TAG_RE.fullmatch(candidate_tag)
+    if candidate_match is None:
+        raise ValueError(f"Unsupported RHDS candidate tag: {candidate_tag}")
+
+    latest_tag = select_latest_progressing_rhds_tag(tags, candidate_tag)
+    if latest_tag is not None:
+        return f"{repository}:{latest_tag}"
+
+    if candidate_match.group("phase") is not None:
+        raise ValueError(f"No matching published RHDS tag found for family '{candidate_tag}'")
+
+    latest_tag = select_highest_published_rhds_tag_for_release(tags, candidate_match.group("version"))
     return f"{repository}:{latest_tag}"
 
 

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import logging
 import re
 import subprocess
 from dataclasses import dataclass
@@ -27,44 +28,24 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_CONFIG_PATH = ROOT_DIR / "versions_config.yml"
 MANAGED_ROOTS = ("jupyter", "runtimes", "codeserver")
 POLICY_SCHEMA = object()
+GPU_FLAVORS = {
+    "cuda": ("minimal", "pytorch", "pytorch-llmcompressor", "tensorflow"),
+    "rocm": ("minimal", "pytorch", "tensorflow"),
+}
+CPU_BASE_IMAGE_SCHEMA = {
+    "rhds": POLICY_SCHEMA,
+    "odh": POLICY_SCHEMA,
+}
+logger = logging.getLogger(__name__)
+ANSI_GREEN = "\033[32m"
+ANSI_YELLOW = "\033[33m"
+ANSI_RED = "\033[31m"
+ANSI_RESET = "\033[0m"
 
 BASE_IMAGE_SCHEMA = {
-    "cpu": {
-        "rhds": POLICY_SCHEMA,
-        "odh": POLICY_SCHEMA,
-    },
-    "cuda": {
-        "minimal": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-        "pytorch": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-        "pytorch-llmcompressor": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-        "tensorflow": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-    },
-    "rocm": {
-        "minimal": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-        "pytorch": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-        "tensorflow": {
-            "rhds": POLICY_SCHEMA,
-            "odh": POLICY_SCHEMA,
-        },
-    },
+    "cpu": CPU_BASE_IMAGE_SCHEMA,
+    "cuda": {flavor: None for flavor in GPU_FLAVORS["cuda"]},
+    "rocm": {flavor: None for flavor in GPU_FLAVORS["rocm"]},
 }
 
 ROOT_SCHEMA = {
@@ -105,6 +86,7 @@ class BaseImagePolicy:
 class VersionsConfig:
     release: ReleaseConfig
     base_image: dict[str, Any]
+    gpu_acc_versions: dict[tuple[str, str], str]
 
     def policy(self, accelerator: str, distribution: str, flavor: str | None = None) -> BaseImagePolicy:
         if accelerator == "cpu":
@@ -120,6 +102,13 @@ class VersionsConfig:
         raw_version = raw_policy.get(version_key)
         version = None if raw_version is None else resolve_version(raw_version, self.release)
         return BaseImagePolicy(mode=mode, version=version)
+
+    def shared_acc_version(self, accelerator: str, flavor: str | None = None) -> str:
+        if accelerator == "cpu":
+            raise ValueError("CPU does not use acc_version")
+        if flavor is None:
+            raise ValueError(f"Flavor is required for accelerator '{accelerator}'")
+        return self.gpu_acc_versions[(accelerator, flavor)]
 
 
 @dataclass(frozen=True)
@@ -144,6 +133,7 @@ class TargetState:
     original_text: str
     current_base_image: str
     policy: BaseImagePolicy
+    shared_acc_version: str | None = None
 
 
 def scalar_to_string(value: object) -> str:
@@ -152,6 +142,22 @@ def scalar_to_string(value: object) -> str:
     if isinstance(value, int | float):
         return str(value)
     raise TypeError(f"Unsupported scalar value: {value!r}")
+
+
+def log_warning(message: str, *args: object, color: str | None = None) -> None:
+    if color is None:
+        logger.warning(message, *args)
+        return
+
+    rendered_message = message % args if args else message
+    ansi_color = {
+        "green": ANSI_GREEN,
+        "yellow": ANSI_YELLOW,
+        "red": ANSI_RED,
+    }.get(color)
+    if ansi_color is None:
+        raise ValueError(f"Unsupported warning color '{color}'")
+    logger.warning(f"{ansi_color}WARNING: {rendered_message}{ANSI_RESET}")
 
 
 def policy_version_key(accelerator: str) -> str:
@@ -223,6 +229,27 @@ def validate_mapping_schema(data: object, expected: dict[str, Any], context: str
             continue
         if isinstance(child_schema, dict):
             validate_mapping_schema(data[key], child_schema, f"{context}.{key}")
+
+
+def validate_expected_mapping_keys(
+    data: object,
+    expected_keys: set[str],
+    context: str,
+    *,
+    required_keys: set[str] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at {context}")
+
+    actual_keys = set(data)
+    unexpected_keys = sorted(actual_keys - expected_keys)
+    missing_keys = sorted((required_keys or expected_keys) - actual_keys)
+
+    if unexpected_keys:
+        raise ValueError(f"Unexpected keys under {context}: {', '.join(unexpected_keys)}")
+    if missing_keys:
+        raise ValueError(f"Missing keys under {context}: {', '.join(missing_keys)}")
+    return data
 
 
 def validate_version_value(value: object, release: ReleaseConfig, context: str, field_name: str) -> str:
@@ -297,29 +324,133 @@ def validate_distribution_policy(
         raise ValueError(f"odh in-house origin at {context} requires a numeric acc_version")
 
 
-def validate_base_image_config(base_image: dict[str, Any], release: ReleaseConfig) -> None:
+def normalize_gpu_flavor_config(
+    flavor_policy: object,
+    *,
+    accelerator: str,
+    flavor: str,
+    release: ReleaseConfig,
+) -> tuple[dict[str, Any], str]:
+    context = f"root.artifacts.base_image.{accelerator}.{flavor}"
+    mapping = validate_expected_mapping_keys(flavor_policy, {"acc_version", "rhds", "odh"}, context, required_keys={"rhds", "odh"})
+
+    rhds_policy = mapping["rhds"]
+    odh_policy = mapping["odh"]
+
+    if not isinstance(rhds_policy, dict):
+        raise ValueError(f"Expected mapping at {context}.rhds")
+    if not isinstance(odh_policy, dict):
+        raise ValueError(f"Expected mapping at {context}.odh")
+
+    normalized_rhds = dict(rhds_policy)
+    normalized_odh = dict(odh_policy)
+    shared_raw = mapping.get("acc_version")
+
+    if shared_raw is None:
+        validate_distribution_policy(
+            normalized_rhds,
+            distribution="rhds",
+            accelerator=accelerator,
+            context=f"{context}.rhds",
+            release=release,
+        )
+        validate_distribution_policy(
+            normalized_odh,
+            distribution="odh",
+            accelerator=accelerator,
+            context=f"{context}.odh",
+            release=release,
+        )
+
+        shared_versions = [
+            validate_version_value(normalized_odh["acc_version"], release, f"{context}.odh.acc_version", "acc_version")
+        ]
+        if "acc_version" in normalized_rhds:
+            shared_versions.append(
+                validate_version_value(normalized_rhds["acc_version"], release, f"{context}.rhds.acc_version", "acc_version")
+            )
+
+        normalized_versions = {normalize_stream_version(version) for version in shared_versions}
+        if len(normalized_versions) != 1:
+            raise ValueError(f"Legacy rhds and odh acc_version values must match at {context}")
+        return {"rhds": normalized_rhds, "odh": normalized_odh}, shared_versions[0]
+
+    shared_version = validate_version_value(shared_raw, release, f"{context}.acc_version", "acc_version")
+    shared_version_normalized = normalize_stream_version(shared_version)
+
+    for distribution, policy in (("rhds", normalized_rhds), ("odh", normalized_odh)):
+        raw_distribution_version = policy.pop("acc_version", None)
+        if raw_distribution_version is None:
+            continue
+
+        distribution_version = validate_version_value(
+            raw_distribution_version,
+            release,
+            f"{context}.{distribution}.acc_version",
+            "acc_version",
+        )
+        if normalize_stream_version(distribution_version) != shared_version_normalized:
+            raise ValueError(f"Nested {distribution} acc_version at {context}.{distribution} must match shared acc_version")
+
+    if scalar_to_string(normalized_rhds.get("channel", "")) == "fast":
+        normalized_rhds["acc_version"] = shared_version
+    normalized_odh["acc_version"] = shared_version
+
+    validate_distribution_policy(
+        normalized_rhds,
+        distribution="rhds",
+        accelerator=accelerator,
+        context=f"{context}.rhds",
+        release=release,
+    )
+    validate_distribution_policy(
+        normalized_odh,
+        distribution="odh",
+        accelerator=accelerator,
+        context=f"{context}.odh",
+        release=release,
+    )
+    return {"rhds": normalized_rhds, "odh": normalized_odh}, shared_version
+
+
+def normalize_base_image_config(
+    base_image: object,
+    release: ReleaseConfig,
+) -> tuple[dict[str, Any], dict[tuple[str, str], str]]:
+    root_context = "root.artifacts.base_image"
+    mapping = validate_expected_mapping_keys(base_image, set(BASE_IMAGE_SCHEMA), root_context)
+
+    validate_mapping_schema(mapping["cpu"], CPU_BASE_IMAGE_SCHEMA, f"{root_context}.cpu")
+
+    normalized_base_image = {"cpu": mapping["cpu"], "cuda": {}, "rocm": {}}
+    gpu_acc_versions: dict[tuple[str, str], str] = {}
+
     for distribution in ("rhds", "odh"):
         validate_distribution_policy(
-            base_image["cpu"][distribution],
+            mapping["cpu"][distribution],
             distribution=distribution,
             accelerator="cpu",
             context=f"cpu.{distribution}",
             release=release,
         )
 
-    for accelerator, flavors in (
-        ("cuda", ("minimal", "pytorch", "pytorch-llmcompressor", "tensorflow")),
-        ("rocm", ("minimal", "pytorch", "tensorflow")),
-    ):
+    for accelerator, flavors in GPU_FLAVORS.items():
+        accelerator_mapping = validate_expected_mapping_keys(
+            mapping[accelerator],
+            set(flavors),
+            f"{root_context}.{accelerator}",
+        )
         for flavor in flavors:
-            for distribution in ("rhds", "odh"):
-                validate_distribution_policy(
-                    base_image[accelerator][flavor][distribution],
-                    distribution=distribution,
-                    accelerator=accelerator,
-                    context=f"{accelerator}.{flavor}.{distribution}",
-                    release=release,
-                )
+            normalized_flavor, shared_version = normalize_gpu_flavor_config(
+                accelerator_mapping[flavor],
+                accelerator=accelerator,
+                flavor=flavor,
+                release=release,
+            )
+            normalized_base_image[accelerator][flavor] = normalized_flavor
+            gpu_acc_versions[(accelerator, flavor)] = shared_version
+
+    return normalized_base_image, gpu_acc_versions
 
 
 def load_versions_config(path: Path) -> VersionsConfig:
@@ -343,9 +474,8 @@ def load_versions_config(path: Path) -> VersionsConfig:
         raise ValueError("release.rhds_os_base must not be empty")
     normalize_python_version(release.python_version)
 
-    base_image = data["artifacts"]["base_image"]
-    validate_base_image_config(base_image, release)
-    return VersionsConfig(release=release, base_image=base_image)
+    base_image, gpu_acc_versions = normalize_base_image_config(data["artifacts"]["base_image"], release)
+    return VersionsConfig(release=release, base_image=base_image, gpu_acc_versions=gpu_acc_versions)
 
 
 def classify_conf_name(name: str) -> tuple[str, str] | None:
@@ -430,6 +560,186 @@ def split_image_ref(image: str) -> tuple[str, str]:
 
 def normalize_stream_version(version: str) -> str:
     return version.removeprefix("v")
+
+
+def major_minor_stream_version(value: str) -> str | None:
+    match = re.search(r"(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?", value)
+    if match is None:
+        return None
+    return f"{match.group('major')}.{match.group('minor')}"
+
+
+def extract_image_env(config_payload: dict[str, Any]) -> dict[str, str]:
+    config = config_payload.get("config")
+    if not isinstance(config, dict):
+        return {}
+
+    raw_env = config.get("Env")
+    if not isinstance(raw_env, list):
+        return {}
+
+    env: dict[str, str] = {}
+    for entry in raw_env:
+        if not isinstance(entry, str) or "=" not in entry:
+            continue
+        key, value = entry.split("=", 1)
+        env[key] = value
+    return env
+
+
+def extract_image_labels(config_payload: dict[str, Any]) -> dict[str, str]:
+    labels: dict[str, str] = {}
+
+    config = config_payload.get("config")
+    if isinstance(config, dict):
+        config_labels = config.get("Labels")
+        if isinstance(config_labels, dict):
+            labels.update({key: value for key, value in config_labels.items() if isinstance(key, str) and isinstance(value, str)})
+
+    root_labels = config_payload.get("Labels")
+    if isinstance(root_labels, dict):
+        labels.update({key: value for key, value in root_labels.items() if isinstance(key, str) and isinstance(value, str)})
+    return labels
+
+
+def extract_image_history(config_payload: dict[str, Any]) -> list[str]:
+    history = config_payload.get("history")
+    if not isinstance(history, list):
+        return []
+
+    created_by: list[str] = []
+    for layer in history:
+        if not isinstance(layer, dict):
+            continue
+        value = layer.get("created_by")
+        if isinstance(value, str):
+            created_by.append(value)
+    return created_by
+
+
+def inspect_image_config(image: str, *, warning_color: str | None = None) -> dict[str, Any] | None:
+    try:
+        result = subprocess.run(
+            [
+                "skopeo",
+                "inspect",
+                "--retry-times",
+                "3",
+                "--override-arch",
+                "amd64",
+                "--override-os",
+                "linux",
+                "--config",
+                f"docker://{image}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        log_warning("Could not inspect image config for %s: %s", image, exc, color=warning_color)
+        return None
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
+        log_warning("skopeo inspect --config failed for %s: %s", image, detail, color=warning_color)
+        return None
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        log_warning("skopeo inspect --config returned invalid JSON for %s: %s", image, exc, color=warning_color)
+        return None
+
+    if not isinstance(payload, dict):
+        log_warning("skopeo inspect --config returned unexpected payload for %s", image, color=warning_color)
+        return None
+    return payload
+
+
+def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | None:
+    config_payload = inspect_image_config(image, warning_color="red")
+    if config_payload is None:
+        return None
+
+    env = extract_image_env(config_payload)
+    labels = extract_image_labels(config_payload)
+    history = extract_image_history(config_payload)
+
+    if accelerator == "cuda":
+        for value in (env.get("CUDA_VERSION"), labels.get("CUDA_VERSION")):
+            if value is None:
+                continue
+            if version := major_minor_stream_version(value):
+                return version
+
+        requirement = env.get("NVIDIA_REQUIRE_CUDA")
+        if requirement is not None:
+            match = re.search(r"cuda>=(?P<version>\d+\.\d+(?:\.\d+)?)", requirement)
+            if match and (version := major_minor_stream_version(match.group("version"))):
+                return version
+
+        for line in history:
+            match = re.search(r"\bCUDA_VERSION=(?P<version>\d+\.\d+(?:\.\d+)?)\b", line)
+            if match and (version := major_minor_stream_version(match.group("version"))):
+                return version
+        return None
+
+    if accelerator == "rocm":
+        for value in (env.get("ROCM_VERSION"), labels.get("ROCM_VERSION")):
+            if value is None:
+                continue
+            if version := major_minor_stream_version(value):
+                return version
+
+        for line in history:
+            match = re.search(r"\bROCM_VERSION=(?P<version>\d+\.\d+(?:\.\d+)?)\b", line)
+            if match and (version := major_minor_stream_version(match.group("version"))):
+                return version
+        return None
+
+    raise ValueError(f"Unsupported accelerator '{accelerator}'")
+
+
+def warn_on_rhds_stable_acc_version_mismatch(
+    target: ConfTarget,
+    stable_image: str,
+    configured_acc_version: str | None,
+    stable_acc_version_cache: dict[tuple[str, str], str | None],
+) -> None:
+    if target.accelerator == "cpu" or configured_acc_version is None:
+        return
+
+    cache_key = (stable_image, target.accelerator)
+    if cache_key not in stable_acc_version_cache:
+        stable_acc_version_cache[cache_key] = inspect_rhds_stable_acc_version(stable_image, target.accelerator)
+
+    detected_acc_version = stable_acc_version_cache[cache_key]
+    if detected_acc_version is None:
+        log_warning(
+            "Could not determine RHDS stable %s acc_version from %s; continuing with configured shared acc_version %s",
+            target.accelerator,
+            stable_image,
+            normalize_stream_version(configured_acc_version),
+            color="yellow",
+        )
+        return
+
+    configured_normalized = normalize_stream_version(configured_acc_version)
+    detected_normalized = normalize_stream_version(detected_acc_version)
+    if configured_normalized == detected_normalized:
+        return
+
+    log_warning(
+        "Configured shared %s acc_version %s does not match RHDS stable image %s, which appears to use acc_version %s. Consider updating versions_config.yml to use acc_version %s for alignment.",
+        target.accelerator,
+        configured_normalized,
+        stable_image,
+        detected_normalized,
+        detected_normalized,
+        color="green",
+    )
 
 
 def build_rhds_family_pattern(candidate_tag: str) -> re.Pattern[str]:
@@ -691,6 +1001,7 @@ def build_target_base_image(
     state: TargetState,
     release: ReleaseConfig,
     tag_cache: dict[str, tuple[str, ...]],
+    stable_acc_version_cache: dict[tuple[str, str], str | None],
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
 ) -> str:
@@ -700,7 +1011,14 @@ def build_target_base_image(
 
     if target.distribution == "rhds":
         if policy.mode == "stable":
-            return build_rhds_stable_image(target.accelerator, release)
+            stable_image = build_rhds_stable_image(target.accelerator, release)
+            warn_on_rhds_stable_acc_version_mismatch(
+                target,
+                stable_image,
+                state.shared_acc_version,
+                stable_acc_version_cache,
+            )
+            return stable_image
         if policy.version is None:
             raise ValueError(f"Missing {policy_version_key(target.accelerator)} for rhds fast channel in {target.path}")
 
@@ -840,6 +1158,7 @@ def build_makefile_replacements(release: ReleaseConfig) -> dict[str, str]:
 def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
     states: list[TargetState] = []
     tag_cache: dict[str, tuple[str, ...]] = {}
+    stable_acc_version_cache: dict[tuple[str, str], str | None] = {}
 
     for target in collect_conf_targets(root_dir):
         original_text = target.path.read_text(encoding="utf-8")
@@ -854,6 +1173,11 @@ def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
                 original_text=original_text,
                 current_base_image=current_base_image,
                 policy=config.policy(target.accelerator, target.distribution, target.flavor),
+                shared_acc_version=(
+                    None
+                    if target.accelerator == "cpu"
+                    else config.shared_acc_version(target.accelerator, target.flavor)
+                ),
             )
         )
 
@@ -865,6 +1189,7 @@ def plan_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
             state,
             config.release,
             tag_cache,
+            stable_acc_version_cache,
             rhds_bundle_phase_known,
             rhds_bundle_phase,
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -267,6 +267,8 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
                             continue
                         elif s.get("name") in ("CUDA", "ROCm"):
                             expected_version = get_accelerator_version_for_directory(directory, s["name"])
+                            if expected_version is None:
+                                continue
                             manifest_version = s.get("version", "").lstrip("v")
                             assert manifest_version == expected_version, (
                                 f"{s['name']} version in imagestream ({s.get('version')}) does not match "
@@ -811,16 +813,27 @@ def is_dependencies_directory(file: pathlib.Path) -> bool:
     return "dependencies" in file.relative_to(PROJECT_ROOT).parts
 
 
-def get_accelerator_version_for_directory(directory: pathlib.Path, accelerator_name: str) -> str:
-    """Parse the CUDA/ROCm version from the build-args/konflux.{cuda,rocm}.conf BASE_IMAGE value."""
+def get_accelerator_version_for_directory(directory: pathlib.Path, accelerator_name: str) -> str | None:
+    """Parse the CUDA/ROCm version from BASE_IMAGE, if the tag encodes it."""
     flavor = accelerator_name.lower()
     conf_file = directory / "build-args" / f"konflux.{flavor}.conf"
     env = parse_env_file(conf_file)
     base_image = env.get("BASE_IMAGE", "")
+    if re.search(rf"{re.escape(flavor)}-[^:]+:\d+\.\d+\.\d+-stable-\d+$", base_image, flags=re.IGNORECASE):
+        return None
     match = re.search(rf"{re.escape(flavor)}-v?(\d+\.\d+)", base_image, flags=re.IGNORECASE)
     if not match:
         raise ValueError(f"Cannot extract {accelerator_name} version from {conf_file}: BASE_IMAGE={base_image}")
     return match.group(1)
+
+
+def test_get_accelerator_version_for_directory_returns_none_for_gpu_stable_tag(tmp_path: pathlib.Path):
+    directory = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12"
+    conf_file = directory / "build-args" / "konflux.cuda.conf"
+    conf_file.parent.mkdir(parents=True)
+    conf_file.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cuda-el9.6:3.5.0-stable-1780598175\n")
+
+    assert get_accelerator_version_for_directory(directory, "CUDA") is None
 
 
 def _check_all_accelerator_variants(
@@ -841,6 +854,8 @@ def _check_all_accelerator_variants(
         accel_name = "CUDA" if flavor == "cuda" else "ROCm"
         with subtests.test(msg=f"accelerator variant {flavor}", directory=str(directory)):
             expected_version = get_accelerator_version_for_directory(directory, accel_name)
+            if expected_version is None:
+                pytest.skip(f"{accel_name} version is not encoded in stable BASE_IMAGE for {directory}")
 
             try:
                 manifest = load_manifests_file_for(directory, manifests_directory, accelerator_flavor=flavor)

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -32,6 +32,12 @@ def completed_process(
     )
 
 
+DEFAULT_GPU_MINIMAL_ACC_VERSION = {"cuda": "25.0", "rocm": "8.0"}
+RHDS_CPU_EA2_IMAGE = "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771"
+RHDS_CUDA_EA2_IMAGE = "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771"
+RHDS_ROCM_EA2_IMAGE = "quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1777919771"
+
+
 def rhds_gpu_stable_image(
     accelerator: str,
     *,
@@ -87,6 +93,69 @@ def stub_matching_rhds_stable_acc_version(monkeypatch: pytest.MonkeyPatch, updat
         updater,
         "inspect_rhds_stable_acc_version",
         lambda image, accelerator: {"cuda": "25.0", "rocm": "8.0"}.get(accelerator),
+    )
+
+
+def write_conf(path: Path, *lines: str) -> None:
+    path.parent.mkdir(parents=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def gpu_minimal_policy_block(
+    accelerator: str,
+    *,
+    acc_version: str | None = None,
+    rhds_channel: str = "fast",
+    odh_origin: str = "in-house",
+    shared_acc_version: bool = False,
+) -> str:
+    resolved_acc_version = acc_version or DEFAULT_GPU_MINIMAL_ACC_VERSION[accelerator]
+    if shared_acc_version:
+        return (
+            "      minimal:\n"
+            f'        acc_version: "{resolved_acc_version}"\n'
+            "        rhds:\n"
+            f"          channel: {rhds_channel}\n"
+            "        odh:\n"
+            f"          origin: {odh_origin}"
+        )
+    rhds_acc_version = "" if rhds_channel == "stable" else f'          acc_version: "{resolved_acc_version}"\n'
+    return (
+        "      minimal:\n"
+        "        rhds:\n"
+        f"          channel: {rhds_channel}\n"
+        f"{rhds_acc_version}"
+        "        odh:\n"
+        f"          origin: {odh_origin}\n"
+        f'          acc_version: "{resolved_acc_version}"'
+    )
+
+
+def write_gpu_minimal_versions_config(
+    path: Path,
+    *,
+    accelerator: str,
+    full_version: str = "3.5.0",
+    acc_version: str | None = None,
+    rhds_channel: str = "fast",
+    odh_origin: str = "in-house",
+    shared_acc_version: bool = False,
+) -> None:
+    write_versions_config(
+        path,
+        full_version=full_version,
+        replacements=[
+            (
+                gpu_minimal_policy_block(accelerator),
+                gpu_minimal_policy_block(
+                    accelerator,
+                    acc_version=acc_version,
+                    rhds_channel=rhds_channel,
+                    odh_origin=odh_origin,
+                    shared_acc_version=shared_acc_version,
+                ),
+            )
+        ],
     )
 
 
@@ -559,8 +628,7 @@ def test_collect_conf_targets_ignores_base_images_build_args(tmp_path: Path) -> 
 def test_collect_conf_targets_rejects_unknown_build_args_filename(tmp_path: Path) -> None:
     updater = load_updater()
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "gpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=example\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=example")
 
     with pytest.raises(ValueError, match="Unsupported build-args filename"):
         updater.collect_conf_targets(tmp_path)
@@ -702,11 +770,9 @@ def test_plan_updates_caches_rhds_tag_listing_per_repository(
 
     first = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     second = tmp_path / "runtimes" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    first.parent.mkdir(parents=True)
-    second.parent.mkdir(parents=True)
-    base_image = "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777919771\n"
-    first.write_text(f"BASE_IMAGE={base_image}", encoding="utf-8")
-    second.write_text(f"BASE_IMAGE={base_image}", encoding="utf-8")
+    base_image = "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777919771"
+    write_conf(first, f"BASE_IMAGE={base_image}")
+    write_conf(second, f"BASE_IMAGE={base_image}")
 
     calls: list[str] = []
 
@@ -730,13 +796,8 @@ def test_plan_updates_infers_bundle_phase_for_stable_to_fast_target(
 
     target_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     peer_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    target_conf.parent.mkdir(parents=True)
-    peer_conf.parent.mkdir(parents=True)
-    target_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
-    peer_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(target_conf, "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5")
+    write_conf(peer_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -768,13 +829,8 @@ def test_plan_updates_infers_ga_phase_for_stable_to_fast_target(
 
     target_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
     peer_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    target_conf.parent.mkdir(parents=True)
-    peer_conf.parent.mkdir(parents=True)
-    target_conf.write_text(f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}\n", encoding="utf-8")
-    peer_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(target_conf, f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}")
+    write_conf(peer_conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1777919771")
 
     seen: list[str] = []
 
@@ -806,10 +862,8 @@ def test_plan_updates_falls_back_to_ea1_without_any_bundle_fast_style_peers(
 
     first_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     second_conf = tmp_path / "runtimes" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    first_conf.parent.mkdir(parents=True)
-    second_conf.parent.mkdir(parents=True)
-    first_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
-    second_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+    write_conf(first_conf, "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5")
+    write_conf(second_conf, "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5")
 
     seen: list[str] = []
 
@@ -839,19 +893,10 @@ def test_plan_updates_uses_highest_observed_bundle_phase_for_existing_fast_targe
 
     cpu_conf = tmp_path / "runtimes" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     cuda_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    cpu_conf.parent.mkdir(parents=True)
-    cuda_conf.parent.mkdir(parents=True)
-    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780600064\n", encoding="utf-8")
-    cuda_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(cpu_conf, "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780600064")
+    write_conf(cuda_conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771")
     rocm_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.rocm.conf"
-    rocm_conf.parent.mkdir(parents=True)
-    rocm_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(rocm_conf, "BASE_IMAGE=quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1777919771")
 
     seen: list[str] = []
 
@@ -887,13 +932,8 @@ def test_plan_updates_uses_forward_discovery_not_bundle_phase_for_lagging_target
 
     cpu_conf = tmp_path / "runtimes" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     cuda_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    cpu_conf.parent.mkdir(parents=True)
-    cuda_conf.parent.mkdir(parents=True)
-    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1780600064\n", encoding="utf-8")
-    cuda_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(cpu_conf, "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1780600064")
+    write_conf(cuda_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     def fake_list_tags(repository: str, tag_cache=None) -> tuple[str, ...]:
         if repository == "quay.io/aipcc/base-images/cpu":
@@ -930,13 +970,8 @@ def test_plan_updates_starts_new_release_at_ea1_when_peers_are_older_release(
 
     target_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     peer_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    target_conf.parent.mkdir(parents=True)
-    peer_conf.parent.mkdir(parents=True)
-    target_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
-    peer_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(target_conf, "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5")
+    write_conf(peer_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -968,11 +1003,7 @@ def test_plan_updates_uses_published_ga_for_new_release_when_available(
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771")
 
     monkeypatch.setattr(
         updater.subprocess,
@@ -998,11 +1029,7 @@ def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missi
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771")
 
     monkeypatch.setattr(
         updater.subprocess,
@@ -1030,8 +1057,7 @@ def test_plan_updates_stable_to_fast_forward_uses_highest_published_phase_for_ne
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
 
     conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.4\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.4")
 
     monkeypatch.setattr(
         updater.subprocess,
@@ -1057,11 +1083,7 @@ def test_plan_updates_new_release_without_published_tags_keeps_strict_failure(
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771")
 
     monkeypatch.setattr(
         updater.subprocess,
@@ -1083,11 +1105,7 @@ def test_plan_updates_builds_fast_rhds_candidate_before_latest_resolution(
     write_versions_config(tmp_path / "versions_config.yml")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771")
 
     seen: list[str] = []
 
@@ -1114,8 +1132,7 @@ def test_plan_updates_rollback_targets_ga_family_for_older_release(
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
 
     conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+    write_conf(conf, f"BASE_IMAGE={RHDS_CPU_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -1148,8 +1165,7 @@ def test_plan_updates_uses_hard_coded_rhds_cpu_version_for_fast_channel(
     )
 
     conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+    write_conf(conf, f"BASE_IMAGE={RHDS_CPU_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -1174,13 +1190,8 @@ def test_plan_updates_rollback_ignores_newer_fast_peers(
 
     cpu_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     cuda_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    cpu_conf.parent.mkdir(parents=True)
-    cuda_conf.parent.mkdir(parents=True)
-    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064\n", encoding="utf-8")
-    cuda_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(cpu_conf, "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064")
+    write_conf(cuda_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -1211,8 +1222,7 @@ def test_plan_updates_rollback_falls_back_to_highest_published_phase_when_ga_mis
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
 
     conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+    write_conf(conf, f"BASE_IMAGE={RHDS_CPU_EA2_IMAGE}")
 
     monkeypatch.setattr(
         updater.subprocess,
@@ -1238,8 +1248,7 @@ def test_plan_updates_rollback_from_stable_target_uses_ga_seed(
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
 
     conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5")
 
     seen: list[str] = []
 
@@ -1265,21 +1274,16 @@ def test_plan_updates_allows_independent_mixed_rhds_channels(
         full_version="3.5.0",
         replacements=[
             (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                gpu_minimal_policy_block("cuda"),
+                gpu_minimal_policy_block("cuda", rhds_channel="stable"),
             )
         ],
     )
 
     cpu_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     cuda_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    cpu_conf.parent.mkdir(parents=True)
-    cuda_conf.parent.mkdir(parents=True)
-    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
-    cuda_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(cpu_conf, f"BASE_IMAGE={RHDS_CPU_EA2_IMAGE}")
+    write_conf(cuda_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -1304,29 +1308,17 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator="cuda",
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-            )
-        ],
+        rhds_channel="stable",
     )
 
     minimal_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
     pytorch_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    minimal_conf.parent.mkdir(parents=True)
-    pytorch_conf.parent.mkdir(parents=True)
-    minimal_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
-    pytorch_conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(minimal_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
+    write_conf(pytorch_conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     seen: list[str] = []
 
@@ -1346,31 +1338,37 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
     assert rendered[pytorch_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
 
 
-def test_plan_updates_uses_rhds_cuda_stable_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("accelerator", "current_image", "acc_version"),
+    [
+        ("cuda", RHDS_CUDA_EA2_IMAGE, "25.0"),
+        ("rocm", RHDS_ROCM_EA2_IMAGE, "8.0"),
+    ],
+)
+def test_plan_updates_uses_rhds_gpu_stable_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    accelerator: str,
+    current_image: str,
+    acc_version: str,
+) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator=accelerator,
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-            )
-        ],
+        acc_version=acc_version,
+        rhds_channel="stable",
     )
 
-    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / f"konflux.{accelerator}.conf"
+    write_conf(conf, f"BASE_IMAGE={current_image}")
 
     stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     stub_matching_rhds_stable_acc_version(monkeypatch, updater)
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}"
+    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image(accelerator)}"
 
 
 def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
@@ -1387,56 +1385,25 @@ def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+    write_conf(conf, f"BASE_IMAGE={RHDS_CPU_EA2_IMAGE}")
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5"
 
 
-def test_plan_updates_uses_rhds_rocm_stable_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    updater = load_updater()
-    write_versions_config(
-        tmp_path / "versions_config.yml",
-        full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
-                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
-            )
-        ],
-    )
-
-    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.rocm.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
-
-    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
-    stub_matching_rhds_stable_acc_version(monkeypatch, updater)
-    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
-
-    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image('rocm')}"
-
-
 def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
-                '      minimal:\n        acc_version: "8.0"\n        rhds:\n          channel: fast\n        odh:\n          origin: midstream',
-            )
-        ],
+        accelerator="rocm",
+        acc_version="8.0",
+        odh_origin="midstream",
+        shared_acc_version=True,
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "rocm.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0")
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -1448,23 +1415,17 @@ def test_plan_updates_picks_rhds_stable_tag_matching_shared_acc_version_over_new
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator="cuda",
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        acc_version: "24.9"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
-            )
-        ],
+        acc_version="24.9",
+        rhds_channel="stable",
+        shared_acc_version=True,
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     stub_rhds_repository_tags(
         monkeypatch,
@@ -1516,23 +1477,17 @@ def test_plan_updates_raises_in_red_when_rhds_stable_candidates_cannot_be_inspec
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator="cuda",
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
-            )
-        ],
+        acc_version="25.0",
+        rhds_channel="stable",
+        shared_acc_version=True,
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     monkeypatch.setattr(
@@ -1554,23 +1509,17 @@ def test_plan_updates_raises_when_rhds_stable_acc_version_cannot_be_determined(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator="cuda",
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
-            )
-        ],
+        acc_version="25.0",
+        rhds_channel="stable",
+        shared_acc_version=True,
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: None)
@@ -1584,23 +1533,17 @@ def test_plan_updates_raises_when_no_rhds_stable_image_matches_shared_acc_versio
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator="cuda",
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
-            )
-        ],
+        acc_version="25.0",
+        rhds_channel="stable",
+        shared_acc_version=True,
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, f"BASE_IMAGE={RHDS_CUDA_EA2_IMAGE}")
 
     stub_rhds_repository_tags(
         monkeypatch,
@@ -1629,8 +1572,7 @@ def test_plan_updates_uses_odh_midstream_cpu_repo(tmp_path: Path) -> None:
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest")
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -1642,8 +1584,7 @@ def test_plan_updates_uses_odh_in_house_cpu_repo_from_release_python_version(tmp
     write_versions_config(tmp_path / "versions_config.yml", python_version="3.11")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "cpu.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest")
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -1655,8 +1596,7 @@ def test_plan_updates_can_switch_odh_rocm_back_to_in_house_repo(tmp_path: Path) 
     write_versions_config(tmp_path / "versions_config.yml")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "rocm.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest\n", encoding="utf-8")
+    write_conf(conf, "BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest")
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -1671,16 +1611,15 @@ def test_plan_updates_rewrites_release_to_minor_version(
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.6.0")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
+    write_conf(
+        conf,
         textwrap.dedent(
             """\
             BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771
             PYLOCK_FLAVOR=cuda
             RELEASE=3.5
             """
-        ),
-        encoding="utf-8",
+        ).rstrip(),
     )
 
     monkeypatch.setattr(
@@ -1704,8 +1643,8 @@ def test_main_updates_base_image_and_release_lines(tmp_path: Path, monkeypatch: 
     write_versions_config(tmp_path / "versions_config.yml")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
+    write_conf(
+        conf,
         textwrap.dedent(
             """\
             INDEX_URL=unchanged
@@ -1713,8 +1652,7 @@ def test_main_updates_base_image_and_release_lines(tmp_path: Path, monkeypatch: 
             PYLOCK_FLAVOR=cuda
             RELEASE=3.5
             """
-        ),
-        encoding="utf-8",
+        ).rstrip(),
     )
 
     monkeypatch.setattr(
@@ -1792,9 +1730,8 @@ def test_main_dry_run_does_not_write_files(tmp_path: Path, monkeypatch: pytest.M
     write_versions_config(tmp_path / "versions_config.yml")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
     original = "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n"
-    conf.write_text(original, encoding="utf-8")
+    write_conf(conf, original.rstrip())
 
     monkeypatch.setattr(
         updater,
@@ -1815,11 +1752,7 @@ def test_main_check_returns_nonzero_when_files_need_updates(
     write_versions_config(tmp_path / "versions_config.yml")
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n",
-        encoding="utf-8",
-    )
+    write_conf(conf, "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771")
 
     monkeypatch.setattr(
         updater,
@@ -1839,20 +1772,18 @@ def test_main_updates_cuda_stable_with_rhds_stable_repo_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updater = load_updater()
-    write_versions_config(
+    write_gpu_minimal_versions_config(
         tmp_path / "versions_config.yml",
+        accelerator="cuda",
         full_version="3.5.0",
-        replacements=[
-            (
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        acc_version: "12.9"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
-            )
-        ],
+        acc_version="12.9",
+        rhds_channel="stable",
+        shared_acc_version=True,
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
-    conf.parent.mkdir(parents=True)
-    conf.write_text(
+    write_conf(
+        conf,
         textwrap.dedent(
             """\
             INDEX_URL=unchanged
@@ -1860,8 +1791,7 @@ def test_main_updates_cuda_stable_with_rhds_stable_repo_override(
             PYLOCK_FLAVOR=cuda
             RELEASE=3.5
             """
-        ),
-        encoding="utf-8",
+        ).rstrip(),
     )
 
     seen: list[str] = []

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -18,6 +18,62 @@ def load_updater():
         pytest.fail(f"Missing sync implementation module: {exc}")
 
 
+def completed_process(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["skopeo"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def rhds_gpu_stable_image(
+    accelerator: str,
+    *,
+    full_version: str = "3.5.0",
+    rhds_os_base: str = "el9.6",
+    build: str = "1780598175",
+) -> str:
+    return f"quay.io/aipcc/base-images/{accelerator}-{rhds_os_base}:{full_version}-stable-{build}"
+
+
+def stub_published_rhds_gpu_stable_tags(
+    monkeypatch: pytest.MonkeyPatch,
+    updater,
+    *,
+    full_version: str = "3.5.0",
+    rhds_os_base: str = "el9.6",
+    cuda_build: str = "1780598175",
+    rocm_build: str = "1780598175",
+) -> None:
+    tags_by_repository = {
+        f"quay.io/aipcc/base-images/cuda-{rhds_os_base}": (f"{full_version}-stable-{cuda_build}",),
+        f"quay.io/aipcc/base-images/rocm-{rhds_os_base}": (f"{full_version}-stable-{rocm_build}",),
+    }
+    monkeypatch.setattr(
+        updater,
+        "list_rhds_repository_tags",
+        lambda repository, tag_cache=None: tags_by_repository.get(repository, ()),
+    )
+
+
+def stub_rhds_repository_tags(
+    monkeypatch: pytest.MonkeyPatch,
+    updater,
+    tags_by_repository: dict[str, tuple[str, ...]],
+) -> None:
+    monkeypatch.setattr(
+        updater,
+        "list_rhds_repository_tags",
+        lambda repository, tag_cache=None: tags_by_repository.get(repository, ()),
+    )
+
+
 def stub_empty_rhds_tag_listing(monkeypatch: pytest.MonkeyPatch, updater) -> None:
     monkeypatch.setattr(
         updater,
@@ -538,15 +594,16 @@ def test_build_rhds_pinned_tag_targets_ga_family_on_rollback() -> None:
 def test_resolve_latest_published_rhds_image_uses_skopeo_tags(monkeypatch: pytest.MonkeyPatch) -> None:
     updater = load_updater()
 
-    class Completed:
-        returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
-            '["3.6.0-ea.1-1777919000","3.6.0-ea.1-1777919999","3.6.0-ea.2-1777920000"]}'
-        )
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+                '["3.6.0-ea.1-1777919000","3.6.0-ea.1-1777919999","3.6.0-ea.2-1777920000"]}'
+            )
+        ),
+    )
 
     latest = updater.resolve_latest_published_rhds_image(
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
@@ -560,15 +617,16 @@ def test_resolve_latest_published_rhds_image_rollback_falls_back_to_highest_phas
 ) -> None:
     updater = load_updater()
 
-    class Completed:
-        returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
-            '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.5.0-1777921111"]}'
-        )
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+                '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.5.0-1777921111"]}'
+            )
+        ),
+    )
 
     latest = updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-0")
 
@@ -580,12 +638,13 @@ def test_resolve_latest_published_rhds_image_rollback_raises_when_release_is_unp
 ) -> None:
     updater = load_updater()
 
-    class Completed:
-        returncode = 0
-        stdout = '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":["3.5.0-ea.2-1777919999"]}'
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout='{"Repository":"quay.io/aipcc/base-images/cpu","Tags":["3.5.0-ea.2-1777919999"]}'
+        ),
+    )
 
     with pytest.raises(ValueError, match=r"release '3.4.0'"):
         updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-0")
@@ -596,12 +655,11 @@ def test_resolve_latest_published_rhds_image_raises_on_skopeo_failure(
 ) -> None:
     updater = load_updater()
 
-    class Completed:
-        returncode = 1
-        stdout = ""
-        stderr = "manifest unknown"
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(returncode=1, stderr="manifest unknown"),
+    )
 
     with pytest.raises(ValueError, match="skopeo list-tags failed"):
         updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000")
@@ -652,14 +710,9 @@ def test_plan_updates_caches_rhds_tag_listing_per_repository(
 
     calls: list[str] = []
 
-    class Completed:
-        returncode = 0
-        stdout = '{"Tags":["3.6.0-ea.1-1777919999"]}'
-        stderr = ""
-
     def fake_run(cmd, **kwargs):
         calls.append(cmd[-1])
-        return Completed()
+        return completed_process(stdout='{"Tags":["3.6.0-ea.1-1777919999"]}')
 
     monkeypatch.setattr(updater.subprocess, "run", fake_run)
 
@@ -717,7 +770,7 @@ def test_plan_updates_infers_ga_phase_for_stable_to_fast_target(
     peer_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
     target_conf.parent.mkdir(parents=True)
     peer_conf.parent.mkdir(parents=True)
-    target_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5\n", encoding="utf-8")
+    target_conf.write_text(f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}\n", encoding="utf-8")
     peer_conf.write_text(
         "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1777919771\n",
         encoding="utf-8",
@@ -921,15 +974,16 @@ def test_plan_updates_uses_published_ga_for_new_release_when_available(
         encoding="utf-8",
     )
 
-    class Completed:
-        returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
-            '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999","3.5.0-1777921111"]}'
-        )
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999","3.5.0-1777921111"]}'
+            )
+        ),
+    )
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -950,15 +1004,16 @@ def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missi
         encoding="utf-8",
     )
 
-    class Completed:
-        returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
-            '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
-        )
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+            )
+        ),
+    )
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -978,14 +1033,16 @@ def test_plan_updates_stable_to_fast_forward_uses_highest_published_phase_for_ne
     conf.parent.mkdir(parents=True)
     conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.4\n", encoding="utf-8")
 
-    class Completed:
-        returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
-        )
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+            )
+        ),
+    )
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -1006,12 +1063,13 @@ def test_plan_updates_new_release_without_published_tags_keeps_strict_failure(
         encoding="utf-8",
     )
 
-    class Completed:
-        returncode = 0
-        stdout = '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":["3.4.0-ea.2-1777919771"]}'
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout='{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":["3.4.0-ea.2-1777919771"]}'
+        ),
+    )
 
     with pytest.raises(ValueError, match="No matching published RHDS tag found"):
         updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
@@ -1156,15 +1214,16 @@ def test_plan_updates_rollback_falls_back_to_highest_published_phase_when_ga_mis
     conf.parent.mkdir(parents=True)
     conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
 
-    class Completed:
-        returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
-            '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.5.0-ea.2-1777921111"]}'
-        )
-        stderr = ""
-
-    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+                '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.5.0-ea.2-1777921111"]}'
+            )
+        ),
+    )
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
@@ -1229,6 +1288,7 @@ def test_plan_updates_allows_independent_mixed_rhds_channels(
         return "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
 
     monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     stub_matching_rhds_stable_acc_version(monkeypatch, updater)
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
@@ -1236,7 +1296,7 @@ def test_plan_updates_allows_independent_mixed_rhds_channels(
 
     assert seen == ["quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771"]
     assert rendered["konflux.cpu.conf"] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
-    assert rendered["konflux.cuda.conf"] == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert rendered["konflux.cuda.conf"] == f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}"
 
 
 def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
@@ -1275,13 +1335,14 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
         return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
 
     monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     stub_matching_rhds_stable_acc_version(monkeypatch, updater)
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
     rendered = {update.target.path: update.updated_text.strip() for update in updates}
 
     assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771"]
-    assert rendered[minimal_conf] == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert rendered[minimal_conf] == f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}"
     assert rendered[pytorch_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
 
 
@@ -1305,10 +1366,11 @@ def test_plan_updates_uses_rhds_cuda_stable_repo(tmp_path: Path, monkeypatch: py
         encoding="utf-8",
     )
 
+    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     stub_matching_rhds_stable_acc_version(monkeypatch, updater)
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}"
 
 
 def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
@@ -1353,10 +1415,11 @@ def test_plan_updates_uses_rhds_rocm_stable_repo(tmp_path: Path, monkeypatch: py
         encoding="utf-8",
     )
 
+    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     stub_matching_rhds_stable_acc_version(monkeypatch, updater)
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-rocm-stable-ubi9:3.5"
+    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image('rocm')}"
 
 
 def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
@@ -1380,10 +1443,9 @@ def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
     assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-8-0:latest"
 
 
-def test_plan_updates_warns_when_rhds_stable_image_acc_version_differs_from_shared_config(
+def test_plan_updates_picks_rhds_stable_tag_matching_shared_acc_version_over_newer_build(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     updater = load_updater()
     write_versions_config(
@@ -1392,7 +1454,7 @@ def test_plan_updates_warns_when_rhds_stable_image_acc_version_differs_from_shar
         replacements=[
             (
                 '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
-                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
+                '      minimal:\n        acc_version: "24.9"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
             )
         ],
     )
@@ -1404,15 +1466,28 @@ def test_plan_updates_warns_when_rhds_stable_image_acc_version_differs_from_shar
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: "24.9")
+    stub_rhds_repository_tags(
+        monkeypatch,
+        updater,
+        {
+            "quay.io/aipcc/base-images/cuda-el9.6": (
+                "3.5.0-stable-1780598175",
+                "3.5.0-stable-1780598176",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        updater,
+        "inspect_rhds_stable_acc_version",
+        lambda image, accelerator: {
+            rhds_gpu_stable_image("cuda", build="1780598175"): "24.9",
+            rhds_gpu_stable_image("cuda", build="1780598176"): "25.0",
+        }[image],
+    )
 
-    with caplog.at_level("WARNING"):
-        updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
-    assert caplog.records[-1].msg.startswith("\x1b[32mWARNING:")
-    assert "Configured shared cuda acc_version 25.0" in caplog.text
-    assert "use acc_version 24.9" in caplog.text
+    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image('cuda', build='1780598175')}"
 
 
 def test_inspect_image_config_warns_in_red_on_skopeo_failure(
@@ -1424,26 +1499,18 @@ def test_inspect_image_config_warns_in_red_on_skopeo_failure(
     monkeypatch.setattr(
         updater.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
-            args=["skopeo"],
-            returncode=1,
-            stdout="",
-            stderr="fatal auth error",
-        ),
+        lambda *args, **kwargs: completed_process(returncode=1, stderr="fatal auth error"),
     )
 
     with caplog.at_level("WARNING"):
-        payload = updater.inspect_image_config("quay.io/aipcc/base-image-cuda-stable-ubi9:3.5", warning_color="red")
+        payload = updater.inspect_image_config(rhds_gpu_stable_image("cuda"), warning_color="red")
 
     assert payload is None
-    assert caplog.records[-1].msg.startswith("\x1b[31mWARNING:")
-    assert (
-        "skopeo inspect --config failed for quay.io/aipcc/base-image-cuda-stable-ubi9:3.5: fatal auth error"
-        in caplog.text
-    )
+    assert caplog.records[-1].msg.startswith(f"{updater.ANSI_RED}WARNING:")
+    assert f"skopeo inspect --config failed for {rhds_gpu_stable_image('cuda')}: fatal auth error" in caplog.text
 
 
-def test_plan_updates_warns_only_in_red_when_rhds_stable_inspect_fails(
+def test_plan_updates_raises_in_red_when_rhds_stable_candidates_cannot_be_inspected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1467,31 +1534,24 @@ def test_plan_updates_warns_only_in_red_when_rhds_stable_inspect_fails(
         encoding="utf-8",
     )
 
+    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     monkeypatch.setattr(
         updater.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
-            args=["skopeo"],
-            returncode=1,
-            stdout="",
-            stderr="fatal auth error",
-        ),
+        lambda *args, **kwargs: completed_process(returncode=1, stderr="fatal auth error"),
     )
 
-    with caplog.at_level("WARNING"):
-        updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    with caplog.at_level("WARNING"), pytest.raises(ValueError, match=r"matches configured shared acc_version 25\.0"):
+        updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
     assert len(caplog.records) == 1
-    assert caplog.records[-1].msg.startswith("\x1b[31mWARNING:")
+    assert caplog.records[-1].msg.startswith(f"{updater.ANSI_RED}WARNING:")
     assert "fatal auth error" in caplog.text
-    assert "Could not determine RHDS stable cuda acc_version" not in caplog.text
 
 
-def test_plan_updates_warns_in_yellow_when_rhds_stable_acc_version_cannot_be_determined(
+def test_plan_updates_raises_when_rhds_stable_acc_version_cannot_be_determined(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     updater = load_updater()
     write_versions_config(
@@ -1512,14 +1572,47 @@ def test_plan_updates_warns_in_yellow_when_rhds_stable_acc_version_cannot_be_det
         encoding="utf-8",
     )
 
+    stub_published_rhds_gpu_stable_tags(monkeypatch, updater)
     monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: None)
 
-    with caplog.at_level("WARNING"):
-        updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    with pytest.raises(ValueError, match=r"matches configured shared acc_version 25\.0"):
+        updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
-    assert caplog.records[-1].msg.startswith("\x1b[33mWARNING:")
-    assert "Could not determine RHDS stable cuda acc_version" in caplog.text
+
+def test_plan_updates_raises_when_no_rhds_stable_image_matches_shared_acc_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    stub_rhds_repository_tags(
+        monkeypatch,
+        updater,
+        {"quay.io/aipcc/base-images/cuda-el9.6": ("3.5.0-stable-1780598175",)},
+    )
+    monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: "24.9")
+
+    with pytest.raises(ValueError, match=r"matches configured shared acc_version 25\.0") as exc_info:
+        updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert "older acc_version 24.9" in str(exc_info.value)
 
 
 def test_plan_updates_uses_odh_midstream_cpu_repo(tmp_path: Path) -> None:
@@ -1739,3 +1832,65 @@ def test_main_check_returns_nonzero_when_files_need_updates(
     assert conf.read_text(encoding="utf-8").strip() == (
         "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771"
     )
+
+
+def test_main_updates_cuda_stable_with_rhds_stable_repo_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        acc_version: "12.9"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            INDEX_URL=unchanged
+            BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.2-1777919771
+            PYLOCK_FLAVOR=cuda
+            RELEASE=3.5
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_list(repository: str, tag_cache=None) -> tuple[str, ...]:
+        seen.append(repository)
+        if repository == "quay.io/example/testing/cuda-el9.6":
+            return ("3.5.0-stable-9999999999",)
+        return ()
+
+    monkeypatch.setattr(updater, "list_rhds_repository_tags", fake_list)
+    monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: "12.9")
+
+    assert (
+        updater.main(
+            [
+                "--root",
+                str(tmp_path),
+                "--config",
+                str(tmp_path / "versions_config.yml"),
+                "--rhds-stable-repo-override=cuda=quay.io/example/testing/cuda-el9.6",
+            ]
+        )
+        == 0
+    )
+    assert seen == ["quay.io/example/testing/cuda-el9.6"]
+    assert conf.read_text(encoding="utf-8").splitlines() == [
+        "INDEX_URL=unchanged",
+        "BASE_IMAGE=quay.io/example/testing/cuda-el9.6:3.5.0-stable-9999999999",
+        "PYLOCK_FLAVOR=cuda",
+        "RELEASE=3.5",
+    ]

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -621,6 +621,20 @@ def test_resolve_latest_published_rhds_image_raises_when_skopeo_missing(
         updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000")
 
 
+def test_resolve_latest_published_rhds_image_raises_when_skopeo_list_tags_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(["skopeo", "list-tags"], timeout=60)
+
+    monkeypatch.setattr(updater.subprocess, "run", raise_timeout)
+
+    with pytest.raises(ValueError, match="skopeo list-tags timed out"):
+        updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000")
+
+
 def test_plan_updates_caches_rhds_tag_listing_per_repository(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1427,6 +1441,51 @@ def test_inspect_image_config_warns_in_red_on_skopeo_failure(
         "skopeo inspect --config failed for quay.io/aipcc/base-image-cuda-stable-ubi9:3.5: fatal auth error"
         in caplog.text
     )
+
+
+def test_plan_updates_warns_only_in_red_when_rhds_stable_inspect_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=["skopeo"],
+            returncode=1,
+            stdout="",
+            stderr="fatal auth error",
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert len(caplog.records) == 1
+    assert caplog.records[-1].msg.startswith("\x1b[31mWARNING:")
+    assert "fatal auth error" in caplog.text
+    assert "Could not determine RHDS stable cuda acc_version" not in caplog.text
 
 
 def test_plan_updates_warns_in_yellow_when_rhds_stable_acc_version_cannot_be_determined(

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -321,7 +321,7 @@ def test_load_versions_config_rejects_invalid_rhds_channel(tmp_path: Path) -> No
         ],
     )
 
-    with pytest.raises(ValueError, match="rhds.*channel"):
+    with pytest.raises(ValueError, match=r"rhds.*channel"):
         updater.load_versions_config(config)
 
 
@@ -389,7 +389,7 @@ def test_load_versions_config_rejects_invalid_odh_origin(tmp_path: Path) -> None
         ],
     )
 
-    with pytest.raises(ValueError, match="odh.*origin"):
+    with pytest.raises(ValueError, match=r"odh.*origin"):
         updater.load_versions_config(config)
 
 
@@ -406,7 +406,7 @@ def test_load_versions_config_rejects_non_latest_cpu_odh_version(tmp_path: Path)
         ],
     )
 
-    with pytest.raises(ValueError, match="cpu.*version.*latest"):
+    with pytest.raises(ValueError, match=r"cpu.*version.*latest"):
         updater.load_versions_config(config)
 
 
@@ -540,7 +540,7 @@ def test_resolve_latest_published_rhds_image_rollback_raises_when_release_is_unp
 
     monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
 
-    with pytest.raises(ValueError, match="release '3.4.0'"):
+    with pytest.raises(ValueError, match=r"release '3.4.0'"):
         updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-0")
 
 
@@ -557,9 +557,7 @@ def test_resolve_latest_published_rhds_image_raises_on_skopeo_failure(
     monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
 
     with pytest.raises(ValueError, match="skopeo list-tags failed"):
-        updater.resolve_latest_published_rhds_image(
-            "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
-        )
+        updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000")
 
 
 def test_resolve_latest_published_rhds_image_raises_when_skopeo_missing(
@@ -573,9 +571,7 @@ def test_resolve_latest_published_rhds_image_raises_when_skopeo_missing(
     monkeypatch.setattr(updater.subprocess, "run", raise_missing)
 
     with pytest.raises(ValueError, match="skopeo is required"):
-        updater.resolve_latest_published_rhds_image(
-            "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
-        )
+        updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000")
 
 
 def test_plan_updates_caches_rhds_tag_listing_per_repository(
@@ -905,7 +901,9 @@ def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missi
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999"
+    assert (
+        updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999"
+    )
 
 
 def test_plan_updates_stable_to_fast_forward_uses_highest_published_phase_for_new_release(
@@ -922,8 +920,7 @@ def test_plan_updates_stable_to_fast_forward_uses_highest_published_phase_for_ne
     class Completed:
         returncode = 0
         stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
-            '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
         )
         stderr = ""
 
@@ -950,10 +947,7 @@ def test_plan_updates_new_release_without_published_tags_keeps_strict_failure(
 
     class Completed:
         returncode = 0
-        stdout = (
-            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
-            '["3.4.0-ea.2-1777919771"]}'
-        )
+        stdout = '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":["3.4.0-ea.2-1777919771"]}'
         stderr = ""
 
     monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
@@ -988,7 +982,9 @@ def test_plan_updates_builds_fast_rhds_candidate_before_latest_resolution(
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919771"]
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"
+    assert (
+        updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"
+    )
 
 
 def test_plan_updates_rollback_targets_ga_family_for_older_release(

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -530,7 +530,7 @@ def test_build_rhds_pinned_tag_targets_ga_family_on_rollback() -> None:
     updater = load_updater()
     release = updater.ReleaseConfig(full_version="3.4.0", rhds_os_base="el9.6", python_version="3.12")
 
-    tag = updater.build_rhds_pinned_tag("3.5.0-ea.2-1777919771", release)
+    tag = updater.build_rhds_pinned_tag("3.5.0-ea.2-1777919771", release.full_version)
 
     assert tag == "3.4.0-1777919771"
 
@@ -1040,6 +1040,40 @@ def test_plan_updates_rollback_targets_ga_family_for_older_release(
 ) -> None:
     updater = load_updater()
     write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
+
+    conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert seen == ["quay.io/aipcc/base-images/cpu:3.4.0-1777919771"]
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+
+
+def test_plan_updates_uses_hard_coded_rhds_cpu_version_for_fast_channel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      rhds:\n        channel: fast\n        version: "<full_version>"',
+                '      rhds:\n        channel: fast\n        version: "3.4.0"',
+            )
+        ],
+    )
 
     conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
     conf.parent.mkdir(parents=True)

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -677,7 +677,161 @@ def test_resolve_latest_published_rhds_image_uses_skopeo_tags(monkeypatch: pytes
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
     )
 
-    assert latest == "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919999"
+    assert latest == "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.2-1777920000"
+
+
+def test_resolve_latest_published_rhds_image_progresses_ea1_to_ea2_without_ga(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-13.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+            )
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image(
+        "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771"
+    )
+
+    assert latest == "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919999"
+
+
+def test_resolve_latest_published_rhds_image_keeps_ea1_when_only_ea1_patches_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-13.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.1-1777919999"]}'
+            )
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image(
+        "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771"
+    )
+
+    assert latest == "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919999"
+
+
+def test_resolve_latest_published_rhds_image_never_regresses_ea2_to_ea1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-13.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919999","3.5.0-ea.2-1777919000"]}'
+            )
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image(
+        "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771"
+    )
+
+    assert latest == "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919000"
+
+
+def test_resolve_latest_published_rhds_image_prefers_ga_over_ea_for_same_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-13.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1780972037","3.5.0-1781269637"]}'
+            )
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image(
+        "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037"
+    )
+
+    assert latest == "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637"
+
+
+def test_resolve_latest_published_rhds_image_keeps_ea_family_when_ga_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cuda-13.0-el9.6","Tags":'
+                '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+            )
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image(
+        "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771"
+    )
+
+    assert latest == "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919999"
+
+
+def test_resolve_latest_published_rhds_image_rollback_from_ea2_targets_ga(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=(
+                '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+                '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.4.0-1777921111"]}'
+            )
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-1777919771")
+
+    assert latest == "quay.io/aipcc/base-images/cpu:3.4.0-1777921111"
+
+
+def test_resolve_latest_published_rhds_image_rollback_from_ga_targets_latest_ga(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: completed_process(
+            stdout=('{"Repository":"quay.io/aipcc/base-images/cpu","Tags":["3.4.0-1777919000","3.4.0-1777921111"]}')
+        ),
+    )
+
+    latest = updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-1777919771")
+
+    assert latest == "quay.io/aipcc/base-images/cpu:3.4.0-1777921111"
 
 
 def test_resolve_latest_published_rhds_image_rollback_falls_back_to_highest_phase(

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import subprocess
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,14 @@ def stub_empty_rhds_tag_listing(monkeypatch: pytest.MonkeyPatch, updater) -> Non
         updater,
         "list_rhds_repository_tags",
         lambda repository, tag_cache=None: (),
+    )
+
+
+def stub_matching_rhds_stable_acc_version(monkeypatch: pytest.MonkeyPatch, updater) -> None:
+    monkeypatch.setattr(
+        updater,
+        "inspect_rhds_stable_acc_version",
+        lambda image, accelerator: {"cuda": "25.0", "rocm": "8.0"}.get(accelerator),
     )
 
 
@@ -189,6 +198,44 @@ def test_load_versions_config_accepts_schema_version_one(tmp_path: Path) -> None
 
     assert loaded.release.full_version == "3.6.0"
     assert loaded.release.python_version == "3.12"
+
+
+def test_load_versions_config_accepts_shared_gpu_acc_version_layout(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: fast\n        odh:\n          origin: in-house',
+            )
+        ],
+    )
+
+    loaded = updater.load_versions_config(config)
+
+    assert loaded.policy("cuda", "rhds", "minimal").mode == "fast"
+    assert loaded.policy("cuda", "rhds", "minimal").version == "25.0"
+    assert loaded.policy("cuda", "odh", "minimal").mode == "in-house"
+    assert loaded.policy("cuda", "odh", "minimal").version == "25.0"
+
+
+def test_load_versions_config_rejects_mismatched_legacy_gpu_acc_versions(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "24.9"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="must match"):
+        updater.load_versions_config(config)
 
 
 def test_load_versions_config_rejects_schema_version_two(tmp_path: Path) -> None:
@@ -1134,6 +1181,7 @@ def test_plan_updates_allows_independent_mixed_rhds_channels(
         return "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
 
     monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+    stub_matching_rhds_stable_acc_version(monkeypatch, updater)
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
     rendered = {update.target.path.name: update.updated_text.strip() for update in updates}
@@ -1179,6 +1227,7 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
         return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
 
     monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+    stub_matching_rhds_stable_acc_version(monkeypatch, updater)
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
     rendered = {update.target.path: update.updated_text.strip() for update in updates}
@@ -1188,7 +1237,7 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
     assert rendered[pytorch_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
 
 
-def test_plan_updates_uses_rhds_cuda_stable_repo(tmp_path: Path) -> None:
+def test_plan_updates_uses_rhds_cuda_stable_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     updater = load_updater()
     write_versions_config(
         tmp_path / "versions_config.yml",
@@ -1208,6 +1257,7 @@ def test_plan_updates_uses_rhds_cuda_stable_repo(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
+    stub_matching_rhds_stable_acc_version(monkeypatch, updater)
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
@@ -1235,7 +1285,7 @@ def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
     assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5"
 
 
-def test_plan_updates_uses_rhds_rocm_stable_repo(tmp_path: Path) -> None:
+def test_plan_updates_uses_rhds_rocm_stable_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     updater = load_updater()
     write_versions_config(
         tmp_path / "versions_config.yml",
@@ -1255,6 +1305,7 @@ def test_plan_updates_uses_rhds_rocm_stable_repo(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
+    stub_matching_rhds_stable_acc_version(monkeypatch, updater)
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-rocm-stable-ubi9:3.5"
@@ -1267,18 +1318,115 @@ def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
         replacements=[
             (
                 '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
-                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: midstream\n          acc_version: "7.1"',
+                '      minimal:\n        acc_version: "8.0"\n        rhds:\n          channel: fast\n        odh:\n          origin: midstream',
             )
         ],
     )
 
     conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "rocm.conf"
     conf.parent.mkdir(parents=True)
-    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1\n", encoding="utf-8")
+    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0\n", encoding="utf-8")
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest"
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-8-0:latest"
+
+
+def test_plan_updates_warns_when_rhds_stable_image_acc_version_differs_from_shared_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: "24.9")
+
+    with caplog.at_level("WARNING"):
+        updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert caplog.records[-1].msg.startswith("\x1b[32mWARNING:")
+    assert "Configured shared cuda acc_version 25.0" in caplog.text
+    assert "use acc_version 24.9" in caplog.text
+
+
+def test_inspect_image_config_warns_in_red_on_skopeo_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    updater = load_updater()
+
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=["skopeo"],
+            returncode=1,
+            stdout="",
+            stderr="fatal auth error",
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        payload = updater.inspect_image_config("quay.io/aipcc/base-image-cuda-stable-ubi9:3.5", warning_color="red")
+
+    assert payload is None
+    assert caplog.records[-1].msg.startswith("\x1b[31mWARNING:")
+    assert (
+        "skopeo inspect --config failed for quay.io/aipcc/base-image-cuda-stable-ubi9:3.5: fatal auth error"
+        in caplog.text
+    )
+
+
+def test_plan_updates_warns_in_yellow_when_rhds_stable_acc_version_cannot_be_determined(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        acc_version: "25.0"\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(updater, "inspect_rhds_stable_acc_version", lambda image, accelerator: None)
+
+    with caplog.at_level("WARNING"):
+        updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert caplog.records[-1].msg.startswith("\x1b[33mWARNING:")
+    assert "Could not determine RHDS stable cuda acc_version" in caplog.text
 
 
 def test_plan_updates_uses_odh_midstream_cpu_repo(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -1,0 +1,1504 @@
+from __future__ import annotations
+
+import importlib
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def load_updater():
+    try:
+        return importlib.import_module("scripts.update_build_args_from_versions")
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"Missing sync implementation module: {exc}")
+
+
+def stub_empty_rhds_tag_listing(monkeypatch: pytest.MonkeyPatch, updater) -> None:
+    monkeypatch.setattr(
+        updater,
+        "list_rhds_repository_tags",
+        lambda repository, tag_cache=None: (),
+    )
+
+
+def write_versions_config(
+    path: Path,
+    *,
+    schema_version: int = 1,
+    full_version: str = "3.6.0",
+    rhds_os_base: str = "el9.6",
+    python_version: str = "3.12",
+    replacements: list[tuple[str, str]] | None = None,
+) -> None:
+    text = textwrap.dedent(
+        f"""\
+        schema_version: {schema_version}
+
+        release:
+          full_version: "{full_version}"
+          rhds_os_base: "{rhds_os_base}"
+          python_version: "{python_version}"
+
+        artifacts:
+          base_image:
+            cpu:
+              rhds:
+                channel: fast
+                version: "<full_version>"
+              odh:
+                origin: in-house
+                version: "latest"
+
+            cuda:
+              minimal:
+                rhds:
+                  channel: fast
+                  acc_version: "25.0"
+                odh:
+                  origin: in-house
+                  acc_version: "25.0"
+              pytorch:
+                rhds:
+                  channel: fast
+                  acc_version: "25.0"
+                odh:
+                  origin: in-house
+                  acc_version: "25.0"
+              pytorch-llmcompressor:
+                rhds:
+                  channel: fast
+                  acc_version: "25.0"
+                odh:
+                  origin: in-house
+                  acc_version: "25.0"
+              tensorflow:
+                rhds:
+                  channel: fast
+                  acc_version: "24.9"
+                odh:
+                  origin: in-house
+                  acc_version: "24.9"
+
+            rocm:
+              minimal:
+                rhds:
+                  channel: fast
+                  acc_version: "8.0"
+                odh:
+                  origin: in-house
+                  acc_version: "8.0"
+              pytorch:
+                rhds:
+                  channel: fast
+                  acc_version: "8.0"
+                odh:
+                  origin: in-house
+                  acc_version: "8.0"
+              tensorflow:
+                rhds:
+                  channel: fast
+                  acc_version: "8.0"
+                odh:
+                  origin: in-house
+                  acc_version: "8.0"
+        """
+    )
+
+    for old, new in replacements or []:
+        updated = text.replace(old, new)
+        if updated == text:
+            raise AssertionError(f"Replacement did not match config text: {old!r}")
+        text = updated
+
+    path.write_text(text, encoding="utf-8")
+
+
+def test_load_versions_config_rejects_unexpected_keys(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    config.write_text(
+        textwrap.dedent(
+            """\
+            schema_version: 1
+
+            release:
+              full_version: "3.5.0"
+              rhds_os_base: "el9.6"
+              python_version: "3.12"
+
+            artifacts:
+              base_image:
+                cpu:
+                  rhds:
+                    channel: fast
+                    version: "<full_version>"
+                  odh:
+                    origin: in-house
+                    version: "latest"
+                extra:
+                  bogus: {}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unexpected keys"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_missing_required_keys(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    config.write_text(
+        textwrap.dedent(
+            """\
+            schema_version: 1
+
+            release:
+              full_version: "3.5.0"
+              python_version: "3.12"
+
+            artifacts:
+              base_image:
+                cpu:
+                  rhds:
+                    channel: fast
+                    version: "<full_version>"
+                  odh:
+                    origin: in-house
+                    version: "latest"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Missing keys"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_accepts_schema_version_one(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(config)
+
+    loaded = updater.load_versions_config(config)
+
+    assert loaded.release.full_version == "3.6.0"
+    assert loaded.release.python_version == "3.12"
+
+
+def test_load_versions_config_rejects_schema_version_two(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(config, schema_version=2)
+
+    with pytest.raises(ValueError, match="Unsupported schema_version"):
+        updater.load_versions_config(config)
+
+
+def test_resolve_version_uses_full_version_placeholder() -> None:
+    updater = load_updater()
+    release = updater.ReleaseConfig(full_version="3.6.0", rhds_os_base="el9.6", python_version="3.12")
+
+    assert updater.resolve_version("<full_version>", release) == "3.6.0"
+
+
+def test_load_versions_config_rejects_empty_rhds_os_base(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(config, rhds_os_base="")
+
+    with pytest.raises(ValueError, match="rhds_os_base"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_invalid_python_version(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(config, python_version="3")
+
+    with pytest.raises(ValueError, match="python_version"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_non_scalar_cpu_version(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    config.write_text(
+        textwrap.dedent(
+            """\
+            schema_version: 1
+
+            release:
+              full_version: "3.5.0"
+              rhds_os_base: "el9.6"
+              python_version: "3.12"
+
+            artifacts:
+              base_image:
+                cpu:
+                  rhds:
+                    channel: fast
+                    version:
+                      major: 3
+                  odh:
+                    origin: in-house
+                    version: "latest"
+                cuda:
+                  minimal:
+                    rhds:
+                      channel: fast
+                      acc_version: "25.0"
+                    odh:
+                      origin: in-house
+                      acc_version: "25.0"
+                  pytorch:
+                    rhds:
+                      channel: fast
+                      acc_version: "25.0"
+                    odh:
+                      origin: in-house
+                      acc_version: "25.0"
+                  pytorch-llmcompressor:
+                    rhds:
+                      channel: fast
+                      acc_version: "25.0"
+                    odh:
+                      origin: in-house
+                      acc_version: "25.0"
+                  tensorflow:
+                    rhds:
+                      channel: fast
+                      acc_version: "24.9"
+                    odh:
+                      origin: in-house
+                      acc_version: "24.9"
+                rocm:
+                  minimal:
+                    rhds:
+                      channel: fast
+                      acc_version: "8.0"
+                    odh:
+                      origin: in-house
+                      acc_version: "8.0"
+                  pytorch:
+                    rhds:
+                      channel: fast
+                      acc_version: "8.0"
+                    odh:
+                      origin: in-house
+                      acc_version: "8.0"
+                  tensorflow:
+                    rhds:
+                      channel: fast
+                      acc_version: "8.0"
+                    odh:
+                      origin: in-house
+                      acc_version: "8.0"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="version"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_invalid_rhds_channel(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      rhds:\n        channel: fast\n        version: "<full_version>"',
+                '      rhds:\n        channel: default\n        version: "<full_version>"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="rhds.*channel"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_missing_cpu_version_for_fast(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      rhds:\n        channel: fast\n        version: "<full_version>"',
+                "      rhds:\n        channel: fast",
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="version"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_cpu_acc_version_key(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      rhds:\n        channel: fast\n        version: "<full_version>"',
+                '      rhds:\n        channel: fast\n        acc_version: "<full_version>"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Unexpected keys"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_acc_version_for_stable(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        rhds:\n          channel: stable\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="stable"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_invalid_odh_origin(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      odh:\n        origin: in-house\n        version: "latest"',
+                '      odh:\n        origin: default\n        version: "latest"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="odh.*origin"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_non_latest_cpu_odh_version(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      odh:\n        origin: in-house\n        version: "latest"',
+                '      odh:\n        origin: in-house\n        version: "3.12"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="cpu.*version.*latest"):
+        updater.load_versions_config(config)
+
+
+def test_load_versions_config_rejects_non_numeric_cuda_in_house_acc_version(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config,
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "latest"',
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="numeric acc_version"):
+        updater.load_versions_config(config)
+
+
+def test_collect_conf_targets_classifies_managed_paths(tmp_path: Path) -> None:
+    updater = load_updater()
+    managed = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("BASE_IMAGE=example\n", encoding="utf-8")
+
+    targets = updater.collect_conf_targets(tmp_path)
+
+    assert len(targets) == 1
+    assert targets[0].path == managed
+    assert targets[0].distribution == "rhds"
+    assert targets[0].accelerator == "cuda"
+    assert targets[0].flavor == "minimal"
+
+
+def test_collect_conf_targets_ignores_base_images_build_args(tmp_path: Path) -> None:
+    updater = load_updater()
+    managed = tmp_path / "base-images" / "build-args" / "cuda13.0.conf"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("INDEX_URL=https://example.invalid\n", encoding="utf-8")
+
+    targets = updater.collect_conf_targets(tmp_path)
+
+    assert targets == []
+
+
+def test_collect_conf_targets_rejects_unknown_build_args_filename(tmp_path: Path) -> None:
+    updater = load_updater()
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "gpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=example\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported build-args filename"):
+        updater.collect_conf_targets(tmp_path)
+
+
+def test_select_latest_matching_rhds_tag_prefers_highest_build_in_same_family() -> None:
+    updater = load_updater()
+
+    latest = updater.select_latest_matching_rhds_tag(
+        [
+            "3.6.0-ea.1-1777919000",
+            "3.6.0-ea.1-1777919999",
+            "3.6.0-ea.2-1777920000",
+            "3.6.0-1777921111",
+        ],
+        "3.6.0-ea.1-1777000000",
+    )
+
+    assert latest == "3.6.0-ea.1-1777919999"
+
+
+def test_build_rhds_pinned_tag_targets_ga_family_on_rollback() -> None:
+    updater = load_updater()
+    release = updater.ReleaseConfig(full_version="3.4.0", rhds_os_base="el9.6", python_version="3.12")
+
+    tag = updater.build_rhds_pinned_tag("3.5.0-ea.2-1777919771", release)
+
+    assert tag == "3.4.0-1777919771"
+
+
+def test_resolve_latest_published_rhds_image_uses_skopeo_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    updater = load_updater()
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+            '["3.6.0-ea.1-1777919000","3.6.0-ea.1-1777919999","3.6.0-ea.2-1777920000"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    latest = updater.resolve_latest_published_rhds_image(
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
+    )
+
+    assert latest == "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919999"
+
+
+def test_resolve_latest_published_rhds_image_rollback_falls_back_to_highest_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+            '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.5.0-1777921111"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    latest = updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-0")
+
+    assert latest == "quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1777919999"
+
+
+def test_resolve_latest_published_rhds_image_rollback_raises_when_release_is_unpublished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    class Completed:
+        returncode = 0
+        stdout = '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":["3.5.0-ea.2-1777919999"]}'
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    with pytest.raises(ValueError, match="release '3.4.0'"):
+        updater.resolve_latest_published_rhds_image("quay.io/aipcc/base-images/cpu:3.4.0-0")
+
+
+def test_resolve_latest_published_rhds_image_raises_on_skopeo_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    class Completed:
+        returncode = 1
+        stdout = ""
+        stderr = "manifest unknown"
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    with pytest.raises(ValueError, match="skopeo list-tags failed"):
+        updater.resolve_latest_published_rhds_image(
+            "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
+        )
+
+
+def test_resolve_latest_published_rhds_image_raises_when_skopeo_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+
+    def raise_missing(*args, **kwargs):
+        raise FileNotFoundError("skopeo")
+
+    monkeypatch.setattr(updater.subprocess, "run", raise_missing)
+
+    with pytest.raises(ValueError, match="skopeo is required"):
+        updater.resolve_latest_published_rhds_image(
+            "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777000000"
+        )
+
+
+def test_plan_updates_caches_rhds_tag_listing_per_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml")
+
+    first = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    second = tmp_path / "runtimes" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    base_image = "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1777919771\n"
+    first.write_text(f"BASE_IMAGE={base_image}", encoding="utf-8")
+    second.write_text(f"BASE_IMAGE={base_image}", encoding="utf-8")
+
+    calls: list[str] = []
+
+    class Completed:
+        returncode = 0
+        stdout = '{"Tags":["3.6.0-ea.1-1777919999"]}'
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd[-1])
+        return Completed()
+
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+
+    updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert calls == ["docker://quay.io/aipcc/base-images/cpu"]
+
+
+def test_plan_updates_infers_bundle_phase_for_stable_to_fast_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    target_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    peer_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    target_conf.parent.mkdir(parents=True)
+    peer_conf.parent.mkdir(parents=True)
+    target_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+    peer_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        if image == "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-0":
+            return "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == [
+        "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-0",
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771",
+    ]
+    assert rendered[target_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
+    assert rendered[peer_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+
+
+def test_plan_updates_infers_ga_phase_for_stable_to_fast_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    target_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    peer_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    target_conf.parent.mkdir(parents=True)
+    peer_conf.parent.mkdir(parents=True)
+    target_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5\n", encoding="utf-8")
+    peer_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        if image.endswith(":3.5.0-0"):
+            return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000000"
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000001"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == [
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-0",
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777919771",
+    ]
+    assert rendered[target_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000000"
+    assert rendered[peer_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000001"
+
+
+def test_plan_updates_falls_back_to_ea1_without_any_bundle_fast_style_peers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    first_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    second_conf = tmp_path / "runtimes" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    first_conf.parent.mkdir(parents=True)
+    second_conf.parent.mkdir(parents=True)
+    first_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+    second_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == [
+        "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-0",
+        "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-0",
+    ]
+    assert rendered[first_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000"
+    assert rendered[second_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000"
+
+
+def test_plan_updates_uses_highest_observed_bundle_phase_for_existing_fast_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    cpu_conf = tmp_path / "runtimes" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    cuda_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    cpu_conf.parent.mkdir(parents=True)
+    cuda_conf.parent.mkdir(parents=True)
+    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780600064\n", encoding="utf-8")
+    cuda_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n",
+        encoding="utf-8",
+    )
+    rocm_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.rocm.conf"
+    rocm_conf.parent.mkdir(parents=True)
+    rocm_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        if image == "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064":
+            return "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780609999"
+        if image == "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771":
+            return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+        return "quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1780000002"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == [
+        "quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1777919771",
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771",
+        "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064",
+    ]
+    assert rendered[rocm_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1780000002"
+    assert rendered[cuda_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+    assert rendered[cpu_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780609999"
+
+
+def test_plan_updates_uses_forward_discovery_not_bundle_phase_for_lagging_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    cpu_conf = tmp_path / "runtimes" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    cuda_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    cpu_conf.parent.mkdir(parents=True)
+    cuda_conf.parent.mkdir(parents=True)
+    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1780600064\n", encoding="utf-8")
+    cuda_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    def fake_list_tags(repository: str, tag_cache=None) -> tuple[str, ...]:
+        if repository == "quay.io/aipcc/base-images/cpu":
+            return ("3.5.0-ea.1-1777919000",)
+        return ()
+
+    monkeypatch.setattr(updater, "list_rhds_repository_tags", fake_list_tags)
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        if image == "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780600064":
+            return "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780609999"
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780600064" in seen
+    assert "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064" not in seen
+    assert rendered[cpu_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780609999"
+    assert rendered[cuda_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+
+
+def test_plan_updates_starts_new_release_at_ea1_when_peers_are_older_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.6.0")
+
+    target_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    peer_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    target_conf.parent.mkdir(parents=True)
+    peer_conf.parent.mkdir(parents=True)
+    target_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+    peer_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        if image == "quay.io/aipcc/base-images/cpu:3.6.0-ea.1-0":
+            return "quay.io/aipcc/base-images/cpu:3.6.0-ea.1-1780000000"
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1780000001"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+    stub_empty_rhds_tag_listing(monkeypatch, updater)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == [
+        "quay.io/aipcc/base-images/cpu:3.6.0-ea.1-0",
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919771",
+    ]
+    assert rendered[target_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.6.0-ea.1-1780000000"
+    assert rendered[peer_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1780000001"
+
+
+def test_plan_updates_uses_published_ga_for_new_release_when_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+            '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999","3.5.0-1777921111"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777921111"
+
+
+def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+            '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999"
+
+
+def test_plan_updates_stable_to_fast_forward_uses_highest_published_phase_for_new_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.4\n", encoding="utf-8")
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+            '["3.5.0-ea.1-1777919000","3.5.0-ea.2-1777919999"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919999"
+
+
+def test_plan_updates_new_release_without_published_tags_keeps_strict_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.5.0")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cuda-25.0-el9.6","Tags":'
+            '["3.4.0-ea.2-1777919771"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    with pytest.raises(ValueError, match="No matching published RHDS tag found"):
+        updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+
+def test_plan_updates_builds_fast_rhds_candidate_before_latest_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+    stub_empty_rhds_tag_listing(monkeypatch, updater)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919771"]
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"
+
+
+def test_plan_updates_rollback_targets_ga_family_for_older_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
+
+    conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert seen == ["quay.io/aipcc/base-images/cpu:3.4.0-1777919771"]
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+
+
+def test_plan_updates_rollback_ignores_newer_fast_peers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
+
+    cpu_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    cuda_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    cpu_conf.parent.mkdir(parents=True)
+    cuda_conf.parent.mkdir(parents=True)
+    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064\n", encoding="utf-8")
+    cuda_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        if image == "quay.io/aipcc/base-images/cpu:3.4.0-1780600064":
+            return "quay.io/aipcc/base-images/cpu:3.4.0-1780609999"
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.4.0-1780000001"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == [
+        "quay.io/aipcc/base-images/cpu:3.4.0-1780600064",
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.4.0-1777919771",
+    ]
+    assert rendered[cpu_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780609999"
+    assert rendered[cuda_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.4.0-1780000001"
+
+
+def test_plan_updates_rollback_falls_back_to_highest_published_phase_when_ga_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
+
+    conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+
+    class Completed:
+        returncode = 0
+        stdout = (
+            '{"Repository":"quay.io/aipcc/base-images/cpu","Tags":'
+            '["3.4.0-ea.1-1777919000","3.4.0-ea.2-1777919999","3.5.0-ea.2-1777921111"]}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(updater.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1777919999"
+
+
+def test_plan_updates_rollback_from_stable_target_uses_ga_seed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0")
+
+    conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5\n", encoding="utf-8")
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert seen == ["quay.io/aipcc/base-images/cpu:3.4.0-0"]
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+
+
+def test_plan_updates_allows_independent_mixed_rhds_channels(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+            )
+        ],
+    )
+
+    cpu_conf = tmp_path / "jupyter" / "datascience" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    cuda_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    cpu_conf.parent.mkdir(parents=True)
+    cuda_conf.parent.mkdir(parents=True)
+    cpu_conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+    cuda_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path.name: update.updated_text.strip() for update in updates}
+
+    assert seen == ["quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771"]
+    assert rendered["konflux.cpu.conf"] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
+    assert rendered["konflux.cuda.conf"] == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+
+
+def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+            )
+        ],
+    )
+
+    minimal_conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    pytorch_conf = tmp_path / "jupyter" / "pytorch" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    minimal_conf.parent.mkdir(parents=True)
+    pytorch_conf.parent.mkdir(parents=True)
+    minimal_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+    pytorch_conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    def fake_resolve(image: str, tag_cache=None) -> str:
+        seen.append(image)
+        return "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
+
+    monkeypatch.setattr(updater, "resolve_latest_published_rhds_image", fake_resolve)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    rendered = {update.target.path: update.updated_text.strip() for update in updates}
+
+    assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771"]
+    assert rendered[minimal_conf] == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+    assert rendered[pytorch_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
+
+
+def test_plan_updates_uses_rhds_cuda_stable_repo(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "25.0"\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "25.0"',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cuda-stable-ubi9:3.5"
+
+
+def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      rhds:\n        channel: fast\n        version: "<full_version>"',
+                "      rhds:\n        channel: stable",
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771\n", encoding="utf-8")
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5"
+
+
+def test_plan_updates_uses_rhds_rocm_stable_repo(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        full_version="3.5.0",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
+                '      minimal:\n        rhds:\n          channel: stable\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.rocm.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1777919771\n",
+        encoding="utf-8",
+    )
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-rocm-stable-ubi9:3.5"
+
+
+def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        replacements=[
+            (
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: in-house\n          acc_version: "8.0"',
+                '      minimal:\n        rhds:\n          channel: fast\n          acc_version: "8.0"\n        odh:\n          origin: midstream\n          acc_version: "7.1"',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "rocm.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1\n", encoding="utf-8")
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest"
+
+
+def test_plan_updates_uses_odh_midstream_cpu_repo(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(
+        tmp_path / "versions_config.yml",
+        python_version="3.11",
+        replacements=[
+            (
+                '      odh:\n        origin: in-house\n        version: "latest"',
+                '      odh:\n        origin: midstream\n        version: "latest"',
+            )
+        ],
+    )
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest\n", encoding="utf-8")
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-python-base-3-11:latest"
+
+
+def test_plan_updates_uses_odh_in_house_cpu_repo_from_release_python_version(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", python_version="3.11")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "cpu.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest\n", encoding="utf-8")
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py311-c9s:latest"
+
+
+def test_plan_updates_can_switch_odh_rocm_back_to_in_house_repo(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "rocm.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text("BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-7-1:latest\n", encoding="utf-8")
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0"
+
+
+def test_plan_updates_rewrites_release_to_minor_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.6.0")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771
+            PYLOCK_FLAVOR=cuda
+            RELEASE=3.5
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        updater,
+        "resolve_latest_published_rhds_image",
+        lambda image, tag_cache=None: "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+    )
+    stub_empty_rhds_tag_listing(monkeypatch, updater)
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+
+    assert updates[0].updated_text.splitlines() == [
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+        "PYLOCK_FLAVOR=cuda",
+        "RELEASE=3.6",
+    ]
+
+
+def test_main_updates_base_image_and_release_lines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        textwrap.dedent(
+            """\
+            INDEX_URL=unchanged
+            BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771
+            PYLOCK_FLAVOR=cuda
+            RELEASE=3.5
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        updater,
+        "resolve_latest_published_rhds_image",
+        lambda image, tag_cache=None: "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+    )
+    stub_empty_rhds_tag_listing(monkeypatch, updater)
+
+    assert updater.main(["--root", str(tmp_path), "--config", str(tmp_path / "versions_config.yml")]) == 0
+    assert conf.read_text(encoding="utf-8").splitlines() == [
+        "INDEX_URL=unchanged",
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+        "PYLOCK_FLAVOR=cuda",
+        "RELEASE=3.6",
+    ]
+
+
+def test_plan_updates_rewrites_root_makefile_release_defaults(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0", python_version="3.11")
+
+    makefile = tmp_path / "Makefile"
+    makefile.write_text(
+        textwrap.dedent(
+            """\
+            IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images
+            RELEASE          ?= 3.5
+            RELEASE_PYTHON_VERSION ?= 3.12
+            KONFLUX ?= no
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
+    updates_by_path = {update.path if hasattr(update, "path") else update.target.path: update for update in updates}
+
+    assert updates_by_path[makefile].updated_text.splitlines() == [
+        "IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images",
+        "RELEASE          ?= 3.4",
+        "RELEASE_PYTHON_VERSION ?= 3.11",
+        "KONFLUX ?= no",
+    ]
+
+
+def test_main_updates_root_makefile_release_defaults(tmp_path: Path) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml", full_version="3.4.0", python_version="3.11")
+
+    makefile = tmp_path / "Makefile"
+    makefile.write_text(
+        textwrap.dedent(
+            """\
+            IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images
+            RELEASE          ?= 3.5
+            RELEASE_PYTHON_VERSION ?= 3.12
+            KONFLUX ?= no
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    assert updater.main(["--root", str(tmp_path), "--config", str(tmp_path / "versions_config.yml")]) == 0
+    assert makefile.read_text(encoding="utf-8").splitlines() == [
+        "IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images",
+        "RELEASE          ?= 3.4",
+        "RELEASE_PYTHON_VERSION ?= 3.11",
+        "KONFLUX ?= no",
+    ]
+
+
+def test_main_dry_run_does_not_write_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    original = "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n"
+    conf.write_text(original, encoding="utf-8")
+
+    monkeypatch.setattr(
+        updater,
+        "resolve_latest_published_rhds_image",
+        lambda image, tag_cache=None: "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+    )
+    stub_empty_rhds_tag_listing(monkeypatch, updater)
+
+    assert updater.main(["--root", str(tmp_path), "--config", str(tmp_path / "versions_config.yml"), "--dry-run"]) == 0
+    assert conf.read_text(encoding="utf-8") == original
+
+
+def test_main_check_returns_nonzero_when_files_need_updates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
+    write_versions_config(tmp_path / "versions_config.yml")
+
+    conf = tmp_path / "jupyter" / "minimal" / "ubi9-python-3.12" / "build-args" / "konflux.cuda.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        updater,
+        "resolve_latest_published_rhds_image",
+        lambda image, tag_cache=None: "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+    )
+    stub_empty_rhds_tag_listing(monkeypatch, updater)
+
+    assert updater.main(["--root", str(tmp_path), "--config", str(tmp_path / "versions_config.yml"), "--check"]) == 1
+    assert conf.read_text(encoding="utf-8").strip() == (
+        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.1-1777919771"
+    )

--- a/versions_config.yml
+++ b/versions_config.yml
@@ -1,3 +1,4 @@
+---
 schema_version: 1
 
 release:

--- a/versions_config.yml
+++ b/versions_config.yml
@@ -18,53 +18,46 @@ artifacts:
 
     cuda:
       minimal:
+        acc_version: "13.0"
         rhds:
           channel: fast
-          acc_version: "13.0"
         odh:
           origin: in-house
-          acc_version: "13.0"
       pytorch:
+        acc_version: "13.0"
         rhds:
           channel: fast
-          acc_version: "13.0"
         odh:
           origin: in-house
-          acc_version: "13.0"
       pytorch-llmcompressor:
+        acc_version: "13.0"
         rhds:
           channel: fast
-          acc_version: "13.0"
         odh:
           origin: in-house
-          acc_version: "13.0"
       tensorflow:
+        acc_version: "12.9"
         rhds:
           channel: fast
-          acc_version: "12.9"
         odh:
           origin: in-house
-          acc_version: "12.9"
 
     rocm:
       minimal:
+        acc_version: "7.1"
         rhds:
           channel: fast
-          acc_version: "7.1"
         odh:
           origin: in-house
-          acc_version: "7.1"
       pytorch:
+        acc_version: "7.1"
         rhds:
           channel: fast
-          acc_version: "7.1"
         odh:
           origin: in-house
-          acc_version: "7.1"
       tensorflow:
+        acc_version: "7.1"
         rhds:
           channel: fast
-          acc_version: "7.1"
         odh:
           origin: in-house
-          acc_version: "7.1"

--- a/versions_config.yml
+++ b/versions_config.yml
@@ -1,0 +1,69 @@
+schema_version: 1
+
+release:
+  full_version: "3.5.0"
+  rhds_os_base: "el9.6"
+  python_version: "3.12"
+
+artifacts:
+  base_image:
+    cpu:
+      rhds:
+        channel: fast
+        version: "<full_version>"
+      odh:
+        origin: in-house
+        version: "latest"
+
+    cuda:
+      minimal:
+        rhds:
+          channel: fast
+          acc_version: "13.0"
+        odh:
+          origin: in-house
+          acc_version: "13.0"
+      pytorch:
+        rhds:
+          channel: fast
+          acc_version: "13.0"
+        odh:
+          origin: in-house
+          acc_version: "13.0"
+      pytorch-llmcompressor:
+        rhds:
+          channel: fast
+          acc_version: "13.0"
+        odh:
+          origin: in-house
+          acc_version: "13.0"
+      tensorflow:
+        rhds:
+          channel: fast
+          acc_version: "12.9"
+        odh:
+          origin: in-house
+          acc_version: "12.9"
+
+    rocm:
+      minimal:
+        rhds:
+          channel: fast
+          acc_version: "7.1"
+        odh:
+          origin: in-house
+          acc_version: "7.1"
+      pytorch:
+        rhds:
+          channel: fast
+          acc_version: "7.1"
+        odh:
+          origin: in-house
+          acc_version: "7.1"
+      tensorflow:
+        rhds:
+          channel: fast
+          acc_version: "7.1"
+        odh:
+          origin: in-house
+          acc_version: "7.1"


### PR DESCRIPTION
Related to: https://redhat.atlassian.net/browse/RHAIENG-4892 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Introduces a centralized base-image version sync flow driven by `versions_config.yml`. Maintainers edit one config file, run `make sync-build-args-from-versions`, and the repo updates managed `build-args/*.conf` files plus root `Makefile` release defaults.

This replaces manual, per-image BASE_IMAGE edits with a validated, policy-driven workflow for RHDS (Konflux) and ODH base images across CPU, CUDA, and ROCm families.

**What operators can do**
Single entry point for version updates
- Edit `versions_config.yml` at the repo root.
- Run `make sync-build-args-from-versions` to apply changes across jupyter/, runtimes/, and codeserver/.
- Use `--dry-run` to preview diffs or `--check` to fail when the repo is out of sync.

For more info read its documentation file: [base_image_versions_update_configuration.md](https://github.com/atheo89/notebooks/blob/cetralized-version/docs/base_image_versions_update_configuration.md)
## How Has This Been Tested?

**manual user check/understanding:**
Update the `versions_config.yml` version command with desired versions and run the `make sync-build-args-from-versions` 

**embedded test:**
`./uv run pytest tests/unit/scripts/test_update_build_args_from_versions.py -q`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gmake sync-build-args-from-versions` to sync `BASE_IMAGE`/release build-args from a central `versions_config.yml`, with argument validation and `--dry-run`/`--check` diff output.
* **Documentation**
  * Expanded the README with an “Update base image versions” section and added a dedicated how-to guide and troubleshooting notes.
* **Chores**
  * Added/updated `versions_config.yml`, refreshed guidance comments across many build-arg configs, and updated one ROCm runtime `BASE_IMAGE`.
* **Tests**
  * Added unit tests for the sync/update flow and adjusted image-variant checks to skip accelerator validation when GPU stable versions can’t be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->