### PR TITLE
draft: Use global.conf for all builds

### DIFF
--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -17,6 +17,7 @@ metadata:
       !("manifests/base/params-latest.env".pathChanged()) &&
       (
         ".tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml".pathChanged() ||
+        "build-args/global.conf".pathChanged() ||
         "jupyter/utils/**".pathChanged() ||
         "jupyter/minimal/ubi9-python-3.12/**".pathChanged() ||
         "jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf".pathChanged()
@@ -49,7 +50,14 @@ spec:
   - name: path-context
     value: .
   - name: build-args-file
-    value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+    value: build-args/global.conf
+  # We don't actually need these two params. 
+  # - Dockerfile.cuda should have PYLOCK_FLAVOR=cuda
+  # - LABEL_COMPONENT should be derived from component name
+  - name: build-args
+    value:
+    - PYLOCK_FLAVOR=cuda
+    - LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-ubi9
   # Hermetic build: RPMs + generic artifacts from repo-root prefetch-input/odh; pip from requirements.cuda.txt
   - name: hermetic
     value: 'true'

--- a/build-args/global.conf
+++ b/build-args/global.conf
@@ -1,0 +1,6 @@
+BASE_IMAGE_CPU=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest
+BASE_IMAGE_CUDA=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
+BASE_IMAGE_ROCM=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.1
+PRODUCT=odh
+RELEASE=3.5
+LABEL_REGISTRY_PREFIX=opendatahub

--- a/build-args/konflux.global.conf
+++ b/build-args/konflux.global.conf
@@ -1,0 +1,6 @@
+BASE_IMAGE_CPU=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
+BASE_IMAGE_CUDA=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037
+BASE_IMAGE_ROCM=quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1780597719
+PRODUCT=rhoai
+RELEASE=3.5
+LABEL_REGISTRY_PREFIX=rhoai

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -3,12 +3,13 @@ ARG TARGETARCH
 #########################
 # configuration args    #
 #########################
-ARG BASE_IMAGE
+ARG PYLOCK_FLAVOR=cuda
+ARG BASE_IMAGE_CUDA
 
 ####################
 # cuda-base        #
 ####################
-FROM ${BASE_IMAGE} AS cuda-base
+FROM ${BASE_IMAGE_CUDA} AS cuda-base
 
 WORKDIR /opt/app-root/bin
 

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,0 @@
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0
-PYLOCK_FLAVOR=cuda
-LABEL_REGISTRY_PREFIX=opendatahub
-LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-ubi9
-PRODUCT=odh
-RELEASE=3.5


### PR DESCRIPTION
refactor: Use global.conf for all builds

- This sample should be able to build it on Konflux.
- For GHA Build, we need to tweak the makefile to read those settings from global.conf and LABEL_COMPONENT from .tekton file. We need to treat .tekton file as SoT for all the builds.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
