### PR TITLE
RHAIENG-5297: ci(.github): gate ODH MintMaker to main branch only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,8 @@
 //   - opendatahub-io/notebooks @ main
 //   - red-hat-data-services/notebooks @ rhoai-2.25, rhoai-3.3, rhoai-3.4
 // MintMaker OFF:
+//   - opendatahub-io/notebooks @ stable, candidate, legacy poc branches (release-data may
+//     still list them until an ops MR removes them — packageRules gate PR creation)
 //   - red-hat-data-services/notebooks @ main (autosync from ODH main), EA, EOL branches
 //
 // This file is ignored if `.github/renovate.json` is also present —
@@ -142,6 +144,17 @@
       "description": "Prefix PR titles with branch name for non-main branches",
       "matchBaseBranches": ["!/^main$/"],
       "commitMessagePrefix": "[{{{baseBranch}}}]",
+    },
+    {
+      description: "ODH upstream: disable MintMaker on all branches by default",
+      matchRepositories: ["opendatahub-io/notebooks"],
+      enabled: false,
+    },
+    {
+      description: "ODH upstream: enable MintMaker on main only",
+      matchRepositories: ["opendatahub-io/notebooks"],
+      matchBaseBranches: ["main"],
+      enabled: true,
     },
     {
       description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL, rhoai-2.24 — release-data may still list 2.24 until ops MR)",

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -16,8 +16,11 @@ ROOT = SCRIPTS_CI.parent.parent
 DEFAULT_CONFIG = ROOT / ".github" / "renovate.json5"
 
 REQUIRED_ENABLED_MANAGERS = frozenset({"tekton", "dockerfile", "custom.regex", "github-actions"})
+ODH_REPO = "opendatahub-io/notebooks"
+ODH_ENABLED_BRANCHES = frozenset({"main"})
 RHDS_REPO = "red-hat-data-services/notebooks"
 RHDS_ENABLED_BRANCHES = frozenset({"rhoai-2.25", "rhoai-3.3", "rhoai-3.4"})
+ODH_DISABLED_BRANCHES = frozenset({"stable", "candidate", "konflux-poc-1"})
 PREFIX_RULE_DESCRIPTION = "Prefix PR titles with branch name for non-main branches"
 EXPECTED_PREFIX_MATCH_BASE = ["!/^main$/"]
 EXPECTED_COMMIT_MESSAGE_PREFIX = "[{{{baseBranch}}}]"
@@ -54,6 +57,29 @@ def rule_applies(rule: dict[str, Any], base_branch: str) -> bool:
     if "enabled" in rule and rule["enabled"] is False:
         return False
     return match_base_branches(rule, base_branch)
+
+
+def _rule_matches_repository(rule: dict[str, Any], repository: str) -> bool:
+    repos = rule.get("matchRepositories")
+    if not repos:
+        return True
+    if not isinstance(repos, list):
+        return True
+    return repository in repos
+
+
+def renovate_enabled_for(config: dict[str, Any], repository: str, base_branch: str) -> bool:
+    enabled = True
+    for rule in config.get("packageRules", []):
+        if not isinstance(rule, dict):
+            continue
+        if not _rule_matches_repository(rule, repository):
+            continue
+        if not match_base_branches(rule, base_branch):
+            continue
+        if "enabled" in rule:
+            enabled = bool(rule["enabled"])
+    return enabled
 
 
 def commit_message_prefix_for_branch(config: dict[str, Any], base_branch: str) -> str | None:
@@ -120,6 +146,38 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
                 f"{EXPECTED_COMMIT_MESSAGE_PREFIX!r}, got {prefix_rule.get('commitMessagePrefix')!r}"
             )
 
+    odh_disable = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("matchRepositories") == [ODH_REPO]
+            and rule.get("enabled") is False
+            and "matchBaseBranches" not in rule
+        ),
+        None,
+    )
+    if odh_disable is None:
+        errors.append(f"missing ODH MintMaker disable rule for {ODH_REPO!r}")
+
+    odh_enable = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("matchRepositories") == [ODH_REPO]
+            and rule.get("enabled") is True
+        ),
+        None,
+    )
+    if odh_enable is None:
+        errors.append(f"missing ODH MintMaker enable rule for {ODH_REPO!r}")
+    elif set(odh_enable.get("matchBaseBranches", [])) != ODH_ENABLED_BRANCHES:
+        errors.append(
+            "ODH enable rule matchBaseBranches must be "
+            f"{sorted(ODH_ENABLED_BRANCHES)!r}, got {odh_enable.get('matchBaseBranches')!r}"
+        )
+
     rhds_disable = next(
         (
             rule
@@ -165,6 +223,12 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
         errors.append("missing github-actions group packageRule")
     elif gh_actions_pin.get("pinDigests") is not True:
         errors.append("github-actions group rule must set pinDigests: true")
+
+    if not renovate_enabled_for(config, ODH_REPO, "main"):
+        errors.append(f"MintMaker must stay enabled for {ODH_REPO!r} @ main")
+    for branch in ODH_DISABLED_BRANCHES:
+        if renovate_enabled_for(config, ODH_REPO, branch):
+            errors.append(f"MintMaker must be disabled for {ODH_REPO!r} @ {branch!r}")
 
     if commit_message_prefix_for_branch(config, "main") is not None:
         errors.append("commitMessagePrefix must not apply to base branch 'main'")

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,7 +29,6 @@ class MintMakerRepoPolicy:
     label: str
     repository: str
     enabled_branches: frozenset[str]
-    disabled_branches: frozenset[str]
 
 
 MINTMAKER_POLICIES = (
@@ -38,13 +36,11 @@ MINTMAKER_POLICIES = (
         label="ODH",
         repository=ODH_REPO,
         enabled_branches=frozenset({"main"}),
-        disabled_branches=frozenset({"stable", "candidate"}),
     ),
     MintMakerRepoPolicy(
         label="RHDS",
         repository=RHDS_REPO,
         enabled_branches=RHDS_ENABLED_BRANCHES,
-        disabled_branches=frozenset({"main"}),
     ),
 )
 
@@ -57,31 +53,6 @@ def load_config(path: Path) -> dict[str, Any]:
         msg = f"{path}: expected top-level object, got {type(data).__name__}"
         raise ValueError(msg)
     return data
-
-
-def _pattern_matches_branch(pattern: str, base_branch: str) -> bool:
-    if pattern.startswith("!/") and pattern.endswith("/"):
-        inner = pattern[2:-1]
-        return re.fullmatch(inner, base_branch) is None
-    if pattern.startswith("/") and pattern.endswith("/"):
-        inner = pattern[1:-1]
-        return re.fullmatch(inner, base_branch) is not None
-    return pattern == base_branch
-
-
-def match_base_branches(rule: dict[str, Any], base_branch: str) -> bool:
-    patterns = rule.get("matchBaseBranches")
-    if not patterns:
-        return True
-    if not isinstance(patterns, list):
-        return True
-    return any(_pattern_matches_branch(str(item), base_branch) for item in patterns)
-
-
-def rule_applies(rule: dict[str, Any], base_branch: str) -> bool:
-    if "enabled" in rule and rule["enabled"] is False:
-        return False
-    return match_base_branches(rule, base_branch)
 
 
 def find_repo_rule(
@@ -107,24 +78,7 @@ def find_repo_rule(
     return None
 
 
-def renovate_enabled_for(config: dict[str, Any], repository: str, base_branch: str) -> bool:
-    enabled = True
-    for rule in config.get("packageRules", []):
-        if not isinstance(rule, dict):
-            continue
-        repos = rule.get("matchRepositories")
-        if not isinstance(repos, list) or repository not in repos:
-            continue
-        if "enabled" not in rule:
-            continue
-        if not match_base_branches(rule, base_branch):
-            continue
-        enabled = bool(rule["enabled"])
-    return enabled
-
-
 def validate_mintmaker_policy(
-    config: dict[str, Any],
     package_rules: list[Any],
     policy: MintMakerRepoPolicy,
 ) -> list[str]:
@@ -153,30 +107,7 @@ def validate_mintmaker_policy(
             f"{sorted(policy.enabled_branches)!r}, got {enable_rule.get('matchBaseBranches')!r}"
         )
 
-    for branch in sorted(policy.enabled_branches):
-        if not renovate_enabled_for(config, policy.repository, branch):
-            errors.append(f"MintMaker must stay enabled for {policy.repository!r} @ {branch}")
-
-    for branch in sorted(policy.disabled_branches):
-        if renovate_enabled_for(config, policy.repository, branch):
-            errors.append(f"MintMaker must be disabled for {policy.repository!r} @ {branch!r}")
-
     return errors
-
-
-def commit_message_prefix_for_branch(config: dict[str, Any], base_branch: str) -> str | None:
-    prefix: str | None = None
-    for rule in config.get("packageRules", []):
-        if not isinstance(rule, dict):
-            continue
-        if not rule_applies(rule, base_branch):
-            continue
-        if "commitMessagePrefix" in rule:
-            raw = rule["commitMessagePrefix"]
-            if not isinstance(raw, str):
-                continue
-            prefix = raw.replace("{{{baseBranch}}}", base_branch)
-    return prefix
 
 
 def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".github") -> list[str]:
@@ -229,7 +160,7 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
             )
 
     for policy in MINTMAKER_POLICIES:
-        errors.extend(validate_mintmaker_policy(config, package_rules, policy))
+        errors.extend(validate_mintmaker_policy(package_rules, policy))
 
     gh_actions_pin = next(
         (
@@ -245,16 +176,6 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
         errors.append("missing github-actions group packageRule")
     elif gh_actions_pin.get("pinDigests") is not True:
         errors.append("github-actions group rule must set pinDigests: true")
-
-    if commit_message_prefix_for_branch(config, "main") is not None:
-        errors.append("commitMessagePrefix must not apply to base branch 'main'")
-    for branch in sorted(RHDS_ENABLED_BRANCHES):
-        expected = f"[{branch}]"
-        actual = commit_message_prefix_for_branch(config, branch)
-        if actual != expected:
-            errors.append(
-                f"commitMessagePrefix for {branch!r} must be {expected!r}, got {actual!r}"
-            )
 
     return errors
 

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -38,7 +38,7 @@ MINTMAKER_POLICIES = (
         label="ODH",
         repository=ODH_REPO,
         enabled_branches=frozenset({"main"}),
-        disabled_branches=frozenset({"stable", "candidate", "konflux-poc-1"}),
+        disabled_branches=frozenset({"stable", "candidate"}),
     ),
     MintMakerRepoPolicy(
         label="RHDS",

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -17,13 +18,37 @@ DEFAULT_CONFIG = ROOT / ".github" / "renovate.json5"
 
 REQUIRED_ENABLED_MANAGERS = frozenset({"tekton", "dockerfile", "custom.regex", "github-actions"})
 ODH_REPO = "opendatahub-io/notebooks"
-ODH_ENABLED_BRANCHES = frozenset({"main"})
 RHDS_REPO = "red-hat-data-services/notebooks"
 RHDS_ENABLED_BRANCHES = frozenset({"rhoai-2.25", "rhoai-3.3", "rhoai-3.4"})
-ODH_DISABLED_BRANCHES = frozenset({"stable", "candidate", "konflux-poc-1"})
 PREFIX_RULE_DESCRIPTION = "Prefix PR titles with branch name for non-main branches"
 EXPECTED_PREFIX_MATCH_BASE = ["!/^main$/"]
 EXPECTED_COMMIT_MESSAGE_PREFIX = "[{{{baseBranch}}}]"
+
+
+@dataclass(frozen=True)
+class MintMakerRepoPolicy:
+    label: str
+    repository: str
+    enabled_branches: frozenset[str]
+    disabled_branches: frozenset[str]
+
+
+MINTMAKER_POLICIES = (
+    MintMakerRepoPolicy(
+        label="ODH",
+        repository=ODH_REPO,
+        enabled_branches=frozenset({"main"}),
+        disabled_branches=frozenset({"stable", "candidate", "konflux-poc-1"}),
+    ),
+    MintMakerRepoPolicy(
+        label="RHDS",
+        repository=RHDS_REPO,
+        enabled_branches=RHDS_ENABLED_BRANCHES,
+        disabled_branches=frozenset({"main"}),
+    ),
+)
+
+ODH_ENABLED_BRANCHES = MINTMAKER_POLICIES[0].enabled_branches
 
 
 def load_config(path: Path) -> dict[str, Any]:
@@ -59,13 +84,27 @@ def rule_applies(rule: dict[str, Any], base_branch: str) -> bool:
     return match_base_branches(rule, base_branch)
 
 
-def _rule_matches_repository(rule: dict[str, Any], repository: str) -> bool:
-    repos = rule.get("matchRepositories")
-    if not repos:
-        return True
-    if not isinstance(repos, list):
-        return True
-    return repository in repos
+def find_repo_rule(
+    package_rules: list[Any],
+    repository: str,
+    *,
+    enabled: bool,
+    require_match_base_branches: bool | None = None,
+) -> dict[str, Any] | None:
+    for rule in package_rules:
+        if not isinstance(rule, dict):
+            continue
+        if rule.get("matchRepositories") != [repository]:
+            continue
+        if rule.get("enabled") is not enabled:
+            continue
+        has_match_base_branches = "matchBaseBranches" in rule
+        if require_match_base_branches is True and not has_match_base_branches:
+            continue
+        if require_match_base_branches is False and has_match_base_branches:
+            continue
+        return rule
+    return None
 
 
 def renovate_enabled_for(config: dict[str, Any], repository: str, base_branch: str) -> bool:
@@ -73,13 +112,56 @@ def renovate_enabled_for(config: dict[str, Any], repository: str, base_branch: s
     for rule in config.get("packageRules", []):
         if not isinstance(rule, dict):
             continue
-        if not _rule_matches_repository(rule, repository):
+        repos = rule.get("matchRepositories")
+        if not isinstance(repos, list) or repository not in repos:
+            continue
+        if "enabled" not in rule:
             continue
         if not match_base_branches(rule, base_branch):
             continue
-        if "enabled" in rule:
-            enabled = bool(rule["enabled"])
+        enabled = bool(rule["enabled"])
     return enabled
+
+
+def validate_mintmaker_policy(
+    config: dict[str, Any],
+    package_rules: list[Any],
+    policy: MintMakerRepoPolicy,
+) -> list[str]:
+    errors: list[str] = []
+
+    disable_rule = find_repo_rule(
+        package_rules,
+        policy.repository,
+        enabled=False,
+        require_match_base_branches=False,
+    )
+    if disable_rule is None:
+        errors.append(f"missing {policy.label} MintMaker disable rule for {policy.repository!r}")
+
+    enable_rule = find_repo_rule(
+        package_rules,
+        policy.repository,
+        enabled=True,
+        require_match_base_branches=True,
+    )
+    if enable_rule is None:
+        errors.append(f"missing {policy.label} MintMaker enable rule for {policy.repository!r}")
+    elif set(enable_rule.get("matchBaseBranches", [])) != policy.enabled_branches:
+        errors.append(
+            f"{policy.label} enable rule matchBaseBranches must be "
+            f"{sorted(policy.enabled_branches)!r}, got {enable_rule.get('matchBaseBranches')!r}"
+        )
+
+    for branch in sorted(policy.enabled_branches):
+        if not renovate_enabled_for(config, policy.repository, branch):
+            errors.append(f"MintMaker must stay enabled for {policy.repository!r} @ {branch}")
+
+    for branch in sorted(policy.disabled_branches):
+        if renovate_enabled_for(config, policy.repository, branch):
+            errors.append(f"MintMaker must be disabled for {policy.repository!r} @ {branch!r}")
+
+    return errors
 
 
 def commit_message_prefix_for_branch(config: dict[str, Any], base_branch: str) -> str | None:
@@ -146,68 +228,8 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
                 f"{EXPECTED_COMMIT_MESSAGE_PREFIX!r}, got {prefix_rule.get('commitMessagePrefix')!r}"
             )
 
-    odh_disable = next(
-        (
-            rule
-            for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("matchRepositories") == [ODH_REPO]
-            and rule.get("enabled") is False
-            and "matchBaseBranches" not in rule
-        ),
-        None,
-    )
-    if odh_disable is None:
-        errors.append(f"missing ODH MintMaker disable rule for {ODH_REPO!r}")
-
-    odh_enable = next(
-        (
-            rule
-            for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("matchRepositories") == [ODH_REPO]
-            and rule.get("enabled") is True
-        ),
-        None,
-    )
-    if odh_enable is None:
-        errors.append(f"missing ODH MintMaker enable rule for {ODH_REPO!r}")
-    elif set(odh_enable.get("matchBaseBranches", [])) != ODH_ENABLED_BRANCHES:
-        errors.append(
-            "ODH enable rule matchBaseBranches must be "
-            f"{sorted(ODH_ENABLED_BRANCHES)!r}, got {odh_enable.get('matchBaseBranches')!r}"
-        )
-
-    rhds_disable = next(
-        (
-            rule
-            for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("matchRepositories") == [RHDS_REPO]
-            and rule.get("enabled") is False
-        ),
-        None,
-    )
-    if rhds_disable is None:
-        errors.append(f"missing RHDS MintMaker disable rule for {RHDS_REPO!r}")
-
-    rhds_enable = next(
-        (
-            rule
-            for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("matchRepositories") == [RHDS_REPO]
-            and rule.get("enabled") is True
-        ),
-        None,
-    )
-    if rhds_enable is None:
-        errors.append(f"missing RHDS MintMaker enable rule for {RHDS_REPO!r}")
-    elif set(rhds_enable.get("matchBaseBranches", [])) != RHDS_ENABLED_BRANCHES:
-        errors.append(
-            "RHDS enable rule matchBaseBranches must be "
-            f"{sorted(RHDS_ENABLED_BRANCHES)!r}, got {rhds_enable.get('matchBaseBranches')!r}"
-        )
+    for policy in MINTMAKER_POLICIES:
+        errors.extend(validate_mintmaker_policy(config, package_rules, policy))
 
     gh_actions_pin = next(
         (
@@ -224,15 +246,9 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
     elif gh_actions_pin.get("pinDigests") is not True:
         errors.append("github-actions group rule must set pinDigests: true")
 
-    if not renovate_enabled_for(config, ODH_REPO, "main"):
-        errors.append(f"MintMaker must stay enabled for {ODH_REPO!r} @ main")
-    for branch in ODH_DISABLED_BRANCHES:
-        if renovate_enabled_for(config, ODH_REPO, branch):
-            errors.append(f"MintMaker must be disabled for {ODH_REPO!r} @ {branch!r}")
-
     if commit_message_prefix_for_branch(config, "main") is not None:
         errors.append("commitMessagePrefix must not apply to base branch 'main'")
-    for branch in ("rhoai-3.4", "rhoai-2.25"):
+    for branch in sorted(RHDS_ENABLED_BRANCHES):
         expected = f"[{branch}]"
         actual = commit_message_prefix_for_branch(config, branch)
         if actual != expected:

--- a/tests/unit/scripts/ci/renovate_config_testdata.py
+++ b/tests/unit/scripts/ci/renovate_config_testdata.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from scripts.ci.validate_renovate_config import (
     EXPECTED_COMMIT_MESSAGE_PREFIX,
     EXPECTED_PREFIX_MATCH_BASE,
     MINTMAKER_POLICIES,
-    MintMakerRepoPolicy,
     PREFIX_RULE_DESCRIPTION,
     REQUIRED_ENABLED_MANAGERS,
+    MintMakerRepoPolicy,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def prefix_rule() -> dict[str, Any]:
@@ -56,11 +58,7 @@ def with_package_rules_removed(
     config: dict[str, Any],
     predicate: Callable[[dict[str, Any]], bool],
 ) -> dict[str, Any]:
-    package_rules = [
-        rule
-        for rule in config["packageRules"]
-        if not (isinstance(rule, dict) and predicate(rule))
-    ]
+    package_rules = [rule for rule in config["packageRules"] if not (isinstance(rule, dict) and predicate(rule))]
     return {**config, "packageRules": package_rules}
 
 

--- a/tests/unit/scripts/ci/renovate_config_testdata.py
+++ b/tests/unit/scripts/ci/renovate_config_testdata.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from scripts.ci.validate_renovate_config import (
+    EXPECTED_COMMIT_MESSAGE_PREFIX,
+    EXPECTED_PREFIX_MATCH_BASE,
+    MINTMAKER_POLICIES,
+    MintMakerRepoPolicy,
+    PREFIX_RULE_DESCRIPTION,
+    REQUIRED_ENABLED_MANAGERS,
+)
+
+
+def prefix_rule() -> dict[str, Any]:
+    return {
+        "description": PREFIX_RULE_DESCRIPTION,
+        "matchBaseBranches": EXPECTED_PREFIX_MATCH_BASE,
+        "commitMessagePrefix": EXPECTED_COMMIT_MESSAGE_PREFIX,
+    }
+
+
+def mintmaker_gate_rules(policy: MintMakerRepoPolicy) -> list[dict[str, Any]]:
+    return [
+        {"matchRepositories": [policy.repository], "enabled": False},
+        {
+            "matchRepositories": [policy.repository],
+            "matchBaseBranches": sorted(policy.enabled_branches),
+            "enabled": True,
+        },
+    ]
+
+
+def github_actions_group_rule() -> dict[str, Any]:
+    return {
+        "matchManagers": ["github-actions"],
+        "groupName": "github-actions",
+        "pinDigests": True,
+    }
+
+
+def minimal_valid_config(*extra_rules: dict[str, Any]) -> dict[str, Any]:
+    package_rules: list[dict[str, Any]] = [prefix_rule()]
+    for policy in MINTMAKER_POLICIES:
+        package_rules.extend(mintmaker_gate_rules(policy))
+    package_rules.append(github_actions_group_rule())
+    package_rules.extend(extra_rules)
+    return {
+        "enabledManagers": list(REQUIRED_ENABLED_MANAGERS),
+        "packageRules": package_rules,
+    }
+
+
+def with_package_rules_removed(
+    config: dict[str, Any],
+    predicate: Callable[[dict[str, Any]], bool],
+) -> dict[str, Any]:
+    package_rules = [
+        rule
+        for rule in config["packageRules"]
+        if not (isinstance(rule, dict) and predicate(rule))
+    ]
+    return {**config, "packageRules": package_rules}
+
+
+def policy_by_label(label: str) -> MintMakerRepoPolicy:
+    for policy in MINTMAKER_POLICIES:
+        if policy.label == label:
+            return policy
+    msg = f"unknown MintMaker policy label: {label!r}"
+    raise KeyError(msg)
+
+
+def remove_mintmaker_disable(config: dict[str, Any], policy: MintMakerRepoPolicy) -> dict[str, Any]:
+    return with_package_rules_removed(
+        config,
+        lambda rule: rule.get("matchRepositories") == [policy.repository] and rule.get("enabled") is False,
+    )
+
+
+def remove_mintmaker_enable(config: dict[str, Any], policy: MintMakerRepoPolicy) -> dict[str, Any]:
+    return with_package_rules_removed(
+        config,
+        lambda rule: (
+            rule.get("matchRepositories") == [policy.repository]
+            and rule.get("enabled") is True
+            and "matchBaseBranches" in rule
+        ),
+    )
+
+
+def mintmaker_enable_with_branches(
+    config: dict[str, Any],
+    policy: MintMakerRepoPolicy,
+    branches: list[str],
+) -> dict[str, Any]:
+    updated_rules: list[dict[str, Any]] = []
+    for rule in config["packageRules"]:
+        if not isinstance(rule, dict):
+            updated_rules.append(rule)
+            continue
+        if (
+            rule.get("matchRepositories") == [policy.repository]
+            and rule.get("enabled") is True
+            and "matchBaseBranches" in rule
+        ):
+            updated_rules.append({**rule, "matchBaseBranches": branches})
+            continue
+        updated_rules.append(rule)
+    return {**config, "packageRules": updated_rules}

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -1,22 +1,94 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
 from scripts.ci import validate_renovate_config as validator
+from tests.unit.scripts.ci import renovate_config_testdata as testdata
+
+POLICY_ENABLED_CASES = [
+    pytest.param(policy, branch, True, id=f"{policy.label}-{branch}-enabled")
+    for policy in validator.MINTMAKER_POLICIES
+    for branch in sorted(policy.enabled_branches)
+]
+
+POLICY_DISABLED_CASES = [
+    pytest.param(policy, branch, False, id=f"{policy.label}-{branch}-disabled")
+    for policy in validator.MINTMAKER_POLICIES
+    for branch in sorted(policy.disabled_branches)
+]
+
+MATCH_BASE_BRANCH_CASES = [
+    pytest.param({"matchBaseBranches": ["main"]}, "main", True, id="exact-main"),
+    pytest.param({"matchBaseBranches": ["!/^main$/"]}, "main", False, id="negated-main"),
+    pytest.param({"matchBaseBranches": ["!/^main$/"]}, "rhoai-3.4", True, id="negated-release"),
+    pytest.param({"matchBaseBranches": ["/^rhoai-3\\.4$/"]}, "rhoai-3.4", True, id="anchored-release"),
+]
+
+PREFIX_CASES = [
+    pytest.param("main", None, id="main-unprefixed"),
+    *[
+        pytest.param(branch, f"[{branch}]", id=f"{branch}-prefixed")
+        for branch in sorted(validator.RHDS_ENABLED_BRANCHES)
+    ],
+]
 
 
-def test_pattern_matches_branch_exact_and_negation() -> None:
-    assert validator._pattern_matches_branch("main", "main") is True, "Expected exact branch match for 'main'"
-    assert validator._pattern_matches_branch("!/^main$/", "main") is False, (
-        "Expected negated main pattern to reject 'main'"
+def _odh_policy() -> validator.MintMakerRepoPolicy:
+    return testdata.policy_by_label("ODH")
+
+
+def _rhds_policy() -> validator.MintMakerRepoPolicy:
+    return testdata.policy_by_label("RHDS")
+
+
+def test_minimal_valid_config_passes_validation() -> None:
+    errors = validator.validate_config(testdata.minimal_valid_config())
+    assert errors == [], f"Expected minimal synthetic config to pass validation, got: {errors}"
+
+
+@pytest.mark.parametrize(("policy", "branch", "expected_enabled"), POLICY_ENABLED_CASES)
+def test_renovate_enabled_for_matches_policy_enabled_branches(
+    policy: validator.MintMakerRepoPolicy,
+    branch: str,
+    expected_enabled: bool,
+) -> None:
+    config = {"packageRules": testdata.mintmaker_gate_rules(policy)}
+    assert validator.renovate_enabled_for(config, policy.repository, branch) is expected_enabled, (
+        f"Expected MintMaker enabled={expected_enabled} for {policy.repository!r} @ {branch!r}"
     )
-    assert validator._pattern_matches_branch("!/^main$/", "rhoai-3.4") is True, (
-        "Expected negated main pattern to accept 'rhoai-3.4'"
-    )
-    assert validator._pattern_matches_branch("/^rhoai-3\\.4$/", "rhoai-3.4") is True, (
-        "Expected anchored rhoai-3.4 pattern to match 'rhoai-3.4'"
+
+
+@pytest.mark.parametrize(("policy", "branch", "expected_enabled"), POLICY_DISABLED_CASES)
+def test_renovate_enabled_for_matches_policy_disabled_branches(
+    policy: validator.MintMakerRepoPolicy,
+    branch: str,
+    expected_enabled: bool,
+) -> None:
+    config = {"packageRules": testdata.mintmaker_gate_rules(policy)}
+    assert validator.renovate_enabled_for(config, policy.repository, branch) is expected_enabled, (
+        f"Expected MintMaker enabled={expected_enabled} for {policy.repository!r} @ {branch!r}"
     )
 
 
-def test_commit_message_prefix_for_branch_merged_rules() -> None:
+@pytest.mark.parametrize(("rule", "branch", "expected"), MATCH_BASE_BRANCH_CASES)
+def test_match_base_branches(rule: dict[str, Any], branch: str, expected: bool) -> None:
+    assert validator.match_base_branches(rule, branch) is expected, (
+        f"Expected match_base_branches({rule!r}, {branch!r}) == {expected}"
+    )
+
+
+@pytest.mark.parametrize(("branch", "expected_prefix"), PREFIX_CASES)
+def test_commit_message_prefix_for_branch(branch: str, expected_prefix: str | None) -> None:
+    config = testdata.minimal_valid_config()
+    assert validator.commit_message_prefix_for_branch(config, branch) == expected_prefix, (
+        f"Expected commitMessagePrefix for {branch!r} to be {expected_prefix!r}"
+    )
+
+
+def test_commit_message_prefix_skips_disabled_main_rule() -> None:
     config = {
         "packageRules": [
             {
@@ -30,72 +102,125 @@ def test_commit_message_prefix_for_branch_merged_rules() -> None:
         ]
     }
     assert validator.commit_message_prefix_for_branch(config, "main") is None, (
-        "Expected disabled main rule to remove prefix"
-    )
-    assert validator.commit_message_prefix_for_branch(config, "rhoai-3.4") == "[rhoai-3.4]", (
-        "Expected release branch prefix from merged packageRules"
+        "Expected disabled main rule to suppress prefix on main"
     )
 
 
-def test_renovate_enabled_for_odh_main_only() -> None:
-    config = {
-        "packageRules": [
-            {"matchRepositories": [validator.ODH_REPO], "enabled": False},
-            {
-                "matchRepositories": [validator.ODH_REPO],
-                "matchBaseBranches": sorted(validator.ODH_ENABLED_BRANCHES),
-                "enabled": True,
+@pytest.mark.parametrize(
+    ("mutator", "expected_errors"),
+    [
+        pytest.param(
+            lambda config: testdata.with_package_rules_removed(
+                config,
+                lambda rule: rule.get("description", "").startswith(validator.PREFIX_RULE_DESCRIPTION),
+            ),
+            [
+                f"missing packageRule: {validator.PREFIX_RULE_DESCRIPTION!r}",
+                "commitMessagePrefix for 'rhoai-2.25' must be '[rhoai-2.25]', got None",
+                "commitMessagePrefix for 'rhoai-3.3' must be '[rhoai-3.3]', got None",
+                "commitMessagePrefix for 'rhoai-3.4' must be '[rhoai-3.4]', got None",
+            ],
+            id="missing-prefix-rule",
+        ),
+        pytest.param(
+            lambda config: testdata.remove_mintmaker_disable(config, _odh_policy()),
+            [
+                "missing ODH MintMaker disable rule for 'opendatahub-io/notebooks'",
+                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'candidate'",
+                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'konflux-poc-1'",
+                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'",
+            ],
+            id="missing-odh-disable",
+        ),
+        pytest.param(
+            lambda config: testdata.remove_mintmaker_enable(config, _odh_policy()),
+            [
+                "missing ODH MintMaker enable rule for 'opendatahub-io/notebooks'",
+                "MintMaker must stay enabled for 'opendatahub-io/notebooks' @ main",
+            ],
+            id="missing-odh-enable",
+        ),
+        pytest.param(
+            lambda config: testdata.mintmaker_enable_with_branches(config, _odh_policy(), ["stable"]),
+            [
+                "ODH enable rule matchBaseBranches must be ['main'], got ['stable']",
+                "MintMaker must stay enabled for 'opendatahub-io/notebooks' @ main",
+                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'",
+            ],
+            id="odh-enable-wrong-branches",
+        ),
+        pytest.param(
+            lambda config: testdata.remove_mintmaker_disable(config, _rhds_policy()),
+            [
+                "missing RHDS MintMaker disable rule for 'red-hat-data-services/notebooks'",
+                "MintMaker must be disabled for 'red-hat-data-services/notebooks' @ 'main'",
+            ],
+            id="missing-rhds-disable",
+        ),
+        pytest.param(
+            lambda config: testdata.remove_mintmaker_enable(config, _rhds_policy()),
+            [
+                "missing RHDS MintMaker enable rule for 'red-hat-data-services/notebooks'",
+                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-2.25",
+                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.3",
+                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.4",
+            ],
+            id="missing-rhds-enable",
+        ),
+        pytest.param(
+            lambda config: testdata.mintmaker_enable_with_branches(
+                config,
+                _rhds_policy(),
+                ["rhoai-2.25"],
+            ),
+            [
+                "RHDS enable rule matchBaseBranches must be "
+                "['rhoai-2.25', 'rhoai-3.3', 'rhoai-3.4'], got ['rhoai-2.25']",
+                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.3",
+                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.4",
+            ],
+            id="rhds-enable-wrong-branches",
+        ),
+        pytest.param(
+            lambda config: testdata.with_package_rules_removed(
+                config,
+                lambda rule: rule.get("groupName") == "github-actions",
+            ),
+            ["missing github-actions group packageRule"],
+            id="missing-github-actions-group",
+        ),
+        pytest.param(
+            lambda config: {
+                **config,
+                "packageRules": [
+                    *config["packageRules"],
+                    {
+                        "matchRepositories": [validator.ODH_REPO],
+                        "matchBaseBranches": ["stable"],
+                        "enabled": True,
+                    },
+                ],
             },
-        ]
-    }
-    assert validator.renovate_enabled_for(config, validator.ODH_REPO, "main") is True, (
-        "Expected MintMaker enabled on ODH main"
-    )
-    assert validator.renovate_enabled_for(config, validator.ODH_REPO, "stable") is False, (
-        "Expected MintMaker disabled on ODH stable"
-    )
-
-
-def test_validate_config_reports_missing_prefix_rule() -> None:
-    config = {"enabledManagers": list(validator.REQUIRED_ENABLED_MANAGERS), "packageRules": []}
+            ["MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'"],
+            id="odh-stable-enabled-by-extra-rule",
+        ),
+    ],
+)
+def test_validate_config_reports_expected_errors(
+    mutator: Callable[[dict[str, Any]], dict[str, Any]],
+    expected_errors: list[str],
+) -> None:
+    config = mutator(testdata.minimal_valid_config())
     errors = validator.validate_config(config)
-    assert any("Prefix PR titles" in message for message in errors), (
-        f"Expected missing prefix rule error, got: {errors}"
-    )
+    assert errors == expected_errors, f"Expected validation errors {expected_errors!r}, got {errors!r}"
 
 
 def test_validate_config_rejects_shadow_renovate_json(tmp_path) -> None:
     shadow = tmp_path / "renovate.json"
     shadow.write_text("{}", encoding="utf-8")
 
-    config = {
-        "enabledManagers": list(validator.REQUIRED_ENABLED_MANAGERS),
-        "packageRules": [
-            {
-                "description": validator.PREFIX_RULE_DESCRIPTION,
-                "matchBaseBranches": validator.EXPECTED_PREFIX_MATCH_BASE,
-                "commitMessagePrefix": validator.EXPECTED_COMMIT_MESSAGE_PREFIX,
-            },
-            {"matchRepositories": [validator.ODH_REPO], "enabled": False},
-            {
-                "matchRepositories": [validator.ODH_REPO],
-                "matchBaseBranches": sorted(validator.ODH_ENABLED_BRANCHES),
-                "enabled": True,
-            },
-            {"matchRepositories": [validator.RHDS_REPO], "enabled": False},
-            {
-                "matchRepositories": [validator.RHDS_REPO],
-                "matchBaseBranches": sorted(validator.RHDS_ENABLED_BRANCHES),
-                "enabled": True,
-            },
-            {
-                "matchManagers": ["github-actions"],
-                "groupName": "github-actions",
-                "pinDigests": True,
-            },
-        ],
-    }
-    errors = validator.validate_config(config, config_dir=tmp_path)
-    assert any("must not exist" in message for message in errors), (
+    errors = validator.validate_config(testdata.minimal_valid_config(), config_dir=tmp_path)
+    assert len(errors) == 1, f"Expected one shadow-file error, got: {errors}"
+    assert "must not exist (shadows renovate.json5)" in errors[0], (
         f"Expected shadow renovate.json validation error, got: {errors}"
     )

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -37,6 +37,25 @@ def test_commit_message_prefix_for_branch_merged_rules() -> None:
     )
 
 
+def test_renovate_enabled_for_odh_main_only() -> None:
+    config = {
+        "packageRules": [
+            {"matchRepositories": [validator.ODH_REPO], "enabled": False},
+            {
+                "matchRepositories": [validator.ODH_REPO],
+                "matchBaseBranches": sorted(validator.ODH_ENABLED_BRANCHES),
+                "enabled": True,
+            },
+        ]
+    }
+    assert validator.renovate_enabled_for(config, validator.ODH_REPO, "main") is True, (
+        "Expected MintMaker enabled on ODH main"
+    )
+    assert validator.renovate_enabled_for(config, validator.ODH_REPO, "stable") is False, (
+        "Expected MintMaker disabled on ODH stable"
+    )
+
+
 def test_validate_config_reports_missing_prefix_rule() -> None:
     config = {"enabledManagers": list(validator.REQUIRED_ENABLED_MANAGERS), "packageRules": []}
     errors = validator.validate_config(config)
@@ -56,6 +75,12 @@ def test_validate_config_rejects_shadow_renovate_json(tmp_path) -> None:
                 "description": validator.PREFIX_RULE_DESCRIPTION,
                 "matchBaseBranches": validator.EXPECTED_PREFIX_MATCH_BASE,
                 "commitMessagePrefix": validator.EXPECTED_COMMIT_MESSAGE_PREFIX,
+            },
+            {"matchRepositories": [validator.ODH_REPO], "enabled": False},
+            {
+                "matchRepositories": [validator.ODH_REPO],
+                "matchBaseBranches": sorted(validator.ODH_ENABLED_BRANCHES),
+                "enabled": True,
             },
             {"matchRepositories": [validator.RHDS_REPO], "enabled": False},
             {

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from scripts.ci import validate_renovate_config as validator
 from tests.unit.scripts.ci import renovate_config_testdata as testdata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 POLICY_ENABLED_CASES = [
     pytest.param(policy, branch, True, id=f"{policy.label}-{branch}-enabled")
@@ -173,8 +175,10 @@ def test_commit_message_prefix_skips_disabled_main_rule() -> None:
                 ["rhoai-2.25"],
             ),
             [
-                "RHDS enable rule matchBaseBranches must be "
-                "['rhoai-2.25', 'rhoai-3.3', 'rhoai-3.4'], got ['rhoai-2.25']",
+                (
+                    "RHDS enable rule matchBaseBranches must be "
+                    "['rhoai-2.25', 'rhoai-3.3', 'rhoai-3.4'], got ['rhoai-2.25']"
+                ),
                 "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.3",
                 "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.4",
             ],

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -10,33 +10,6 @@ from tests.unit.scripts.ci import renovate_config_testdata as testdata
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-POLICY_ENABLED_CASES = [
-    pytest.param(policy, branch, True, id=f"{policy.label}-{branch}-enabled")
-    for policy in validator.MINTMAKER_POLICIES
-    for branch in sorted(policy.enabled_branches)
-]
-
-POLICY_DISABLED_CASES = [
-    pytest.param(policy, branch, False, id=f"{policy.label}-{branch}-disabled")
-    for policy in validator.MINTMAKER_POLICIES
-    for branch in sorted(policy.disabled_branches)
-]
-
-MATCH_BASE_BRANCH_CASES = [
-    pytest.param({"matchBaseBranches": ["main"]}, "main", True, id="exact-main"),
-    pytest.param({"matchBaseBranches": ["!/^main$/"]}, "main", False, id="negated-main"),
-    pytest.param({"matchBaseBranches": ["!/^main$/"]}, "rhoai-3.4", True, id="negated-release"),
-    pytest.param({"matchBaseBranches": ["/^rhoai-3\\.4$/"]}, "rhoai-3.4", True, id="anchored-release"),
-]
-
-PREFIX_CASES = [
-    pytest.param("main", None, id="main-unprefixed"),
-    *[
-        pytest.param(branch, f"[{branch}]", id=f"{branch}-prefixed")
-        for branch in sorted(validator.RHDS_ENABLED_BRANCHES)
-    ],
-]
-
 
 def _odh_policy() -> validator.MintMakerRepoPolicy:
     return testdata.policy_by_label("ODH")
@@ -51,63 +24,6 @@ def test_minimal_valid_config_passes_validation() -> None:
     assert errors == [], f"Expected minimal synthetic config to pass validation, got: {errors}"
 
 
-@pytest.mark.parametrize(("policy", "branch", "expected_enabled"), POLICY_ENABLED_CASES)
-def test_renovate_enabled_for_matches_policy_enabled_branches(
-    policy: validator.MintMakerRepoPolicy,
-    branch: str,
-    expected_enabled: bool,
-) -> None:
-    config = {"packageRules": testdata.mintmaker_gate_rules(policy)}
-    assert validator.renovate_enabled_for(config, policy.repository, branch) is expected_enabled, (
-        f"Expected MintMaker enabled={expected_enabled} for {policy.repository!r} @ {branch!r}"
-    )
-
-
-@pytest.mark.parametrize(("policy", "branch", "expected_enabled"), POLICY_DISABLED_CASES)
-def test_renovate_enabled_for_matches_policy_disabled_branches(
-    policy: validator.MintMakerRepoPolicy,
-    branch: str,
-    expected_enabled: bool,
-) -> None:
-    config = {"packageRules": testdata.mintmaker_gate_rules(policy)}
-    assert validator.renovate_enabled_for(config, policy.repository, branch) is expected_enabled, (
-        f"Expected MintMaker enabled={expected_enabled} for {policy.repository!r} @ {branch!r}"
-    )
-
-
-@pytest.mark.parametrize(("rule", "branch", "expected"), MATCH_BASE_BRANCH_CASES)
-def test_match_base_branches(rule: dict[str, Any], branch: str, expected: bool) -> None:
-    assert validator.match_base_branches(rule, branch) is expected, (
-        f"Expected match_base_branches({rule!r}, {branch!r}) == {expected}"
-    )
-
-
-@pytest.mark.parametrize(("branch", "expected_prefix"), PREFIX_CASES)
-def test_commit_message_prefix_for_branch(branch: str, expected_prefix: str | None) -> None:
-    config = testdata.minimal_valid_config()
-    assert validator.commit_message_prefix_for_branch(config, branch) == expected_prefix, (
-        f"Expected commitMessagePrefix for {branch!r} to be {expected_prefix!r}"
-    )
-
-
-def test_commit_message_prefix_skips_disabled_main_rule() -> None:
-    config = {
-        "packageRules": [
-            {
-                "matchBaseBranches": ["!/^main$/"],
-                "commitMessagePrefix": "[{{{baseBranch}}}]",
-            },
-            {
-                "matchBaseBranches": ["main"],
-                "enabled": False,
-            },
-        ]
-    }
-    assert validator.commit_message_prefix_for_branch(config, "main") is None, (
-        "Expected disabled main rule to suppress prefix on main"
-    )
-
-
 @pytest.mark.parametrize(
     ("mutator", "expected_errors"),
     [
@@ -116,56 +32,32 @@ def test_commit_message_prefix_skips_disabled_main_rule() -> None:
                 config,
                 lambda rule: rule.get("description", "").startswith(validator.PREFIX_RULE_DESCRIPTION),
             ),
-            [
-                f"missing packageRule: {validator.PREFIX_RULE_DESCRIPTION!r}",
-                "commitMessagePrefix for 'rhoai-2.25' must be '[rhoai-2.25]', got None",
-                "commitMessagePrefix for 'rhoai-3.3' must be '[rhoai-3.3]', got None",
-                "commitMessagePrefix for 'rhoai-3.4' must be '[rhoai-3.4]', got None",
-            ],
+            [f"missing packageRule: {validator.PREFIX_RULE_DESCRIPTION!r}"],
             id="missing-prefix-rule",
         ),
         pytest.param(
             lambda config: testdata.remove_mintmaker_disable(config, _odh_policy()),
-            [
-                "missing ODH MintMaker disable rule for 'opendatahub-io/notebooks'",
-                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'candidate'",
-                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'",
-            ],
+            ["missing ODH MintMaker disable rule for 'opendatahub-io/notebooks'"],
             id="missing-odh-disable",
         ),
         pytest.param(
             lambda config: testdata.remove_mintmaker_enable(config, _odh_policy()),
-            [
-                "missing ODH MintMaker enable rule for 'opendatahub-io/notebooks'",
-                "MintMaker must stay enabled for 'opendatahub-io/notebooks' @ main",
-            ],
+            ["missing ODH MintMaker enable rule for 'opendatahub-io/notebooks'"],
             id="missing-odh-enable",
         ),
         pytest.param(
             lambda config: testdata.mintmaker_enable_with_branches(config, _odh_policy(), ["stable"]),
-            [
-                "ODH enable rule matchBaseBranches must be ['main'], got ['stable']",
-                "MintMaker must stay enabled for 'opendatahub-io/notebooks' @ main",
-                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'",
-            ],
+            ["ODH enable rule matchBaseBranches must be ['main'], got ['stable']"],
             id="odh-enable-wrong-branches",
         ),
         pytest.param(
             lambda config: testdata.remove_mintmaker_disable(config, _rhds_policy()),
-            [
-                "missing RHDS MintMaker disable rule for 'red-hat-data-services/notebooks'",
-                "MintMaker must be disabled for 'red-hat-data-services/notebooks' @ 'main'",
-            ],
+            ["missing RHDS MintMaker disable rule for 'red-hat-data-services/notebooks'"],
             id="missing-rhds-disable",
         ),
         pytest.param(
             lambda config: testdata.remove_mintmaker_enable(config, _rhds_policy()),
-            [
-                "missing RHDS MintMaker enable rule for 'red-hat-data-services/notebooks'",
-                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-2.25",
-                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.3",
-                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.4",
-            ],
+            ["missing RHDS MintMaker enable rule for 'red-hat-data-services/notebooks'"],
             id="missing-rhds-enable",
         ),
         pytest.param(
@@ -179,8 +71,6 @@ def test_commit_message_prefix_skips_disabled_main_rule() -> None:
                     "RHDS enable rule matchBaseBranches must be "
                     "['rhoai-2.25', 'rhoai-3.3', 'rhoai-3.4'], got ['rhoai-2.25']"
                 ),
-                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.3",
-                "MintMaker must stay enabled for 'red-hat-data-services/notebooks' @ rhoai-3.4",
             ],
             id="rhds-enable-wrong-branches",
         ),
@@ -191,21 +81,6 @@ def test_commit_message_prefix_skips_disabled_main_rule() -> None:
             ),
             ["missing github-actions group packageRule"],
             id="missing-github-actions-group",
-        ),
-        pytest.param(
-            lambda config: {
-                **config,
-                "packageRules": [
-                    *config["packageRules"],
-                    {
-                        "matchRepositories": [validator.ODH_REPO],
-                        "matchBaseBranches": ["stable"],
-                        "enabled": True,
-                    },
-                ],
-            },
-            ["MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'"],
-            id="odh-stable-enabled-by-extra-rule",
         ),
     ],
 )

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -127,7 +127,6 @@ def test_commit_message_prefix_skips_disabled_main_rule() -> None:
             [
                 "missing ODH MintMaker disable rule for 'opendatahub-io/notebooks'",
                 "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'candidate'",
-                "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'konflux-poc-1'",
                 "MintMaker must be disabled for 'opendatahub-io/notebooks' @ 'stable'",
             ],
             id="missing-odh-disable",


### PR DESCRIPTION
## Summary

- Add ODH-specific `packageRules` to `.github/renovate.json5` so MintMaker/Renovate only opens updates for `opendatahub-io/notebooks` on `main` (mirrors the existing RHDS disable/enable pattern).
- Refactor `scripts/ci/validate_renovate_config.py` to a policy-driven model (`MintMakerRepoPolicy`, `find_repo_rule`, `validate_mintmaker_policy`) covering ODH and RHDS structural + behavioral checks.
- Replace ad-hoc unit tests with table-driven builders (`tests/unit/scripts/ci/renovate_config_testdata.py`) and parametrized violation cases.

Stops unwanted Konflux reference PRs such as [#3880](https://github.com/opendatahub-io/notebooks/pull/3880) (`stable`) and [#3881](https://github.com/opendatahub-io/notebooks/pull/3881) (`candidate`).

Supersedes #3906 (rebased onto current `origin/main`).

## Notes

- Does **not** set top-level `baseBranches` / `baseBranchPatterns` (would break RHDS release-branch MintMaker).
- Non-`main` ODH branches are disabled by repo-wide `enabled: false` plus re-enable on `main` only; the validator explicitly asserts `stable` and `candidate` (branches where MintMaker was wrongly active). Other branches need no explicit listing.
- MintMaker release-data may still schedule runs for stale branches until an ops MR removes them; repo config prevents PR creation.

## Test plan

- [x] `uv run python scripts/ci/validate_renovate_config.py`
- [x] `uv run pytest tests/unit/scripts/ci/test_validate_renovate_config.py tests/test_renovate_config.py -q`
- [ ] Merge and close stale `[stable]` / `[candidate]` MintMaker PRs (#3880, #3881)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for configuration validation with new test scenarios and helper utilities.

* **Chores**
  * Updated CI pipeline configuration to support additional repository branches and improved gating rules.
  * Enhanced configuration validation tooling for better consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->