### PR TITLE
Bump CRI-O and Kubernetes to 1.36 in CI k8s provisioning

### DIFF
--- a/.github/actions/provision-k8s/action.yml
+++ b/.github/actions/provision-k8s/action.yml
@@ -83,12 +83,12 @@ runs:
         sudo systemctl daemon-reload
         sudo systemctl start crio.service
       env:
-        CRIO_VERSION: 1.34
+        CRIO_VERSION: 1.36
         # This has to be kept in sync with the packages above, otherwise
         # [ERROR KubeletVersion]: the kubelet version is higher than the control plane version.
         #  This is not a supported version skew and may lead to a malfunctional cluster.
         #  Kubelet version: "1.33.0" Control plane version: "1.30.12"
-        KUBERNETES_VERSION: 1.34
+        KUBERNETES_VERSION: 1.36
         # Also update version in kubeadm.yaml
 
     - run: sudo crictl info

--- a/ci/cached-builds/kubeadm.yaml
+++ b/ci/cached-builds/kubeadm.yaml
@@ -39,7 +39,7 @@ timeouts:
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
-kubernetesVersion: 1.34.0
+kubernetesVersion: 1.36.2
 clusterName: kubernetes
 caCertificateValidityPeriod: 87600h0m0s
 certificateValidityPeriod: 8760h0m0s


### PR DESCRIPTION
## Summary
- Bumps CRI-O from 1.34 to 1.36 and Kubernetes from 1.34 to 1.36 in the `provision-k8s` GHA action
- Updates `kubeadm.yaml` to pin `kubernetesVersion: 1.36.2`

## Versions installed (from CI logs)

| Component | Version |
|---|---|
| CRI-O | 1.36.1-1.1 |
| kubelet | 1.36.2-2.1 |
| kubeadm | 1.36.2-2.1 |
| kubectl | 1.36.2-2.1 (already on runner) |
| Kubernetes control plane | v1.36.2 |
| local-path-provisioner | v0.0.32 (unchanged) |

## Notes
- Kubernetes 1.35 was skipped — the project jumps from 1.34 to 1.36
- kubeadm reported a minor sandbox image mismatch (`pause:3.10.1` vs `3.10.2`) — harmless warning, CRI-O ships its own pause image
- The `sed` workaround for unqualified rancher image names (short-name-mode enforcing) is still in place with v0.0.32; this was fixed upstream in v0.0.36 ([rancher/local-path-provisioner#571](https://github.com/rancher/local-path-provisioner/issues/571)) — a follow-up bump to v0.0.36 could remove the `sed`

## Test plan
- [x] CI `test-provisioning` job passed: [run 27825310647](https://github.com/opendatahub-io/notebooks/actions/runs/27825310647/job/82348109427?pr=3869)

🤖 Generated with [Claude Code](https://claude.com/claude-code)