### PR TITLE
ISSUE #3919: test(gha): add container IP and DNS checks to test-install-podman

### DIFF
--- a/.github/workflows/test-install-podman.yaml
+++ b/.github/workflows/test-install-podman.yaml
@@ -42,3 +42,29 @@ jobs:
 
           # https://github.com/containers/podman/blob/main/docs/tutorials/podman_tutorial.md#running-a-sample-container
           podman run --name basic_httpd -dt -p 8080:80/tcp docker.io/nginx
+
+      - name: Test container networking (IP and DNS)
+        run: |
+          set -Eeuxo pipefail
+
+          # Well-known IPs — raw L3/L4 reachability without DNS (TCP to public resolvers).
+          # Do not use HTTP to 1.1.1.1:80; Cloudflare DNS is not a web server on port 80.
+          podman run --rm docker.io/alpine sh -euxc \
+            'nc -zvw5 8.8.8.8 53 && nc -zvw5 1.1.1.1 53'
+
+          # Public hostname — exercises container DNS via libc resolver (catches 127.0.0.53 stub leaks).
+          # Explicit UDP/TCP resolver checks (catches pasta TCP regressions: podman #23239).
+          podman run --rm docker.io/alpine sh -euxc '
+            apk add --no-cache bind-tools ca-certificates >/dev/null
+            wget -q -O /dev/null -T 15 http://example.com/
+            wget -q -O /dev/null -T 15 https://github.com/
+            dig @8.8.8.8 +short example.com | grep -q .
+            dig @8.8.8.8 +tcp +short example.com | grep -q .
+            dig @8.8.8.8 +short github.com | grep -q .
+            dig @8.8.8.8 +tcp +short github.com | grep -q .
+          '
+
+          echo "Container IP and DNS reachability OK"
+        env:
+          # Match build workflows: remote client talks to rootful podman.socket.
+          CONTAINER_HOST: unix:///var/run/podman/podman.sock


### PR DESCRIPTION
## Summary
- Add `Test container networking (IP and DNS)` step to `test-install-podman` after the existing nginx smoke test
- Probes raw egress (`nc` to `8.8.8.8:53` / `1.1.1.1:53`), libc DNS + HTTP (`wget` example.com), HTTPS (`wget` github.com), and explicit `dig` UDP/TCP resolver checks

## Test plan
- [x] `workflow_dispatch` on `test-install-podman` passes on `ubuntu-24.04`
- [x] Merge before #3921 (linuxbrew removal) so network regressions are caught on current main


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new check in the Podman install workflow to verify container networking.
  * The validation confirms containers can reach public DNS services and resolve common hostnames over both UDP and TCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->