### PR TITLE
Migrate all GHA runners from ubuntu-24.04 to ubuntu-26.04

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -5,13 +5,13 @@ List for
 and for
 [private repositories](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for--private-repositories).
 
-- **Linux**: `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-24.04-arm`
+- **Linux**: `ubuntu-26.04`, `ubuntu-26.04-arm`
 
 We have [IBM PowerPC and Z runners](https://community.ibm.com/community/user/blogs/elizabeth-k-joseph1/2025/05/19/expanding-open-source-access-hosted-github-actions) available through
 
 * https://github.com/IBM/actionspz/issues/63
 
-- **Linux**: `ubuntu-24.04-ppc64le`, `ubuntu-24.04-s390x`
+- **Linux**: `ubuntu-26.04-ppc64le`, `ubuntu-26.04-s390x`
 
 We have considered investigating custom runners, either just plain containers/VMs, or something fronting an OpenShift cluster, in
 

--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -11,7 +11,7 @@ We have [IBM PowerPC and Z runners](https://community.ibm.com/community/user/blo
 
 * https://github.com/IBM/actionspz/issues/63
 
-- **Linux**: `ubuntu-26.04-ppc64le`, `ubuntu-26.04-s390x`
+- **Linux**: `ubuntu-24.04-ppc64le`, `ubuntu-24.04-s390x`
 
 We have considered investigating custom runners, either just plain containers/VMs, or something fronting an OpenShift cluster, in
 

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+---
+# actionlint 1.7.12 (used by CodeRabbit) does not yet list ubuntu-26.04 hosted
+# runners; register them here until upstream adds GA preview labels.
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04
+    - ubuntu-26.04-arm

--- a/.github/actions/capture-kernel-logs/action.yml
+++ b/.github/actions/capture-kernel-logs/action.yml
@@ -24,6 +24,7 @@ runs:
 
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
+        name: kernel-logs-${{ inputs.log-prefix }}
         path: "${{ runner.temp }}/kernel-logs/${{ inputs.log-prefix }}_dmesg.log"
         archive: false
         retention-days: 14
@@ -33,6 +34,7 @@ runs:
 
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
+        name: kernel-logs-${{ inputs.log-prefix }}
         path: "${{ runner.temp }}/kernel-logs/${{ inputs.log-prefix }}_journalctl-k.log"
         archive: false
         retention-days: 14

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -106,7 +106,7 @@ runs:
         sudo cp ci/cached-builds/podman.service /usr/local/lib/systemd/system/podman.service
         sudo cp ci/cached-builds/podman.socket /usr/local/lib/systemd/system/podman.socket
         sudo systemctl daemon-reload
-        sudo systemctl unmask --now podman.service podman.socket
+        sudo systemctl unmask podman.service podman.socket
         sudo systemctl start podman.socket
 
         # needed (much) later for trivy

--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   add-to-project:
     name: Add issue to projects
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Generate github-app token
         id: app-token

--- a/.github/workflows/build-browser-tests.yaml
+++ b/.github/workflows/build-browser-tests.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.arch }})
-    runs-on: ${{ fromJSON('{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}')[matrix.arch] }}
+    runs-on: ${{ fromJSON('{"amd64":"ubuntu-26.04","arm64":"ubuntu-26.04-arm"}')[matrix.arch] }}
     permissions:
       contents: read
     strategy:
@@ -68,7 +68,7 @@ jobs:
 
   manifest:
     name: Create and push multiarch manifest
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.push_image == true
     permissions:

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -38,10 +38,10 @@ name: Build & Publish Notebook Servers (TEMPLATE)
         # language=json
         default: >-
           {
-            "linux/amd64": "ubuntu-24.04",
-            "linux/arm64": "ubuntu-24.04-arm",
-            "linux/ppc64le": "ubuntu-24.04",
-            "linux/s390x": "ubuntu-24.04"
+            "linux/amd64": "ubuntu-26.04",
+            "linux/arm64": "ubuntu-26.04-arm",
+            "linux/ppc64le": "ubuntu-26.04",
+            "linux/s390x": "ubuntu-26.04"
           }
         description: "Available contexts for runs-on are: github, inputs, matrix, needs, strategy, vars. Let's use inputs"
         type: string

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -26,7 +26,7 @@ jobs:
   authorize:
     name: Authorize
     permissions: {}  # only needs implicit metadata:read for getCollaboratorPermissionLevel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
     steps:
@@ -66,7 +66,7 @@ jobs:
     name: Generate job matrix
     needs: [authorize]
     if: needs.authorize.outputs.authorized == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     # rhds/notebooks builds from AIPCC bases and requires pull_request_target trigger
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -26,7 +26,7 @@ jobs:
   authorize:
     name: Authorize
     permissions: {}  # only needs implicit metadata:read for getCollaboratorPermissionLevel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
     steps:
@@ -66,7 +66,7 @@ jobs:
     name: Generate job matrix
     needs: [authorize]
     if: needs.authorize.outputs.authorized == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Generate job matrix
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   gen:
     name: Generate job matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     # for odh-io/notebooks and rhds/notebooks, allow only main, rhoai-*, release-*
     if: ${{ github.event_name == 'workflow_dispatch' ||
       (github.repository != 'opendatahub-io/notebooks' && github.repository != 'red-hat-data-services/notebooks')

--- a/.github/workflows/check-image-availability.yaml
+++ b/.github/workflows/check-image-availability.yaml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check-odh-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -30,7 +30,7 @@ jobs:
             manifests/odh/base/params.env
 
   notify-on-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     needs: check-odh-images
     if: failure()
     permissions:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   check-generated-code:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -38,7 +38,7 @@ jobs:
           fi
 
   pytest-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -80,7 +80,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   go-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -122,7 +122,7 @@ jobs:
           files: scripts/buildinputs/junit-go.xml
 
   code-static-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -174,7 +174,7 @@ jobs:
   # https://github.com/pre-commit/action
   prek:
     name: "prek"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -200,7 +200,7 @@ jobs:
 
   action-pin-check:
     name: GitHub Actions SHA pinning
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   analyze:
     name: CodeQL (${{ matrix.language }})
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -41,7 +41,7 @@ env:
 jobs:
   release:
     name: Create opendatahub-io/notebooks release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   generate-releasenotes:
     name: Generate list of images for release notes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   scan:
     name: Gitleaks secret scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/insta-merge.yaml
+++ b/.github/workflows/insta-merge.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: insta-merge
         if: ${{ github.event.sender.login == 'red-hat-konflux[bot]' && ( contains(github.event.pull_request.title, 'Update odh-workbench-jupyter-') || contains(github.event.pull_request.title, 'Update odh-workbench-codeserver-') || contains(github.event.pull_request.title, 'Update odh-pipeline-runtime-') ) }}

--- a/.github/workflows/merge-main-to-stable-fast-forward.yaml
+++ b/.github/workflows/merge-main-to-stable-fast-forward.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   fast-forward-stable:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   validation-of-params-env:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -45,7 +45,7 @@ jobs:
   refresh-lock-files:
     # Only run on Wednesday schedule or manual dispatch with 'update-lockfiles' operation
     if: (github.event_name == 'workflow_dispatch' && github.event.inputs.operation == 'update-lockfiles') || (github.event_name == 'schedule' && github.event.schedule == '0 1 * * 3')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     concurrency:
       group: refresh-lock-files-${{ github.ref }}
       cancel-in-progress: false
@@ -143,7 +143,7 @@ jobs:
   auto-merge-lockfile-prs:
     # Run on auto-merge schedule or manual dispatch with 'auto-merge' operation
     if: (github.event_name == 'workflow_dispatch' && github.event.inputs.operation == 'auto-merge') || (github.event_name == 'schedule' && github.event.schedule == '0 9,15 * * 1-5')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       pull-requests: write  # github.token is only used for PR approval (line 225)
     steps:

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -11,7 +11,7 @@ env:
   QUAY_IMAGE_REPO: ${{ secrets.QUAY_IMAGE_REPO }}
 jobs:
   delete-pr-quay-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Git checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       # addLabels on PRs needs this despite docs saying issues:write suffices
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
 
       # SECURITY: never clone untrusted code in pull_request_target workflows
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
 
       # SECURITY: never clone untrusted code in pull_request_target workflows

--- a/.github/workflows/purge-ghcr.yaml
+++ b/.github/workflows/purge-ghcr.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   clean:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     name: Delete old test images
     steps:
       # https://github.com/snok/container-retention-policy?tab=readme-ov-file#parameters

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -61,7 +61,7 @@ jobs:
       github.event_name != 'schedule'
       || github.repository_owner == 'opendatahub-io'
       || github.repository == 'red-hat-data-services/notebooks'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     env:
       CONTAINER_ENGINE: docker
       # Pin with scripts/ci/renovate_run.py default; bump both when upgrading Renovate.

--- a/.github/workflows/rpms-lock-renewal.yaml
+++ b/.github/workflows/rpms-lock-renewal.yaml
@@ -31,7 +31,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   refresh-rpm-lock-files:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 2 * * 3')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     concurrency:
       group: refresh-rpm-lock-files-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -16,7 +16,7 @@ env:
   RELEASE_VERSION_N_1: 2023a
 jobs:
   initialize:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   check-vulnerabilities:
     needs: [initialize]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     steps:
@@ -122,7 +122,7 @@ jobs:
   # Creates the Pull Request
   open-pull-request:
     needs: [check-vulnerabilities]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,7 +10,7 @@ name: Security
 jobs:
   build:
     name: Trivy scan (fs)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   scan:
     name: Semgrep scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/software-versions.yaml
+++ b/.github/workflows/software-versions.yaml
@@ -28,7 +28,7 @@ jobs:
   validation-of-sw-versions-in-imagestreams:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/stale-prs.yaml
+++ b/.github/workflows/stale-prs.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
         with:

--- a/.github/workflows/sync-branches-through-pr.yml
+++ b/.github/workflows/sync-branches-through-pr.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -33,7 +33,7 @@ jobs:
   find-images:
     name: Find test images
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
     steps:
@@ -86,7 +86,7 @@ jobs:
   container-tests:
     name: "${{ matrix.name }}"
     needs: find-images
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -146,3 +146,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml
+
+      - name: Capture kernel logs on failure
+        if: ${{ failure() }}
+        uses: ./.github/actions/capture-kernel-logs
+        with:
+          log-prefix: ${{ matrix.name }}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -99,8 +99,25 @@ jobs:
       - name: Install deps
         run: uv sync --locked
 
+      # Workaround: ubuntu-26.04 AppArmor stub profile for podman blocks SIGTERM to pasta
+      # causing "rootless netns: kill network process: permission denied" on container stop.
+      # The base AppArmor abstraction only allows "signal (receive) peer=unconfined", but
+      # the podman stub profile gives podman a named label instead of "unconfined".
+      # Must be removed before any podman command runs (podman re-exec fails if profile
+      # is removed after the process already started under it).
+      # Fixed upstream: apparmor 4.1.0~beta5-4 removes the stub entirely.
+      # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1100135
+      - name: Remove AppArmor podman stub profile
+        run: |
+          set -Eeuxo pipefail
+          if [[ -f /etc/apparmor.d/podman ]]; then
+            sudo apparmor_parser -R /etc/apparmor.d/podman
+            sudo rm -f /etc/apparmor.d/podman
+          fi
+
       - name: Start Podman socket
         run: |
+          set -Eeuxo pipefail
           podman --version
           systemctl --user enable --now podman.socket
           echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> "$GITHUB_ENV"

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -99,20 +99,18 @@ jobs:
       - name: Install deps
         run: uv sync --locked
 
-      # Workaround: ubuntu-26.04 AppArmor stub profile for podman blocks SIGTERM to pasta
-      # causing "rootless netns: kill network process: permission denied" on container stop.
-      # The base AppArmor abstraction only allows "signal (receive) peer=unconfined", but
-      # the podman stub profile gives podman a named label instead of "unconfined".
-      # Must be removed before any podman command runs (podman re-exec fails if profile
-      # is removed after the process already started under it).
-      # Fixed upstream: apparmor 4.1.0~beta5-4 removes the stub entirely.
+      # Workaround: ubuntu-26.04 AppArmor stub profile for podman gives it a named label
+      # ("podman") instead of "unconfined". The pasta profile only allows signals from
+      # "unconfined" (via abstractions/base), so podman can't SIGTERM pasta on container
+      # stop → "rootless netns: kill network process: permission denied".
+      # Fix: allow pasta to receive signals from the podman profile.
       # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1100135
-      - name: Remove AppArmor podman stub profile
+      - name: Fix AppArmor pasta/podman signal conflict
         run: |
           set -Eeuxo pipefail
-          if [[ -f /etc/apparmor.d/podman ]]; then
-            sudo apparmor_parser -R /etc/apparmor.d/podman
-            sudo rm -f /etc/apparmor.d/podman
+          if [[ -f /etc/apparmor.d/abstractions/pasta ]] && ! grep -q 'peer=podman' /etc/apparmor.d/abstractions/pasta; then
+            echo '  signal (receive) peer=podman,' | sudo tee -a /etc/apparmor.d/abstractions/pasta
+            sudo apparmor_parser -r /etc/apparmor.d/usr.bin.pasta
           fi
 
       - name: Start Podman socket

--- a/.github/workflows/test-install-podman.yaml
+++ b/.github/workflows/test-install-podman.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   test-install:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/test-playwright-action.yaml
+++ b/.github/workflows/test-playwright-action.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint:
     name: Lint & Typecheck
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   test-playwright:
     name: Test Playwright Browser Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/test-provision-k8s.yaml
+++ b/.github/workflows/test-provision-k8s.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test-provisioning:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/test-setup-uv.yaml
+++ b/.github/workflows/test-setup-uv.yaml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   test-setup-uv:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/test-trivy-scan-action.yaml
+++ b/.github/workflows/test-trivy-scan-action.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test-scan-type-image:
     name: Test Image Scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       # random image from our past, don't update it all the time
       TEST_IMAGE: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9:2025b-v1.40
@@ -86,7 +86,7 @@ jobs:
 
   test-scan-type-fs:
     name: Test FS scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -14,7 +14,7 @@ name: Update commit-latest.env on params-latest.env change
 
 jobs:
   sync-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     concurrency:
       group: update-commit-latest-env-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
         required: true
 jobs:
   update-tags:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -28,7 +28,7 @@ jobs:
       (github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io')
       && (github.event_name != 'pull_request'
           || github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/tweak-gha.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/tweak-gha.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 # tweak-gha.sh — Reduce VS Code build parallelism for GitHub Actions runners.
 #
-# GitHub Actions runners (ubuntu-24.04) have only 16GB RAM. The VS Code build
+# GitHub Actions runners (ubuntu-26.04) have only 16GB RAM. The VS Code build
 # spawns multiple worker processes that each load the full TypeScript project
 # via ts.createLanguageService (~2-3GB per worker). With upstream defaults
 # (4 mangler workers + cpus/2 transpiler workers + 16GB Node heap), total

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -75,7 +75,7 @@ class TestWorkbenchImage:
             container.with_network(network)
             try:
                 client = testcontainers.core.docker_client.DockerClient()
-                rootless: bool = client.client.info()["Rootless"]
+                rootless: bool = client.client.info().get("Rootless", False)
                 # with rootful podman, --publish does not expose IPv6-only ports
                 # see https://github.com/containers/podman/issues/14491 and friends
                 container.start(wait_for_readiness=rootless)

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -75,6 +75,7 @@ class TestWorkbenchImage:
             container.with_network(network)
             try:
                 client = testcontainers.core.docker_client.DockerClient()
+                # Rootless is a podman-only flag; .get() defaults for Docker API compat
                 rootless: bool = client.client.info().get("Rootless", False)
                 # with rootful podman, --publish does not expose IPv6-only ports
                 # see https://github.com/containers/podman/issues/14491 and friends


### PR DESCRIPTION
## Summary

Migrates all GitHub Actions runners from `ubuntu-24.04` to `ubuntu-26.04` LTS, including both pinned `ubuntu-24.04` and `ubuntu-latest` references.

Closes #3872

## What changed

- 39 files updated: `ubuntu-24.04` → `ubuntu-26.04`, `ubuntu-24.04-arm` → `ubuntu-26.04-arm`, `ubuntu-latest` → `ubuntu-26.04`
- `PLATFORM_RUNNERS` default in `build-notebooks-TEMPLATE.yaml` switched to `ubuntu-26.04`
- Documentation (`ACTIONS.md`) updated

## What Ubuntu 26.04 brings

| Component | 24.04 | 26.04 |
|---|---|---|
| Kernel | 6.8 | **7.0** |
| Python | 3.12 | **3.14** (already our target) |
| Node.js | 20 | **22** (LTS) |
| apt | 2.8 | **3.1** |
| cgroup | v2 default | **v2 only** |

## Prerequisites (already merged)

- #3873 — apt `.sources` file cleanup for apt 3.1 compatibility
- #3875 — Linuxbrew cache key with `ImageOS` via `GITHUB_OUTPUT`

## Test plan

Key jobs to verify on ubuntu-26.04:
- [ ] `test-provision-k8s` — k8s cluster provisioning, kernel modules, apt repos
- [ ] `test-install-podman` — Linuxbrew Podman on cgroup v2-only, cache key shows `ubuntu26`
- [ ] `test-containers` — container build tests
- [ ] `code-quality` — Python linting, Go tests, pytest
- [ ] `test-playwright-action` — browser tests (containerized)
- [ ] `build-browser-tests` — pnpm build on Node 22
- [ ] `Test Template with Minimal Notebook` — full build + LVM overlay + e2e test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD and automation workflows to use Ubuntu 26.04 runner labels across build, test, security, release, and maintenance jobs.
  * Updated the GitHub Actions runner documentation to reflect the new Ubuntu 26.04 options.
  * Adjusted Podman systemd setup to unmask units without immediately starting them.
* **Bug Fixes**
  * Improved container test reliability on Ubuntu 26.04 by preparing Podman/AppArmor and capturing kernel logs when tests fail.
  * Fixed the IPv6-only workbench test to handle missing rootless status safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->