### PR TITLE
RHAIENG-5587: Fix ODH codeserver build failure: httpd RPM version conflict during hermetic dnf install

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml
@@ -9,6 +9,11 @@
 # The lock file (rpms.lock.yaml) is auto-generated with exact versions and hashes.
 #
 # Previously, the Dockerfile ran `dnf install` with network access.
+#
+# The shared Dockerfile always runs `dnf install ... httpd`. RHDS prefetches
+# httpd (prefetch-input/rhds). ODH must NOT list httpd here — it is already
+# on odh-base-image-cpu-py312-c9s; prefetching a newer CentOS Stream httpd
+# causes a version conflict with base httpd-devel during the build.
 
 contentOrigin:
   repofiles:
@@ -66,11 +71,10 @@ packages:
   - nodejs-packaging
   - npm
 
-  # Web servers
+  # Web servers (httpd is already on odh-base-image-cpu-py312-c9s — do not list here)
   - nginx
   - nginx-mod-stream
   - nginx-mod-http-perl
-  - httpd
   - nss_wrapper
 
   # SELinux

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4,34 +4,6 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/apr-1.7.0-12.el9_3.aarch64.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 125170
-    checksum: sha256:374ddeebd8141091d4930fe1d80482af730729037f08e092c3a4e417973d66a5
-    name: apr
-    evr: 1.7.0-12.el9_3
-    sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/apr-util-1.6.1-23.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 100645
-    checksum: sha256:7a4c6d9667176da5d9f7d471be8e98a7ba4f1235357ebf5c43ede7d6bcd3ad51
-    name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 14452
-    checksum: sha256:099574e9b736916e44070e851691172b380b00bf82ec8023c7f1624a9fb76347
-    name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 16614
-    checksum: sha256:ffffa1f27c75146b511e0e9f17991641e9b71abe3114e1ddc423bec452e18b10
-    name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 697155
@@ -928,13 +900,6 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.aarch64.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 168297
-    checksum: sha256:ea5866eb3812e4d18758d1615bc202199732795dc9e9be264a728ac171feae75
-    name: mod_http2
-    evr: 2.0.26-6.el9_8
-    sourcerpm: mod_http2-2.0.26-6.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 92062
@@ -2048,27 +2013,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8
     sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.13-2.el9_8.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 33253
-    checksum: sha256:1132db054b33d20b7704844ac7a69402b58f2bea74ffd0104e02ba6e2a609861
+    size: 32869
+    checksum: sha256:4667f425d230510ab2dae3036c963184faf5c260ec58d8b97b83aa6d879c2253
     name: python3.12
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.13-2.el9_8.aarch64.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 338959
-    checksum: sha256:4aa74754c38109817617c19fc363dd65dec2f43cfb32f7b2486818630bf9930a
+    size: 338631
+    checksum: sha256:0bec62c34012faa6a41afc19dd410582d21849314d4f3c939528f50b8d4bb080
     name: python3.12-devel
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.13-2.el9_8.aarch64.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 10134136
-    checksum: sha256:888d030f73b8d0377837eb5ee7d857a0d550793fd0c8c5994676dd6b76a98804
+    size: 10136661
+    checksum: sha256:015287583cea3c5c744788b2368963ff50e099e30dd12f9216d1399287938315
     name: python3.12-libs
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1527128
@@ -2076,13 +2041,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-tkinter-3.12.13-2.el9_8.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 434655
-    checksum: sha256:886d2603e5e20bc4d0a33352a708f3e18a1e7796fa4d95946ea638eec4a98bef
+    size: 434236
+    checksum: sha256:36b0735865f07abc0115e4a7f485c6766e3afc5482f44f669fe242e07bb8dbeb
     name: python3.12-tkinter
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9344
@@ -2265,20 +2230,6 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-8.32-40.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 1178977
-    checksum: sha256:232157668e7d2b80c61fe60da1c8165c3f5e50a417d1a6e04408ecd6d692bbf2
-    name: coreutils
-    evr: 8.32-40.el9
-    sourcerpm: coreutils-8.32-40.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-common-8.32-40.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 2116174
-    checksum: sha256:d50877ba7f37788625d6b52d175f2e71bbf160075da235458975361ffdc4811f
-    name: coreutils-common
-    evr: 8.32-40.el9
-    sourcerpm: coreutils-8.32-40.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cpio-2.13-16.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 284454
@@ -2447,13 +2398,6 @@ arches:
     name: gnupg2
     evr: 2.3.3-5.el9_7
     sourcerpm: gnupg2-2.3.3-5.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gnutls-3.8.10-4.el9_8.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 1339137
-    checksum: sha256:9510c4ee6a5c3ff8292c57c3a4594d798d2933322f7e394f0e048647b92ed4e1
-    name: gnutls
-    evr: 3.8.10-4.el9_8
-    sourcerpm: gnutls-3.8.10-4.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gpgme-1.15.1-6.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 209615
@@ -2825,13 +2769,6 @@ arches:
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 76024
-    checksum: sha256:fc1d5e93483d166ca7f2acb50c04c181db2f3e7b89dba8edc6b1e5f2b0f10619
-    name: libseccomp
-    evr: 2.5.2-2.el9
-    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 120963
@@ -2881,13 +2818,6 @@ arches:
     name: libstdc++
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libtasn1-4.16.0-9.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 77910
-    checksum: sha256:64fca0d49523ffb182e8bad1b8d52e2c2b7b722ceb54e4fb03e118d07fb59db1
-    name: libtasn1
-    evr: 4.16.0-9.el9
-    sourcerpm: libtasn1-4.16.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libtirpc-1.3.3-9.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 98735
@@ -2965,13 +2895,6 @@ arches:
     name: lz4-libs
     evr: 1.9.3-5.el9
     sourcerpm: lz4-1.9.3-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/mailcap-2.1.49-5.el9.noarch.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 35492
-    checksum: sha256:6c880effa119e3eaf709ba6290a4f6e2b7294de64baf19ee84f672a89e732090
-    name: mailcap
-    evr: 2.1.49-5.el9
-    sourcerpm: mailcap-2.1.49-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 550249
@@ -3217,20 +3140,6 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 1244527
-    checksum: sha256:ccc46a8ea5f30d071e075ad53b5d39d191cfca4614090435528f2d2f944f88a2
-    name: shadow-utils
-    evr: 2:4.9-16.el9
-    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-subid-4.9-16.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 85318
-    checksum: sha256:74ace5717c8bc87aedf563a93373eb71abc5893d516a9ea61760ba429726236c
-    name: shadow-utils-subid
-    evr: 2:4.9-16.el9
-    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 660260
@@ -3700,34 +3609,6 @@ arches:
     name: glib2-devel
     evr: 2.68.4-20.el9
     sourcerpm: glib2-2.68.4-20.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/httpd-2.4.62-13.el9.aarch64.rpm
-    repoid: appstream
-    size: 47398
-    checksum: sha256:99aa08faa7cb8f263fc442cc3d4785bb0d5b72ea3a1063f0664ccd1b39187cdf
-    name: httpd
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/httpd-core-2.4.62-13.el9.aarch64.rpm
-    repoid: appstream
-    size: 1567639
-    checksum: sha256:bdf9bb39b2d5c0759c475f4f4a66a725ca77796514ce496511ad1c37498bb0b0
-    name: httpd-core
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/httpd-filesystem-2.4.62-13.el9.noarch.rpm
-    repoid: appstream
-    size: 12371
-    checksum: sha256:f0c77844b786163a6d0ab01792e6eb7f7ac4a969a521866505970368ba3f9995
-    name: httpd-filesystem
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/httpd-tools-2.4.62-13.el9.aarch64.rpm
-    repoid: appstream
-    size: 81452
-    checksum: sha256:d8c6c4389487ac09efd1ee42e3167244576a5853c09e067a4c337dc770f0563a
-    name: httpd-tools
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-710.el9.aarch64.rpm
     repoid: appstream
     size: 2102257
@@ -3735,13 +3616,13 @@ arches:
     name: kernel-headers
     evr: 5.14.0-710.el9
     sourcerpm: kernel-5.14.0-710.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libpng-devel-1.6.37-16.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libpng-devel-1.6.37-17.el9.aarch64.rpm
     repoid: appstream
-    size: 298981
-    checksum: sha256:a4027d92f935228106783f42c08b7919b9bc1c0c9c8d048255ad165f092d785c
+    size: 299117
+    checksum: sha256:993d19b0859953d61613f0dd6009d9e3c482ce3c0f9fd1044d1e40abdc39ea27
     name: libpng-devel
-    evr: 2:1.6.37-16.el9
-    sourcerpm: libpng-1.6.37-16.el9.src.rpm
+    evr: 2:1.6.37-17.el9
+    sourcerpm: libpng-1.6.37-17.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libselinux-devel-3.6-4.el9.aarch64.rpm
     repoid: appstream
     size: 161987
@@ -3777,13 +3658,6 @@ arches:
     name: llvm-libs
     evr: 22.1.3-1.el9
     sourcerpm: llvm-22.1.3-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/mod_lua-2.4.62-13.el9.aarch64.rpm
-    repoid: appstream
-    size: 57892
-    checksum: sha256:fc7c1bacb025edbdbaceaaffc26bfa351b4f16765e5e88762f5681a21c37e8fc
-    name: mod_lua
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/nginx-1.20.1-30.el9.aarch64.rpm
     repoid: appstream
     size: 38160
@@ -4603,20 +4477,20 @@ arches:
     name: spirv-tools-libs
     evr: 2026.1-1.el9
     sourcerpm: spirv-tools-2026.1-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/systemtap-sdt-devel-5.5-1.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/systemtap-sdt-devel-5.5-2.el9.aarch64.rpm
     repoid: appstream
-    size: 69785
-    checksum: sha256:39cdfa1d71e14435ba76b2cb53965cc76d65df9e384186ff37dd7b52a17086bc
+    size: 69767
+    checksum: sha256:508ebaa61e1ad063d13670f09ce04ce2224ad8477abac888564533f0d0d95e86
     name: systemtap-sdt-devel
-    evr: 5.5-1.el9
-    sourcerpm: systemtap-5.5-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/systemtap-sdt-dtrace-5.5-1.el9.aarch64.rpm
+    evr: 5.5-2.el9
+    sourcerpm: systemtap-5.5-2.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/systemtap-sdt-dtrace-5.5-2.el9.aarch64.rpm
     repoid: appstream
-    size: 70593
-    checksum: sha256:b101b90ab8457e891a286fcfbb90ada4352e46893fe5a4087331fb9458157780
+    size: 70581
+    checksum: sha256:4bd44e46954dbd49eef947ace063fde7206e68d8295f9dd2c94c631149e7f722
     name: systemtap-sdt-dtrace
-    evr: 5.5-1.el9
-    sourcerpm: systemtap-5.5-1.el9.src.rpm
+    evr: 5.5-2.el9
+    sourcerpm: systemtap-5.5-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/zlib-devel-1.2.11-41.el9.aarch64.rpm
     repoid: appstream
     size: 45783
@@ -4624,27 +4498,41 @@ arches:
     name: zlib-devel
     evr: 1.2.11-41.el9
     sourcerpm: zlib-1.2.11-41.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/centos-gpg-keys-9.0-36.el9.noarch.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/centos-gpg-keys-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 24758
-    checksum: sha256:74a2fd87698b149861d74b9e63a211cb820cff4a5d7cab18ec1876c00891ffd7
+    size: 24958
+    checksum: sha256:b6dcd5a16160ab017bf5e871975aef477d34ce61b660eeb3f4aa6973dcc6f916
     name: centos-gpg-keys
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/centos-stream-release-9.0-36.el9.noarch.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/centos-stream-release-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 24338
-    checksum: sha256:070842a36a215d6963918898dbe2d4587cc9119238868f3dc8819d63d607c053
+    size: 24542
+    checksum: sha256:04a24747b2884f59d8ac5583f162dbc5ed043f5ccf602ef6274349f1d7ca9a8e
     name: centos-stream-release
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/centos-stream-repos-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 8917
-    checksum: sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8
+    size: 9116
+    checksum: sha256:ae98322c35b3eb7b013c8989a8b318993e3bec71018e213f729a156c2bbd508d
     name: centos-stream-repos
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/coreutils-8.32-42.el9.aarch64.rpm
+    repoid: baseos
+    size: 1170351
+    checksum: sha256:67c236099b7dea7c4feef1805251b92db6ffdc8d0edd23d8bf213cc61c61ec25
+    name: coreutils
+    evr: 8.32-42.el9
+    sourcerpm: coreutils-8.32-42.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/coreutils-common-8.32-42.el9.aarch64.rpm
+    repoid: baseos
+    size: 2106698
+    checksum: sha256:948664931c5bd2e5e99e63d34b9259e937de415345adb0e483f29fe013195886
+    name: coreutils-common
+    evr: 8.32-42.el9
+    sourcerpm: coreutils-8.32-42.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/curl-7.76.1-43.el9.aarch64.rpm
     repoid: baseos
     size: 296267
@@ -4722,6 +4610,13 @@ arches:
     name: glib2
     evr: 2.68.4-20.el9
     sourcerpm: glib2-2.68.4-20.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/gnutls-3.8.10-5.el9.aarch64.rpm
+    repoid: baseos
+    size: 1329623
+    checksum: sha256:611478ba2161392d417219f6e83a559287d01c493376e99b2d7dfb01f3d23a3f
+    name: gnutls
+    evr: 3.8.10-5.el9
+    sourcerpm: gnutls-3.8.10-5.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/jq-1.6-21.el9.aarch64.rpm
     repoid: baseos
     size: 184566
@@ -4750,13 +4645,20 @@ arches:
     name: libnghttp2
     evr: 1.43.0-7.el9
     sourcerpm: nghttp2-1.43.0-7.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/libpng-1.6.37-16.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/libpng-1.6.37-17.el9.aarch64.rpm
     repoid: baseos
-    size: 116461
-    checksum: sha256:0b365fff2132a0b5238b74ca598f48c83d37ee3dc4ee86d5d89b3e997aa10c09
+    size: 116798
+    checksum: sha256:7dc02f8279ac6310a1b6b7da7e30aad988289f0199325c508361c7a09569ba4e
     name: libpng
-    evr: 2:1.6.37-16.el9
-    sourcerpm: libpng-1.6.37-16.el9.src.rpm
+    evr: 2:1.6.37-17.el9
+    sourcerpm: libpng-1.6.37-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/libseccomp-2.5.6-1.el9.aarch64.rpm
+    repoid: baseos
+    size: 70875
+    checksum: sha256:74a99b069ffe2fdd6f2ee19c73197c0ad1b71353df39c5af8c404932a5817974
+    name: libseccomp
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/libselinux-3.6-4.el9.aarch64.rpm
     repoid: baseos
     size: 86314
@@ -4771,6 +4673,13 @@ arches:
     name: libselinux-utils
     evr: 3.6-4.el9
     sourcerpm: libselinux-3.6-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/libtasn1-4.16.0-10.el9.aarch64.rpm
+    repoid: baseos
+    size: 73901
+    checksum: sha256:18fee5d9b7dc486f774d1fac61238a6d6ac1a2dbdf61fdc38496838015e61712
+    name: libtasn1
+    evr: 4.16.0-10.el9
+    sourcerpm: libtasn1-4.16.0-10.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/libxml2-2.9.13-15.el9.aarch64.rpm
     repoid: baseos
     size: 747314
@@ -4848,6 +4757,20 @@ arches:
     name: python3-policycoreutils
     evr: 3.6-7.el9
     sourcerpm: policycoreutils-3.6-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/shadow-utils-4.9-17.el9.aarch64.rpm
+    repoid: baseos
+    size: 1242951
+    checksum: sha256:3edd4c583815a1e74b05972137144264bd2fe062106f63697fddffc4a5fc957d
+    name: shadow-utils
+    evr: 2:4.9-17.el9
+    sourcerpm: shadow-utils-4.9-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/shadow-utils-subid-4.9-17.el9.aarch64.rpm
+    repoid: baseos
+    size: 85377
+    checksum: sha256:28b8b6e8ec917190a43d14893afa977b4cf01c26422f3686e474c4bfb668c28d
+    name: shadow-utils-subid
+    evr: 2:4.9-17.el9
+    sourcerpm: shadow-utils-4.9-17.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-252-70.el9.aarch64.rpm
     repoid: baseos
     size: 4148320
@@ -4927,40 +4850,12 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/621582699093764071dcb13c1cda18cbac3af1c15eb649df4d4991ec621c92be-modules.yaml.xz
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34b41ae0540392d8938295baa3b0843c59fdc54710efcf15a1cc57fe852942db-modules.yaml.xz
     repoid: appstream
-    size: 15840
-    checksum: sha256:621582699093764071dcb13c1cda18cbac3af1c15eb649df4d4991ec621c92be
+    size: 16260
+    checksum: sha256:34b41ae0540392d8938295baa3b0843c59fdc54710efcf15a1cc57fe852942db
 - arch: ppc64le
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/a/apr-1.7.0-12.el9_3.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 144334
-    checksum: sha256:680f7ece233fcd28f6a51f73bf31a7e6b97990c1ebb8c3cbfb7d285cfab7eb6e
-    name: apr
-    evr: 1.7.0-12.el9_3
-    sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/a/apr-util-1.6.1-23.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 111855
-    checksum: sha256:5cb74aa5533426565635ba94dd07923b799f179e77b8fd0612dd61c32ae8509b
-    name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 14844
-    checksum: sha256:da540d1d08706e41d7bbb6cca14d781b993d3dfb98d4c2056e8ff8babc404fa4
-    name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 17128
-    checksum: sha256:b475b23df9afee4b66de967750473754890a83b919ef1b9a88270c0e10d1c9a3
-    name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 697155
@@ -5878,13 +5773,6 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 182346
-    checksum: sha256:7f10fdda0b86a6a9f7b88fd134a973e64a1b546927280e7c77756b0f7e3d3e5b
-    name: mod_http2
-    evr: 2.0.26-6.el9_8
-    sourcerpm: mod_http2-2.0.26-6.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 106314
@@ -6998,27 +6886,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8
     sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.13-2.el9_8.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 33306
-    checksum: sha256:edf5c9d6a9ae9c778860b23e765b1ff839bb678363a9d5d2e0d5f465bd6d97fa
+    size: 32918
+    checksum: sha256:0ab848f1495a179200530f9621e1c7661a299e943af3a6ec5e3536ce61f31223
     name: python3.12
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.13-2.el9_8.ppc64le.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 339052
-    checksum: sha256:7dae62500e7c504f05bc878c154c38e79b8dcace164696ee851c861de91b812b
+    size: 338619
+    checksum: sha256:06166d21bb02e3ea0a45ab29b956bab7a1d788732081f02542c188069dd49627
     name: python3.12-devel
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.13-2.el9_8.ppc64le.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 10087921
-    checksum: sha256:88a1ef8f5123365ad3e6588e24bc34b10243800808bd48572b8708ab19dd49e7
+    size: 10089884
+    checksum: sha256:90ca863d280bae69c81722b9629cb5122d067be725afabef57818f71a3f05372
     name: python3.12-libs
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 1527128
@@ -7026,13 +6914,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-tkinter-3.12.13-2.el9_8.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 433656
-    checksum: sha256:39dc0dbb35ea71965ed730a48d6e9fbadd88a829116ebe36f1f38461d62dece0
+    size: 433046
+    checksum: sha256:59abc53eba2909eeb2daf8d536b41a9f6e9beddcfe5cc7fabb8198f30d1d7a80
     name: python3.12-tkinter
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 9344
@@ -7215,20 +7103,6 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/coreutils-8.32-40.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 1260238
-    checksum: sha256:7ce7a3c81486a57c9ae5691a0a626dbe115fc7984675bf13cfd7e6b2b82b405b
-    name: coreutils
-    evr: 8.32-40.el9
-    sourcerpm: coreutils-8.32-40.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-40.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 2115656
-    checksum: sha256:a45bc3aa0cd59398688210573c2c2b617ca9232d33df792f755a9e6caff742ff
-    name: coreutils-common
-    evr: 8.32-40.el9
-    sourcerpm: coreutils-8.32-40.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/cpio-2.13-16.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 292586
@@ -7397,13 +7271,6 @@ arches:
     name: gnupg2
     evr: 2.3.3-5.el9_7
     sourcerpm: gnupg2-2.3.3-5.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gnutls-3.8.10-4.el9_8.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 1386875
-    checksum: sha256:32dfcdf7942ddb045cc88abfba807be5610b48e57181e53520f25508b306025c
-    name: gnutls
-    evr: 3.8.10-4.el9_8
-    sourcerpm: gnutls-3.8.10-4.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gpgme-1.15.1-6.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 235171
@@ -7789,13 +7656,6 @@ arches:
     name: librtas
     evr: 2.0.6-3.el9
     sourcerpm: librtas-2.0.6-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 84378
-    checksum: sha256:ef769ff2877361cbce88aac5e35091e9798c7cc23f91f12637b1a4229e056ea6
-    name: libseccomp
-    evr: 2.5.2-2.el9
-    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 136617
@@ -7845,13 +7705,6 @@ arches:
     name: libstdc++
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libtasn1-4.16.0-9.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 84469
-    checksum: sha256:05d77fc16cb5888d298a1d57d419da59894e60eed3220f674f74d50337db167f
-    name: libtasn1
-    evr: 4.16.0-9.el9
-    sourcerpm: libtasn1-4.16.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libtirpc-1.3.3-9.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 112487
@@ -7929,13 +7782,6 @@ arches:
     name: lz4-libs
     evr: 1.9.3-5.el9
     sourcerpm: lz4-1.9.3-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/mailcap-2.1.49-5.el9.noarch.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 35492
-    checksum: sha256:6c880effa119e3eaf709ba6290a4f6e2b7294de64baf19ee84f672a89e732090
-    name: mailcap
-    evr: 2.1.49-5.el9
-    sourcerpm: mailcap-2.1.49-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/make-4.3-8.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 567121
@@ -8181,20 +8027,6 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/shadow-utils-4.9-16.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 1272229
-    checksum: sha256:819ad6d1fc2127bc867b0c0bb569b62fc2894bde75e304d90e3145c7b05a810c
-    name: shadow-utils
-    evr: 2:4.9-16.el9
-    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/shadow-utils-subid-4.9-16.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 97312
-    checksum: sha256:8371fd2f56f19cf5ea35697cda34fe7adaa2d47fc74daad0432ec42be8859c19
-    name: shadow-utils-subid
-    evr: 2:4.9-16.el9
-    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 758081
@@ -8650,34 +8482,6 @@ arches:
     name: glib2-devel
     evr: 2.68.4-20.el9
     sourcerpm: glib2-2.68.4-20.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/httpd-2.4.62-13.el9.ppc64le.rpm
-    repoid: appstream
-    size: 48470
-    checksum: sha256:84408e32445a50864275de3d117f17204331079500cb5ea1e12c40cda0edfe74
-    name: httpd
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/httpd-core-2.4.62-13.el9.ppc64le.rpm
-    repoid: appstream
-    size: 1672296
-    checksum: sha256:da95bf791d374136fe40ccef0bf1b5876d1682ca49f2e26a080e8edf8c8e882b
-    name: httpd-core
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/httpd-filesystem-2.4.62-13.el9.noarch.rpm
-    repoid: appstream
-    size: 12371
-    checksum: sha256:f0c77844b786163a6d0ab01792e6eb7f7ac4a969a521866505970368ba3f9995
-    name: httpd-filesystem
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/httpd-tools-2.4.62-13.el9.ppc64le.rpm
-    repoid: appstream
-    size: 84130
-    checksum: sha256:5e1ee6230362c3f915d3fbe3975f6081197cd83e94fe6073e27ece4e6c660369
-    name: httpd-tools
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/kernel-headers-5.14.0-710.el9.ppc64le.rpm
     repoid: appstream
     size: 2126105
@@ -8685,13 +8489,13 @@ arches:
     name: kernel-headers
     evr: 5.14.0-710.el9
     sourcerpm: kernel-5.14.0-710.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/libpng-devel-1.6.37-16.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/libpng-devel-1.6.37-17.el9.ppc64le.rpm
     repoid: appstream
-    size: 301821
-    checksum: sha256:6d9616bc4bb95e3f24b7621be8861575097d0b0d170bc68d9fdec3be36c95d27
+    size: 301963
+    checksum: sha256:d5352d92315d98b2021934a92c51158bba8f0367731d96ae02829385a5b3b343
     name: libpng-devel
-    evr: 2:1.6.37-16.el9
-    sourcerpm: libpng-1.6.37-16.el9.src.rpm
+    evr: 2:1.6.37-17.el9
+    sourcerpm: libpng-1.6.37-17.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/libselinux-devel-3.6-4.el9.ppc64le.rpm
     repoid: appstream
     size: 162009
@@ -8727,13 +8531,6 @@ arches:
     name: llvm-libs
     evr: 22.1.3-1.el9
     sourcerpm: llvm-22.1.3-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/mod_lua-2.4.62-13.el9.ppc64le.rpm
-    repoid: appstream
-    size: 63696
-    checksum: sha256:d2d163307d4aa39ebfe31170af8047f658203bca110baf6284044026e0591495
-    name: mod_lua
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/nginx-1.20.1-30.el9.ppc64le.rpm
     repoid: appstream
     size: 38184
@@ -9553,20 +9350,20 @@ arches:
     name: spirv-tools-libs
     evr: 2026.1-1.el9
     sourcerpm: spirv-tools-2026.1-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/systemtap-sdt-devel-5.5-1.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/systemtap-sdt-devel-5.5-2.el9.ppc64le.rpm
     repoid: appstream
-    size: 69818
-    checksum: sha256:b601218423a3e4af3dd3586620758c77b4197cf310a63a2687b352031f2e4b33
+    size: 69794
+    checksum: sha256:b241d4f237ce4cc25fbdb346f306b25ac2e8629b990c6dadc65ef1b7d7df5969
     name: systemtap-sdt-devel
-    evr: 5.5-1.el9
-    sourcerpm: systemtap-5.5-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/systemtap-sdt-dtrace-5.5-1.el9.ppc64le.rpm
+    evr: 5.5-2.el9
+    sourcerpm: systemtap-5.5-2.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/systemtap-sdt-dtrace-5.5-2.el9.ppc64le.rpm
     repoid: appstream
-    size: 70629
-    checksum: sha256:43c4adf3d31ed38ef9f06c40dca5e25a43875a20f759d2ac0d5309bc566670f6
+    size: 70611
+    checksum: sha256:e08343d89b7ca40a52d306d37eb4fa370e083535972e9205c040acd5d6b0f364
     name: systemtap-sdt-dtrace
-    evr: 5.5-1.el9
-    sourcerpm: systemtap-5.5-1.el9.src.rpm
+    evr: 5.5-2.el9
+    sourcerpm: systemtap-5.5-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/zlib-devel-1.2.11-41.el9.ppc64le.rpm
     repoid: appstream
     size: 45813
@@ -9574,27 +9371,41 @@ arches:
     name: zlib-devel
     evr: 1.2.11-41.el9
     sourcerpm: zlib-1.2.11-41.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/centos-gpg-keys-9.0-36.el9.noarch.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/centos-gpg-keys-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 24758
-    checksum: sha256:74a2fd87698b149861d74b9e63a211cb820cff4a5d7cab18ec1876c00891ffd7
+    size: 24958
+    checksum: sha256:b6dcd5a16160ab017bf5e871975aef477d34ce61b660eeb3f4aa6973dcc6f916
     name: centos-gpg-keys
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/centos-stream-release-9.0-36.el9.noarch.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/centos-stream-release-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 24338
-    checksum: sha256:070842a36a215d6963918898dbe2d4587cc9119238868f3dc8819d63d607c053
+    size: 24542
+    checksum: sha256:04a24747b2884f59d8ac5583f162dbc5ed043f5ccf602ef6274349f1d7ca9a8e
     name: centos-stream-release
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/centos-stream-repos-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 8917
-    checksum: sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8
+    size: 9116
+    checksum: sha256:ae98322c35b3eb7b013c8989a8b318993e3bec71018e213f729a156c2bbd508d
     name: centos-stream-repos
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/coreutils-8.32-42.el9.ppc64le.rpm
+    repoid: baseos
+    size: 1254233
+    checksum: sha256:b97a77ded522e14f5eb26856a6d962d1371d9e53ee911f0e31bbf6a98dabd0e2
+    name: coreutils
+    evr: 8.32-42.el9
+    sourcerpm: coreutils-8.32-42.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/coreutils-common-8.32-42.el9.ppc64le.rpm
+    repoid: baseos
+    size: 2107418
+    checksum: sha256:baf8a1e1484dd6cef384ebca30f8e22488dc7e8085a236cfdd913b0f2bb5afc5
+    name: coreutils-common
+    evr: 8.32-42.el9
+    sourcerpm: coreutils-8.32-42.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/curl-7.76.1-43.el9.ppc64le.rpm
     repoid: baseos
     size: 303123
@@ -9672,6 +9483,13 @@ arches:
     name: glib2
     evr: 2.68.4-20.el9
     sourcerpm: glib2-2.68.4-20.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/gnutls-3.8.10-5.el9.ppc64le.rpm
+    repoid: baseos
+    size: 1377591
+    checksum: sha256:c395b1463bfc75b8b044dee5a67502378a58e84755df0bb3b56e2e4a7f4c2699
+    name: gnutls
+    evr: 3.8.10-5.el9
+    sourcerpm: gnutls-3.8.10-5.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/jq-1.6-21.el9.ppc64le.rpm
     repoid: baseos
     size: 203855
@@ -9700,13 +9518,20 @@ arches:
     name: libnghttp2
     evr: 1.43.0-7.el9
     sourcerpm: nghttp2-1.43.0-7.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/libpng-1.6.37-16.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/libpng-1.6.37-17.el9.ppc64le.rpm
     repoid: baseos
-    size: 138948
-    checksum: sha256:d78ee80daef5358d90f82b6784c484e13179626f01b214597a3889342d4e1f93
+    size: 139365
+    checksum: sha256:af1b368f6ff19379892ed2bc47508ec33467fb2a416201edfb1e0c0b00f001a7
     name: libpng
-    evr: 2:1.6.37-16.el9
-    sourcerpm: libpng-1.6.37-16.el9.src.rpm
+    evr: 2:1.6.37-17.el9
+    sourcerpm: libpng-1.6.37-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/libseccomp-2.5.6-1.el9.ppc64le.rpm
+    repoid: baseos
+    size: 78798
+    checksum: sha256:303dc9d0f6b43352fe4714eb83d6a25a022cb4fb90a97e11f3724de109f8fda8
+    name: libseccomp
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/libselinux-3.6-4.el9.ppc64le.rpm
     repoid: baseos
     size: 98977
@@ -9721,6 +9546,13 @@ arches:
     name: libselinux-utils
     evr: 3.6-4.el9
     sourcerpm: libselinux-3.6-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/libtasn1-4.16.0-10.el9.ppc64le.rpm
+    repoid: baseos
+    size: 80502
+    checksum: sha256:74ef2e5c1139705dc17363e93de7c92dc71c80f59ca4e8176a9c66a8ca2730f1
+    name: libtasn1
+    evr: 4.16.0-10.el9
+    sourcerpm: libtasn1-4.16.0-10.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/libxml2-2.9.13-15.el9.ppc64le.rpm
     repoid: baseos
     size: 842298
@@ -9798,6 +9630,20 @@ arches:
     name: python3-policycoreutils
     evr: 3.6-7.el9
     sourcerpm: policycoreutils-3.6-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/shadow-utils-4.9-17.el9.ppc64le.rpm
+    repoid: baseos
+    size: 1272492
+    checksum: sha256:2e67c5fee72fa867fd97d3491141911ff359a9529d58f2bcb71e8e6ae7663d87
+    name: shadow-utils
+    evr: 2:4.9-17.el9
+    sourcerpm: shadow-utils-4.9-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/shadow-utils-subid-4.9-17.el9.ppc64le.rpm
+    repoid: baseos
+    size: 97400
+    checksum: sha256:d95525d385e1f528f4cfca750e1734dfcb7b97e0a752cd96db59d68b99b5a6f3
+    name: shadow-utils-subid
+    evr: 2:4.9-17.el9
+    sourcerpm: shadow-utils-4.9-17.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-252-70.el9.ppc64le.rpm
     repoid: baseos
     size: 4428177
@@ -9877,40 +9723,12 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc961b034a1d7174409ed69de91f8bbbfdb697011ffb0bb1f0806b2624a5452e-modules.yaml.xz
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/3ed1147676b66f6ef7b14e45c67934c99112fdf6f75370aa6259e56e5e07f690-modules.yaml.xz
     repoid: appstream
-    size: 15844
-    checksum: sha256:fc961b034a1d7174409ed69de91f8bbbfdb697011ffb0bb1f0806b2624a5452e
+    size: 16264
+    checksum: sha256:3ed1147676b66f6ef7b14e45c67934c99112fdf6f75370aa6259e56e5e07f690
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/apr-1.7.0-12.el9_3.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 129032
-    checksum: sha256:7a8d216d45355f7b656777fcb874a0803d5e97a3e7575b8b58dc7bf608919459
-    name: apr
-    evr: 1.7.0-12.el9_3
-    sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/apr-util-1.6.1-23.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 99555
-    checksum: sha256:fdafa0c878091c68d7e4ff66bdffa2d3a39904351128b55caafc896175651718
-    name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 14447
-    checksum: sha256:d996f1e3b3375cd48b9910f31965e0e8c0df99b553dcac8c4368ac6ed5177623
-    name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 16990
-    checksum: sha256:6bb1406bff8e1232134161c6cbfc4dd07a36c2fd7a2b3a95fba8d842bf76fe2e
-    name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 697155
@@ -10828,13 +10646,6 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 173558
-    checksum: sha256:7b9da0a6138f1f7f2bf57f2daf7aaa2cb03dd2bc0e74870f65c32157073a99c7
-    name: mod_http2
-    evr: 2.0.26-6.el9_8
-    sourcerpm: mod_http2-2.0.26-6.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 89670
@@ -11948,27 +11759,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8
     sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.13-2.el9_8.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 33278
-    checksum: sha256:b534b3693ac5571ace6bcbeb0c65e7bf3d9e326bc622c7fac51015d32b45d216
+    size: 32914
+    checksum: sha256:e50145488995952c3b02a65120b5dfe47d7908f2b5f7b42e992c861abc48df18
     name: python3.12
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.13-2.el9_8.x86_64.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 339080
-    checksum: sha256:19862bcc0babbb7ea4a876073e26d74258f102c4d0672d26c53b118de200d3ed
+    size: 338840
+    checksum: sha256:518953b2cfb5d392bb2f025a86a0244180161250b3f8d17e9ea61f72522d8f0a
     name: python3.12-devel
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.13-2.el9_8.x86_64.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 10217208
-    checksum: sha256:16baa9a7786c1cba3707593a61b12aae9134e4303670e218fc8a94f8d5db08b5
+    size: 10209196
+    checksum: sha256:a56d49d22c4636edc1e2a4f357bea45085a513c0a3b4a7c4021db2816a30d6fd
     name: python3.12-libs
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1527128
@@ -11976,13 +11787,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-tkinter-3.12.13-2.el9_8.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 434401
-    checksum: sha256:628985544200ba0698e97a45baa41c30432710920d13dbcf14e9e2a0947526d7
+    size: 434125
+    checksum: sha256:d87d6405c8950319d25823a84a33c8356ffb87760fcd0ec38252c552f3c97672
     name: python3.12-tkinter
-    evr: 3.12.13-2.el9_8
-    sourcerpm: python3.12-3.12.13-2.el9_8.src.rpm
+    evr: 3.12.13-3.el9_8
+    sourcerpm: python3.12-3.12.13-3.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9344
@@ -12165,20 +11976,6 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-8.32-40.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1223184
-    checksum: sha256:506252b4d9569a738189c8592f6a9fa0f934b7700e019f3cb5748ba5badd7fbd
-    name: coreutils
-    evr: 8.32-40.el9
-    sourcerpm: coreutils-8.32-40.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-common-8.32-40.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 2112892
-    checksum: sha256:1b901fc27ee96272908a3fbc16998f57eec143e5762db2d8d64ce1d8d488601f
-    name: coreutils-common
-    evr: 8.32-40.el9
-    sourcerpm: coreutils-8.32-40.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cpio-2.13-16.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 286157
@@ -12347,13 +12144,6 @@ arches:
     name: gnupg2
     evr: 2.3.3-5.el9_7
     sourcerpm: gnupg2-2.3.3-5.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gnutls-3.8.10-4.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1453051
-    checksum: sha256:fa0bee169195f1aa26c58bd62649787dccbdcd255f8c6a90473b0ab3be4a531e
-    name: gnutls
-    evr: 3.8.10-4.el9_8
-    sourcerpm: gnutls-3.8.10-4.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gpgme-1.15.1-6.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 215857
@@ -12746,13 +12536,6 @@ arches:
     name: libquadmath
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 76200
-    checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
-    name: libseccomp
-    evr: 2.5.2-2.el9
-    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 123449
@@ -12802,13 +12585,6 @@ arches:
     name: libstdc++
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libtasn1-4.16.0-9.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 78596
-    checksum: sha256:3c619506cf4283d4d30d9e681a3565f79c1009f5e4a47d71b0de78c5ee24c91d
-    name: libtasn1
-    evr: 4.16.0-9.el9
-    sourcerpm: libtasn1-4.16.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libtirpc-1.3.3-9.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 98934
@@ -12886,13 +12662,6 @@ arches:
     name: lz4-libs
     evr: 1.9.3-5.el9
     sourcerpm: lz4-1.9.3-5.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/mailcap-2.1.49-5.el9.noarch.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 35492
-    checksum: sha256:6c880effa119e3eaf709ba6290a4f6e2b7294de64baf19ee84f672a89e732090
-    name: mailcap
-    evr: 2.1.49-5.el9
-    sourcerpm: mailcap-2.1.49-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 553896
@@ -13138,20 +12907,6 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1250179
-    checksum: sha256:17294ee3fbc09c1b5cfc4114d3815cbd92584d6d70a6288e1dce2fda0a62dc59
-    name: shadow-utils
-    evr: 2:4.9-16.el9
-    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-16.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 86705
-    checksum: sha256:7ec945faa9fb963f46c863e8f32dd9192e60b548e126296b832b3ecd75f47b47
-    name: shadow-utils-subid
-    evr: 2:4.9-16.el9
-    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 664960
@@ -13621,34 +13376,6 @@ arches:
     name: glib2-devel
     evr: 2.68.4-20.el9
     sourcerpm: glib2-2.68.4-20.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/httpd-2.4.62-13.el9.x86_64.rpm
-    repoid: appstream
-    size: 47869
-    checksum: sha256:0abcb011489cc4b0acd41bb1c6c2419918aaca3c399b7e54558776afe9d089c4
-    name: httpd
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/httpd-core-2.4.62-13.el9.x86_64.rpm
-    repoid: appstream
-    size: 1586619
-    checksum: sha256:c91eb42024cd7fafaf649de4668d514ed90cdad47a65f91a79ddb77fd20b8e98
-    name: httpd-core
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/httpd-filesystem-2.4.62-13.el9.noarch.rpm
-    repoid: appstream
-    size: 12371
-    checksum: sha256:f0c77844b786163a6d0ab01792e6eb7f7ac4a969a521866505970368ba3f9995
-    name: httpd-filesystem
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/httpd-tools-2.4.62-13.el9.x86_64.rpm
-    repoid: appstream
-    size: 83183
-    checksum: sha256:55f8420da38c025eddbe6c231dc520491843a0eee284666e96aa98181eabb1ce
-    name: httpd-tools
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-headers-5.14.0-710.el9.x86_64.rpm
     repoid: appstream
     size: 2141557
@@ -13656,13 +13383,13 @@ arches:
     name: kernel-headers
     evr: 5.14.0-710.el9
     sourcerpm: kernel-5.14.0-710.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libpng-devel-1.6.37-16.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libpng-devel-1.6.37-17.el9.x86_64.rpm
     repoid: appstream
-    size: 298991
-    checksum: sha256:993d96ba3c37fdcde26d273724ddb078a01d37509cf7bf9d0bc99accaac70e96
+    size: 299129
+    checksum: sha256:74d797143d1fb53ef6de826d55867e8571189b21181dfb9b492332cb8ef7b8f7
     name: libpng-devel
-    evr: 2:1.6.37-16.el9
-    sourcerpm: libpng-1.6.37-16.el9.src.rpm
+    evr: 2:1.6.37-17.el9
+    sourcerpm: libpng-1.6.37-17.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libselinux-devel-3.6-4.el9.x86_64.rpm
     repoid: appstream
     size: 162026
@@ -13698,13 +13425,6 @@ arches:
     name: llvm-libs
     evr: 22.1.3-1.el9
     sourcerpm: llvm-22.1.3-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/mod_lua-2.4.62-13.el9.x86_64.rpm
-    repoid: appstream
-    size: 60204
-    checksum: sha256:49c4aa30cbccb3774f007e6cc76289bc74ffa4076d224a95670d841cee16d568
-    name: mod_lua
-    evr: 2.4.62-13.el9
-    sourcerpm: httpd-2.4.62-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/nginx-1.20.1-30.el9.x86_64.rpm
     repoid: appstream
     size: 38196
@@ -14524,20 +14244,20 @@ arches:
     name: spirv-tools-libs
     evr: 2026.1-1.el9
     sourcerpm: spirv-tools-2026.1-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/systemtap-sdt-devel-5.5-1.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/systemtap-sdt-devel-5.5-2.el9.x86_64.rpm
     repoid: appstream
-    size: 69834
-    checksum: sha256:4aefeb06c5b3ff5cafa5c8c14e5a5b99e7836d47f33862e0565e11d9a0c387a9
+    size: 69810
+    checksum: sha256:f487ac90e58b5399d3ae5cd988f867eaf0bb584de63a3a8cbba9fd121742bbee
     name: systemtap-sdt-devel
-    evr: 5.5-1.el9
-    sourcerpm: systemtap-5.5-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/systemtap-sdt-dtrace-5.5-1.el9.x86_64.rpm
+    evr: 5.5-2.el9
+    sourcerpm: systemtap-5.5-2.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/systemtap-sdt-dtrace-5.5-2.el9.x86_64.rpm
     repoid: appstream
-    size: 70645
-    checksum: sha256:59bd7786e9f16fc7b92047ce531c925a9b87dc91a8c67bbecdf3121332bc6f5c
+    size: 70622
+    checksum: sha256:74902952a15b76cf5794bb6f951b82237bbe70b4c7db9f43bee8895977779169
     name: systemtap-sdt-dtrace
-    evr: 5.5-1.el9
-    sourcerpm: systemtap-5.5-1.el9.src.rpm
+    evr: 5.5-2.el9
+    sourcerpm: systemtap-5.5-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/zlib-devel-1.2.11-41.el9.x86_64.rpm
     repoid: appstream
     size: 45834
@@ -14545,27 +14265,41 @@ arches:
     name: zlib-devel
     evr: 1.2.11-41.el9
     sourcerpm: zlib-1.2.11-41.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-36.el9.noarch.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 24758
-    checksum: sha256:74a2fd87698b149861d74b9e63a211cb820cff4a5d7cab18ec1876c00891ffd7
+    size: 24958
+    checksum: sha256:b6dcd5a16160ab017bf5e871975aef477d34ce61b660eeb3f4aa6973dcc6f916
     name: centos-gpg-keys
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-release-9.0-36.el9.noarch.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-release-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 24338
-    checksum: sha256:070842a36a215d6963918898dbe2d4587cc9119238868f3dc8819d63d607c053
+    size: 24542
+    checksum: sha256:04a24747b2884f59d8ac5583f162dbc5ed043f5ccf602ef6274349f1d7ca9a8e
     name: centos-stream-release
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-36.el9.noarch.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-38.el9.noarch.rpm
     repoid: baseos
-    size: 8917
-    checksum: sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8
+    size: 9116
+    checksum: sha256:ae98322c35b3eb7b013c8989a8b318993e3bec71018e213f729a156c2bbd508d
     name: centos-stream-repos
-    evr: 9.0-36.el9
-    sourcerpm: centos-stream-release-9.0-36.el9.src.rpm
+    evr: 9.0-38.el9
+    sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/coreutils-8.32-42.el9.x86_64.rpm
+    repoid: baseos
+    size: 1214539
+    checksum: sha256:7cbac0f804d680ae2918d20f5364001083a3c0465449beb404632e61b5752a2e
+    name: coreutils
+    evr: 8.32-42.el9
+    sourcerpm: coreutils-8.32-42.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/coreutils-common-8.32-42.el9.x86_64.rpm
+    repoid: baseos
+    size: 2108727
+    checksum: sha256:8e3c3d2d6e494435053410a53717d2cc499f4929c457361f87fa00236feb19a3
+    name: coreutils-common
+    evr: 8.32-42.el9
+    sourcerpm: coreutils-8.32-42.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/curl-7.76.1-43.el9.x86_64.rpm
     repoid: baseos
     size: 299432
@@ -14643,6 +14377,13 @@ arches:
     name: glib2
     evr: 2.68.4-20.el9
     sourcerpm: glib2-2.68.4-20.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/gnutls-3.8.10-5.el9.x86_64.rpm
+    repoid: baseos
+    size: 1436056
+    checksum: sha256:ab7a9a7e5ce2a976e07632ebd0a1a5267f55026437e2fa4a37e36da0f2589ee0
+    name: gnutls
+    evr: 3.8.10-5.el9
+    sourcerpm: gnutls-3.8.10-5.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/jq-1.6-21.el9.x86_64.rpm
     repoid: baseos
     size: 190805
@@ -14671,13 +14412,20 @@ arches:
     name: libnghttp2
     evr: 1.43.0-7.el9
     sourcerpm: nghttp2-1.43.0-7.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libpng-1.6.37-16.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libpng-1.6.37-17.el9.x86_64.rpm
     repoid: baseos
-    size: 118150
-    checksum: sha256:b0eb8f37b0bd69cef1861f89b866197d248b09bf35831a1a3c68fba123c0b35a
+    size: 118608
+    checksum: sha256:d9b73980df44529d8abf0be618640cbb0651ca5c8dd545f1612ed35c6fd74fab
     name: libpng
-    evr: 2:1.6.37-16.el9
-    sourcerpm: libpng-1.6.37-16.el9.src.rpm
+    evr: 2:1.6.37-17.el9
+    sourcerpm: libpng-1.6.37-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libseccomp-2.5.6-1.el9.x86_64.rpm
+    repoid: baseos
+    size: 70501
+    checksum: sha256:73779d9eb83b4334fb312a7a6bcf7764780777f168724d7e57f6477fd912ac0a
+    name: libseccomp
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libselinux-3.6-4.el9.x86_64.rpm
     repoid: baseos
     size: 86465
@@ -14692,6 +14440,13 @@ arches:
     name: libselinux-utils
     evr: 3.6-4.el9
     sourcerpm: libselinux-3.6-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libtasn1-4.16.0-10.el9.x86_64.rpm
+    repoid: baseos
+    size: 74580
+    checksum: sha256:05f75ceb9f083ec511756eb9ed4078368c56ad55a6fe0abb819b8948e50b0d90
+    name: libtasn1
+    evr: 4.16.0-10.el9
+    sourcerpm: libtasn1-4.16.0-10.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libxml2-2.9.13-15.el9.x86_64.rpm
     repoid: baseos
     size: 764520
@@ -14769,6 +14524,20 @@ arches:
     name: python3-policycoreutils
     evr: 3.6-7.el9
     sourcerpm: policycoreutils-3.6-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/shadow-utils-4.9-17.el9.x86_64.rpm
+    repoid: baseos
+    size: 1250273
+    checksum: sha256:1b9b0829668ce68f0ff0904fa651005e9c0c5e53b7481adb41f8f6b758d9e36a
+    name: shadow-utils
+    evr: 2:4.9-17.el9
+    sourcerpm: shadow-utils-4.9-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/shadow-utils-subid-4.9-17.el9.x86_64.rpm
+    repoid: baseos
+    size: 87043
+    checksum: sha256:8792e56a4a0502fce0a15fdbe2eadcdef1a467874666a2ca15ad95a3112878c1
+    name: shadow-utils-subid
+    evr: 2:4.9-17.el9
+    sourcerpm: shadow-utils-4.9-17.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-252-70.el9.x86_64.rpm
     repoid: baseos
     size: 4395611
@@ -14848,7 +14617,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/8c0cbe82aa3ecaca4826fd98fbd71a623eb9de91e6610b0eed7607adfc32a758-modules.yaml.xz
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/459ba5d5c1750ff705e0b11e900bda0a03957bcaa00e0136c0b44d74e40a6cfe-modules.yaml.xz
     repoid: appstream
-    size: 15796
-    checksum: sha256:8c0cbe82aa3ecaca4826fd98fbd71a623eb9de91e6610b0eed7607adfc32a758
+    size: 16220
+    checksum: sha256:459ba5d5c1750ff705e0b11e900bda0a03957bcaa00e0136c0b44d74e40a6cfe

--- a/codeserver/ubi9-python-3.12/prefetch-input/repos/ubi.repo
+++ b/codeserver/ubi9-python-3.12/prefetch-input/repos/ubi.repo
@@ -25,8 +25,8 @@ baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/ap
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
-# Exclude httpd and its sub-packages so the resolver uses the CentOS Stream
-# version, which matches the httpd already in the ODH c9s base image.
+# Exclude httpd* from UBI repos. httpd is provided by the ODH c9s base image
+# and is not listed in codeserver prefetch-input/odh/rpms.in.yaml packages.
 exclude=httpd*
 
 [ubi-9-for-$basearch-appstream-debug-rpms]


### PR DESCRIPTION
Fix ODH codeserver build failure: httpd RPM version conflict during hermetic dnf install

## Description
ODH codeserver builds fail because the base image already has httpd-2.4.62-13 (with httpd-devel), while the ODH lockfile prefetched a newer httpd-2.4.62-14 from CentOS Stream, so dnf install httpd hits a version conflict. Fix: remove httpd from prefetch-input/odh/rpms.in.yaml, regenerate rpms.lock.yaml, and leave the shared Dockerfile unchanged — ODH uses the base image’s httpd, and RHDS still installs it from prefetch-input/rhds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system package dependencies and repository configurations to ensure compatibility across multiple architectures (aarch64, ppc64le, x86_64).
  * Refreshed package versions and metadata for core system libraries and utilities, including Python 3.12 subpackages and related dependencies.
  * Enhanced repository configuration documentation for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->