### PR TITLE
chore(ci): switch self-hosted Renovate to upstream pinned image

### DIFF
--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -65,7 +65,7 @@ jobs:
     env:
       CONTAINER_ENGINE: docker
       # Pin with scripts/ci/renovate_run.py default; bump both when upgrading Renovate.
-      RENOVATE_IMAGE: quay.io/jdanek/renovate:43-fix42554
+      RENOVATE_IMAGE: ghcr.io/renovatebot/renovate:43@sha256:575256ce227ca81cd2a316d33f35108fe5c978d479c29232ec74cf9c0904a351  # 43.216.4
       DOCKER_CONFIG: /tmp/renovate-docker-config
     permissions:
       contents: read

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     env:
       CONTAINER_ENGINE: docker
-      RENOVATE_IMAGE: quay.io/jdanek/renovate:43-fix42554
+      RENOVATE_IMAGE: ghcr.io/renovatebot/renovate:43@sha256:575256ce227ca81cd2a316d33f35108fe5c978d479c29232ec74cf9c0904a351  # 43.216.4
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -57,7 +57,7 @@ processing this remote.
    digest/grouping rules).
 
 2. **Add `.github/workflows/renovate-self-hosted.yaml`** (optional) to run
-   [`scripts/ci/renovate_run.py`](../../../scripts/ci/renovate_run.py) (Renovate container via Docker on CI, `CONTAINER_ENGINE=docker`) on a schedule and `workflow_dispatch`, using the same config file and a **`RENOVATE_TOKEN`** PAT so PRs can trigger normal CI. The workflow no longer uses `renovatebot/github-action`; the Renovate **image tag** is pinned with **`RENOVATE_IMAGE`** (default `ghcr.io/renovatebot/renovate:43`), so bump that env var in the workflow or script when upgrading.
+   [`scripts/ci/renovate_run.py`](../../../scripts/ci/renovate_run.py) (Renovate container via Docker on CI, `CONTAINER_ENGINE=docker`) on a schedule and `workflow_dispatch`, using the same config file and a **`RENOVATE_TOKEN`** PAT so PRs can trigger normal CI. The workflow no longer uses `renovatebot/github-action`; the Renovate **image** is pinned with **`RENOVATE_IMAGE`** (default upstream `ghcr.io/renovatebot/renovate:43@sha256:…`), so bump that env var in the workflow and `DEFAULT_RENOVATE_IMAGE` in the script when upgrading.
 
 3. **The self-hosted workflow** uses a split gate:
    `github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'`
@@ -164,13 +164,13 @@ Renovate only changed unrestricted paths like `build-args/konflux.*.conf`.
 
 - **Upstream bug**: [renovatebot/renovate#42554](https://github.com/renovatebot/renovate/issues/42554)
 - **`platformCommit: "disabled"`** does NOT help — `commitFiles()` always calls `pushFiles()`
-- **Workaround**: ask the org admin (Ugo Giordano / `@U02AADEDP7B` in Slack
-  `#wg-openshift-ai-odh-github`) to add the Renovate PAT user (`ide-developer`)
-  as a **bypass actor** on the file path restriction ruleset. This was already done
-  for [`opendatahub-io/opendatahub-tests`](https://redhat-internal.slack.com/archives/C09BV0L6ULQ/p1773076687051249?thread_ts=1772554653.543679&cid=C09BV0L6ULQ).
-- **Proposed fix**: use `base_tree` + only changed files in `POST /git/trees` instead of
-  the full tree. A patched image is available at `quay.io/jdanek/renovate:43-fix42554`
-  (amd64 + arm64); to test, set `RENOVATE_IMAGE` in the workflow env.
+- **MintMaker workaround**: add the MintMaker GitHub App as a **bypass actor** on the
+  file path restriction ruleset (done for this org).
+- **Self-hosted workaround (historical)**: a patched image at `quay.io/jdanek/renovate:43-fix42554`
+  used `base_tree` + only changed files. **Superseded** by upstream fix
+  [renovatebot/renovate#42556](https://github.com/renovatebot/renovate/pull/42556)
+  (released in 43.216.3). Self-hosted workflows now pin upstream
+  `ghcr.io/renovatebot/renovate:43@sha256:…` (amd64 digest for GHA `ubuntu-latest`).
 
 ### Self-hosted run log quirks (forks)
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -108,12 +108,13 @@ directly in a repo will be rejected by the push ruleset. See the
 [security-config sync config](https://github.com/opendatahub-io/security-config/blob/main/sync-config.yml)
 for the full list of synced repos.
 
-**Known issue with Renovate:** Renovate's `pushFiles` sends the full tree via
-`POST /git/trees` without `base_tree`, so GitHub validates all file paths -- including
-unchanged protected ones -- and rejects the push with 422 "File path is restricted".
-This broke MintMaker (Konflux's Renovate instance); Ugo added the MintMaker GitHub App
-as a bypass actor on the ruleset to fix it.
-Upstream bug: [renovatebot/renovate#42555](https://github.com/renovatebot/renovate/discussions/42555).
+**Renovate and org rulesets:** Renovate's `pushFiles` used to send the full tree via
+`POST /git/trees` without `base_tree`, so GitHub validated all file paths -- including
+unchanged protected ones -- and rejected the push with 422 "File path is restricted".
+MintMaker was unblocked by adding the MintMaker GitHub App as a bypass actor on the
+ruleset. Upstream fixed this in [renovatebot/renovate#42556](https://github.com/renovatebot/renovate/pull/42556)
+(released in 43.216.3); self-hosted Renovate now uses upstream `ghcr.io/renovatebot/renovate`.
+Original report: [renovatebot/renovate#42554](https://github.com/renovatebot/renovate/issues/42554).
 
 ## Branch protection
 

--- a/scripts/ci/renovate_run.py
+++ b/scripts/ci/renovate_run.py
@@ -34,7 +34,7 @@ from pathlib import Path
 SCRIPTS_CI = Path(__file__).resolve().parent
 ROOT = SCRIPTS_CI.parent.parent
 REMOTE_DEFAULT_REPO = "opendatahub-io/notebooks"
-DEFAULT_RENOVATE_IMAGE = "quay.io/jdanek/renovate:43-fix42554"
+DEFAULT_RENOVATE_IMAGE = "ghcr.io/renovatebot/renovate:43@sha256:575256ce227ca81cd2a316d33f35108fe5c978d479c29232ec74cf9c0904a351"
 DEFAULT_GIT_AUTHOR = "ide-developer <rhoai-ide-konflux@redhat.com>"
 LOCAL_MODES = ("local", "local-lookup")
 REMOTE_MODES = ("remote", "lookup")


### PR DESCRIPTION
## Summary
- Replace patched `quay.io/jdanek/renovate:43-fix42554` with upstream `ghcr.io/renovatebot/renovate:43` pinned by amd64 digest (43.216.4).
- Upstream fix for org ruleset 422 errors landed in [renovatebot/renovate#42556](https://github.com/renovatebot/renovate/pull/42556) (released in 43.216.3).
- Update ADR 0013 and docs/github.md to document the upstream fix and retire the patched image.

## Self-hosted Renovate validation run

Triggered manually from this branch to verify the upstream image on GHA:

**Run:** https://github.com/opendatahub-io/notebooks/actions/runs/27200101744  
**Branch:** `chore/switch-upstream-renovate` · **Trigger:** `workflow_dispatch` · **Duration:** ~1m 42s · **Job result:** ✅ success

| Check | Result |
| --- | --- |
| Image pulled | `ghcr.io/renovatebot/renovate:43@sha256:575256…` |
| Renovate version | **43.216.4** |
| Org ruleset 422 / push rejections | **None** — 5 git pushes succeeded |
| Primary goal (upstream `base_tree` fix) | ✅ **Confirmed** |

### Branch outcomes (7 candidates)

| Branch | Result | Notes |
| --- | --- | --- |
| `konflux/mintmaker/main/konflux-base_image-quay.io-aipcc-base-images-cpu` | ✅ updated | PR [#3797](https://github.com/opendatahub-io/notebooks/pull/3797) rebased |
| `…/cuda-12.9-el9.6` | ✅ updated | PR [#3798](https://github.com/opendatahub-io/notebooks/pull/3798) rebased |
| `…/cuda-13.0-el9.6` | ✅ updated | PR [#3799](https://github.com/opendatahub-io/notebooks/pull/3799) rebased |
| `…/rocm-7.1-el9.6` | ✅ updated | PR [#3800](https://github.com/opendatahub-io/notebooks/pull/3800) rebased |
| `konflux/mintmaker/main/github-actions` | ❌ error | Failed updating `.github/workflows/code-quality.yaml` — `golangci/golangci-lint` digest not found in file (`foundValue: undefined`); likely pre-existing Renovate config issue, not image-specific |
| `konflux/references/main` | ⏭ not-scheduled | Tekton schedule: `after 5am on saturday` |
| `…/ubi9-go-toolset-1.x` | ⏭ not-scheduled | Dockerfile schedule: `before 5am` (run was 10:31 UTC) |

Renovate finished with `repoProblems`: config warnings (global-only keys in `renovate.json5`, `matchBaseBranches` without `baseBranchPatterns`) plus the `github-actions` branch failure above. These do **not** block the image switch; the patched image is no longer needed for the org ruleset 422 workaround.

### Other observations (non-blocking)

- **Workflow vs effective config:** workflow sets `RENOVATE_ENABLED_MANAGERS` without `tekton`, but inherited MintMaker config still enabled the tekton manager (65 `.tekton` files scanned).
- **Registry auth:** Quay v1 401 on private `aipcc` images → Docker v2 fallback succeeded.
- **Logs:** `RENOVATE_HOST_RULES` echoed to `$GITHUB_ENV`; passwords masked, but OCM username visible in env block.

## Test plan
- [x] `gmake validate-renovate-config`
- [x] `./uv run pytest tests/test_renovate_config.py`
- [x] Self-hosted Renovate workflow dispatch on PR branch — [run 27200101744](https://github.com/opendatahub-io/notebooks/actions/runs/27200101744)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Renovate container image to use the official upstream version with SHA256 digest pinning across CI/CD workflows and documentation, replacing the previous custom patched image with improved security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->