### PR TITLE
fix(scripts/cve): set Target Version on CVE tracker issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pygments",
     # rich powers the local live progress table in ci/check-image-availability.py
     "rich>=14.3.2",
+    "inline-snapshot>=0.34.1",
 ]
 
 [tool.uv]
@@ -110,6 +111,10 @@ show_missing = true
 skip_empty = true
 
 # inspired from https://github.com/red-hat-data-services/ods-ci/blob/master/pyproject.toml
+
+# https://15r10nk.github.io/inline-snapshot/configuration/
+[tool.inline-snapshot]
+format-command = "ruff format --stdin-filename {filename}"
 
 # https://microsoft.github.io/pyright/#/configuration
 [tool.pyright]

--- a/scripts/cve/create_cve_trackers.py
+++ b/scripts/cve/create_cve_trackers.py
@@ -51,6 +51,9 @@ RHAIENG_TEAM_OPTION_ID_DEFAULT = "ec74d716-af36-4b3c-950f-f79213d08f71-62"
 # Contributors multi-user picker (changelog text may say "involved users").
 RHAIENG_CONTRIBUTORS_FIELD = "customfield_10466"
 
+# Target Version (multi-version picker).
+RHAIENG_TARGET_VERSION_FIELD = "customfield_10855"
+
 EMBARGOED_SECURITY_LEVEL = "Embargoed Security Issue"
 DEFAULT_SECURITY_LEVEL = "Red Hat Employee"
 
@@ -415,12 +418,15 @@ def create_tracker_issue(
 
     contributor_ids = resolve_tracker_contributors(client, cve_info)
     extra_fields: dict[str, Any] = dict(team_extra)
+    if cve_info.version:
+        extra_fields[RHAIENG_TARGET_VERSION_FIELD] = [{"name": cve_info.version}]
     if contributor_ids:
         extra_fields[RHAIENG_CONTRIBUTORS_FIELD] = contributors_field_value(contributor_ids)
 
     print(f"\n{'[DRY RUN] ' if dry_run else ''}Creating tracker for {cve_info.cve_id}:")
     print(f"  Summary: {summary}")
     print(f"  Version: {cve_info.version}")
+    print(f"  Target Version field: {extra_fields.get(RHAIENG_TARGET_VERSION_FIELD, '(not set)')}")
     print(f"  Embargoed: {cve_info.is_embargoed}")
     print(f"  Security level: {security_level}")
     print(f"  Child issues: {cve_info.issue_count}")

--- a/scripts/cve/create_cve_trackers.py
+++ b/scripts/cve/create_cve_trackers.py
@@ -239,6 +239,16 @@ def build_description(cve_info: CVEInfo, base_url: str = JIRA_DEFAULT_URL, track
         )
     )]
 
+    branch_suffix = f" (branch: {cve_info.version})" if cve_info.version else " (on the respective release branch)"
+    content.append(_adf_paragraph(
+        _adf_text("Fix should be applied to: "),
+        _adf_link(
+            "https://github.com/red-hat-data-services/notebooks",
+            "https://github.com/red-hat-data-services/notebooks",
+        ),
+        _adf_text(branch_suffix),
+    ))
+
     if child_keys:
         content.append(_adf_paragraph(
             _adf_text(f"Blocked Issues ({count}): ", marks=[{"type": "strong"}]),

--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
+
+from inline_snapshot import snapshot
 
 from scripts.cve import create_cve_trackers as cct
 
@@ -8,6 +10,30 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch, Subtests
 
     from scripts.cve.jira_client import JiraClient
+
+
+def _render_adf_inline(node: dict) -> str:
+    text = node.get("text", "")
+    marks = node.get("marks", [])
+    for mark in marks:
+        if mark["type"] == "strong":
+            text = f"**{text}**"
+        elif mark["type"] == "link":
+            href = mark.get("attrs", {}).get("href", "")
+            text = f"[{text}]({href})"
+    return text
+
+
+def adf_to_text(doc: dict) -> str:
+    parts: list[str] = []
+    for node in doc.get("content", []):
+        if node["type"] == "paragraph":
+            line = "".join(_render_adf_inline(child) for child in node.get("content", []))
+            parts.append(line)
+        elif node["type"] == "codeBlock":
+            code = "".join(child.get("text", "") for child in node.get("content", []))
+            parts.append(f"`{code}`")
+    return "\n".join(parts)
 
 
 def test_extract_cve_id_from_label_and_summary(subtests: Subtests) -> None:
@@ -145,3 +171,106 @@ def test_find_orphan_cves_groups_embargo_and_contributors() -> None:
     assert info.contributor_account_ids == {"user-a"}
     assert info.cve_id == "CVE-2026-8643"
     assert info.version == "rhoai-2.25"
+
+
+def test_build_description_with_version() -> None:
+    info = cct.CVEInfo(
+        cve_id="CVE-2026-8643",
+        version="rhoai-2.25",
+        description="Path traversal flaw",
+        issues=[{"key": "RHOAIENG-64025"}, {"key": "RHOAIENG-64026"}],
+    )
+    assert adf_to_text(cct.build_description(info)) == snapshot("""\
+Tracker for CVE-2026-8643 - Path traversal flaw affecting Notebooks Images components.
+Fix should be applied to: [https://github.com/red-hat-data-services/notebooks](https://github.com/red-hat-data-services/notebooks) (branch: rhoai-2.25)
+**Blocked Issues (2): **RHOAIENG-64025, RHOAIENG-64026
+**JQL Query to View All Blocked Issues: **
+[View all 2 blocked issues](https://redhat.atlassian.net/issues/?jql=key%20in%20%28RHOAIENG-64025%2C%20RHOAIENG-64026%29%20ORDER%20BY%20key%20ASC)\
+""")
+
+
+def test_build_description_no_version() -> None:
+    info = cct.CVEInfo(
+        cve_id="CVE-2026-8643",
+        version="",
+        description="Path traversal flaw",
+    )
+    assert adf_to_text(cct.build_description(info)) == snapshot("""\
+Tracker for CVE-2026-8643 - Path traversal flaw affecting Notebooks Images components.
+Fix should be applied to: [https://github.com/red-hat-data-services/notebooks](https://github.com/red-hat-data-services/notebooks) (on the respective release branch)\
+""")
+
+
+def test_create_tracker_issue_api_payload(monkeypatch: MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        def create_issue(self, **kwargs: Any) -> dict:
+            captured.update(kwargs)
+            return {"key": "RHAIENG-9999"}
+
+        def get_current_user(self) -> dict:
+            return {"accountId": "runner-id-123"}
+
+    monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
+    monkeypatch.delenv("JIRA_RUNNER_ACCOUNT_ID", raising=False)
+
+    info = cct.CVEInfo(
+        cve_id="CVE-2026-8643",
+        version="rhoai-3.3",
+        description="Path traversal flaw",
+        issues=[{"key": "RHOAIENG-64025"}],
+        is_embargoed=False,
+        contributor_account_ids={"child-contrib-id"},
+    )
+
+    result = cct.create_tracker_issue(cast("JiraClient", FakeClient()), info)
+    assert result == "RHAIENG-9999"
+
+    assert adf_to_text(captured.pop("description")) == snapshot("""\
+Tracker for CVE-2026-8643 - Path traversal flaw affecting Notebooks Images components.
+Fix should be applied to: [https://github.com/red-hat-data-services/notebooks](https://github.com/red-hat-data-services/notebooks) (branch: rhoai-3.3)
+**Blocked Issues (1): **RHOAIENG-64025
+**JQL Query to View All Blocked Issues: **
+[View all 1 blocked issues](https://redhat.atlassian.net/issues/?jql=key%20in%20%28RHOAIENG-64025%29%20ORDER%20BY%20key%20ASC)\
+""")
+
+    assert captured == snapshot(
+        {
+            "project_key": "RHAIENG",
+            "summary": "CVE-2026-8643 Path traversal flaw [rhoai-3.3]",
+            "issue_type": "Bug",
+            "labels": ["CVE", "CVE-2026-8643", "security"],
+            "components": ["Notebooks"],
+            "security_level": "Red Hat Employee",
+            "extra_fields": {
+                "customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-62",
+                "customfield_10855": [{"name": "rhoai-3.3"}],
+                "customfield_10466": [{"accountId": "child-contrib-id"}, {"accountId": "runner-id-123"}],
+            },
+        }
+    )
+
+
+def test_create_tracker_issue_no_version_omits_target_version(monkeypatch: MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        def create_issue(self, **kwargs: Any) -> dict:
+            captured.update(kwargs)
+            return {"key": "RHAIENG-8888"}
+
+        def get_current_user(self) -> dict:
+            return {"accountId": "runner-id-123"}
+
+    monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
+    monkeypatch.delenv("JIRA_RUNNER_ACCOUNT_ID", raising=False)
+
+    info = cct.CVEInfo(
+        cve_id="CVE-2026-9999",
+        version="",
+        description="Some flaw",
+    )
+
+    cct.create_tracker_issue(cast("JiraClient", FakeClient()), info)
+    assert cct.RHAIENG_TARGET_VERSION_FIELD not in captured.get("extra_fields", {})

--- a/uv.lock
+++ b/uv.lock
@@ -630,6 +630,22 @@ wheels = [
 ]
 
 [[package]]
+name = "inline-snapshot"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "executing", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/2e/00c99468c7788bdb4f7d861bcfbfb091a5fe1bc475f9dd031f667c422a73/inline_snapshot-0.34.1.tar.gz", hash = "sha256:f8af37876c42069b7c0ed73f64357ace482955c3225ebcd27f243197ecfbcb65", size = 2638769, upload-time = "2026-06-05T16:58:47.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/83/21747d0ee2276e973a2889e960f2ec904fbbe83fac6fecd8a57995bb81df/inline_snapshot-0.34.1-py3-none-any.whl", hash = "sha256:4c043215866dfdbe6a3ead92d9d0a9294720c7deebddc346dc781654cb19daa9", size = 90039, upload-time = "2026-06-05T16:58:46.038Z" },
+]
+
+[[package]]
 name = "invoke"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +985,7 @@ dev = [
     { name = "authlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "inline-snapshot", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "keyring", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "kubernetes", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "openshift-python-wrapper", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1000,6 +1017,7 @@ dev = [
     { name = "authlib", specifier = ">=1.6.12" },
     { name = "certifi" },
     { name = "docker" },
+    { name = "inline-snapshot", specifier = ">=0.34.1" },
     { name = "keyring" },
     { name = "kubernetes" },
     { name = "openshift-python-wrapper" },


### PR DESCRIPTION
## Summary

- Set Jira **Target Version** (`customfield_10855`) on CVE tracker issues created by `create_cve_trackers.py`, using the version extracted from child issue summaries (e.g. `rhoai-3.3`)
- Add branch information to the tracker description ADF content
- Adopt `inline-snapshot` for approval-style tests with an `adf_to_text()` test printer

## Changes

1. **Target Version field** — when `cve_info.version` is set, the tracker issue gets `customfield_10855: [{"name": "rhoai-3.3"}]`
2. **Branch info in description** — ADF now includes "Fix should be applied to: [repo link] (branch: rhoai-X.Y)"
3. **inline-snapshot tests** — replace 60-line nested dict assertions with readable markdown snapshots; add `inline-snapshot` dev dep with ruff formatter config

## Test plan

- [x] `uv run pytest tests/unit/scripts/cve/ -x` — 17 passed
- [x] Snapshot tests verify full `create_issue` API payload including Target Version
- [x] No-version case correctly omits `customfield_10855`

🤖 Generated with [Claude Code](https://claude.com/claude-code)