### PR TITLE
ci(codeserver): experiment f3-split-runroot (#3949)

### DIFF
--- a/ci/cached-builds/storage.conf
+++ b/ci/cached-builds/storage.conf
@@ -7,7 +7,7 @@
 driver = "overlay"
 
 graphroot = "/home/runner/.local/share/containers/storage"
-runroot = "/home/runner/.local/share/containers/storage"
+runroot = "/home/runner/.local/share/containers/runroot"
 
 # https://www.redhat.com/en/blog/speed-containers-podman-raspberry-pi
 transient_store = true

--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -327,3 +327,5 @@ and remove with `podman rm codeserver`.
 
 - **PYTHONPATH:** The image sets `ENV PYTHONPATH=/opt/app-root/lib/python3.12/site-packages` so that the app Python interpreter and runtime-installed packages (e.g. `pip install mysql-connector-python`) are found. See [docs/mysql-test-failure-analysis.md](docs/mysql-test-failure-analysis.md) for details.
 - **Image metadata in CI:** On GitHub Actions, container tests run against rootful Podman. Image labels can be returned in `ContainerConfig` instead of `Config`; the test suite reads from both so code-server detection and the MySQL connection test work in CI. See [tests/containers/docs/github-vs-local-image-metadata.md](../../tests/containers/docs/github-vs-local-image-metadata.md).
+
+<!-- ci-exp: f3-split-runroot — matrix selector only, no functional change -->


### PR DESCRIPTION
Draft CI experiment **f3**: separate runroot in storage.conf; baseline test order.

Made with [Cursor](https://cursor.com)