### PR TITLE
fix(ci): run Playwright before check-payload and narrow podman unmount

### DIFF
--- a/.github/actions/playwright-test/action.yml
+++ b/.github/actions/playwright-test/action.yml
@@ -120,6 +120,7 @@ runs:
           --env "CI=true" \
           --env "PNPM_CONFIG_fund=false" \
           --env "DEBUG=testcontainers:*" \
+          --env "TESTCONTAINERS_RYUK_DISABLED=true" \
           --env "PODMAN_SOCK=/var/run/docker.sock" \
           --env "TEST_TARGET" \
           --env "GREP_PATTERN" \

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -436,6 +436,28 @@ jobs:
       - name: "Show podman images information"
         run: podman images --digests
 
+      # region TypeScript (browser) image tests
+
+      # https://playwright.dev/docs/ci
+      # https://playwright.dev/docs/docker
+      # we leave little free disk space after we mount LVM for podman storage
+      # not enough to install playwright; running playwright in podman uses the space we have
+      # Run before pytest/k8s testcontainers: storage.conf transient_store drops overlay
+      # layers when containers exit; later testcontainers calls then hit stale graph-driver
+      # metadata (opendatahub-io/notebooks#3949).
+      - name: Run Playwright tests
+        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
+        uses: ./.github/actions/playwright-test
+        with:
+          test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
+          podman-socket: /var/run/podman/podman.sock
+          upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
+          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
+          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
+          grep-pattern: '@codeserver'
+
+      # endregion
+
       # endregion
 
       # region TypeScript (browser) image tests

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -436,39 +436,16 @@ jobs:
       - name: "Show podman images information"
         run: podman images --digests
 
-      # region TypeScript (browser) image tests
-
-      # https://playwright.dev/docs/ci
-      # https://playwright.dev/docs/docker
-      # we leave little free disk space after we mount LVM for podman storage
-      # not enough to install playwright; running playwright in podman uses the space we have
-      # Run before pytest/k8s testcontainers: storage.conf transient_store drops overlay
-      # layers when containers exit; later testcontainers calls then hit stale graph-driver
-      # metadata (opendatahub-io/notebooks#3949).
-      - name: Run Playwright tests
-        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
-        uses: ./.github/actions/playwright-test
-        with:
-          test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
-          podman-socket: /var/run/podman/podman.sock
-          upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
-          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
-          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
-          grep-pattern: '@codeserver'
-
-      # endregion
-
       # endregion
 
       # region TypeScript (browser) image tests
 
       # opendatahub-io/notebooks/issues/3949: podman transient_store seems unreliable
       #  faccessat .../storage/overlay/d43b43566b744...: no such file or directory
-      # therefore, run this first thing in the job
-
+      # Run before pytest/k8s testcontainers: transient_store drops overlay layers when
+      # containers exit; later testcontainers calls then hit stale graph-driver metadata.
       # https://playwright.dev/docs/ci
       # https://playwright.dev/docs/docker
-      # opendatahub-io/notebooks#3965: podman storage is configured to have sufficient disk space
       - name: Run Playwright tests
         if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
         uses: ./.github/actions/playwright-test

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -627,15 +627,17 @@ jobs:
         run: |
           set -Eeuxo pipefail
           PODMAN="$(which podman)"
-          IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}")
+          IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${OUTPUT_IMAGE}")
           sudo "${PODMAN}" run --rm --user=0 \
             -v "${IMAGE_MOUNT_DIR}:${IMAGE_MOUNT_DIR}:ro,z" \
             -v "${PWD}/scripts/check-payload/config.toml:/config.toml:ro,z" \
             "${CHECK_PAYLOAD_IMAGE}" \
             scan local --path "${IMAGE_MOUNT_DIR}" -c /config.toml
-          sudo "${PODMAN}" image unmount --all
+          # unmount only this image; --all left Podman overlay storage inconsistent (#3949)
+          sudo "${PODMAN}" image unmount "${OUTPUT_IMAGE}"
         env:
           CHECK_PAYLOAD_IMAGE: ghcr.io/${{ github.repository }}/check-payload:0.3.16
+          OUTPUT_IMAGE: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
 
       # endregion
 

--- a/.github/workflows/experiment-codeserver-ci.yaml
+++ b/.github/workflows/experiment-codeserver-ci.yaml
@@ -1,0 +1,231 @@
+---
+# Codeserver CI experiments: skip image build, pull a pre-built image, run test stages only.
+#
+# Trigger (after pushing this branch):
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e1-playwright-only
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e2-playwright-then-testcontainers
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e3-testcontainers-then-playwright
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e4-no-transient-store
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e4-split-runroot
+#
+# Optional image override (skip auto-resolve from ghcr main tags):
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> \
+#     -f experiment=e1-playwright-only \
+#     -f image_ref=ghcr.io/opendatahub-io/notebooks/workbench-images:codeserver-ubi9-python-3.12-main_<sha>_odh_linux_amd64
+#
+# Fire all five in parallel:
+#   for e in e1-playwright-only e2-playwright-then-testcontainers e3-testcontainers-then-playwright \
+#            e4-no-transient-store e4-split-runroot; do
+#     gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment="$e"
+#   done
+name: Experiment Codeserver CI
+
+"on":
+  workflow_dispatch:
+    inputs:
+      experiment:
+        description: "Which test/storage experiment to run"
+        type: choice
+        required: true
+        options:
+          - e1-playwright-only
+          - e2-playwright-then-testcontainers
+          - e3-testcontainers-then-playwright
+          - e4-no-transient-store
+          - e4-split-runroot
+      image_ref:
+        description: "Full image ref to test; empty = latest main codeserver from ghcr"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  TMPDIR: /home/runner/.local/share/containers/tmpdir
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
+
+jobs:
+  experiment:
+    name: "${{ inputs.experiment }}"
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Downcase IMAGE_REGISTRY
+        run: echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> "$GITHUB_ENV"
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Mount lvm overlay for podman storage
+        run: |
+          set -Eeuxo pipefail
+          df -h
+          bash ./ci/cached-builds/gha_lvm_overlay.sh
+          df -h
+
+      - name: Apply storage.conf experiment variant
+        run: |
+          set -Eeuxo pipefail
+          case "${EXPERIMENT}" in
+            e4-no-transient-store)
+              cp ci/cached-builds/storage.conf.no-transient-store ci/cached-builds/storage.conf
+              echo "Using storage.conf.no-transient-store (transient_store=false)"
+              ;;
+            e4-split-runroot)
+              cp ci/cached-builds/storage.conf.split-runroot ci/cached-builds/storage.conf
+              echo "Using storage.conf.split-runroot (separate runroot)"
+              ;;
+            *)
+              echo "Using default ci/cached-builds/storage.conf"
+              ;;
+          esac
+          grep -E '^(graphroot|runroot|transient_store)' ci/cached-builds/storage.conf || true
+        env:
+          EXPERIMENT: ${{ inputs.experiment }}
+
+      - name: Install Podman
+        uses: ./.github/actions/install-podman-action
+        with:
+          platform: linux/amd64
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve test image
+        id: image
+        env:
+          IMAGE_REF_INPUT: ${{ inputs.image_ref }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: python
+        # language=python
+        run: |
+          import json, os, re, subprocess, sys
+
+          image_ref = os.environ["IMAGE_REF_INPUT"].strip()
+          if image_ref:
+              if not re.fullmatch(r"[a-zA-Z0-9_./:@-]+", image_ref):
+                  print(f"::error::Invalid image_ref: {image_ref}", file=sys.stderr)
+                  sys.exit(1)
+              resolved = image_ref
+          else:
+              sys.path.insert(0, "ci")
+              from find_images_for_test_matrix import find_suitable_sha
+
+              registry = os.environ["IMAGE_REGISTRY"]
+              suffix = "_odh_linux_amd64"
+              required = ["codeserver-ubi9-python-3.12"]
+              result = subprocess.run(
+                  ["skopeo", "list-tags", "--creds", f"token:{os.environ['GH_TOKEN']}", f"docker://{registry}"],
+                  capture_output=True,
+                  text=True,
+                  timeout=180,
+              )
+              if result.returncode != 0:
+                  print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
+                  sys.exit(1)
+              sha = find_suitable_sha(suffix, required, result.stdout)
+              resolved = f"{registry}:codeserver-ubi9-python-3.12-main_{sha}{suffix}"
+              print(f"Auto-resolved latest main codeserver tag (sha={sha})")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"ref={resolved}\n")
+          print(f"Test image: {resolved}")
+
+      - name: Pull test image
+        run: |
+          set -Eeuxo pipefail
+          podman pull "${IMAGE_REF}"
+          podman images --digests
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
+      - name: Install from uv.lock (project + dev deps)
+        run: uv sync --group dev --locked
+
+      - name: Run Testcontainers container tests (before Playwright)
+        id: pytest-testcontainers-first
+        if: ${{ inputs.experiment == 'e3-testcontainers-then-playwright' }}
+        env:
+          DOCKER_HOST: "unix:///var/run/podman/podman.sock"
+          TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          OUTPUT_IMAGE: "${{ steps.image.outputs.ref }}"
+          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_testcontainers-first-junit.xml"
+        run: |
+          set -Eeuxo pipefail
+          mkdir -p "$(dirname "${JUNIT_XML}")"
+          uv run pytest --capture=fd tests/containers \
+            -m 'not openshift and not cuda and not rocm and not manifest_validation' \
+            --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
+
+      - name: Run Playwright tests (first)
+        id: playwright-first
+        if: ${{ !cancelled() && inputs.experiment != 'e3-testcontainers-then-playwright' }}
+        uses: ./.github/actions/playwright-test
+        with:
+          test-target: ${{ steps.image.outputs.ref }}
+          podman-socket: /var/run/podman/podman.sock
+          upload-report: "true"
+          artifact-name: "${{ inputs.experiment }}_playwright-report"
+          junit-artifact-file: "${{ inputs.experiment }}_playwright-junit.xml"
+          grep-pattern: "@codeserver"
+
+      - name: Run Testcontainers container tests (after Playwright)
+        id: pytest-testcontainers-after
+        if: ${{ !cancelled() && contains(fromJSON('["e2-playwright-then-testcontainers", "e4-no-transient-store", "e4-split-runroot"]'), inputs.experiment) }}
+        env:
+          DOCKER_HOST: "unix:///var/run/podman/podman.sock"
+          TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          OUTPUT_IMAGE: "${{ steps.image.outputs.ref }}"
+          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_testcontainers-after-junit.xml"
+        run: |
+          set -Eeuxo pipefail
+          mkdir -p "$(dirname "${JUNIT_XML}")"
+          uv run pytest --capture=fd tests/containers \
+            -m 'not openshift and not cuda and not rocm and not manifest_validation' \
+            --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
+
+      - name: Run Playwright tests (after Testcontainers)
+        id: playwright-after
+        if: ${{ !cancelled() && inputs.experiment == 'e3-testcontainers-then-playwright' }}
+        uses: ./.github/actions/playwright-test
+        with:
+          test-target: ${{ steps.image.outputs.ref }}
+          podman-socket: /var/run/podman/podman.sock
+          upload-report: "true"
+          artifact-name: "${{ inputs.experiment }}_playwright-report"
+          junit-artifact-file: "${{ inputs.experiment }}_playwright-junit.xml"
+          grep-pattern: "@codeserver"
+
+      - name: Upload Testcontainers pytest JUnit XML
+        if: ${{ always() && (steps.pytest-testcontainers-first.conclusion == 'success' || steps.pytest-testcontainers-first.conclusion == 'failure' || steps.pytest-testcontainers-after.conclusion == 'success' || steps.pytest-testcontainers-after.conclusion == 'failure') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_*-junit.xml"
+          archive: false
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Capture kernel logs on failure
+        if: failure()
+        uses: ./.github/actions/capture-kernel-logs
+        with:
+          log-prefix: "${{ inputs.experiment }}"

--- a/.github/workflows/experiment-codeserver-ci.yaml
+++ b/.github/workflows/experiment-codeserver-ci.yaml
@@ -1,40 +1,45 @@
 ---
-# Codeserver CI experiments: skip image build, pull a pre-built image, run test stages only.
+# Codeserver CI experiments: skip image build, pull a pre-built GHCR image, run test stages only.
 #
-# Trigger (after pushing this branch):
-#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e1-playwright-only
-#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e2-playwright-then-testcontainers
-#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e3-testcontainers-then-playwright
-#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e4-no-transient-store
-#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=e4-split-runroot
+# Phase 1 — reproduce Playwright overlay failure (~30–45 min, no `make codeserver-*`):
+#   gh workflow run experiment-codeserver-ci.yaml \
+#     --ref fix/ci-codeserver-playwright-after-check-payload-unmount \
+#     -f experiment=baseline
 #
-# Optional image override (skip auto-resolve from ghcr main tags):
-#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> \
-#     -f experiment=e1-playwright-only \
+# Optional explicit image (e.g. from failing main before #3951):
+#   gh workflow run experiment-codeserver-ci.yaml \
+#     --ref fix/ci-codeserver-playwright-after-check-payload-unmount \
+#     -f experiment=baseline \
 #     -f image_ref=ghcr.io/opendatahub-io/notebooks/workbench-images:codeserver-ubi9-python-3.12-main_<sha>_odh_linux_amd64
 #
-# Fire all five in parallel:
-#   for e in e1-playwright-only e2-playwright-then-testcontainers e3-testcontainers-then-playwright \
-#            e4-no-transient-store e4-split-runroot; do
-#     gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment="$e"
-#   done
+# Phase 2 — one-knob fix experiments (same pre-pulled image, workflow_dispatch only):
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=f1-playwright-first
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=f2-no-transient-store
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=f3-split-runroot
+#   gh workflow run experiment-codeserver-ci.yaml --ref <branch> -f experiment=f4-prune-before-playwright
+#
+# Expected baseline failure signature (Playwright step, after check-payload unmount --all):
+#   faccessat .../storage/overlay/...: no such file or directory
+#   error creating container storage: getting graph driver info: ...
+# See opendatahub-io/notebooks#3949.
 name: Experiment Codeserver CI
 
 "on":
   workflow_dispatch:
     inputs:
       experiment:
-        description: "Which test/storage experiment to run"
+        description: "baseline = old CI order (Playwright last); f1–f4 = single-knob fixes"
         type: choice
         required: true
+        default: baseline
         options:
-          - e1-playwright-only
-          - e2-playwright-then-testcontainers
-          - e3-testcontainers-then-playwright
-          - e4-no-transient-store
-          - e4-split-runroot
+          - baseline
+          - f1-playwright-first
+          - f2-no-transient-store
+          - f3-split-runroot
+          - f4-prune-before-playwright
       image_ref:
-        description: "Full image ref to test; empty = latest main codeserver from ghcr"
+        description: "Full image ref; empty = latest main codeserver tag from ghcr"
         type: string
         required: false
         default: ""
@@ -46,6 +51,7 @@ permissions:
 env:
   TMPDIR: /home/runner/.local/share/containers/tmpdir
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
+  TARGET: codeserver-ubi9-python-3.12
 
 jobs:
   experiment:
@@ -76,16 +82,16 @@ jobs:
         run: |
           set -Eeuxo pipefail
           case "${EXPERIMENT}" in
-            e4-no-transient-store)
+            f2-no-transient-store)
               cp ci/cached-builds/storage.conf.no-transient-store ci/cached-builds/storage.conf
-              echo "Using storage.conf.no-transient-store (transient_store=false)"
+              echo "F2: transient_store=false"
               ;;
-            e4-split-runroot)
+            f3-split-runroot)
               cp ci/cached-builds/storage.conf.split-runroot ci/cached-builds/storage.conf
-              echo "Using storage.conf.split-runroot (separate runroot)"
+              echo "F3: separate runroot from graphroot"
               ;;
             *)
-              echo "Using default ci/cached-builds/storage.conf"
+              echo "Default storage.conf (transient_store=true, shared runroot/graphroot)"
               ;;
           esac
           grep -E '^(graphroot|runroot|transient_store)' ci/cached-builds/storage.conf || true
@@ -96,6 +102,12 @@ jobs:
         uses: ./.github/actions/install-podman-action
         with:
           platform: linux/amd64
+
+      - name: Install skopeo
+        uses: ./.github/actions/apt-install
+        with:
+          packages: skopeo
+          update: "false"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
@@ -109,12 +121,14 @@ jobs:
         env:
           IMAGE_REF_INPUT: ${{ inputs.image_ref }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          TARGET: ${{ env.TARGET }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: python
         # language=python
         run: |
-          import json, os, re, subprocess, sys
+          import os, re, subprocess, sys
 
+          target = os.environ["TARGET"]
           image_ref = os.environ["IMAGE_REF_INPUT"].strip()
           if image_ref:
               if not re.fullmatch(r"[a-zA-Z0-9_./:@-]+", image_ref):
@@ -127,7 +141,7 @@ jobs:
 
               registry = os.environ["IMAGE_REGISTRY"]
               suffix = "_odh_linux_amd64"
-              required = ["codeserver-ubi9-python-3.12"]
+              required = [target]
               result = subprocess.run(
                   ["skopeo", "list-tags", "--creds", f"token:{os.environ['GH_TOKEN']}", f"docker://{registry}"],
                   capture_output=True,
@@ -138,12 +152,25 @@ jobs:
                   print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
                   sys.exit(1)
               sha = find_suitable_sha(suffix, required, result.stdout)
-              resolved = f"{registry}:codeserver-ubi9-python-3.12-main_{sha}{suffix}"
+              resolved = f"{registry}:{target}-main_{sha}{suffix}"
               print(f"Auto-resolved latest main codeserver tag (sha={sha})")
+
+          # registry:target-main_<sha>_odh_linux_amd64
+          registry, _, tag = resolved.rpartition(":")
+          prefix = f"{target}-"
+          if not tag.startswith(prefix):
+              print(f"::error::Tag {tag!r} does not start with {prefix!r}", file=sys.stderr)
+              sys.exit(1)
+          image_tag = tag.removeprefix(prefix)
+          notebook_tag = tag
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"ref={resolved}\n")
+              f.write(f"registry={registry}\n")
+              f.write(f"image_tag={image_tag}\n")
+              f.write(f"notebook_tag={notebook_tag}\n")
           print(f"Test image: {resolved}")
+          print(f"IMAGE_TAG={image_tag} NOTEBOOK_TAG={notebook_tag}")
 
       - name: Pull test image
         run: |
@@ -153,31 +180,23 @@ jobs:
         env:
           IMAGE_REF: ${{ steps.image.outputs.ref }}
 
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version: "stable"
+          cache-dependency-path: |
+            scripts/buildinputs/go.mod
+            scripts/check-payload/go.mod
+
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
 
       - name: Install from uv.lock (project + dev deps)
         run: uv sync --group dev --locked
 
-      - name: Run Testcontainers container tests (before Playwright)
-        id: pytest-testcontainers-first
-        if: ${{ inputs.experiment == 'e3-testcontainers-then-playwright' }}
-        env:
-          DOCKER_HOST: "unix:///var/run/podman/podman.sock"
-          TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
-          TESTCONTAINERS_RYUK_DISABLED: "true"
-          OUTPUT_IMAGE: "${{ steps.image.outputs.ref }}"
-          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_testcontainers-first-junit.xml"
-        run: |
-          set -Eeuxo pipefail
-          mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers \
-            -m 'not openshift and not cuda and not rocm and not manifest_validation' \
-            --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
-
+      # F1: Playwright before pytest (matches #3951 ordering fix; only knob changed).
       - name: Run Playwright tests (first)
         id: playwright-first
-        if: ${{ !cancelled() && inputs.experiment != 'e3-testcontainers-then-playwright' }}
+        if: ${{ inputs.experiment == 'f1-playwright-first' }}
         uses: ./.github/actions/playwright-test
         with:
           test-target: ${{ steps.image.outputs.ref }}
@@ -187,15 +206,16 @@ jobs:
           junit-artifact-file: "${{ inputs.experiment }}_playwright-junit.xml"
           grep-pattern: "@codeserver"
 
-      - name: Run Testcontainers container tests (after Playwright)
-        id: pytest-testcontainers-after
-        if: ${{ !cancelled() && contains(fromJSON('["e2-playwright-then-testcontainers", "e4-no-transient-store", "e4-split-runroot"]'), inputs.experiment) }}
+      # Old CI order: testcontainers → k8s → openshift → check-payload → Playwright last.
+      - name: Run Testcontainers container tests (in PyTest)
+        id: pytest-testcontainers
+        if: ${{ !cancelled() }}
         env:
           DOCKER_HOST: "unix:///var/run/podman/podman.sock"
           TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           OUTPUT_IMAGE: "${{ steps.image.outputs.ref }}"
-          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_testcontainers-after-junit.xml"
+          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_testcontainers-junit.xml"
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
@@ -203,26 +223,101 @@ jobs:
             -m 'not openshift and not cuda and not rocm and not manifest_validation' \
             --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
 
-      - name: Run Playwright tests (after Testcontainers)
-        id: playwright-after
-        if: ${{ !cancelled() && inputs.experiment == 'e3-testcontainers-then-playwright' }}
-        uses: ./.github/actions/playwright-test
-        with:
-          test-target: ${{ steps.image.outputs.ref }}
-          podman-socket: /var/run/podman/podman.sock
-          upload-report: "true"
-          artifact-name: "${{ inputs.experiment }}_playwright-report"
-          junit-artifact-file: "${{ inputs.experiment }}_playwright-junit.xml"
-          grep-pattern: "@codeserver"
-
       - name: Upload Testcontainers pytest JUnit XML
-        if: ${{ always() && (steps.pytest-testcontainers-first.conclusion == 'success' || steps.pytest-testcontainers-first.conclusion == 'failure' || steps.pytest-testcontainers-after.conclusion == 'success' || steps.pytest-testcontainers-after.conclusion == 'failure') }}
+        if: ${{ always() && steps.pytest-testcontainers.conclusion != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          path: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_*-junit.xml"
+          path: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_testcontainers-junit.xml"
           archive: false
           retention-days: 14
           if-no-files-found: warn
+
+      - name: Change pull policy to IfNotPresent
+        if: ${{ !cancelled() && steps.pytest-testcontainers.outcome == 'success' }}
+        run: |
+          set -Eeuxo pipefail
+          find . \( -name "statefulset.yaml" -o -name "pod.yaml" \) -type f -exec \
+            sed -i'' 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' {} \;
+          git diff --stat
+
+      - name: Provision K8s cluster
+        id: provision-k8s
+        if: ${{ !cancelled() && steps.pytest-testcontainers.outcome == 'success' }}
+        uses: ./.github/actions/provision-k8s
+
+      - name: Run image tests
+        id: makefile-tests
+        if: ${{ !cancelled() && steps.pytest-testcontainers.outcome == 'success' && steps.provision-k8s.outcome == 'success' }}
+        run: python3 ci/cached-builds/make_test.py --target ${{ env.TARGET }}
+        env:
+          IMAGE_TAG: "${{ steps.image.outputs.image_tag }}"
+          NOTEBOOK_TAG: "${{ steps.image.outputs.notebook_tag }}"
+          IMAGE_REGISTRY: "${{ steps.image.outputs.registry }}"
+          KONFLUX: "no"
+
+      - name: Run OpenShift container tests (in PyTest)
+        id: pytest-openshift
+        if: ${{ !cancelled() && steps.pytest-testcontainers.outcome == 'success' && steps.provision-k8s.outcome == 'success' }}
+        env:
+          DOCKER_HOST: "unix:///var/run/podman/podman.sock"
+          TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          OUTPUT_IMAGE: "${{ steps.image.outputs.ref }}"
+          JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_openshift-junit.xml"
+        run: |
+          set -Eeuxo pipefail
+          mkdir -p "$(dirname "${JUNIT_XML}")"
+          uv run pytest --capture=fd tests/containers \
+            -m 'openshift and not cuda and not rocm' \
+            --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
+
+      - name: Upload OpenShift pytest JUnit XML
+        if: ${{ always() && steps.pytest-openshift.conclusion != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: "${{ runner.temp }}/pytest-reports/${{ inputs.experiment }}_openshift-junit.xml"
+          archive: false
+          retention-days: 14
+          if-no-files-found: warn
+
+      # Old CI: check-payload with `image unmount --all` immediately before Playwright (#3949).
+      - name: Check image with check-payload for FIPS compliance
+        id: fips-check
+        if: ${{ !cancelled() && steps.pytest-testcontainers.outcome == 'success' }}
+        run: |
+          set -Eeuxo pipefail
+          PODMAN="$(which podman)"
+          OUTPUT_IMAGE="${{ steps.image.outputs.ref }}"
+          IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${OUTPUT_IMAGE}")
+          sudo --preserve-env=PATH,GOCACHE,GOMODCACHE go tool github.com/openshift/check-payload scan local --path "${IMAGE_MOUNT_DIR}"
+          sudo "${PODMAN}" image unmount --all
+        working-directory: scripts/check-payload
+        env:
+          GOCACHE: /home/runner/.cache/go-build
+          GOMODCACHE: /home/runner/go/pkg/mod
+
+      # F4: prune exited containers before Playwright (single knob; Playwright still last).
+      - name: Prune podman containers before Playwright
+        if: ${{ !cancelled() && inputs.experiment == 'f4-prune-before-playwright' && steps.fips-check.outcome == 'success' }}
+        run: |
+          set -Eeuxo pipefail
+          podman container prune -f
+          podman ps -a
+
+      - name: Run Playwright tests (last)
+        id: playwright-last
+        if: ${{ !cancelled() && inputs.experiment != 'f1-playwright-first' && steps.fips-check.outcome == 'success' }}
+        uses: ./.github/actions/playwright-test
+        with:
+          test-target: ${{ steps.image.outputs.ref }}
+          podman-socket: /var/run/podman/podman.sock
+          upload-report: "true"
+          artifact-name: "${{ inputs.experiment }}_playwright-report"
+          junit-artifact-file: "${{ inputs.experiment }}_playwright-junit.xml"
+          grep-pattern: "@codeserver"
+
+      - run: df -h
+        if: ${{ !cancelled() }}
 
       - name: Capture kernel logs on failure
         if: failure()

--- a/ci/cached-builds/storage.conf.no-transient-store
+++ b/ci/cached-builds/storage.conf.no-transient-store
@@ -1,0 +1,14 @@
+# Experiment variant: disable transient_store (default CI uses transient_store=true).
+# https://github.com/containers/storage/blob/main/docs/containers-storage.conf.5.md
+[storage]
+driver = "overlay"
+
+graphroot = "/home/runner/.local/share/containers/storage"
+runroot = "/home/runner/.local/share/containers/storage"
+
+transient_store = false
+
+[storage.options]
+pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
+
+[storage.options.overlay]

--- a/ci/cached-builds/storage.conf.split-runroot
+++ b/ci/cached-builds/storage.conf.split-runroot
@@ -1,0 +1,14 @@
+# Experiment variant: separate graphroot and runroot (default CI uses the same path for both).
+# https://github.com/containers/storage/blob/main/docs/containers-storage.conf.5.md
+[storage]
+driver = "overlay"
+
+graphroot = "/home/runner/.local/share/containers/storage"
+runroot = "/home/runner/.local/share/containers/runroot"
+
+transient_store = true
+
+[storage.options]
+pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
+
+[storage.options.overlay]

--- a/tests/browser/tests/testcontainers.ts
+++ b/tests/browser/tests/testcontainers.ts
@@ -18,16 +18,15 @@ export function setupTestcontainers() {
                 const XDG_RUNTIME_DIR = process.env['XDG_RUNTIME_DIR'] || `/var/run/user/${process.env['UID']}`
                 process.env['DOCKER_HOST'] = `unix://${XDG_RUNTIME_DIR}/podman/podman.sock`;
             }
-            process.env['TESTCONTAINERS_RYUK_DISABLED'] = 'false';
-            process.env['TESTCONTAINERS_RYUK_PRIVILEGED'] = 'true';
+            // Match pytest CI: Ryuk pulls from docker.io and is disabled in GHA workflows.
+            process.env['TESTCONTAINERS_RYUK_DISABLED'] ??= 'true';
             break
         }
         case "darwin": {
             // let result = spawnSync('podman', ['machine', 'inspect', '--format={{.ConnectionInfo.PodmanSocket.Path}}']);
             // let dockerHost = result.stdout.toString().trimEnd()
             // process.env['DOCKER_HOST'] = `unix://${dockerHost}`;
-            process.env['TESTCONTAINERS_RYUK_DISABLED'] = 'false';
-            process.env['TESTCONTAINERS_RYUK_PRIVILEGED'] = 'true';
+            process.env['TESTCONTAINERS_RYUK_DISABLED'] ??= 'true';
             break
         }
     }


### PR DESCRIPTION
## Summary

Fixes #3949.

Codeserver Playwright jobs were failing reproducibly after the check-payload FIPS step with Podman overlay storage errors (`faccessat .../storage/overlay/...: no such file or directory`). Build, testcontainers, and K8s tests passed in the same job; only Playwright failed immediately after `sudo podman image unmount --all`.

This PR applies two mitigations:

1. **Reorder steps** — run Playwright (codeserver only) **before** check-payload so testcontainers is not using Podman storage after the FIPS mount/unmount cycle.
2. **Targeted unmount** — replace `podman image unmount --all` with `podman image unmount "${OUTPUT_IMAGE}"` so we only unmount the image mounted for the FIPS scan.

## Test plan

- [ ] `codeserver-ubi9-python-3.12` GHA jobs pass Playwright on `linux/amd64` and `linux/arm64`
- [ ] check-payload FIPS scan still passes after reordering
- [ ] Non-codeserver notebook builds unaffected (Playwright step remains gated on `contains(inputs.target, 'codeserver')`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CI experiment workflow for running codeserver validation with selectable experiment modes and optional image overrides.
  * Introduced additional CI storage configurations to support different Podman storage setups.

* **Bug Fixes**
  * Moved browser Playwright tests earlier in the CI flow and improved how test artifacts are named and collected.
  * Updated FIPS image scanning to target the correct built image and clean up only that image afterward.
  * Improved Testcontainers setup so browser tests run more reliably across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->