### PR TITLE
docs(jupyter): validate #3928 permissions rollout

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,7 +113,7 @@ build steps create directly (e.g. `jupyter_server_config.py`, `labconfig/`, `pf.
 from `apply.sh`) get explicit modes or `chmod` at creation time; see [#3928](https://github.com/opendatahub-io/notebooks/issues/3928).
 
 Non-konflux `Dockerfile.cpu|cuda|rocm` paths are symlinks to `Dockerfile.konflux.*` and
-inherit the same ownership model.
+inherit the same ownership model. Rollout tracked in [#3928](https://github.com/opendatahub-io/notebooks/issues/3928).
 
 ## Testing layers
 


### PR DESCRIPTION
## Summary
Part **4/4** of #3928 phased rollout. **Stacked on #3934.**

Adds #3928 cross-reference in `ARCHITECTURE.md`. Final validation: Konflux CI + arbitrary-UID container tests after PR3 merges.

## Test plan
- [ ] Post-merge cold-build timing note on #3928 (minimal + pytorch)
- [ ] Close #3928 when all four PRs merged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture notes with an added rollout note for the OpenShift file ownership behavior, clarifying that the change is tracked separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->