### PR TITLE
perf(jupyter): replace fix-permissions with umask and filtered find (#3928)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,7 +106,9 @@ Notebook images target OpenShift arbitrary UID with supplemental **gid 0**. Herm
 **`umask 0002`** so new files are group-writable where the umask applies. Any remaining
 paths (wheel ZIP modes from `uv`) get a single filtered pass via
 `base-images/utils/ensure-openshift-site-packages.sh` (`find ! -perm -g+w -exec chmod g+w {} +`).
-Leaf stages do not run full-tree `fix-permissions`.
+Leaf stages do not run full-tree `fix-permissions`. Paths outside site-packages that
+build steps create directly (e.g. `jupyter_server_config.py`, `labconfig/`, `pf.css`
+from `apply.sh`) get explicit modes or `chmod` at creation time; see [#3928](https://github.com/opendatahub-io/notebooks/issues/3928).
 
 Non-konflux `Dockerfile.cpu|cuda|rocm` paths are symlinks to `Dockerfile.konflux.*` and
 inherit the same ownership model.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,9 +105,9 @@ Notebook images target OpenShift arbitrary UID with supplemental **gid 0**. Herm
 `uv pip install` runs as **`USER 1001:0`** after root-only `dnf`/PDF stages, with
 **`umask 0002`** so new files are group-writable where the umask applies. Any remaining
 paths (wheel ZIP modes from `uv`) get a filtered pass via
-`base-images/utils/ensure-openshift-site-packages.sh`: `chmod g+w` on files and
-directories only, then `chmod -h g+w` on symlinks (does not follow link targets,
-e.g. rocm pytorch `de-vendor-torch.py` into system libs).
+`base-images/utils/ensure-openshift-site-packages.sh`: `chmod g+w` on regular files
+and directories only; symlinks are skipped (UBI `chmod` has no `-h`, and following
+de-vendor links would touch system libs under rocm pytorch).
 Leaf stages do not run full-tree `fix-permissions`. Paths outside site-packages that
 build steps create directly (e.g. `jupyter_server_config.py`, `labconfig/`, `pf.css`
 from `apply.sh`) get explicit modes or `chmod` at creation time; see [#3928](https://github.com/opendatahub-io/notebooks/issues/3928).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -99,6 +99,18 @@ paths resolve to the same content, so the meaningful difference is the selected
 build-args file and manifest set rather than a separate Dockerfile implementation.
 Both variants can be built locally or on Konflux/Tekton.
 
+### OpenShift file ownership during image build (#3928)
+
+Notebook images target OpenShift arbitrary UID with supplemental **gid 0**. Hermetic
+`uv pip install` runs as **`USER 1001:0`** after root-only `dnf`/PDF stages, with
+**`umask 0002`** so new files are group-writable where the umask applies. Any remaining
+paths (wheel ZIP modes from `uv`) get a single filtered pass via
+`base-images/utils/ensure-openshift-site-packages.sh` (`find ! -perm -g+w -exec chmod g+w {} +`).
+Leaf stages do not run full-tree `fix-permissions`.
+
+Non-konflux `Dockerfile.cpu|cuda|rocm` paths are symlinks to `Dockerfile.konflux.*` and
+inherit the same ownership model.
+
 ## Testing layers
 
 | Layer | Location | What it tests | How to run |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,8 +104,10 @@ Both variants can be built locally or on Konflux/Tekton.
 Notebook images target OpenShift arbitrary UID with supplemental **gid 0**. Hermetic
 `uv pip install` runs as **`USER 1001:0`** after root-only `dnf`/PDF stages, with
 **`umask 0002`** so new files are group-writable where the umask applies. Any remaining
-paths (wheel ZIP modes from `uv`) get a single filtered pass via
-`base-images/utils/ensure-openshift-site-packages.sh` (`find ! -perm -g+w -exec chmod g+w {} +`).
+paths (wheel ZIP modes from `uv`) get a filtered pass via
+`base-images/utils/ensure-openshift-site-packages.sh`: `chmod g+w` on files and
+directories only, then `chmod -h g+w` on symlinks (does not follow link targets,
+e.g. rocm pytorch `de-vendor-torch.py` into system libs).
 Leaf stages do not run full-tree `fix-permissions`. Paths outside site-packages that
 build steps create directly (e.g. `jupyter_server_config.py`, `labconfig/`, `pf.css`
 from `apply.sh`) get explicit modes or `chmod` at creation time; see [#3928](https://github.com/opendatahub-io/notebooks/issues/3928).

--- a/base-images/utils/ensure-openshift-site-packages.sh
+++ b/base-images/utils/ensure-openshift-site-packages.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Add group-write on site-packages paths that lack it (OpenShift arbitrary UID, gid 0).
-# Uses one find walk; only chmods entries where GNU find ! -perm -g+w matches.
+# Only chmods entries where GNU find ! -perm -g+w matches.
+# Skip symlink targets (rocm pytorch de-vendor-torch.py links torch/lib into /opt/rocm and /usr/lib64).
 set -Eeuo pipefail
 
 SITE_PACKAGES="${1:-/opt/app-root/lib/python3.12/site-packages}"
@@ -10,4 +11,5 @@ if [ ! -d "${SITE_PACKAGES}" ]; then
   exit 1
 fi
 
-find -L "${SITE_PACKAGES}" ! -perm -g+w -exec chmod g+w {} +
+find "${SITE_PACKAGES}" \( -type f -o -type d \) ! -perm -g+w -exec chmod g+w {} +
+find "${SITE_PACKAGES}" -type l ! -perm -g+w -exec chmod -h g+w {} +

--- a/base-images/utils/ensure-openshift-site-packages.sh
+++ b/base-images/utils/ensure-openshift-site-packages.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Add group-write on site-packages paths that lack it (OpenShift arbitrary UID, gid 0).
-# Only chmods entries where GNU find ! -perm -g+w matches.
-# Skip symlink targets (rocm pytorch de-vendor-torch.py links torch/lib into /opt/rocm and /usr/lib64).
+# chmod g+w on regular files and directories only; symlinks are skipped (plain chmod
+# follows targets; GNU chmod on UBI/RHEL has no -h).
 set -Eeuo pipefail
 
 SITE_PACKAGES="${1:-/opt/app-root/lib/python3.12/site-packages}"
@@ -12,4 +12,3 @@ if [ ! -d "${SITE_PACKAGES}" ]; then
 fi
 
 find "${SITE_PACKAGES}" \( -type f -o -type d \) ! -perm -g+w -exec chmod g+w {} +
-find "${SITE_PACKAGES}" -type l ! -perm -g+w -exec chmod -h g+w {} +

--- a/base-images/utils/ensure-openshift-site-packages.sh
+++ b/base-images/utils/ensure-openshift-site-packages.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Add group-write on site-packages paths that lack it (OpenShift arbitrary UID, gid 0).
 # Uses one find walk; only chmods entries where GNU find ! -perm -g+w matches.
-set -eu
+set -Eeuo pipefail
 
 SITE_PACKAGES="${1:-/opt/app-root/lib/python3.12/site-packages}"
 

--- a/base-images/utils/ensure-openshift-site-packages.sh
+++ b/base-images/utils/ensure-openshift-site-packages.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Add group-write on site-packages paths that lack it (OpenShift arbitrary UID, gid 0).
+# Uses one find walk; only chmods entries where GNU find ! -perm -g+w matches.
+set -eu
+
+SITE_PACKAGES="${1:-/opt/app-root/lib/python3.12/site-packages}"
+
+if [ ! -d "${SITE_PACKAGES}" ]; then
+  echo "ensure-openshift-site-packages: missing ${SITE_PACKAGES}" >&2
+  exit 1
+fi
+
+find -L "${SITE_PACKAGES}" ! -perm -g+w -exec chmod g+w {} +

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -140,10 +140,13 @@ COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
 COPY ${DATASCIENCE_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --no-index \
@@ -165,7 +168,7 @@ install -D -m 0644 /opt/app-root/bin/utils/jupyter_server_config.py \
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
 /opt/app-root/bin/utils/addons/apply.sh
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -74,7 +74,7 @@ ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
@@ -136,11 +136,11 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
 
 # hadolint ignore=DL3002
-# Python install as 1001:0; post-install chmod/fix-permissions unchanged in this stage.
+# Python install as 1001:0 with umask 0002; site-packages fixup via ensure-openshift-site-packages.sh
 COPY ${DATASCIENCE_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
-COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
+COPY --chown=1001:0 ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 USER 1001:0
 
@@ -163,10 +163,12 @@ mkdir /opt/app-root/pipeline-runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" \
     /opt/app-root/share/jupyter/kernels/python3/kernel.json
-install -D -m 0644 /opt/app-root/bin/utils/jupyter_server_config.py \
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh
 EOF

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -76,10 +76,13 @@ COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.tom
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Install Python packages from lockfile (Cachi2 prefetched pip deps; --no-deps per pylock.toml)
@@ -98,9 +101,9 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 # copy jupyter configuration
 cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
-fix-permissions /opt/app-root -P
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -54,7 +54,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 
 WORKDIR /opt/app-root/bin
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
@@ -76,7 +76,7 @@ COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.tom
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 USER 1001:0
 
@@ -97,10 +97,12 @@ pandoc --version
 
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -53,7 +53,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 
 WORKDIR /opt/app-root/bin
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
@@ -75,7 +75,7 @@ COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.tom
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 USER 1001:0
 
@@ -96,10 +96,12 @@ pandoc --version
 
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -75,10 +75,13 @@ COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.tom
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Install Python packages from lockfile (Cachi2 prefetched pip deps; --no-deps per pylock.toml)
@@ -97,9 +100,9 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 # copy jupyter configuration
 cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
-fix-permissions /opt/app-root -P
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -77,10 +77,13 @@ COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.tom
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Install Python packages from lockfile (Cachi2 prefetched pip deps; --no-deps per pylock.toml)
@@ -99,9 +102,9 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
 # copy jupyter configuration
 cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
-fix-permissions /opt/app-root -P
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 # Workaround for https://issues.redhat.com/browse/AIPCC-8152

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -55,7 +55,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 
 WORKDIR /opt/app-root/bin
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
@@ -77,7 +77,7 @@ COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.tom
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY --chown=1001:0 ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 USER 1001:0
 
@@ -98,10 +98,12 @@ pandoc --version
 
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -163,8 +163,11 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Install Python packages from lockfile (hermetic: use Cachi2 prefetched pip deps)
@@ -192,7 +195,7 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -85,7 +85,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
@@ -127,7 +127,7 @@ COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/mongocli
 USER 1001
 
 # Copy Elyra and Kale setup to utils so that they are sourced at startup
-COPY "${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh" "${DATASCIENCE_SOURCE_CODE}/setup-kale.sh" "${DATASCIENCE_SOURCE_CODE}/utils" ./utils/
+COPY --chown=1001:0 "${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh" "${DATASCIENCE_SOURCE_CODE}/setup-kale.sh" "${DATASCIENCE_SOURCE_CODE}/utils" ./utils/
 
 WORKDIR /opt/app-root/src
 
@@ -163,7 +163,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
@@ -187,12 +187,14 @@ mkdir /opt/app-root/runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Disable kale extension
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -74,7 +74,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 # Invalidate cached layer when RPM prefetch input changes.
 COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
@@ -112,7 +112,7 @@ COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/mongocli
 
 USER 1001
 
-COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
+COPY --chown=1001:0 ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 WORKDIR /opt/app-root/src
 
@@ -145,7 +145,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 USER 1001:0
 
@@ -169,12 +169,14 @@ mkdir /opt/app-root/runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Disable kale extension
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -145,10 +145,13 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --no-index \
@@ -174,7 +177,7 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -64,7 +64,7 @@ ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
@@ -112,7 +112,7 @@ COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
 
 USER 1001
 
-COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
+COPY --chown=1001:0 ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 WORKDIR /opt/app-root/src
 
@@ -143,6 +143,8 @@ COPY ${PYTORCH_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${PYTORCH_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.py ./
 
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 
@@ -167,12 +169,14 @@ mkdir /opt/app-root/runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Disable kale extension
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 # De-vendor the ROCm libs that are embedded in Pytorch

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -148,6 +148,7 @@ USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Cachi2 prefetched pip deps; --no-deps per pylock.toml
@@ -177,7 +178,7 @@ jupyter labextension disable jupyterlab-kubeflow-kale
 # De-vendor the ROCm libs that are embedded in Pytorch
 python3 ./de-vendor-torch.py
 rm ./de-vendor-torch.py
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 0

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -162,8 +162,11 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 # Install Python packages from lockfile (requirements.rocm.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Install Python packages from lockfile (hermetic: use Cachi2 prefetched pip deps)
@@ -190,7 +193,7 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 COPY ${JUPYTER_REUSABLE_UTILS}/usercustomize.pth ${JUPYTER_REUSABLE_UTILS}/monkey_patch_protobuf_6x.py /opt/app-root/lib/python3.12/site-packages/

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -198,7 +198,7 @@ chmod g+w /opt/app-root/etc/jupyter/labconfig
 /usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
-COPY ${JUPYTER_REUSABLE_UTILS}/usercustomize.pth ${JUPYTER_REUSABLE_UTILS}/monkey_patch_protobuf_6x.py /opt/app-root/lib/python3.12/site-packages/
+COPY --chown=1001:0 --chmod=0664 ${JUPYTER_REUSABLE_UTILS}/usercustomize.pth ${JUPYTER_REUSABLE_UTILS}/monkey_patch_protobuf_6x.py /opt/app-root/lib/python3.12/site-packages/
 
 USER 0
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -85,7 +85,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
@@ -127,7 +127,7 @@ COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/mongocli
 USER 1001
 
 # Copy Elyra  and Kale setup to utils so that they are sourced at startup
-COPY "${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh" "${DATASCIENCE_SOURCE_CODE}/setup-kale.sh" "${DATASCIENCE_SOURCE_CODE}/utils" ./utils/
+COPY --chown=1001:0 "${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh" "${DATASCIENCE_SOURCE_CODE}/setup-kale.sh" "${DATASCIENCE_SOURCE_CODE}/utils" ./utils/
 
 WORKDIR /opt/app-root/src
 
@@ -162,7 +162,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 # Install Python packages from lockfile (requirements.rocm.txt used only for Cachi2 prefetch)
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
@@ -185,12 +185,14 @@ mkdir /opt/app-root/runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Disable kale extension
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -162,8 +162,11 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 COPY ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 
 echo "Installing software and packages"
 # Install Python packages from lockfile (hermetic: use Cachi2 prefetched pip deps)
@@ -191,7 +194,7 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -85,7 +85,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
@@ -127,7 +127,7 @@ COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/mongocli
 USER 1001
 
 # Copy Elyra and Kale setup to utils so that they are sourced at startup
-COPY "${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh" "${DATASCIENCE_SOURCE_CODE}/setup-kale.sh" "${DATASCIENCE_SOURCE_CODE}/utils" ./utils/
+COPY --chown=1001:0 "${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh" "${DATASCIENCE_SOURCE_CODE}/setup-kale.sh" "${DATASCIENCE_SOURCE_CODE}/utils" ./utils/
 
 WORKDIR /opt/app-root/src
 
@@ -162,7 +162,7 @@ LABEL name="${LABEL_REGISTRY_PREFIX}/${LABEL_COMPONENT}" \
 COPY ${TENSORFLOW_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml
 COPY ${TENSORFLOW_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.txt
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
@@ -186,12 +186,14 @@ mkdir /opt/app-root/runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Disable kale extension
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -165,10 +165,13 @@ EOF
 
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements-trustyai.txt
 
+COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+
 USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 echo "Installing trustworthy-ai stack"
 UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --no-index \
     --strict --no-deps --no-config --no-progress \
@@ -178,12 +181,14 @@ UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --n
     --requirements=./requirements-trustyai.txt
 
 pandoc --version
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
+umask 0002
 # setup path for runtime configuration
 mkdir /opt/app-root/runtimes
 # Remove default Elyra runtime-images
@@ -198,7 +203,7 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 jupyter labextension disable jupyterlab-kubeflow-kale
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
-fix-permissions /opt/app-root -P
+/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 WORKDIR /opt/app-root/src

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -70,7 +70,7 @@ ARG MINIMAL_SOURCE_CODE=jupyter/minimal/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-COPY ${JUPYTER_REUSABLE_UTILS} utils/
+COPY --chown=1001:0 ${JUPYTER_REUSABLE_UTILS} utils/
 COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
 USER 0
@@ -117,8 +117,8 @@ RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-h
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/
 
 # hadolint ignore=DL3002
-# Python install as 1001:0; post-install chmod/fix-permissions unchanged in this stage.
-COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
+# Datascience stage files; leaf install uses umask 0002 and ensure-openshift-site-packages.sh
+COPY --chown=1001:0 ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/setup-kale.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 
@@ -165,7 +165,7 @@ EOF
 
 COPY ${TRUSTYAI_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements-trustyai.txt
 
-COPY base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
+COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
 USER 1001:0
 
@@ -181,7 +181,6 @@ UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --n
     --requirements=./requirements-trustyai.txt
 
 pandoc --version
-/usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
 USER 1001
@@ -195,12 +194,14 @@ mkdir /opt/app-root/runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y
 sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" /opt/app-root/share/jupyter/kernels/python3/kernel.json
-# copy jupyter configuration
-cp /opt/app-root/bin/utils/jupyter_server_config.py /opt/app-root/etc/jupyter
+# copy jupyter configuration (install -m 0664 for OpenShift gid 0 g+w)
+install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
+  /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Disable kale extension
 jupyter labextension disable jupyterlab-kubeflow-kale
+chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -183,7 +183,7 @@ UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --n
 pandoc --version
 EOF
 
-USER 1001
+USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -207,4 +207,5 @@ chmod g+w /opt/app-root/etc/jupyter/labconfig
 /usr/local/bin/ensure-openshift-site-packages.sh
 EOF
 
+USER 1001
 WORKDIR /opt/app-root/src

--- a/jupyter/utils/addons/apply.sh
+++ b/jupyter/utils/addons/apply.sh
@@ -36,8 +36,8 @@ if [ ! -f "$css_file" ]; then
   fi
 fi
 
-# Copy the tree-shaken CSS file to the static directory
-cp "$css_file" "$static_dir/pf.css"
+# Install tree-shaken CSS with group-writable mode for OpenShift arbitrary UID (gid 0)
+install -m 0664 "$css_file" "$static_dir/pf.css"
 
 head_content=$(tr -d '\n' <"$head_file" | sed 's/@/\\@/g')
 body_content=$(tr -d '\n' <"$body_file" | sed 's/@/\\@/g')

--- a/jupyter/utils/addons/apply.sh
+++ b/jupyter/utils/addons/apply.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -Eeuo pipefail
 
 # See https://github.com/jupyterlab/jupyterlab/issues/5463
 # This is a hack to apply partial HTML code to JupyterLab's `index.html` file


### PR DESCRIPTION
## Summary

Closes the core permission work for [#3928](https://github.com/opendatahub-io/notebooks/issues/3928): stop running expensive full-tree `fix-permissions /opt/app-root -P` on leaf Jupyter images, and instead create files with the right ownership/modes at install time.

**Build-time model** (documented in [`ARCHITECTURE.md` § OpenShift file ownership](https://github.com/opendatahub-io/notebooks/blob/perf/3928-umask-filtered-find/ARCHITECTURE.md#openshift-file-ownership-during-image-build-3928)):

- `USER 1001:0` + `umask 0002` for pip / jupyter provisioning `RUN`s
- `base-images/utils/ensure-openshift-site-packages.sh` — `chmod g+w` on regular **files and directories** under site-packages that lack group-write (wheel ZIP modes from `uv`); **symlinks skipped** (UBI `chmod` has no `-h`; rocm pytorch `de-vendor-torch.py` links must not be followed)
- **Surgical fixes** at creation for non–site-packages paths: `install -m 0664` for `jupyter_server_config.py` and `pf.css`, `chmod g+w` on `labconfig/` after `jupyter labextension disable`
- `USER 1001` restored before final `WORKDIR` on leaf stages (runtime not primary gid 0)
- Drop full-tree `fix-permissions` on all 10 leaf `Dockerfile.konflux.*` stages

Depends on [#3932](https://github.com/opendatahub-io/notebooks/pull/3932) and [#3933](https://github.com/opendatahub-io/notebooks/pull/3933) (merged).

## Changes (13 files)

| Area | What |
|------|------|
| **ensure script** | New `base-images/utils/ensure-openshift-site-packages.sh` (`set -Eeuo pipefail`) |
| **10 leaf Dockerfiles** | `umask 0002`, ensure call after `apply.sh`, drop `fix-permissions`, `COPY --chown=1001:0` for ensure helper |
| **Non–site-packages g+w** | `install -m 0664` / `chmod g+w labconfig` across leaves; rocm-tensorflow late site-packages `COPY` with `--chown=1001:0 --chmod=0664` |
| **rocm pytorch** | Missing ensure-helper `COPY`; de-vendor runs before ensure (symlink-safe ensure behavior) |
| **trustyai** | Split pip vs jupyter `RUN`s stay on `USER 1001:0`; reset `USER 1001` after provisioning |
| **apply.sh** | `set -Eeuo pipefail`; `install -m 0664` for `pf.css` |
| **ARCHITECTURE.md** | OpenShift ownership section + #3928 link |

## Intentionally not done

- No full-tree `fix-permissions` restore (build perf; fix at creation site instead)
- No broad `find` on `/opt/app-root/etc/jupyter` + `share/jupyter`
- No wheel ZIP rewrite; no `ci/build-profile/` harness on `main`
- CUDA tensorflow protobuf `usercustomize.pth` parity with rocm-tensorflow — tracked separately if needed (CodeRabbit nit)

## Validation

- **GHA:** leaf image builds (incl. rocm-jupyter-pytorch after de-vendor / ensure fix)
- **Remote perm battery** ([#3941](https://github.com/opendatahub-io/notebooks/issues/3941)): datascience cpu, cuda/rocm minimal, cuda pytorch — **PASS** (`g+w` site-packages + etc/share jupyter, arbitrary UID, pip cowsay); rocm pytorch blocked on host `/tmp` stash quota (infra), not permissions
- **CI gap:** existing `test_pip_install_cowsay_runs` does not assert filesystem `g+w`; follow-up in #3941

## Test plan

- [x] GHA notebook builds for touched leaf images
- [x] Remote permission battery on representative leaves (see #3941)
- [ ] `make test` / `test_pip_install_cowsay_runs` on built images (`KONFLUX` matched)
- [ ] Merge #3935 docs cross-ref after this lands

## Related

- #3928 — parent issue
- #3940 — deduplicate jupyter provisioning RUN blocks (future)
- #3941 — permission validation procedure + CI enhancement proposal