### PR TITLE
Bump local-path-provisioner to v0.0.36, remove sed workaround

### DIFF
--- a/.github/actions/provision-k8s/action.yml
+++ b/.github/actions/provision-k8s/action.yml
@@ -179,11 +179,8 @@ runs:
       shell: bash
       run: |
         set -Eeuxo pipefail
-        # InspectFailed Failed to inspect image "": rpc error: code = Unknown desc = short name mode is enforcing, but image name rancher/local-path-provisioner:v0.0.31 returns ambiguous list
-        (curl -fsSL https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.32/deploy/local-path-storage.yaml |
-          sed 's|image: rancher/local-path-provisioner|image: docker.io/rancher/local-path-provisioner|g' |
+        curl -fsSL "https://raw.githubusercontent.com/rancher/local-path-provisioner/v${RANCHER_FULL_VERSION}/deploy/local-path-storage.yaml" |
           kubectl apply -f -
-        )
         kubectl wait deployments --all --namespace=local-path-storage --for=condition=Available --timeout=100s || (
           kubectl describe deployments --namespace=local-path-storage
           kubectl --namespace=local-path-storage get events --sort-by='.lastTimestamp'
@@ -193,3 +190,5 @@ runs:
         # https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
         kubectl get storageclass
         kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+      env:
+        RANCHER_FULL_VERSION: 0.0.36


### PR DESCRIPTION
## Summary
- Bumps rancher/local-path-provisioner from v0.0.32 to v0.0.36
- Removes the `sed` workaround for unqualified image names — v0.0.36 ships fully-qualified `docker.io/` prefixed images ([#571](https://github.com/rancher/local-path-provisioner/issues/571), [#569](https://github.com/rancher/local-path-provisioner/issues/569))
- Extracts version into `RANCHER_FULL_VERSION` env var for easier future bumps

## What changed upstream (v0.0.32 → v0.0.36)
- Provisioner image now uses `docker.io/rancher/local-path-provisioner` (fixes CRI-O short-name-mode=enforcing)
- Helper pod busybox image now uses `docker.io/library/busybox` (fixes Docker Hub rate limit issues on shared NAT)

## Test plan
- [ ] CI `test-provisioning` job provisions cluster and local-path storageclass successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes provisioning configuration to use versioned manifest from Rancher repository, improving deployment consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->