### PR TITLE
ci(codeserver): experiment f1-playwright-first (#3949)

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -463,6 +463,24 @@ jobs:
       - name: "Show podman images information"
         run: podman images --digests
 
+      # region TypeScript (browser) image tests
+
+      # https://playwright.dev/docs/ci
+      # https://playwright.dev/docs/docker
+      # ci-exp f1: Playwright before testcontainers (ordering knob only; unmount --all unchanged).
+      - name: Run Playwright tests
+        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
+        uses: ./.github/actions/playwright-test
+        with:
+          test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
+          podman-socket: /var/run/podman/podman.sock
+          upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
+          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
+          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
+          grep-pattern: '@codeserver'
+
+      # endregion
+
       # endregion
 
       # region Pytest image tests
@@ -666,24 +684,6 @@ jobs:
 
       # endregion
 
-      # region TypeScript (browser) image tests
-
-      # https://playwright.dev/docs/ci
-      # https://playwright.dev/docs/docker
-      # we leave little free disk space after we mount LVM for podman storage
-      # not enough to install playwright; running playwright in podman uses the space we have
-      - name: Run Playwright tests
-        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
-        uses: ./.github/actions/playwright-test
-        with:
-          test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
-          podman-socket: /var/run/podman/podman.sock
-          upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
-          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
-          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
-          grep-pattern: '@codeserver'
-
-      # endregion
 
       - run: df -h
         if: "${{ !cancelled() }}"

--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -327,3 +327,5 @@ and remove with `podman rm codeserver`.
 
 - **PYTHONPATH:** The image sets `ENV PYTHONPATH=/opt/app-root/lib/python3.12/site-packages` so that the app Python interpreter and runtime-installed packages (e.g. `pip install mysql-connector-python`) are found. See [docs/mysql-test-failure-analysis.md](docs/mysql-test-failure-analysis.md) for details.
 - **Image metadata in CI:** On GitHub Actions, container tests run against rootful Podman. Image labels can be returned in `ContainerConfig` instead of `Config`; the test suite reads from both so code-server detection and the MySQL connection test work in CI. See [tests/containers/docs/github-vs-local-image-metadata.md](../../tests/containers/docs/github-vs-local-image-metadata.md).
+
+<!-- ci-exp: f1-playwright-first — matrix selector only, no functional change -->


### PR DESCRIPTION
Draft CI experiment **f1**: Playwright before testcontainers only; keep unmount --all. Matrix: codeserver only.

Made with [Cursor](https://cursor.com)