### PR TITLE
revert versions back to EA2

### DIFF
--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-rhel9

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-rhel9

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-rhel9

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1781269697
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.2-1780971970
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-rhel9

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-rhel9

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-rhel9

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1781269701
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780972106
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-rhel9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1781269637
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1780972037
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1781269697
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-ea.2-1780971970
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-rhel9


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

This PR reverts the PR from renovate bot that merged before Fridays Code freeze : https://redhat-internal.slack.com/archives/C096ZR053RQ/p1781613866268469?thread_ts=1781576175.541949&cid=C096ZR053RQ

Once this PR merged we have to run pylock renewal to refresh the pylocks back to EA2
https://github.com/opendatahub-io/notebooks/actions/workflows/piplock-renewal.yaml

https://github.com/opendatahub-io/notebooks/pull/3842
https://github.com/opendatahub-io/notebooks/pull/3843
https://github.com/opendatahub-io/notebooks/pull/3844


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container image versions across CodeServer, Jupyter, and Runtime environments to newer releases
  * Applied updates to both CPU and CUDA-based image configurations
  * Changes applied across datascience, minimal, pytorch, tensorflow, trustyai, and pytorch+llmcompressor environment variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->