### PR TITLE
RHAIENG-5829: fix scripts/lockfile-generators, enable RHEL 9.6 EUS repos for RHDS lockfile regen

### DIFF
--- a/scripts/lockfile-generators/helpers/rpm-lockfile-generate.sh
+++ b/scripts/lockfile-generators/helpers/rpm-lockfile-generate.sh
@@ -63,11 +63,22 @@ pushd "/workspace/$PREFETCH_INPUT_DIR" >/dev/null
         overall_status=$(subscription-manager status 2>/dev/null | grep "Overall Status" | awk -F': ' '{print $2}' || true)
         echo "System Registration Status: $overall_status"
 
-        # CRB is disabled by default in RHEL subscriptions but needed for
-        # -devel packages (openblas-devel, pybind11-devel, ninja-build, etc.)
-        echo "Enabling codeready-builder (CRB) repo..."
+        # RHOAI/AIPCC runtime images use RHEL 9.6 EUS repos (baseos/appstream/CRB).
+        # Without EUS enabled, rpm-lockfile-prototype resolves system RPMs like python3
+        # from the older non-EUS dist channel (el9_6.2) instead of EUS (el9_6.6).
         basearch=$(rpm --eval '%{_arch}')
-        subscription-manager repos --enable="codeready-builder-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
+        echo "Enabling RHEL 9.6 EUS repos (match AIPCC/RHOAI base images)..."
+        for repo in \
+            "rhel-9-for-${basearch}-baseos-eus-rpms" \
+            "rhel-9-for-${basearch}-appstream-eus-rpms" \
+            "codeready-builder-for-rhel-9-${basearch}-eus-rpms"; do
+            subscription-manager repos --enable="$repo" 2>/dev/null || true
+        done
+
+        # Layered-product repos for openshift-clients and texlive-tcolorbox (also set in
+        # Dockerfile.rpm-lockfile at image build time; re-enable here for cached images).
+        dnf config-manager --set-enabled "rhocp-4.16-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
+        dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
 
         # subscription-manager generates redhat.repo with literal x86_64
         # in URLs (e.g. .../9.6/x86_64/appstream/os). For multi-arch


### PR DESCRIPTION
## Summary
- Enable RHEL 9.6 EUS baseos, appstream, and CRB repos during RHDS `rpms.lock.yaml` generation
- Re-enable rhocp/rhelai layered repos at generation time (for cached lockfile images)
- Prevents automated regen from pinning system RPMs (e.g. `python3`) to non-EUS `el9_6.2` instead of AIPCC-aligned `el9_6.6`

## Test plan
- [x] GHA RHDS lockfile regen on this branch: [run #27997982828](https://github.com/opendatahub-io/notebooks/actions/runs/27997982828)
- [x] Verified `python3` / `python3-devel` pin to `3.9.21-2.el9_6.6` with `content/eus/` URLs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved repository configuration for Red Hat Enterprise Linux 9.6 EUS systems, enabling better access to essential packages and layered products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->