### PR TITLE
NO-JIRA: chore(ci): speed up CI k8s provisioning: 1 CoreDNS replica, parallel deploys

### DIFF
--- a/.github/actions/provision-k8s/action.yml
+++ b/.github/actions/provision-k8s/action.yml
@@ -104,7 +104,7 @@ runs:
         sudo journalctl -xeu crio.service
 
     # do this early, it's a good check that cri-o is not completely broken
-    - name: "Show crio images information"
+    - name: Show crio images information
       shell: bash
       run: sudo crictl images
 
@@ -168,27 +168,35 @@ runs:
         kubectl describe nodes
         kubectl wait --for=condition=Ready nodes --all --timeout=100s || (kubectl describe nodes && false)
 
-    - name: Wait for pods to be running
+    - name: Deploy local-path provisioner
       shell: bash
       run: |
         set -Eeuxo pipefail
-        kubectl wait deployments --all --all-namespaces --for=condition=Available --timeout=100s
-        kubectl wait pods --all --all-namespaces --for=condition=Ready --timeout=100s
-
-    - name: "Install local-path provisioner"
-      shell: bash
-      run: |
-        set -Eeuxo pipefail
-        curl -fsSL "https://raw.githubusercontent.com/rancher/local-path-provisioner/v${RANCHER_FULL_VERSION}/deploy/local-path-storage.yaml" |
+        # Deploy early so its image pull overlaps with CoreDNS becoming ready
+        curl --retry 3 --retry-delay 5 --retry-all-errors -fsSL \
+          "https://raw.githubusercontent.com/rancher/local-path-provisioner/v${RANCHER_FULL_VERSION}/deploy/local-path-storage.yaml" |
           kubectl apply -f -
-        kubectl wait deployments --all --namespace=local-path-storage --for=condition=Available --timeout=100s || (
-          kubectl describe deployments --namespace=local-path-storage
-          kubectl --namespace=local-path-storage get events --sort-by='.lastTimestamp'
-          kubectl --namespace=local-path-storage describe pods
+      env:
+        RANCHER_FULL_VERSION: 0.0.36
+
+    - name: Wait for all deployments and pods
+      shell: bash
+      run: |
+        set -Eeuxo pipefail
+        kubectl wait deployments --all --all-namespaces --for=condition=Available --timeout=100s || (
+          kubectl describe deployments --all-namespaces
+          kubectl get events --all-namespaces --sort-by='.lastTimestamp'
+          kubectl describe pods --all-namespaces
           false
         )
+        kubectl wait pods --all --all-namespaces --for=condition=Ready --timeout=100s || (
+          kubectl describe pods --all-namespaces
+          false
+        )
+
+    - name: Configure default StorageClass
+      shell: bash
+      run: |
         # https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
         kubectl get storageclass
         kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-      env:
-        RANCHER_FULL_VERSION: 0.0.36

--- a/ci/cached-builds/kubeadm-patches/corednsdeployment+merge.yaml
+++ b/ci/cached-builds/kubeadm-patches/corednsdeployment+merge.yaml
@@ -1,0 +1,4 @@
+---
+# Single-node CI cluster does not need 2 CoreDNS replicas
+spec:
+  replicas: 1

--- a/ci/cached-builds/kubeadm.yaml
+++ b/ci/cached-builds/kubeadm.yaml
@@ -56,7 +56,9 @@ networking:
   serviceSubnet: 10.96.0.0/12
 apiServer: {}
 controllerManager: {}
-dns: {}
+# Single-node CI cluster doesn't need 2 CoreDNS replicas; saves ~5-10s on pod scheduling
+dns:
+  replicas: 1
 proxy: {}
 scheduler: {}
 ---

--- a/ci/cached-builds/kubeadm.yaml
+++ b/ci/cached-builds/kubeadm.yaml
@@ -28,6 +28,8 @@ nodeRegistration:
     #  https://cep.dev/posts/adventure-trying-change-kubelet-rootdir/
     - name: root-dir
       value: /home/runner/.local/share/containers/kubelet-root-dir
+patches:
+  directory: ci/cached-builds/kubeadm-patches
 timeouts:
   controlPlaneComponentHealthCheck: 4m0s
   discovery: 5m0s
@@ -56,9 +58,7 @@ networking:
   serviceSubnet: 10.96.0.0/12
 apiServer: {}
 controllerManager: {}
-# Single-node CI cluster doesn't need 2 CoreDNS replicas; saves ~5-10s on pod scheduling
-dns:
-  replicas: 1
+dns: {}
 proxy: {}
 scheduler: {}
 ---


### PR DESCRIPTION
## Summary

Optimizes CI k8s cluster provisioning with three changes:

1. **1 CoreDNS replica** via kubeadm `--patches` (declarative strategic merge patch on the CoreDNS Deployment) — the biggest time sink in provisioning
2. **Parallel local-path-provisioner deploy** — deploys before waiting for CoreDNS, so image pulls overlap
3. **Reliability improvements** — curl retry for local-path manifest, failure diagnostics on pod wait

## Motivation: timing analysis

Profiling the `test-provisioning` job from PRs #3869 and #3870 reveals that **waiting for CoreDNS** consumes 47% of total provisioning time:

```
 0s ├─ apt-install prereqs (software-properties-common, curl)     6s
 6s ├─ GPG keys + apt repos + apt-get update                      5s
11s ├─ apt-get install cri-o + k8s packages                      11s
22s ├─ crio start + crictl info/images                            1s
23s ├─ kubeadm init (image pull 8s + certs + bootstrap)          16s
39s ├─ nodes Ready                                                3s
42s ├─ *** CoreDNS deployment Available ***                      42s  ← 47% of total
84s ├─ local-path-provisioner deploy + wait                       5s
89s └─ done
```

On a single-node CI cluster, the second CoreDNS replica adds no resilience value — if the node goes down, both pods go with it.

## Implementation

- **CoreDNS replica reduction**: Uses kubeadm's `--patches` flag with a `corednsdeployment+merge.yaml` strategic merge patch file. This is applied declaratively during `kubeadm init`, avoiding the race condition of a post-init `kubectl scale` (which was attempted first but [flagged by CodeRabbit](https://github.com/opendatahub-io/notebooks/pull/3871#issuecomment-2987069987) because `dns.replicas` doesn't exist in kubeadm's v1beta4 API).
- **Parallel deploy**: `kubectl apply` for local-path-provisioner runs right after nodes are Ready, before the combined wait step. One `kubectl wait --all --all-namespaces` covers both kube-system and local-path-storage.
- **Curl retry**: `--retry 3 --retry-delay 5 --retry-all-errors` on the raw.githubusercontent.com fetch, matching the retry pattern used for k8s/CRI-O package keys earlier in the file.
- **Pod wait diagnostics**: `kubectl describe pods --all-namespaces` on failure, matching the deployment wait's error handling.

## Roads not taken

| Option | Why deferred |
|---|---|
| **Pre-pull k8s images during apt install** (~8s) | Requires splitting apt install to get kubeadm first, then backgrounding image pull. Invasive for moderate gain. |
| **Skip first `apt-get update`** (~3s) | Risk if runner image changes; `software-properties-common` and `curl` are pre-installed today but not guaranteed. |
| **Skip unconditional `kubectl describe nodes`** (~1s) | Negligible savings, has diagnostic value. |
| **Combine deployment + pod `kubectl wait`** (marginal) | Reduces diagnostic clarity on failure for negligible savings. |

## Test plan
- [ ] CI `test-provisioning` job passes
- [ ] kubeadm logs show `[patches] Applied patch` for CoreDNS deployment
- [ ] Only 1 CoreDNS pod is created (vs 2 before)
- [ ] Compare total job time vs baseline (~90s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)