### PR TITLE
ISSUE#3872: fix(gha): Linuxbrew cache key: use GITHUB_OUTPUT for ImageOS

### DIFF
--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -15,10 +15,12 @@ runs:
 
     # Ensure parent dir exists and is runner-owned so cache restore can set file modes (avoids "Cannot change mode: Operation not permitted").
     - name: Prepare .linuxbrew parent for cache
+      id: prep-linuxbrew
       shell: bash
       run: |
         sudo mkdir -p /home/linuxbrew
         sudo chown -R "$(whoami):$(whoami)" /home/linuxbrew
+        echo "image-os=${ImageOS:-unknown}" >> "$GITHUB_OUTPUT"
 
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       # https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
@@ -26,7 +28,7 @@ runs:
       id: cached-linuxbrew
       with:
         path: /home/linuxbrew/.linuxbrew
-        key: linuxbrew-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}
+        key: linuxbrew-${{ runner.os }}-${{ runner.arch }}-${{ steps.prep-linuxbrew.outputs.image-os }}
 
     # Restored cache can have wrong ownership or immutable flags; fix so brew/podman and mode changes work.
     - name: Fix .linuxbrew ownership and permissions after cache restore


### PR DESCRIPTION
## Summary

Fixes the Linuxbrew cache key from PR #3873, which evaluated to `linuxbrew-Linux-X64-` (empty `ImageOS`).

`${{ env.ImageOS }}` doesn't work in composite action `with:` inputs because the `env` expression context [only contains workflow/job/step-defined variables](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts), not runner-process env vars like `ImageOS`.

**Fix**: Surface `ImageOS` via `GITHUB_OUTPUT` in the existing prep step, then reference it as a step output.

```
Before: linuxbrew-Linux-X64-          (broken, empty ImageOS)
After:  linuxbrew-Linux-X64-ubuntu24  (correct, auto-busts on OS version change)
```

Tracking issue: #3872

## Test plan
- [x] CI logs show `key: linuxbrew-Linux-X64-ubuntu24` (no trailing dash) — [job 82379983948](https://github.com/opendatahub-io/notebooks/actions/runs/27834754531/job/82379983948)
- [x] Cache populated on first run (`Cache not found`)
- [x] Cache restored on rerun (`Cache restored from key: linuxbrew-Linux-X64-ubuntu24`) — [job 82383709144](https://github.com/opendatahub-io/notebooks/actions/runs/27834754531/job/82383709144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)