### PR TITLE
RHAIENG-2186: install all texlive PDF deps from RPMs

### DIFF
--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# Install dependencies required for Notebooks PDF exports
+# Install dependencies required for Notebooks PDF exports.
+# Texlive components are installed from RPMs (see RHAIENG-2186).
 
 set -Eeuxo pipefail
 
@@ -42,8 +43,7 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-# available in epel but not in rhel9
-#texlive-tcolorbox
+texlive-tcolorbox
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -63,20 +63,6 @@ dnf install -y "${PACKAGES[@]}"
 dnf clean all
 
 pdflatex --version
-
-# install texlive-tcolorbox by other means
-# This is a temporary solution because not all jupyter images are hermetic yet;
-# once we update each image to hermetic build we can just dnf install texlive-tcolorbox
-if [ -n "$(find /cachi2/output/deps/rpm/ -name 'texlive-tcolorbox*' 2>/dev/null)" ]; then
-    dnf install -y texlive-tcolorbox
-else
-    dnf install -y cpio
-    pushd /
-    texlive_toolbox_rpm=https://download.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
-    curl -sSfL ${texlive_toolbox_rpm} | rpm2cpio /dev/stdin | cpio -idmv
-    popd
-fi
-dnf clean all
 texhash
 kpsewhich tcolorbox.sty
 

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -115,7 +115,7 @@ def main():
         """),
         "Dependencies for PDF export": textwrap.dedent(r"""
             RUN ./utils/install_pdf_deps.sh
-            ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
+            ENV PATH="/usr/local/pandoc/bin:$PATH"
         """),
         "mongocli-builder stage": textwrap.dedent(r"""
             ######################################################


### PR DESCRIPTION
Install texlive-tcolorbox in the main dnf package list and drop the EPEL rpm2cpio fallback. Pandoc install is unchanged. Remove the obsolete CTAN texlive PATH from Dockerfile fragments.

## Description
Install texlive-tcolorbox in the main dnf package list and drop the EPEL rpm2cpio fallback. Pandoc install is unchanged. Remove the obsolete CTAN texlive PATH from Dockerfile fragments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized PDF export build process by streamlining TeX Live dependency installation and removing fallback installation logic.
  * Updated Docker build configuration for PDF export dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->