### PR TITLE
ci(codeserver): experiment baseline (#3949)

### DIFF
--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -327,3 +327,5 @@ and remove with `podman rm codeserver`.
 
 - **PYTHONPATH:** The image sets `ENV PYTHONPATH=/opt/app-root/lib/python3.12/site-packages` so that the app Python interpreter and runtime-installed packages (e.g. `pip install mysql-connector-python`) are found. See [docs/mysql-test-failure-analysis.md](docs/mysql-test-failure-analysis.md) for details.
 - **Image metadata in CI:** On GitHub Actions, container tests run against rootful Podman. Image labels can be returned in `ContainerConfig` instead of `Config`; the test suite reads from both so code-server detection and the MySQL connection test work in CI. See [tests/containers/docs/github-vs-local-image-metadata.md](../../tests/containers/docs/github-vs-local-image-metadata.md).
+
+<!-- ci-exp: baseline — matrix selector only, no functional change -->


### PR DESCRIPTION
Draft CI experiment **baseline** for #3949. Reproduces main test order: testcontainers → k8s → openshift → check-payload unmount --all → Playwright last. Matrix: codeserver README comment only (~2 jobs).

Made with [Cursor](https://cursor.com)