### PR TITLE
RHOAIENG-67031: test(jupyter/pytorch+llmcompressor): align compressed-tensors version with lock

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/test/test_notebook.ipynb
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/test/test_notebook.ipynb
@@ -2,14 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "fc39f0e9",
       "metadata": {
         "vscode": {
           "languageId": "plaintext"
         }
       },
-      "outputs": [],
       "source": [
         "import os\n",
         "import ssl\n",
@@ -29,11 +26,11 @@
         "_EXTRA_EXPECTED_MAJOR_MINOR = {\n",
         "    \"Python\": \"3.12\",\n",
         "    \"JupyterLab\": \"4.5\",\n",
-        "    \"compressed-tensors\": \"0.14\",\n",
+        "    \"compressed-tensors\": \"0.16\",\n",
         "    \"lm-eval\": \"0.4\",\n",
         "    \"speculators\": \"0.5\",\n",
-        "    \"llmcompressor\": \"0.10\",       \n",
-        "    \"numpy\": \"2.3\", \n",
+        "    \"llmcompressor\": \"0.11\",\n",
+        "    \"numpy\": \"2.4\",\n",
         "}\n",
         "\n",
         "def get_major_minor(version_str):\n",
@@ -114,7 +111,10 @@
         "# --- Execution logic ---\n",
         "expected_versions = load_expected_versions()\n",
         "unittest.main(argv=[''], verbosity=2, exit=False)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "fc39f0e9"
     }
   ],
   "metadata": {

--- a/scripts/test_jupyter_with_papermill.sh
+++ b/scripts/test_jupyter_with_papermill.sh
@@ -297,9 +297,24 @@ function _create_test_versions_source_of_truth()
     nbgitpuller_version="$(_get_package_version_from_requirements 'nbgitpuller' "${requirements_file}")"
     nbgitpuller_version="${nbgitpuller_version:-1.3}"
 
+    # llmcompressor-only packages are not listed in ImageStream annotations; read pins from lock output.
+    local compressed_tensors_version=''
+    local lm_eval_version=''
+    local speculators_version=''
+    if [[ "${notebook_id}" == *llmcompressor* ]]; then
+        compressed_tensors_version="$(_get_package_version_from_requirements 'compressed-tensors' "${requirements_file}")"
+        lm_eval_version="$(_get_package_version_from_requirements 'lm-eval' "${requirements_file}")"
+        speculators_version="$(_get_package_version_from_requirements 'speculators' "${requirements_file}")"
+    fi
+
     expected_versions=$("${yqbin}" '.spec.tags[0].annotations | .["opendatahub.io/notebook-software"] + .["opendatahub.io/notebook-python-dependencies"]' "${test_version_truth_filepath}" |
         "${yqbin}" -N -p json -o yaml |
-        nbdime_version=${nbdime_version} nbgitpuller_version=${nbgitpuller_version} "${yqbin}" '. + [{"name": "nbdime", "version": strenv(nbdime_version)},{"name": "nbgitpuller", "version": strenv(nbgitpuller_version)}]' |
+        nbdime_version=${nbdime_version} nbgitpuller_version=${nbgitpuller_version} \
+        compressed_tensors_version=${compressed_tensors_version} lm_eval_version=${lm_eval_version} speculators_version=${speculators_version} \
+        "${yqbin}" '. + [{"name": "nbdime", "version": strenv(nbdime_version)}, {"name": "nbgitpuller", "version": strenv(nbgitpuller_version)}]
+          + (strenv(compressed_tensors_version) | select(. != "") | [{"name": "compressed-tensors", "version": .}] // [])
+          + (strenv(lm_eval_version) | select(. != "") | [{"name": "lm-eval", "version": .}] // [])
+          + (strenv(speculators_version) | select(. != "") | [{"name": "speculators", "version": .}] // [])' |
         "${yqbin}" -N -o json '[ .[] | (.name | key) = "key" | (.version | key) = "value" ] | from_entries')
 
     # Following disabled shellcheck intentional as the intended behavior is for those ${1}, ${2} variables to only be expanded when running within kubernetes


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-67031

## Summary

Follow-up to #3811: fixes `test_compressed_tensors_version` failure after the lock upgrade bumped `compressed-tensors` from 0.14 to 0.16.

- Inject `compressed-tensors`, `lm-eval`, and `speculators` pins from `requirements.cuda.txt` into `expected_versions.json` for llmcompressor images (these packages are not in ImageStream annotations).
- Update stale fallbacks in `test_notebook.ipynb` (compressed-tensors 0.16, llmcompressor 0.11, numpy 2.4).

## Test plan

- [x] `make test-jupyter-pytorch-llmcompressor` (or integration path that runs papermill `test_notebook.ipynb`)
- [ ] CI green on merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test version expectations for dependencies to validate compatibility with newer package releases.
  * Enhanced automated Jupyter notebook testing to verify additional package versions as part of test workflows.

* **Chores**
  * Reorganized notebook test data structure for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->