### PR TITLE
RHAIENG-5327: add operator script to remove orphaned RStudio BuildConfigs

### DIFF
--- a/docs/rstudio-deprecation-upgrade.md
+++ b/docs/rstudio-deprecation-upgrade.md
@@ -1,0 +1,77 @@
+# RStudio deprecation after RHOAI 3.4 → 3.5 upgrade
+
+RStudio workbench images were removed from the notebooks repository in [RHAIENG-4776](https://redhat.atlassian.net/browse/RHAIENG-4776) and are no longer shipped with RHOAI 3.5. Fresh 3.5 installs do not include RStudio.
+
+When upgrading an existing cluster from **RHOAI 3.4** to **3.5**, orphaned RStudio resources can remain in the workbenches namespace:
+
+| Resource kind | Name | Action |
+| --- | --- | --- |
+| BuildConfig | `rstudio-server-rhel9` | Delete |
+| BuildConfig | `cuda-rstudio-server-rhel9` | Delete |
+| ImageStream | `rstudio-rhel9` | Delete (build output) |
+| ImageStream | `cuda-rstudio-rhel9` | Delete (build output) |
+| ImageStream | `rstudio-gpu-notebook` | Deprecate all tags |
+| ImageStream | `rstudio-notebook` | Deprecate all tags (if present) |
+
+These leftovers do not block the upgrade or normal RHOAI operation, but they can confuse operators and still expose RStudio in the workbench spawner.
+
+## Who should run this
+
+Platform or cluster administrators with `oc` access to the RHOAI/ODH applications namespace, typically after the operator upgrade to 3.5 has completed.
+
+## Prerequisites
+
+- Logged in to the target cluster (`oc login`)
+- `jq` installed
+- Permission to delete BuildConfigs/ImageStreams and patch ImageStreams in the workbenches namespace
+
+## Script
+
+[`scripts/deprecate-rstudio-on-upgrade.sh`](../scripts/deprecate-rstudio-on-upgrade.sh)
+
+### Usage
+
+Preview changes:
+
+```bash
+./scripts/deprecate-rstudio-on-upgrade.sh --dry-run
+```
+
+Apply on RHOAI (default namespace auto-detection tries `redhat-ods-applications`, then `opendatahub`):
+
+```bash
+./scripts/deprecate-rstudio-on-upgrade.sh
+```
+
+Explicit namespace:
+
+```bash
+./scripts/deprecate-rstudio-on-upgrade.sh -n redhat-ods-applications
+```
+
+### What the script does
+
+1. **Deletes** the two legacy RStudio BuildConfigs and their internal build ImageStreams.
+2. **Deprecates** remaining RStudio notebook ImageStreams by setting on every tag:
+   - `opendatahub.io/image-tag-outdated: "true"`
+   - `opendatahub.io/workbench-image-recommended: "false"`
+
+Deprecation follows the same pattern used for N-1 workbench image tags elsewhere in this repository. Existing RStudio workbenches continue to run; the images are hidden from the spawner for new workbenches.
+
+The script is idempotent: missing resources are skipped safely.
+
+## Verification
+
+```bash
+# BuildConfigs should be gone
+oc get buildconfig -n redhat-ods-applications | grep -i rstudio || echo "no rstudio buildconfigs"
+
+# Notebook imagestreams should show outdated tags (if still present)
+oc get imagestream rstudio-gpu-notebook -n redhat-ods-applications \
+  -o jsonpath='{range .spec.tags[*]}{.name}{": outdated="}{.annotations.opendatahub\.io/image-tag-outdated}{"\n"}{end}'
+```
+
+## Related work
+
+- [RHAIENG-5327](https://redhat.atlassian.net/browse/RHAIENG-5327) — operator/build-config removal for 3.5
+- [RHAIENG-4776](https://redhat.atlassian.net/browse/RHAIENG-4776) — notebooks repo RStudio removal

--- a/scripts/deprecate-rstudio-on-upgrade.sh
+++ b/scripts/deprecate-rstudio-on-upgrade.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Deprecate and remove leftover RStudio workbench resources after upgrading
+# from RHOAI 3.4 to 3.5 (or ODH equivalent). RStudio was removed from the
+# notebooks main branch in RHAIENG-4776; upgraded clusters can retain orphaned
+# BuildConfigs and ImageStreams from the previous release.
+#
+# See docs/rstudio-deprecation-upgrade.md for usage and background.
+
+set -euo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+
+# BuildConfigs shipped in RHOAI 3.4 manifests/rhoai/base/*-rstudio-buildconfig.yaml
+readonly RSTUDIO_BUILDCONFIGS=(
+  rstudio-server-rhel9
+  cuda-rstudio-server-rhel9
+)
+
+# Internal ImageStreams created alongside those BuildConfigs.
+readonly RSTUDIO_BUILD_IMAGESTREAMS=(
+  rstudio-rhel9
+  cuda-rstudio-rhel9
+)
+
+# Workbench ImageStreams shown in the spawner UI (RHOAI 3.4 shipped GPU only;
+# CPU imagestream existed in ODH manifests and may be present on some clusters).
+readonly RSTUDIO_NOTEBOOK_IMAGESTREAMS=(
+  rstudio-notebook
+  rstudio-gpu-notebook
+)
+
+NAMESPACE=""
+DRY_RUN=false
+
+log() {
+  printf '[%s] %s\n' "${SCRIPT_NAME}" "$*"
+}
+
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Remove orphaned RStudio BuildConfigs and mark any remaining RStudio workbench
+ImageStreams as deprecated after upgrading to RHOAI 3.5.
+
+Options:
+  -n, --namespace NAME   Target namespace (default: auto-detect)
+  --dry-run              Print actions without modifying the cluster
+  -h, --help             Show this help message
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} -n redhat-ods-applications
+  ${SCRIPT_NAME} --dry-run
+EOF
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+detect_namespace() {
+  local candidate
+  for candidate in redhat-ods-applications opendatahub; do
+    if oc get namespace "${candidate}" >/dev/null 2>&1; then
+      printf '%s' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_namespace() {
+  if [[ -n "${NAMESPACE}" ]]; then
+    oc get namespace "${NAMESPACE}" >/dev/null 2>&1 \
+      || die "Namespace '${NAMESPACE}' was not found"
+    return
+  fi
+
+  NAMESPACE="$(detect_namespace || true)"
+  [[ -n "${NAMESPACE}" ]] \
+    || die "Could not auto-detect namespace; pass -n redhat-ods-applications (RHOAI) or -n opendatahub (ODH)"
+  log "Using namespace: ${NAMESPACE}"
+}
+
+delete_resource() {
+  local kind="$1"
+  local name="$2"
+
+  if ! oc get "${kind}" "${name}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+    log "Skip ${kind}/${name}: not found"
+    return 0
+  fi
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "[dry-run] Would delete ${kind}/${name}"
+    return 0
+  fi
+
+  oc delete "${kind}" "${name}" -n "${NAMESPACE}" --wait=false
+  log "Deleted ${kind}/${name}"
+}
+
+deprecate_imagestream() {
+  local name="$1"
+
+  if ! oc get imagestream "${name}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+    log "Skip ImageStream/${name}: not found"
+    return 0
+  fi
+
+  local patch
+  patch="$(oc get imagestream "${name}" -n "${NAMESPACE}" -o json | jq -c '
+    .spec.tags |= map(
+      .annotations = (.annotations // {}) |
+      .annotations["opendatahub.io/image-tag-outdated"] = "true" |
+      .annotations["opendatahub.io/workbench-image-recommended"] = "false"
+    )
+  ')"
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    local tags
+    tags="$(printf '%s' "${patch}" | jq -r '[.spec.tags[].name] | join(", ")')"
+    log "[dry-run] Would deprecate ImageStream/${name} tags: ${tags:-<none>}"
+    return 0
+  fi
+
+  oc patch imagestream "${name}" -n "${NAMESPACE}" --type=merge -p "${patch}"
+  log "Deprecated all tags on ImageStream/${name}"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n|--namespace)
+        [[ $# -ge 2 ]] || die "Missing value for ${1}"
+        NAMESPACE="$2"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "Unknown argument: $1 (use --help)"
+        ;;
+    esac
+  done
+}
+
+main() {
+  parse_args "$@"
+
+  require_command oc
+  require_command jq
+
+  oc whoami >/dev/null 2>&1 || die "Not logged in to a cluster (run 'oc login' first)"
+  resolve_namespace
+
+  log "Starting RStudio deprecation cleanup in namespace ${NAMESPACE}"
+
+  local bc
+  for bc in "${RSTUDIO_BUILDCONFIGS[@]}"; do
+    delete_resource buildconfig "${bc}"
+  done
+
+  local build_is
+  for build_is in "${RSTUDIO_BUILD_IMAGESTREAMS[@]}"; do
+    delete_resource imagestream "${build_is}"
+  done
+
+  local notebook_is
+  for notebook_is in "${RSTUDIO_NOTEBOOK_IMAGESTREAMS[@]}"; do
+    deprecate_imagestream "${notebook_is}"
+  done
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "Dry run complete. Re-run without --dry-run to apply changes."
+  else
+    log "RStudio deprecation cleanup complete."
+    log "Existing RStudio workbenches keep running; new workbenches can no longer select these images."
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
[RHAIENG-5327](https://redhat.atlassian.net/browse/RHAIENG-5327): add operator script to remove orphaned RStudio BuildConfigs

## Description
[RHAIENG-5327](https://redhat.atlassian.net/browse/RHAIENG-5327): add operator script to remove orphaned RStudio BuildConfigs
Provide a cluster cleanup script and upgrade documentation for platform admins upgrading from RHOAI 3.4 to 3.5.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive upgrade documentation covering RStudio deprecation in version 3.5 and detailed resource cleanup procedures for users upgrading from version 3.4

* **New Tools & Utilities**
  * Introduced automated cleanup utility for managing deprecated RStudio resources following upgrades, featuring preview mode for change verification and automatic namespace detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHAIENG-5327]: https://redhat.atlassian.net/browse/RHAIENG-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5327]: https://redhat.atlassian.net/browse/RHAIENG-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ