### PR TITLE
RHAIENG-5652: fix(codeserver): use relative nginx redirects to prevent open redirect

### DIFF
--- a/codeserver/ubi9-python-3.12/nginx/httpconf/http.conf
+++ b/codeserver/ubi9-python-3.12/nginx/httpconf/http.conf
@@ -43,6 +43,6 @@ map $http_x_forwarded_proto $custom_scheme {
 # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
 ###############
 upstream workbench_server {
-    server localhost:8787 max_fails=0;
+    server 127.0.0.1:8787 max_fails=0;
 }
 ###############

--- a/codeserver/ubi9-python-3.12/nginx/root/opt/app-root/nginxconf.sed
+++ b/codeserver/ubi9-python-3.12/nginx/root/opt/app-root/nginxconf.sed
@@ -1,5 +1,8 @@
-# Change port
+# Change port; run-nginx.sh removes the IPv6 listen at runtime when IPv6 is disabled via sysctl.
 /listen/s%80%8888 default_server%
+
+# Keep Location headers relative so port-mapped container tests and routes preserve the client port.
+/server {/a\        absolute_redirect off;
 
 # One worker only
 /worker_processes/s%auto%1%

--- a/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template
+++ b/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template
@@ -16,12 +16,12 @@ location /api/ {
 # api calls from culler get to CGI processing
 ###############
 location = /api/kernels {
-    return 302 $custom_scheme://$http_host/api/kernels/;
+    return 302 /api/kernels/;
     access_log  off;
 }
 
 location /api/kernels/ {
-  proxy_pass http://localhost:8080;
+  proxy_pass http://127.0.0.1:8080;
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -35,11 +35,11 @@ location /api/kernels/ {
 # root and prefix get to code-server endpoint
 ###############
 location = / {
-    return 302 $custom_scheme://$http_host/codeserver/;
+    return 302 /codeserver/;
 }
 
 location = /codeserver {
-    return 302 $custom_scheme://$http_host/codeserver/;
+    return 302 /codeserver/;
 }
 
 location /codeserver/ {

--- a/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
@@ -16,17 +16,17 @@ location ${NB_PREFIX}/api/ {
 # api calls from culler get to CGI processing
 ###############
 location = ${NB_PREFIX}/api/kernels {
-    return 302 $custom_scheme://$http_host${NB_PREFIX}/api/kernels/;
+    return 302 ${NB_PREFIX}/api/kernels/;
     access_log  off;
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 $custom_scheme://$http_host${NB_PREFIX}/api/kernels/;
+    return 302 ${NB_PREFIX}/api/kernels/;
     access_log  off;
 }
 
 location /api/kernels/ {
-  proxy_pass http://localhost:8080;
+  proxy_pass http://127.0.0.1:8080;
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -40,15 +40,15 @@ location /api/kernels/ {
 # root and prefix get to code-server endpoint
 ###############
 location ${NB_PREFIX} {
-    return 302 $custom_scheme://$http_host${NB_PREFIX}/codeserver/;
+    return 302 ${NB_PREFIX}/codeserver/;
 }
 
 location = /codeserver {
-    return 302 $custom_scheme://$http_host${NB_PREFIX}/codeserver/;
+    return 302 ${NB_PREFIX}/codeserver/;
 }
 
 location = / {
-    return 302 $custom_scheme://$http_host${NB_PREFIX}/codeserver/;
+    return 302 ${NB_PREFIX}/codeserver/;
 }
 
 location ${NB_PREFIX}/codeserver/ {

--- a/codeserver/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver/ubi9-python-3.12/run-code-server.sh
@@ -121,14 +121,14 @@ if [ ! -d "$logs_dir" ]; then
   mkdir -p "$logs_dir"
 fi
 
-# IPv6 support
+# IPv6 support (skip when IPv6 is disabled, e.g. via container sysctls in CI)
 echo "Checking IPv6 support..."
-if [ -f /proc/net/if_inet6 ]; then
+if [ -f /proc/net/if_inet6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null)" != "1" ]; then
     BIND_ADDR="[::]:8787"  # IPv6/dual-stack
     echo "IPv6 detected: binding to all interfaces (IPv4 + IPv6)"
 else
     BIND_ADDR="0.0.0.0:8787"  # IPv4 only
-    echo "IPv6 not detected: falling back to IPv4 only"
+    echo "IPv6 not available: falling back to IPv4 only"
 fi
 
 # Start server with explicit --user-data-dir so code-server writes settings,

--- a/codeserver/ubi9-python-3.12/run-nginx.sh
+++ b/codeserver/ubi9-python-3.12/run-nginx.sh
@@ -36,4 +36,22 @@ else
     rm -f "$tmp"
 fi
 
+# When IPv6 is disabled (e.g. container sysctls in CI), nginx cannot bind [::]:8888.
+# Use a temp file: sed -i writes into /etc/nginx/ which is not writable by UID 1001.
+if [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null)" = "1" ]; then
+    tmp=$(mktemp)
+    sed '/listen[[:space:]]\+\[::\]:8888/d' /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
+fi
+
+# Relative return 302 paths must emit relative Location headers; otherwise nginx
+# expands them with the container listen port (8888) and breaks port-mapped clients.
+if ! grep -q 'absolute_redirect off' /etc/nginx/nginx.conf; then
+    tmp=$(mktemp)
+    sed '/server {/a\        absolute_redirect off;' /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
+fi
+
 nginx

--- a/docs/gateway-api-migration-guide.md
+++ b/docs/gateway-api-migration-guide.md
@@ -218,7 +218,7 @@ fetch(menuUrl).then(...);
 ```nginx
 # ❌ REMOVE THIS - Too broad, causes infinite loops
 location ${NB_PREFIX}/ {
-    return 302 $custom_scheme://$http_host/app/;
+    return 302 /myapp/;
 }
 ```
 
@@ -226,21 +226,28 @@ location ${NB_PREFIX}/ {
 
 ### 2. Update Redirects to Preserve NB_PREFIX
 
-**All redirects must include `${NB_PREFIX}`** to keep requests within the Gateway route:
+**All redirects must include `${NB_PREFIX}`** to keep requests within the Gateway route. Use **relative** redirect targets only — do not build `Location` from `$http_host` or `$custom_scheme` (CWE-601 open redirect when the pod is accessed directly with a crafted `Host` header).
 
 ```nginx
 # ❌ BAD - Strips prefix
 location = ${NB_PREFIX} {
-    return 302 $custom_scheme://$http_host/myapp/;
+    return 302 /myapp/;
 }
 
-# ✅ GOOD - Preserves prefix
+# ❌ BAD - Reflects client Host header into Location (CWE-601)
 location ${NB_PREFIX} {
     return 302 $custom_scheme://$http_host${NB_PREFIX}/myapp/;
 }
+
+# ✅ GOOD - Relative path preserves prefix; nginx must not rewrite it absolute
+location ${NB_PREFIX} {
+    return 302 ${NB_PREFIX}/myapp/;
+}
 ```
 
-**Note**: Use `location ${NB_PREFIX}` (without `=`) to handle both with and without trailing slash.
+Set `absolute_redirect off;` in the nginx `server` block (or at build time via `nginxconf.sed`) so nginx keeps `Location` relative instead of expanding it with the listen address and client `Host`.
+
+**Note**: Use `location ${NB_PREFIX}` (without `=`) to handle both with and without trailing slash. `${NB_PREFIX}` is substituted at container startup by the platform, not taken from request headers.
 
 ### 3. Add Prefix-Aware Proxy Location
 
@@ -251,8 +258,8 @@ location ${NB_PREFIX}/myapp/ {
     # Strip the prefix before proxying to backend
     rewrite ^${NB_PREFIX}/myapp/(.*)$ /$1 break;
     
-    # Proxy to your application
-    proxy_pass http://localhost:8080/;
+    # Proxy to your application (127.0.0.1 avoids localhost → ::1 resolution on IPv6 hosts)
+    proxy_pass http://127.0.0.1:8080/;
     proxy_http_version 1.1;
     
     # Essential for WebSocket support
@@ -370,14 +377,14 @@ location /prefix {
 For Gateway API, you need:
 
 ```nginx
-# Redirect root to app
+# Redirect root to app (relative Location; requires absolute_redirect off)
 location ${NB_PREFIX} {
-    return 302 $custom_scheme://$http_host${NB_PREFIX}/myapp/;
+    return 302 ${NB_PREFIX}/myapp/;
 }
 
 # Proxy app traffic (longer prefix wins)
 location ${NB_PREFIX}/myapp/ {
-    proxy_pass http://localhost:8080/;
+    proxy_pass http://127.0.0.1:8080/;
 }
 ```
 

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -232,13 +232,12 @@ class ImageDeployment:
 
             self.port = p.get_actual_port()
             LOGGER.debug(f"Listening on port {self.port}")
-            # Use 60s timeout for all architectures to handle slower SSL/TLS negotiation
-            # especially on s390x and other non-native architectures
+            # Use 120s timeout for slower cold starts (e.g. code-server on arm64).
             Wait.until(
                 "Connecting to pod succeeds",
                 1,
-                60,
-                lambda: requests.get(f"http://localhost:{self.port}", timeout=10).status_code == 200,
+                120,
+                lambda: requests.get(f"http://127.0.0.1:{self.port}/api", timeout=10).status_code == 200,
             )
             LOGGER.debug("Done setting up portforward")
 

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import logging
 import os
 import pathlib
@@ -10,6 +11,7 @@ import urllib.error
 import urllib.request
 from typing import TYPE_CHECKING, Self
 
+import allure
 import docker.types
 import pytest
 import testcontainers.core.container
@@ -133,6 +135,52 @@ class TestWorkbenchImage:
                     ],
                 )
 
+    @pytest.mark.codeserver
+    @allure.issue("RHAIENG-5652")
+    def test_nginx_absolute_redirect_off(self, subtests: pytest_subtests.SubTests, codeserver_image: Image) -> None:
+        """CWE-601: absolute_redirect off must be present in the live nginx config."""
+        with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
+            container.start(wait_for_readiness=True)
+            with subtests.test("absolute_redirect off is present in /etc/nginx/nginx.conf"):
+                exit_code, output = container.exec(["grep", "-r", "absolute_redirect off", "/etc/nginx/nginx.conf"])
+                assert exit_code == 0, (
+                    f"'absolute_redirect off' not found in /etc/nginx/nginx.conf — "
+                    f"open-redirect (CWE-601) mitigation may be missing.\nOutput: {output.decode()}"
+                )
+
+    @pytest.mark.codeserver
+    @allure.issue("RHAIENG-5652")
+    def test_nginx_no_open_redirect(self, subtests: pytest_subtests.SubTests, codeserver_image: Image) -> None:
+        """CWE-601 regression: return 302 rules must emit relative Location headers (FIND-011).
+
+        A forged Host header must not appear in the Location response header.
+        """
+        redirect_paths = ["/", "/codeserver"]
+        forged_host = "evil.example"
+
+        with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
+            container.start(wait_for_readiness=True)
+            port = int(container.get_exposed_port(container.port))
+
+            for path in redirect_paths:
+                with subtests.test(f"GET {path} with forged Host must yield relative Location"):
+                    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                    try:
+                        conn.request("GET", path, headers={"Host": forged_host})
+                        resp = conn.getresponse()
+                        assert resp.status == 302, f"Expected 302 for {path}, got {resp.status}"
+                        location = resp.getheader("Location", "")
+                        assert not location.startswith("http"), (
+                            f"Open redirect (CWE-601): GET {path} with Host:{forged_host} "
+                            f"returned absolute Location: {location!r}. "
+                            f"Expected a relative path (e.g. '/codeserver/')."
+                        )
+                        assert location.startswith("/"), (
+                            f"Location header for {path} is neither absolute nor relative: {location!r}"
+                        )
+                    finally:
+                        conn.close()
+
     @pytest.mark.openshift
     def test_image_run_on_openshift(self, workbench_image: str):
         client = kubernetes_utils.get_client()
@@ -173,12 +221,19 @@ class WorkbenchContainer(testcontainers.core.container.DockerContainer):
 
         # connect
         host = container_host or self.get_container_host_ip()
+        # Podman publishes IPv4 ports; connecting to "localhost" may resolve to ::1 first.
+        if host == "localhost":
+            host = "127.0.0.1"
         port = container_port or self.get_exposed_port(self.port)
         try:
             # host may be an ipv6 address, need to be careful with formatting this
-            if ":" in host:
-                host = f"[{host}]"
-            result = urllib.request.urlopen(urllib.request.Request(f"http://{host}:{port}{base_url}"), timeout=1)
+            host_for_url = f"[{host}]" if ":" in host else host
+            # /api redirects to /codeserver/healthz/ and avoids the / -> /codeserver/ hop
+            # (absolute redirects on / previously broke Podman port-forward readiness checks).
+            probe_path = base_url or "/api"
+            result = urllib.request.urlopen(
+                urllib.request.Request(f"http://{host_for_url}:{port}{probe_path}"), timeout=1
+            )
         except urllib.error.URLError as e:
             raise e
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5652

## Summary

- Replace eight `return 302` rules in code-server nginx proxy templates that reflected `$custom_scheme://$http_host` with relative paths, fixing CWE-601 open redirect when the pod is accessed directly with a crafted Host header (Project Glasswing FIND-011).
- Set `absolute_redirect off` at build and startup so nginx keeps Location headers relative instead of expanding them from the client Host header.
- Adjust code-server/nginx startup for IPv6-disabled CI environments, point the upstream at `127.0.0.1`, and update container test probes for port-mapped IPv4 connections.

`proxy_set_header Host $http_host` directives are unchanged.

## Test plan

- [ ] `make test-unit`
- [ ] `make test-integration PYTEST_ARGS="--image=codeserver-ubi9-python-3.12"` (or equivalent CI container test run)
- [ ] Verify nginx config: all `return 302` lines use relative paths; no absolute `$http_host` redirects remain


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved IPv6 handling: fall back to IPv4-only when IPv6 is disabled, preventing bind failures.
  * Hardened NGINX redirect behavior by ensuring safe relative `Location` headers (with `absolute_redirect off`) and preserving port-mapped/container test behavior.
  * Switched internal proxying/probing from `localhost` to `127.0.0.1` for more consistent connectivity.
  * Extended Kubernetes port-forward readiness polling for slower starts.

* **Tests**
  * Added/updated readiness checks and added security regression tests to verify redirect/open-redirect hardening.

* **Documentation**
  * Updated Gateway API migration proxy examples to match the new redirect-safety guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->