### PR TITLE
Merge pull request #2360 from red-hat-data-services/autofix/rhaieng-5655

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/start-notebook.sh
+++ b/jupyter/minimal/ubi9-python-3.12/start-notebook.sh
@@ -8,33 +8,39 @@ if [ -f "${SCRIPT_DIR}/utils/setup-elyra.sh" ]; then
   source ${SCRIPT_DIR}/utils/setup-elyra.sh
 fi
 
-# Initialize notebooks arguments variable
-NOTEBOOK_PROGRAM_ARGS=""
+# Initialize notebooks arguments array
+NOTEBOOK_PROGRAM_ARGS=()
 
 # Set default ServerApp.port value if NOTEBOOK_PORT variable is defined
 if [ -n "${NOTEBOOK_PORT}" ]; then
-    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.port=${NOTEBOOK_PORT} "
+    NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.port=${NOTEBOOK_PORT}")
 fi
 
 # Set default ServerApp.base_url value if NOTEBOOK_BASE_URL variable is defined
 if [ -n "${NOTEBOOK_BASE_URL}" ]; then
-    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.base_url=${NOTEBOOK_BASE_URL} "
+    NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.base_url=${NOTEBOOK_BASE_URL}")
 fi
 
 # Set default ServerApp.root_dir value if NOTEBOOK_ROOT_DIR variable is defined
 if [ -n "${NOTEBOOK_ROOT_DIR}" ]; then
-    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.root_dir=${NOTEBOOK_ROOT_DIR} "
+    NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.root_dir=${NOTEBOOK_ROOT_DIR}")
 else
-    NOTEBOOK_PROGRAM_ARGS+="--ServerApp.root_dir=${HOME} "
+    NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.root_dir=${HOME}")
 fi
 
 # Add additional arguments if NOTEBOOK_ARGS variable is defined
+# Word-splitting is intentional: NOTEBOOK_ARGS is newline- or space-separated (see kustomize statefulset.yaml)
 if [ -n "${NOTEBOOK_ARGS}" ]; then
-    NOTEBOOK_PROGRAM_ARGS+=${NOTEBOOK_ARGS}
+    while IFS= read -r line || [ -n "${line}" ]; do
+        if [ -n "${line}" ]; then
+            read -ra _line_args <<< "${line}"
+            NOTEBOOK_PROGRAM_ARGS+=("${_line_args[@]}")
+        fi
+    done <<< "${NOTEBOOK_ARGS}"
 fi
 
 # Start the JupyterLab notebook
-start_process jupyter lab ${NOTEBOOK_PROGRAM_ARGS} \
+start_process jupyter lab "${NOTEBOOK_PROGRAM_ARGS[@]}" \
     --ServerApp.ip="" \
     --ServerApp.allow_origin="*" \
     --ServerApp.open_browser=False


### PR DESCRIPTION
[RHAIENG-5655](https://redhat.atlassian.net/browse/RHAIENG-5655): fix: harden start-notebook.sh against argument injection

## Description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
