### PR TITLE
chore: Tweak download-pip-packages.py to get more error detail and retry on failure

### DIFF
--- a/scripts/lockfile-generators/helpers/download-pip-packages.py
+++ b/scripts/lockfile-generators/helpers/download-pip-packages.py
@@ -46,6 +46,9 @@ WGET_NETWORK_TIMEOUT_SECONDS = 300
 # Per-file wall-clock cap for subprocess.run(); must cover multi-GB wheels when
 # MAX_WORKERS parallel downloads share CI bandwidth (~1GB at ~1 MB/s ≈ 17 min).
 DOWNLOAD_PROCESS_TIMEOUT_SECONDS = 3600
+# Transient wget failures (Akamai/S3 blips under parallel load) are retried
+# sequentially before the prefetch step fails.
+DOWNLOAD_MAX_PASSES = 3
 
 ARCH_ALIASES: dict[str, list[str]] = {
     "amd64": ["x86_64", "amd64"],
@@ -253,6 +256,16 @@ def resolve_one(args: tuple) -> list[tuple[str, str, str]]:
         return fetch_pypi_urls(name, version, wanted_hashes)
 
 
+def _wget_error_detail(result: subprocess.CompletedProcess[str] | subprocess.CalledProcessError) -> str:
+    for stream in (result.stderr, result.stdout):
+        if not stream:
+            continue
+        lines = [line.strip() for line in stream.splitlines() if line.strip()]
+        if lines:
+            return lines[-1]
+    return f"wget exit {result.returncode}"
+
+
 def download_one(args: tuple) -> tuple[bool, str]:
     """Download one file. Called in parallel."""
     url, dest_path, expected_hash = args
@@ -265,19 +278,25 @@ def download_one(args: tuple) -> tuple[bool, str]:
                 url,
             ],
             check=True, timeout=DOWNLOAD_PROCESS_TIMEOUT_SECONDS,
+            capture_output=True, text=True,
         )
     except subprocess.TimeoutExpired:
         Path(dest_path).unlink(missing_ok=True)
         return False, f"TIMEOUT {Path(dest_path).name}"
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
         Path(dest_path).unlink(missing_ok=True)
-        return False, f"FAIL {Path(dest_path).name}: wget error"
+        return False, f"FAIL {Path(dest_path).name}: {_wget_error_detail(e)}"
 
     actual = file_sha256(Path(dest_path))
     if actual != expected_hash:
         Path(dest_path).unlink(missing_ok=True)
         return False, f"HASH MISMATCH {Path(dest_path).name}: got {actual[:16]}..., expected {expected_hash[:16]}..."
     return True, f"OK {Path(dest_path).name}"
+
+
+def _is_retryable(msg: str) -> bool:
+    """Permanent failures (bad digest) should not be retried."""
+    return not msg.startswith("HASH MISMATCH")
 
 
 def file_sha256(path: Path) -> str:
@@ -350,24 +369,49 @@ def main():
         print("\nNothing to download.")
         return
 
-    # Phase 5: parallel download
-    print(f"\nPhase 5: Downloading {len(to_download)} files ({MAX_WORKERS} parallel)...")
-    failures = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-        results = list(executor.map(download_one, to_download))
+    # Phase 5: parallel download with sequential retries for transient failures
+    pending = list(to_download)
+    downloaded = 0
+    last_errors: dict[Path, str] = {}
+    permanent_failures: list[tuple[str, Path, str]] = []
 
-    for ok, msg in results:
-        if not ok:
-            failures.append(msg)
+    for pass_num in range(1, DOWNLOAD_MAX_PASSES + 1):
+        if not pending:
+            break
+
+        workers = MAX_WORKERS if pass_num == 1 else 1
+        if pass_num == 1:
+            print(f"\nPhase 5: Downloading {len(pending)} files ({workers} parallel)...")
+        else:
+            print(f"\nPhase 5 (retry {pass_num - 1}/{DOWNLOAD_MAX_PASSES - 1}): "
+                  f"{len(pending)} failed download(s), retrying sequentially...")
+
+        retry: list[tuple[str, Path, str]] = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            results = list(executor.map(download_one, pending))
+
+        for item, (ok, msg) in zip(pending, results):
+            if ok:
+                downloaded += 1
+            else:
+                last_errors[item[1]] = msg
+                if _is_retryable(msg) and pass_num < DOWNLOAD_MAX_PASSES:
+                    retry.append(item)
+                else:
+                    permanent_failures.append(item)
+
+        pending = retry
+
+    pending = permanent_failures
+    print(f"\n  Downloaded: {downloaded}, Failed: {len(pending)}")
+
+    if pending:
+        for _url, dest_path, _sha in pending:
+            msg = last_errors.get(dest_path, f"FAIL {dest_path.name}")
             print(f"  ERROR: {msg}", file=sys.stderr)
-
-    downloaded = sum(1 for ok, _ in results if ok)
-    print(f"\n  Downloaded: {downloaded}, Failed: {len(failures)}")
-
-    if failures:
-        print(f"\nERROR: {len(failures)} download(s) failed:", file=sys.stderr)
-        for f in failures:
-            print(f"  {f}", file=sys.stderr)
+        print(f"\nERROR: {len(pending)} download(s) failed:", file=sys.stderr)
+        for _url, dest_path, _sha in pending:
+            print(f"  {last_errors.get(dest_path, f'FAIL {dest_path.name}')}", file=sys.stderr)
         sys.exit(1)
 
     total_files = len(list(out_dir.iterdir()))


### PR DESCRIPTION
Tweak download-pip-packages.py to get more error detail and retry on failure

## Description
**Issue**
During pip prefetch for codeserver/ubi9-python-3.12 on aarch64, CI failed downloading a single wheel:

mmh3-5.2.1-2-cp312-cp312-linux_aarch64.whl — 209/210 downloads succeeded.

The package and URL were valid (correct hash, wheel available on the RHOAI index). The failure was a transient wget error under parallel load against packages.redhat.com/Akamai/S3 — the same class of flakiness that led to reducing prefetch workers to 8.

**Fix**
Updated download-pip-packages.py to be more resilient to transient download failures:

Retry failed downloads — up to 3 passes total; first pass uses 8 parallel workers, retries run sequentially to reduce rate-limit pressure.
Skip retries for permanent failures — hash mismatches fail immediately (no pointless re-downloads).
Better error output — capture wget stderr so CI logs show the actual HTTP/network error instead of a generic wget error.

No changes to lockfiles, requirements, or package selection — only download reliability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
