### PR TITLE
fix(ci): pin CentOS Stream 9 base images and document EL9-only policy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -260,6 +260,15 @@
       "allowedVersions": "/^43$/",
     },
     {
+      // Digest-only FROM lines track the registry default tag; quay.io/centos/centos
+      // now resolves stream10.  Keep stream9@sha256 in Dockerfiles and block tag bumps.
+      "description": "Pin CentOS Stream base to stream9 (c9s only; no stream10)",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["quay.io/centos/centos"],
+      "allowedVersions": "/^stream9$/",
+      "pinDigests": true,
+    },
+    {
       "description": "Track registry.redhat.io base images",
       "matchManagers": ["custom.regex"],
       "matchDatasources": ["docker"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,9 @@ make refresh-lock-files
   `.tekton/` pipelines, or renaming image labels in `ci/` metadata files.
 - **Never:** Comment out tests to silence failures. Copy internal-only links or
   hostnames into public docs. Modify `.tekton/` in `red-hat-data-services/notebooks`
-  directly (PipelineRuns are synced from `konflux-central`).
+  directly (PipelineRuns are synced from `konflux-central`). Bump container OS bases
+  to RHEL/UBI/CentOS 10 or accept MintMaker PRs that do — the project stays on EL9;
+  see [base-images/README.md](base-images/README.md#os-version-policy-el9-only).
 
 ## Communication
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,9 @@ that embeds that stage. Do not assume there is one shared parent image definitio
 ### ODH vs RHOAI builds
 
 `KONFLUX` selects the product variant (ODH midstream vs RHOAI downstream), not whether
-the build runs on Konflux/Tekton. See [ARCHITECTURE.md](ARCHITECTURE.md) for details and
+the build runs on Konflux/Tekton. ODH workbenches stack on c9s odh-base-images;
+RHOAI stacks on RHEL 9.6 AIPCC bases (`ubi9-python-*` paths are EL9 naming only).
+See [ARCHITECTURE.md](ARCHITECTURE.md) for details and
 [CONTRIBUTING.md](CONTRIBUTING.md) for local-build gotchas.
 
 ## Common commands

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,9 +43,10 @@ instead.
 
 ### Supported OS versions
 
-The entire project targets **Enterprise Linux 9 only**: CentOS Stream 9 (`c9s`) for
-ODH `base-images/`, UBI 9 for workbench and runtime paths, and RHEL 9 (AIPCC) for
-RHOAI production bases. Do not move to stream10, ubi10, or rhel10 without an explicit
+The entire project targets **Enterprise Linux 9 only**. ODH `base-images/` and ODH
+workbench/runtime builds use CentOS Stream 9 (`c9s`); RHOAI/Konflux builds use
+RHEL 9.6 EUS (AIPCC). The `ubi9-python-*` paths are an EL9 naming convention, not
+`FROM ubi9` bases. Do not move to stream10, ubi10, or rhel10 without an explicit
 project decision. See [base-images/README.md](base-images/README.md#os-version-policy-el9-only)
 for Dockerfile pinning conventions and the Renovate rule that blocks MintMaker stream10
 bumps.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,6 +41,15 @@ CUDA/ROCm versions). In ODH (OpenDataHub), base images are built from `base-imag
 in this repo. In RHOAI (Red Hat OpenShift AI), base images come from the AIPCC pipeline
 instead.
 
+### Supported OS versions
+
+The entire project targets **Enterprise Linux 9 only**: CentOS Stream 9 (`c9s`) for
+ODH `base-images/`, UBI 9 for workbench and runtime paths, and RHEL 9 (AIPCC) for
+RHOAI production bases. Do not move to stream10, ubi10, or rhel10 without an explicit
+project decision. See [base-images/README.md](base-images/README.md#os-version-policy-el9-only)
+for Dockerfile pinning conventions and the Renovate rule that blocks MintMaker stream10
+bumps.
+
 Each image directory (e.g. `jupyter/minimal/ubi9-python-3.12/`) contains:
 - `Dockerfile.*` — one per variant (cpu, cuda, rocm, konflux.cpu, etc.)
 - `pyproject.toml` — Python dependencies

--- a/base-images/README.md
+++ b/base-images/README.md
@@ -9,10 +9,12 @@ All images are **CentOS Stream 9** (c9s) with **Python 3.12**.
 
 ## OS version policy (EL9 only)
 
-This repository builds on **Enterprise Linux 9 only**: CentOS Stream 9 (`stream9`)
-for ODH foundation images in `base-images/`, UBI 9 for workbench and runtime image
-paths, and RHEL 9.6 EUS (AIPCC) for RHOAI production bases. Accidental upgrades to
-stream10, ubi10, or rhel10 are out of scope until explicitly planned.
+This repository builds on **Enterprise Linux 9 only**. ODH `base-images/` and ODH
+workbench/runtime builds use CentOS Stream 9 (`stream9`, `c9s`) via
+`quay.io/opendatahub/odh-base-image-*-py312-c9s`. RHOAI/Konflux builds use RHEL
+9.6 EUS (AIPCC) via `quay.io/aipcc/base-images/*-el9.6`. The `ubi9-python-*`
+directory names denote EL9 compatibility; they are not `FROM ubi9` bases.
+Accidental upgrades to stream10, ubi10, or rhel10 are out of scope until explicitly planned.
 
 Pin OS `FROM` references with an explicit tag and digest — for example
 `quay.io/centos/centos:stream9@sha256:…`. Digest-only refs (without a tag) let

--- a/base-images/README.md
+++ b/base-images/README.md
@@ -7,6 +7,20 @@ All images are **CentOS Stream 9** (c9s) with **Python 3.12**.
 > **RHEL 9.6 EUS** base images from [AIPCC](https://gitlab.com/redhat/rhel-ai/core/base-images/app),
 > not these c9s images.
 
+## OS version policy (EL9 only)
+
+This repository builds on **Enterprise Linux 9 only**: CentOS Stream 9 (`stream9`)
+for ODH foundation images in `base-images/`, UBI 9 for workbench and runtime image
+paths, and RHEL 9.6 EUS (AIPCC) for RHOAI production bases. Accidental upgrades to
+stream10, ubi10, or rhel10 are out of scope until explicitly planned.
+
+Pin OS `FROM` references with an explicit tag and digest — for example
+`quay.io/centos/centos:stream9@sha256:…`. Digest-only refs (without a tag) let
+Renovate/MintMaker follow the registry default tag, which can jump to stream10.
+Tag bumps for `quay.io/centos/centos` are blocked by `allowedVersions` in
+[`.github/renovate.json5`](../.github/renovate.json5); digest refreshes within
+`stream9` remain allowed.
+
 ## Layout
 
 | Directory | Purpose |

--- a/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
@@ -1,13 +1,13 @@
 ARG TARGETARCH
 
-FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions base-images/utils/rpm-file-permissions /mnt/usr/bin/
 
 ####################
 # base             #
 ####################
-FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS base
+FROM quay.io/centos/centos:stream9@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0 AS base
 
 ARG PYTHON_VERSION=3.12
 ENV PYTHON=python${PYTHON_VERSION}

--- a/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
@@ -1,15 +1,13 @@
 ARG TARGETARCH
 
-# quay.io/centos/centos:stream9
-FROM quay.io/centos/centos@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions base-images/utils/rpm-file-permissions /mnt/usr/bin/
 
 ####################
 # base             #
 ####################
-# quay.io/centos/centos:stream9
-FROM quay.io/centos/centos@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS base
+FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS base
 
 ARG PYTHON_VERSION=3.12
 ENV PYTHON=python${PYTHON_VERSION}

--- a/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
@@ -1,7 +1,6 @@
 ARG TARGETARCH
 
-# quay.io/centos/centos:stream9
-FROM quay.io/centos/centos@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions /mnt/usr/bin/
 

--- a/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
@@ -1,6 +1,6 @@
 ARG TARGETARCH
 
-FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions /mnt/usr/bin/
 

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -1,7 +1,6 @@
 ARG TARGETARCH
 
-# quay.io/centos/centos:stream9
-FROM quay.io/centos/centos@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions /mnt/usr/bin/
 

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -1,6 +1,6 @@
 ARG TARGETARCH
 
-FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions /mnt/usr/bin/
 

--- a/base-images/rocm/7.1/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/7.1/c9s-python-3.12/Dockerfile.rocm
@@ -1,7 +1,6 @@
 ARG TARGETARCH
 
-# quay.io/centos/centos:stream9
-FROM quay.io/centos/centos@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions /mnt/usr/bin/
 

--- a/base-images/rocm/7.1/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/7.1/c9s-python-3.12/Dockerfile.rocm
@@ -1,6 +1,6 @@
 ARG TARGETARCH
 
-FROM quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56 AS buildscripts
+FROM quay.io/centos/centos:stream9@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0 AS buildscripts
 COPY base-images/utils/aipcc.sh /mnt/aipcc.sh
 COPY base-images/utils/fix-permissions /mnt/usr/bin/
 

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -22,6 +22,8 @@ RHDS_ENABLED_BRANCHES = frozenset({"rhoai-2.25", "rhoai-3.3", "rhoai-3.4"})
 PREFIX_RULE_DESCRIPTION = "Prefix PR titles with branch name for non-main branches"
 EXPECTED_PREFIX_MATCH_BASE = ["!/^main$/"]
 EXPECTED_COMMIT_MESSAGE_PREFIX = "[{{{baseBranch}}}]"
+CENTOS_STREAM_RULE_DESCRIPTION = "Pin CentOS Stream base to stream9 (c9s only; no stream10)"
+CENTOS_STREAM_ALLOWED_VERSIONS = "/^stream9$/"
 
 
 @dataclass(frozen=True)
@@ -176,6 +178,30 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
         errors.append("missing github-actions group packageRule")
     elif gh_actions_pin.get("pinDigests") is not True:
         errors.append("github-actions group rule must set pinDigests: true")
+
+    centos_stream_pin = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("description", "").startswith(CENTOS_STREAM_RULE_DESCRIPTION)
+        ),
+        None,
+    )
+    if centos_stream_pin is None:
+        errors.append(f"missing CentOS Stream pin packageRule: {CENTOS_STREAM_RULE_DESCRIPTION!r}")
+    else:
+        if centos_stream_pin.get("matchManagers") != ["dockerfile"]:
+            errors.append("CentOS Stream pin rule must match dockerfile manager only")
+        if centos_stream_pin.get("matchPackageNames") != ["quay.io/centos/centos"]:
+            errors.append("CentOS Stream pin rule must match quay.io/centos/centos only")
+        if centos_stream_pin.get("allowedVersions") != CENTOS_STREAM_ALLOWED_VERSIONS:
+            errors.append(
+                "CentOS Stream pin rule allowedVersions must be "
+                f"{CENTOS_STREAM_ALLOWED_VERSIONS!r}, got {centos_stream_pin.get('allowedVersions')!r}"
+            )
+        if centos_stream_pin.get("pinDigests") is not True:
+            errors.append("CentOS Stream pin rule must set pinDigests: true")
 
     return errors
 

--- a/tests/unit/scripts/ci/renovate_config_testdata.py
+++ b/tests/unit/scripts/ci/renovate_config_testdata.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from scripts.ci.validate_renovate_config import (
+    CENTOS_STREAM_ALLOWED_VERSIONS,
+    CENTOS_STREAM_RULE_DESCRIPTION,
     EXPECTED_COMMIT_MESSAGE_PREFIX,
     EXPECTED_PREFIX_MATCH_BASE,
     MINTMAKER_POLICIES,
@@ -42,11 +44,22 @@ def github_actions_group_rule() -> dict[str, Any]:
     }
 
 
+def centos_stream_pin_rule() -> dict[str, Any]:
+    return {
+        "description": CENTOS_STREAM_RULE_DESCRIPTION,
+        "matchManagers": ["dockerfile"],
+        "matchPackageNames": ["quay.io/centos/centos"],
+        "allowedVersions": CENTOS_STREAM_ALLOWED_VERSIONS,
+        "pinDigests": True,
+    }
+
+
 def minimal_valid_config(*extra_rules: dict[str, Any]) -> dict[str, Any]:
     package_rules: list[dict[str, Any]] = [prefix_rule()]
     for policy in MINTMAKER_POLICIES:
         package_rules.extend(mintmaker_gate_rules(policy))
     package_rules.append(github_actions_group_rule())
+    package_rules.append(centos_stream_pin_rule())
     package_rules.extend(extra_rules)
     return {
         "enabledManagers": list(REQUIRED_ENABLED_MANAGERS),

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -82,6 +82,14 @@ def test_minimal_valid_config_passes_validation() -> None:
             ["missing github-actions group packageRule"],
             id="missing-github-actions-group",
         ),
+        pytest.param(
+            lambda config: testdata.with_package_rules_removed(
+                config,
+                lambda rule: rule.get("description", "").startswith(validator.CENTOS_STREAM_RULE_DESCRIPTION),
+            ),
+            [f"missing CentOS Stream pin packageRule: {validator.CENTOS_STREAM_RULE_DESCRIPTION!r}"],
+            id="missing-centos-stream-pin",
+        ),
     ],
 )
 def test_validate_config_reports_expected_errors(


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C096ZR053RQ/p1782237027437419

## Summary

- Pin `quay.io/centos/centos` `FROM` lines in ODH base-image Dockerfiles to `:stream9@sha256:` so MintMaker/Renovate tracks the stream9 tag, not the registry default (now stream10).
- Add a Renovate `allowedVersions: /^stream9$/` packageRule with `pinDigests: true` to block stream10 tag bumps while still allowing stream9 digest refreshes.
- Enforce the rule in `scripts/ci/validate_renovate_config.py` and document the EL9-only OS policy in `base-images/README.md`, `ARCHITECTURE.md`, and `AGENTS.md`.

Closes the risk behind #3865 — that PR should not merge.

## Test plan

- [x] `uv run pytest tests/unit/scripts/ci/test_validate_renovate_config.py`
- [x] `uv run python scripts/ci/validate_renovate_config.py`
- [ ] CI `validate-renovate-config` workflow passes on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Documentation**
  * Clarified the project’s Enterprise Linux 9 (EL9) support policy, including which upstream base sources map to each build variant and guidance to prevent accidental upgrades to EL10-style streams.

* **Infrastructure**
  * Enhanced Renovate controls to pin the CentOS Stream 9 image (with digest pinning) and explicitly block CentOS Stream 10 updates.
  * Updated affected base image Dockerfiles to use digest-pinned CentOS Stream 9 references.

* **Tests**
  * Extended Renovate configuration validation coverage for the new CentOS Stream pinning rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->