### PR TITLE
RHAIENG-5387: Add missing base images to params-latest.env for ODH 3.5 EA2

### DIFF
--- a/manifests/odh/base/params-latest.env
+++ b/manifests/odh/base/params-latest.env
@@ -1,3 +1,6 @@
+odh-base-image-cpu-py312-ubi9-n=quay.io/opendatahub/odh-base-image-cpu-py312-ubi9:3.5_ea2-v1.45
+odh-base-image-cuda-12-9-py312-ubi9-n=quay.io/opendatahub/odh-base-image-cuda-12-9-py312-ubi9:3.5_ea2-v1.45
+odh-base-image-rocm-6-4-py312-ubi9-n=quay.io/opendatahub/odh-base-image-rocm-6-4-py312-ubi9:3.5_ea2-v1.45
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:3.5_ea2-v1.45
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:3.5_ea2-v1.45
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-n=quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9:3.5_ea2-v1.45

--- a/manifests/rhoai/base/params-latest.env
+++ b/manifests/rhoai/base/params-latest.env
@@ -1,3 +1,6 @@
+odh-base-image-cpu-py312-ubi9-n=dummy
+odh-base-image-cuda-12-9-py312-ubi9-n=dummy
+odh-base-image-rocm-6-4-py312-ubi9-n=dummy
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-n=dummy
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-n=dummy
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-n=dummy


### PR DESCRIPTION
## Summary

Added the 3 ubi9 base images that were missing from both ODH and RHOAI params-latest.env files:

- `odh-base-image-cpu-py312-ubi9`
- `odh-base-image-cuda-12-9-py312-ubi9`
- `odh-base-image-rocm-6-4-py312-ubi9`

## Problem

These base images have Tekton pipelines in `.tekton/` but were not included in the params-latest.env files. This is the same issue that occurred in EA1 (fixed by PR #3621).

## Verification

Checked all base image pipelines - there are 16 total, split between ubi9 and c9s variants. Since params-latest.env only uses ubi9 images (all existing entries are ubi9, zero c9s), exactly 3 ubi9 base images were missing.

## Files Changed

- `manifests/odh/base/params-latest.env` - Added 3 base images with `3.5_ea2-v1.45` tag
- `manifests/rhoai/base/params-latest.env` - Added 3 base images with `dummy` placeholder

## Test Plan

- [x] Verified all ubi9 base image pipelines have corresponding entries in params-latest.env
- [x] Verified tag format matches existing entries (`3.5_ea2-v1.45`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image references (CPU, CUDA, and ROCm variants) to version 3.5_ea2-v1.45
  * Updated configuration parameters for base image variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->