### PR TITLE
ci(codeserver): experiment f4-prune-before-playwright (#3949)

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -666,6 +666,14 @@ jobs:
 
       # endregion
 
+      # ci-exp f4: prune exited containers before Playwright (baseline test order).
+      - name: Prune podman containers before Playwright
+        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' && steps.fips-check.outcome == 'success' }}
+        run: |
+          set -Eeuxo pipefail
+          podman container prune -f
+          podman ps -a
+
       # region TypeScript (browser) image tests
 
       # https://playwright.dev/docs/ci

--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -327,3 +327,5 @@ and remove with `podman rm codeserver`.
 
 - **PYTHONPATH:** The image sets `ENV PYTHONPATH=/opt/app-root/lib/python3.12/site-packages` so that the app Python interpreter and runtime-installed packages (e.g. `pip install mysql-connector-python`) are found. See [docs/mysql-test-failure-analysis.md](docs/mysql-test-failure-analysis.md) for details.
 - **Image metadata in CI:** On GitHub Actions, container tests run against rootful Podman. Image labels can be returned in `ContainerConfig` instead of `Config`; the test suite reads from both so code-server detection and the MySQL connection test work in CI. See [tests/containers/docs/github-vs-local-image-metadata.md](../../tests/containers/docs/github-vs-local-image-metadata.md).
+
+<!-- ci-exp: f4-prune-before-playwright — matrix selector only, no functional change -->


### PR DESCRIPTION
Draft CI experiment **f4**: podman container prune before Playwright; baseline test order.

Made with [Cursor](https://cursor.com)