### PR TITLE
RHAIENG-5767, RHAIENG-5644: clarify allowed messages in workbench image tests for JupyterLab startup and auth warnings

### DIFF
--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -273,11 +273,11 @@ def grab_and_check_logs(
     # Here is a list of allowed messages that match some block keyword from the list above, but we allow them
     # for some reason.
     allowed_messages = [
-        # We don't touch this - it should be fixed in the future by the package upgrade.
+        # RHAIENG-5767: jupyter-events package emits this on every JupyterLab start
         "JupyterEventsVersionWarning: The `version` property of an event schema must be a string. It has been type coerced, but in a future version of this library, it will fail to validate.",
         # This is a message from our reverse proxy nginx caused by the fact that we attempt to connect to the code-server before it's actually running (container.start(wait_for_readiness=True)).
         "connect() failed (111: Connection refused) while connecting to upstream, client",
-        # We use oauth-proxy to give us authentication, and we use OpenShift route to get HTTPS
+        # RHAIENG-5644: oauth-proxy / kube-rbac-proxy provides external auth; in-container Jupyter auth is disabled
         "WARNING: The Jupyter server is listening on all IP addresses and not using encryption. This is not recommended.",
     ]
     if extra_allowed:


### PR DESCRIPTION
## Description

Add comments explaining some of the allowed workbench startup log messages.

This comes from the work on upgrade tests

* https://github.com/opendatahub-io/opendatahub-tests/pull/1826/changes#diff-d967f8e05a984e913fc03246cc111e8392c0027ef250ca160cbb9e732d836f2eR54

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated clarifying comments for allowed log messages in workbench image tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->