### PR TITLE
ci(codeserver): experiment f2-no-transient-store (#3949)

### DIFF
--- a/ci/cached-builds/storage.conf
+++ b/ci/cached-builds/storage.conf
@@ -10,7 +10,7 @@ graphroot = "/home/runner/.local/share/containers/storage"
 runroot = "/home/runner/.local/share/containers/storage"
 
 # https://www.redhat.com/en/blog/speed-containers-podman-raspberry-pi
-transient_store = true
+transient_store = false
 
 [storage.options]
 # https://www.redhat.com/sysadmin/faster-container-image-pulls

--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -327,3 +327,5 @@ and remove with `podman rm codeserver`.
 
 - **PYTHONPATH:** The image sets `ENV PYTHONPATH=/opt/app-root/lib/python3.12/site-packages` so that the app Python interpreter and runtime-installed packages (e.g. `pip install mysql-connector-python`) are found. See [docs/mysql-test-failure-analysis.md](docs/mysql-test-failure-analysis.md) for details.
 - **Image metadata in CI:** On GitHub Actions, container tests run against rootful Podman. Image labels can be returned in `ContainerConfig` instead of `Config`; the test suite reads from both so code-server detection and the MySQL connection test work in CI. See [tests/containers/docs/github-vs-local-image-metadata.md](../../tests/containers/docs/github-vs-local-image-metadata.md).
+
+<!-- ci-exp: f2-no-transient-store — matrix selector only, no functional change -->


### PR DESCRIPTION
Draft CI experiment **f2**: transient_store=false in storage.conf; baseline test order.

Made with [Cursor](https://cursor.com)