### PR TITLE
RHAIENG-5297: ci(.github): gate ODH MintMaker to main branch only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,8 @@
 //   - opendatahub-io/notebooks @ main
 //   - red-hat-data-services/notebooks @ rhoai-2.25, rhoai-3.3, rhoai-3.4
 // MintMaker OFF:
+//   - opendatahub-io/notebooks @ stable, candidate, legacy poc branches (release-data may
+//     still list them until an ops MR removes them — packageRules gate PR creation)
 //   - red-hat-data-services/notebooks @ main (autosync from ODH main), EA, EOL branches
 //
 // This file is ignored if `.github/renovate.json` is also present —
@@ -142,6 +144,17 @@
       "description": "Prefix PR titles with branch name for non-main branches",
       "matchBaseBranches": ["!/^main$/"],
       "commitMessagePrefix": "[{{{baseBranch}}}]",
+    },
+    {
+      description: "ODH upstream: disable MintMaker on all branches by default",
+      matchRepositories: ["opendatahub-io/notebooks"],
+      enabled: false,
+    },
+    {
+      description: "ODH upstream: enable MintMaker on main only",
+      matchRepositories: ["opendatahub-io/notebooks"],
+      matchBaseBranches: ["main"],
+      enabled: true,
     },
     {
       description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL, rhoai-2.24 — release-data may still list 2.24 until ops MR)",

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -16,8 +16,11 @@ ROOT = SCRIPTS_CI.parent.parent
 DEFAULT_CONFIG = ROOT / ".github" / "renovate.json5"
 
 REQUIRED_ENABLED_MANAGERS = frozenset({"tekton", "dockerfile", "custom.regex", "github-actions"})
+ODH_REPO = "opendatahub-io/notebooks"
+ODH_ENABLED_BRANCHES = frozenset({"main"})
 RHDS_REPO = "red-hat-data-services/notebooks"
 RHDS_ENABLED_BRANCHES = frozenset({"rhoai-2.25", "rhoai-3.3", "rhoai-3.4"})
+ODH_DISABLED_BRANCHES = frozenset({"stable", "candidate", "konflux-poc-1"})
 PREFIX_RULE_DESCRIPTION = "Prefix PR titles with branch name for non-main branches"
 EXPECTED_PREFIX_MATCH_BASE = ["!/^main$/"]
 EXPECTED_COMMIT_MESSAGE_PREFIX = "[{{{baseBranch}}}]"
@@ -54,6 +57,29 @@ def rule_applies(rule: dict[str, Any], base_branch: str) -> bool:
     if "enabled" in rule and rule["enabled"] is False:
         return False
     return match_base_branches(rule, base_branch)
+
+
+def _rule_matches_repository(rule: dict[str, Any], repository: str) -> bool:
+    repos = rule.get("matchRepositories")
+    if not repos:
+        return True
+    if not isinstance(repos, list):
+        return True
+    return repository in repos
+
+
+def renovate_enabled_for(config: dict[str, Any], repository: str, base_branch: str) -> bool:
+    enabled = True
+    for rule in config.get("packageRules", []):
+        if not isinstance(rule, dict):
+            continue
+        if not _rule_matches_repository(rule, repository):
+            continue
+        if not match_base_branches(rule, base_branch):
+            continue
+        if "enabled" in rule:
+            enabled = bool(rule["enabled"])
+    return enabled
 
 
 def commit_message_prefix_for_branch(config: dict[str, Any], base_branch: str) -> str | None:
@@ -120,6 +146,38 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
                 f"{EXPECTED_COMMIT_MESSAGE_PREFIX!r}, got {prefix_rule.get('commitMessagePrefix')!r}"
             )
 
+    odh_disable = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("matchRepositories") == [ODH_REPO]
+            and rule.get("enabled") is False
+            and "matchBaseBranches" not in rule
+        ),
+        None,
+    )
+    if odh_disable is None:
+        errors.append(f"missing ODH MintMaker disable rule for {ODH_REPO!r}")
+
+    odh_enable = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("matchRepositories") == [ODH_REPO]
+            and rule.get("enabled") is True
+        ),
+        None,
+    )
+    if odh_enable is None:
+        errors.append(f"missing ODH MintMaker enable rule for {ODH_REPO!r}")
+    elif set(odh_enable.get("matchBaseBranches", [])) != ODH_ENABLED_BRANCHES:
+        errors.append(
+            "ODH enable rule matchBaseBranches must be "
+            f"{sorted(ODH_ENABLED_BRANCHES)!r}, got {odh_enable.get('matchBaseBranches')!r}"
+        )
+
     rhds_disable = next(
         (
             rule
@@ -165,6 +223,12 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
         errors.append("missing github-actions group packageRule")
     elif gh_actions_pin.get("pinDigests") is not True:
         errors.append("github-actions group rule must set pinDigests: true")
+
+    if not renovate_enabled_for(config, ODH_REPO, "main"):
+        errors.append(f"MintMaker must stay enabled for {ODH_REPO!r} @ main")
+    for branch in ODH_DISABLED_BRANCHES:
+        if renovate_enabled_for(config, ODH_REPO, branch):
+            errors.append(f"MintMaker must be disabled for {ODH_REPO!r} @ {branch!r}")
 
     if commit_message_prefix_for_branch(config, "main") is not None:
         errors.append("commitMessagePrefix must not apply to base branch 'main'")

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -37,6 +37,25 @@ def test_commit_message_prefix_for_branch_merged_rules() -> None:
     )
 
 
+def test_renovate_enabled_for_odh_main_only() -> None:
+    config = {
+        "packageRules": [
+            {"matchRepositories": [validator.ODH_REPO], "enabled": False},
+            {
+                "matchRepositories": [validator.ODH_REPO],
+                "matchBaseBranches": sorted(validator.ODH_ENABLED_BRANCHES),
+                "enabled": True,
+            },
+        ]
+    }
+    assert validator.renovate_enabled_for(config, validator.ODH_REPO, "main") is True, (
+        "Expected MintMaker enabled on ODH main"
+    )
+    assert validator.renovate_enabled_for(config, validator.ODH_REPO, "stable") is False, (
+        "Expected MintMaker disabled on ODH stable"
+    )
+
+
 def test_validate_config_reports_missing_prefix_rule() -> None:
     config = {"enabledManagers": list(validator.REQUIRED_ENABLED_MANAGERS), "packageRules": []}
     errors = validator.validate_config(config)
@@ -56,6 +75,12 @@ def test_validate_config_rejects_shadow_renovate_json(tmp_path) -> None:
                 "description": validator.PREFIX_RULE_DESCRIPTION,
                 "matchBaseBranches": validator.EXPECTED_PREFIX_MATCH_BASE,
                 "commitMessagePrefix": validator.EXPECTED_COMMIT_MESSAGE_PREFIX,
+            },
+            {"matchRepositories": [validator.ODH_REPO], "enabled": False},
+            {
+                "matchRepositories": [validator.ODH_REPO],
+                "matchBaseBranches": sorted(validator.ODH_ENABLED_BRANCHES),
+                "enabled": True,
             },
             {"matchRepositories": [validator.RHDS_REPO], "enabled": False},
             {


### PR DESCRIPTION
## Summary

- Add ODH-specific `packageRules` to `.github/renovate.json5` so MintMaker/Renovate only opens updates for `opendatahub-io/notebooks` on `main` (mirrors the existing RHDS disable/enable pattern).
- Extend `scripts/ci/validate_renovate_config.py` to enforce the ODH rules and assert `stable`, `candidate`, and `konflux-poc-1` stay disabled.

This stops unwanted Konflux reference PRs such as [#3880](https://github.com/opendatahub-io/notebooks/pull/3880) (`stable`) and [#3881](https://github.com/opendatahub-io/notebooks/pull/3881) (`candidate`).

## Notes

- Does **not** set top-level `baseBranches` / `baseBranchPatterns` (would break RHDS release-branch MintMaker).
- MintMaker release-data may still schedule runs for stale branches until an ops MR removes them; repo config prevents PR creation.

## Test plan

- [x] `uv run python scripts/ci/validate_renovate_config.py`
- [x] `uv run pytest tests/unit/scripts/ci/test_validate_renovate_config.py -q`
- [ ] Merge and close stale `[stable]` / `[candidate]` MintMaker PRs (#3880, #3881)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to properly manage MintMaker enablement for the opendatahub-io/notebooks repository, enabling it only for the main branch while disabling it for other branches.
  * Enhanced configuration validation with improved checks to ensure Renovate is correctly configured across repositories and branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->