### PR TITLE
fix(scripts): scope sandbox ci/ ignore to repo root only (#3150)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 # NOTE: scripts/sandbox.py uses a limited parser that only extracts
 # single-segment directory patterns (name/ or **/name/) from this file.
-# Negation (!), globs (*.ext), and multi-segment paths are ignored.
+# Root-relative patterns (ci/) apply only at the repository root; **/name/
+# applies at any depth. Negation (!), globs (*.ext), and multi-segment paths
+# are ignored.
 
 bin/
 ci/

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -119,7 +119,6 @@ def _ignored_dir_names(root: pathlib.Path) -> tuple[set[str], set[str]]:
     are excluded.
 
     TODO: negation patterns (``!name``) are filtered out, not honored as re-inclusions.
-    TODO: followlinks=True in _copy_tree can still loop on circular symlinks.
     """
     root_only: set[str] = set()
     any_depth: set[str] = set()
@@ -179,7 +178,24 @@ def _copy_tree(
         except ValueError:
             repo_base_rel = pathlib.Path()
 
+    if _should_ignore_dir(
+        src.name,
+        pathlib.Path(),
+        repo_base_rel.parent,
+        root_only_ignore,
+        any_depth_ignore,
+    ):
+        return
+
+    visited: set[str] = set()
+
     for dirpath, dirnames, filenames in os.walk(src, followlinks=True):
+        real_dir = os.path.realpath(dirpath)
+        if real_dir in visited:
+            dirnames.clear()
+            continue
+        visited.add(real_dir)
+
         rel = pathlib.Path(dirpath).relative_to(src)
         dirnames[:] = [
             d for d in dirnames

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -106,28 +106,56 @@ def _load_dockerignore(root: pathlib.Path) -> list[str]:
     ]
 
 
-def _ignored_dir_names(root: pathlib.Path) -> set[str]:
-    """Return a set of bare directory names that should be skipped during os.walk.
+def _ignored_dir_names(root: pathlib.Path) -> tuple[set[str], set[str]]:
+    """Return directory-name sets for .dockerignore pruning during os.walk.
 
-    Both ``**/name/`` and root-relative ``name/`` patterns are accepted —
-    any single-segment pattern ending with ``/`` is treated as a directory
-    name to prune at any depth.  Multi-segment paths (e.g. ``a/b/``) and
-    file-glob patterns (e.g. ``*.log``) are excluded.
+    Returns ``(root_only, any_depth)``:
+
+    * ``**/name/`` patterns apply at any depth (e.g. ``**/node_modules/``).
+    * bare ``name/`` patterns apply only when the directory sits at the
+      repository root (e.g. top-level ``ci/``), matching Docker semantics.
+
+    Multi-segment paths (e.g. ``a/b/``) and file-glob patterns (e.g. ``*.log``)
+    are excluded.
 
     TODO: negation patterns (``!name``) are filtered out, not honored as re-inclusions.
     TODO: followlinks=True in _copy_tree can still loop on circular symlinks.
     """
-    ignored: set[str] = set()
+    root_only: set[str] = set()
+    any_depth: set[str] = set()
     for pattern in _load_dockerignore(root):
         if not pattern.endswith("/"):
             continue
+        is_globstar = pattern.startswith("**/")
         name = pattern.removeprefix("**/").removesuffix("/")
         if name and "/" not in name and not any(c in name for c in ("*", "?", "[")):
-            ignored.add(name)
-    return ignored
+            (any_depth if is_globstar else root_only).add(name)
+    return root_only, any_depth
 
 
-def _copy_tree(src: pathlib.Path, dst: pathlib.Path, dir_ignore_names: set[str] | None = None):
+def _should_ignore_dir(
+        dirname: str,
+        rel: pathlib.Path,
+        repo_base_rel: pathlib.Path,
+        root_only_ignore: set[str],
+        any_depth_ignore: set[str],
+) -> bool:
+    if dirname in any_depth_ignore:
+        return True
+    if dirname in root_only_ignore:
+        return len((repo_base_rel / rel).parts) == 0
+    return False
+
+
+def _copy_tree(
+        src: pathlib.Path,
+        dst: pathlib.Path,
+        *,
+        repo_base_rel: pathlib.Path | None = None,
+        root_only_ignore: set[str] | None = None,
+        any_depth_ignore: set[str] | None = None,
+        dir_ignore_names: set[str] | None = None,
+):
     """Copy a directory tree, copying only file content (no metadata/xattrs).
 
     shutil.copytree's internal copystat() on directories fails on macOS with
@@ -136,17 +164,27 @@ def _copy_tree(src: pathlib.Path, dst: pathlib.Path, dir_ignore_names: set[str] 
     Directories that cannot be created (e.g. macOS EPERM on certain dotfiles
     in temp directories) are logged and skipped.
 
-    *dir_ignore_names* is an optional set of bare directory names (e.g.
-    ``{"node_modules", ".pnpm-store"}``) that will be pruned from each
-    ``dirnames`` list during the walk so that os.walk never descends into them.
-    This mirrors the ``**/name/`` patterns in ``.dockerignore`` and avoids the
-    ``OSError: [Errno 63] File name too long`` crash caused by deeply-nested
-    content-addressed stores such as ``.pnpm-store``.
+    *any_depth_ignore* mirrors ``**/name/`` patterns from ``.dockerignore``.
+    *root_only_ignore* mirrors bare ``name/`` patterns and only prunes
+    directories that would live at the repository root.  *dir_ignore_names* is
+    a legacy alias for *any_depth_ignore* (used by unit tests).
     """
+    if dir_ignore_names is not None and any_depth_ignore is None:
+        any_depth_ignore = dir_ignore_names
+    root_only_ignore = root_only_ignore or set()
+    any_depth_ignore = any_depth_ignore or set()
+    if repo_base_rel is None:
+        try:
+            repo_base_rel = src.relative_to(ROOT_DIR)
+        except ValueError:
+            repo_base_rel = pathlib.Path()
+
     for dirpath, dirnames, filenames in os.walk(src, followlinks=True):
-        if dir_ignore_names:
-            dirnames[:] = [d for d in dirnames if d not in dir_ignore_names]
         rel = pathlib.Path(dirpath).relative_to(src)
+        dirnames[:] = [
+            d for d in dirnames
+            if not _should_ignore_dir(d, rel, repo_base_rel, root_only_ignore, any_depth_ignore)
+        ]
         try:
             (dst / rel).mkdir(parents=True, exist_ok=True)
         except PermissionError:
@@ -166,7 +204,7 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
     if gitignore.exists():
         shutil.copy(gitignore, tmpdir)
 
-    dir_ignore_names = _ignored_dir_names(ROOT_DIR)
+    root_only_ignore, any_depth_ignore = _ignored_dir_names(ROOT_DIR)
 
     for dep in prereqs:
         if dep.is_absolute():
@@ -185,7 +223,13 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
                 m_path = pathlib.Path(m)
                 (tmpdir / m_path.parent).mkdir(parents=True, exist_ok=True)
                 if m_path.is_dir():
-                    _copy_tree(m_path, tmpdir / m_path, dir_ignore_names=dir_ignore_names)
+                    _copy_tree(
+                        m_path,
+                        tmpdir / m_path,
+                        repo_base_rel=m_path,
+                        root_only_ignore=root_only_ignore,
+                        any_depth_ignore=any_depth_ignore,
+                    )
                 else:
                     shutil.copy(m_path, tmpdir / m_path.parent)
             continue
@@ -195,7 +239,13 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
             sys.exit(1)
 
         if dep.is_dir():
-            _copy_tree(dep, tmpdir / dep, dir_ignore_names=dir_ignore_names)
+            _copy_tree(
+                dep,
+                tmpdir / dep,
+                repo_base_rel=dep,
+                root_only_ignore=root_only_ignore,
+                any_depth_ignore=any_depth_ignore,
+            )
         else:
             (tmpdir / dep.parent).mkdir(parents=True, exist_ok=True)
             shutil.copy(dep, tmpdir / dep.parent)

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -230,7 +230,7 @@ def _copy_tree_dir(
                 any_depth_ignore,
                 chain,
             )
-        elif entry.is_file(follow_symlinks=False):
+        elif entry.is_file(follow_symlinks=True):
             try:
                 shutil.copy(entry.path, dst_dir / name)
             except PermissionError:

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -132,18 +132,16 @@ def _ignored_dir_names(root: pathlib.Path) -> tuple[set[str], set[str]]:
     return root_only, any_depth
 
 
-def _should_ignore_dir(
+def _ignore_dirname(
         dirname: str,
-        rel: pathlib.Path,
-        repo_base_rel: pathlib.Path,
+        *,
         root_only_ignore: set[str],
         any_depth_ignore: set[str],
+        parent_at_repo_root: bool,
 ) -> bool:
     if dirname in any_depth_ignore:
         return True
-    if dirname in root_only_ignore:
-        return len((repo_base_rel / rel).parts) == 0
-    return False
+    return dirname in root_only_ignore and parent_at_repo_root
 
 
 def _copy_tree(
@@ -153,7 +151,6 @@ def _copy_tree(
         repo_base_rel: pathlib.Path | None = None,
         root_only_ignore: set[str] | None = None,
         any_depth_ignore: set[str] | None = None,
-        dir_ignore_names: set[str] | None = None,
 ):
     """Copy a directory tree, copying only file content (no metadata/xattrs).
 
@@ -163,28 +160,16 @@ def _copy_tree(
     Directories that cannot be created (e.g. macOS EPERM on certain dotfiles
     in temp directories) are logged and skipped.
 
-    *any_depth_ignore* mirrors ``**/name/`` patterns from ``.dockerignore``.
-    *root_only_ignore* mirrors bare ``name/`` patterns and only prunes
-    directories that would live at the repository root.  *dir_ignore_names* is
-    a legacy alias for *any_depth_ignore* (used by unit tests).
+    Ignore sets follow ``_ignored_dir_names`` / ``.dockerignore`` semantics.
     """
-    if dir_ignore_names is not None and any_depth_ignore is None:
-        any_depth_ignore = dir_ignore_names
     root_only_ignore = root_only_ignore or set()
     any_depth_ignore = any_depth_ignore or set()
     if repo_base_rel is None:
-        try:
-            repo_base_rel = src.relative_to(ROOT_DIR)
-        except ValueError:
-            repo_base_rel = pathlib.Path()
+        repo_base_rel = src.relative_to(ROOT_DIR) if src.is_relative_to(ROOT_DIR) else pathlib.Path()
 
-    if _should_ignore_dir(
-        src.name,
-        pathlib.Path(),
-        repo_base_rel.parent,
-        root_only_ignore,
-        any_depth_ignore,
-    ):
+    if src.name in any_depth_ignore:
+        return
+    if src.name in root_only_ignore and len(repo_base_rel.parts) == 1:
         return
 
     visited: set[str] = set()
@@ -197,9 +182,15 @@ def _copy_tree(
         visited.add(real_dir)
 
         rel = pathlib.Path(dirpath).relative_to(src)
+        parent_at_repo_root = len((repo_base_rel / rel).parts) == 0
         dirnames[:] = [
             d for d in dirnames
-            if not _should_ignore_dir(d, rel, repo_base_rel, root_only_ignore, any_depth_ignore)
+            if not _ignore_dirname(
+                d,
+                root_only_ignore=root_only_ignore,
+                any_depth_ignore=any_depth_ignore,
+                parent_at_repo_root=parent_at_repo_root,
+            )
         ]
         try:
             (dst / rel).mkdir(parents=True, exist_ok=True)
@@ -215,7 +206,6 @@ def _copy_tree(
 
 
 def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
-    # always adding .gitignore
     gitignore = ROOT_DIR / ".gitignore"
     if gitignore.exists():
         shutil.copy(gitignore, tmpdir)

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -172,37 +172,69 @@ def _copy_tree(
     if src.name in root_only_ignore and len(repo_base_rel.parts) == 1:
         return
 
-    visited: set[str] = set()
+    _copy_tree_dir(
+        src,
+        dst,
+        pathlib.Path("."),
+        repo_base_rel,
+        root_only_ignore,
+        any_depth_ignore,
+        frozenset(),
+    )
 
-    for dirpath, dirnames, filenames in os.walk(src, followlinks=True):
-        real_dir = os.path.realpath(dirpath)
-        if real_dir in visited:
-            dirnames.clear()
-            continue
-        visited.add(real_dir)
 
-        rel = pathlib.Path(dirpath).relative_to(src)
-        parent_at_repo_root = len((repo_base_rel / rel).parts) == 0
-        dirnames[:] = [
-            d for d in dirnames
-            if not _ignore_dirname(
-                d,
+def _copy_tree_dir(
+        src_dir: pathlib.Path,
+        dst_dir: pathlib.Path,
+        rel: pathlib.Path,
+        repo_base_rel: pathlib.Path,
+        root_only_ignore: set[str],
+        any_depth_ignore: set[str],
+        ancestor_realpaths: frozenset[str],
+) -> None:
+    real_dir = os.path.realpath(src_dir)
+    if real_dir in ancestor_realpaths:
+        return
+
+    try:
+        dst_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(f"cannot create directory, skipping subtree: {rel}")
+        return
+
+    parent_at_repo_root = len((repo_base_rel / rel).parts) == 0
+    chain = ancestor_realpaths | {real_dir}
+
+    try:
+        entries = list(os.scandir(src_dir))
+    except OSError as err:
+        log.warning(f"cannot read directory, skipping subtree: {rel}", error=str(err))
+        return
+
+    for entry in entries:
+        name = entry.name
+        if entry.is_dir(follow_symlinks=True):
+            if _ignore_dirname(
+                name,
                 root_only_ignore=root_only_ignore,
                 any_depth_ignore=any_depth_ignore,
                 parent_at_repo_root=parent_at_repo_root,
+            ):
+                continue
+            _copy_tree_dir(
+                pathlib.Path(entry.path),
+                dst_dir / name,
+                rel / name,
+                repo_base_rel,
+                root_only_ignore,
+                any_depth_ignore,
+                chain,
             )
-        ]
-        try:
-            (dst / rel).mkdir(parents=True, exist_ok=True)
-        except PermissionError:
-            log.warning(f"cannot create directory, skipping subtree: {rel}")
-            dirnames.clear()
-            continue
-        for fname in filenames:
+        elif entry.is_file(follow_symlinks=False):
             try:
-                shutil.copy(pathlib.Path(dirpath) / fname, dst / rel / fname)
+                shutil.copy(entry.path, dst_dir / name)
             except PermissionError:
-                log.warning(f"cannot copy file, skipping: {rel / fname}")
+                log.warning(f"cannot copy file, skipping: {rel / name}")
 
 
 def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -1,17 +1,13 @@
 #! /usr/bin/env python3
 
-import glob
 import pathlib
 import tempfile
 
 import pyfakefs.fake_filesystem
 import pytest
-import structlog
 
 from ci.logging_config import configure_logging
 from scripts.sandbox import _copy_tree, _ignored_dir_names, _load_dockerignore, setup_sandbox
-
-log = structlog.get_logger()
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
 
@@ -54,8 +50,6 @@ class TestSandbox:
 
         with tempfile.TemporaryDirectory(delete=True) as tmpdir:
             setup_sandbox([pathlib.Path("a/b/c")], pathlib.Path(tmpdir))
-            for g in glob.glob("**/*", recursive=True):
-                log.debug(g)
             assert (pathlib.Path(tmpdir) / "a").is_dir()
             assert (pathlib.Path(tmpdir) / "a" / "b").is_dir()
             assert (pathlib.Path(tmpdir) / "a" / "b" / "c").is_file()
@@ -136,7 +130,7 @@ class TestCopyTreeWithIgnore:
 
         dst = tmp_path / "dst"
         dst.mkdir()
-        _copy_tree(src, dst, dir_ignore_names={"node_modules"})
+        _copy_tree(src, dst, any_depth_ignore={"node_modules"})
 
         assert (dst / "keep" / "file.txt").is_file()
         assert not (dst / "node_modules").exists()
@@ -152,7 +146,7 @@ class TestCopyTreeWithIgnore:
 
         dst = tmp_path / "dst"
         dst.mkdir()
-        _copy_tree(src, dst, dir_ignore_names={".pnpm-store"})
+        _copy_tree(src, dst, any_depth_ignore={".pnpm-store"})
 
         assert (dst / "good" / "data").is_file()
         assert not (dst / ".pnpm-store").exists()
@@ -165,7 +159,7 @@ class TestCopyTreeWithIgnore:
 
         dst = tmp_path / "dst"
         dst.mkdir()
-        _copy_tree(src, dst)  # no dir_ignore_names
+        _copy_tree(src, dst)
 
         assert (dst / "node_modules" / "pkg" / "index.js").is_file()
 

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -205,3 +205,36 @@ class TestCopyTreeWithIgnore:
 
         assert not (dst / "repo/ci").exists()
         assert (dst / "repo/keep").is_dir()
+
+    def test_ignored_src_root_not_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "ci"
+        src.mkdir()
+        (src / "build.sh").write_text("#!/bin/bash")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(
+            src,
+            dst / "ci",
+            repo_base_rel=pathlib.Path("ci"),
+            root_only_ignore={"ci"},
+            any_depth_ignore=set(),
+        )
+
+        assert not (dst / "ci").exists()
+
+    def test_symlink_loop_does_not_hang(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "file.txt").write_text("keep")
+        sub = src / "sub"
+        sub.mkdir()
+        (sub / "nested.txt").write_text("nested")
+        sub.joinpath("back").symlink_to(src)
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(src, dst)
+
+        assert (dst / "file.txt").is_file()
+        assert (dst / "sub/nested.txt").is_file()

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -88,36 +88,39 @@ class TestLoadDockerignore:
 class TestIgnoredDirNames:
     def test_extracts_globstar_patterns(self, repo_root: pathlib.Path):
         (repo_root / ".dockerignore").write_text("**/node_modules/\n**/.pnpm-store/\n")
-        result = _ignored_dir_names(repo_root)
-        assert "node_modules" in result
-        assert ".pnpm-store" in result
+        root_only, any_depth = _ignored_dir_names(repo_root)
+        assert root_only == set()
+        assert "node_modules" in any_depth
+        assert ".pnpm-store" in any_depth
 
-    def test_includes_root_relative_patterns(self, repo_root: pathlib.Path):
+    def test_splits_root_relative_patterns(self, repo_root: pathlib.Path):
         (repo_root / ".dockerignore").write_text("ci/\nbin/\nnode_modules/\n")
-        result = _ignored_dir_names(repo_root)
-        assert "ci" in result
-        assert "bin" in result
-        assert "node_modules" in result
+        root_only, any_depth = _ignored_dir_names(repo_root)
+        assert root_only == {"ci", "bin", "node_modules"}
+        assert any_depth == set()
 
     def test_excludes_nested_path_patterns(self, repo_root: pathlib.Path):
         (repo_root / ".dockerignore").write_text("**/a/b/\n")
-        result = _ignored_dir_names(repo_root)
-        assert "a/b" not in result
-        assert "b" not in result
+        root_only, any_depth = _ignored_dir_names(repo_root)
+        assert root_only == set()
+        assert "a/b" not in any_depth
+        assert "b" not in any_depth
 
     def test_excludes_negation_patterns(self, repo_root: pathlib.Path):
         (repo_root / ".dockerignore").write_text("**/vendor/\n!**/vendor/\n")
-        result = _ignored_dir_names(repo_root)
-        assert "vendor" in result
-        assert len(result) == 1
+        root_only, any_depth = _ignored_dir_names(repo_root)
+        assert root_only == set()
+        assert any_depth == {"vendor"}
 
     def test_returns_empty_when_no_dockerignore(self, repo_root: pathlib.Path):
-        assert _ignored_dir_names(repo_root) == set()
+        assert _ignored_dir_names(repo_root) == (set(), set())
 
     def test_real_dockerignore(self):
-        result = _ignored_dir_names(ROOT_DIR)
-        assert result == {
+        root_only, any_depth = _ignored_dir_names(ROOT_DIR)
+        assert root_only == {
             "bin", "ci", "tests", ".idea", "env", "venv", ".venv", "docs", "examples",
+        }
+        assert any_depth == {
             "node_modules", ".mypy_cache", ".pytest_cache", "__pycache__",
         }
 
@@ -165,3 +168,40 @@ class TestCopyTreeWithIgnore:
         _copy_tree(src, dst)  # no dir_ignore_names
 
         assert (dst / "node_modules" / "pkg" / "index.js").is_file()
+
+    def test_root_only_ci_not_ignored_in_nested_tree(self, tmp_path: pathlib.Path):
+        src = tmp_path / "codeserver/prefetch-input/patches/code-server-v4.106.3"
+        (src / "ci/build").mkdir(parents=True)
+        (src / "ci/build/build-vscode.sh").write_text("#!/bin/bash")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(
+            src,
+            dst / src.relative_to(tmp_path),
+            repo_base_rel=src.relative_to(tmp_path),
+            root_only_ignore={"ci"},
+            any_depth_ignore=set(),
+        )
+
+        assert (dst / src.relative_to(tmp_path) / "ci/build/build-vscode.sh").is_file()
+
+    def test_root_only_ci_ignored_at_repo_root(self, tmp_path: pathlib.Path):
+        src = tmp_path / "repo"
+        src.mkdir()
+        (src / "ci").mkdir()
+        (src / "ci/build.sh").write_text("#!/bin/bash")
+        (src / "keep").mkdir()
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        _copy_tree(
+            src,
+            dst / "repo",
+            repo_base_rel=pathlib.Path("."),
+            root_only_ignore={"ci"},
+            any_depth_ignore=set(),
+        )
+
+        assert not (dst / "repo/ci").exists()
+        assert (dst / "repo/keep").is_dir()

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -232,3 +232,18 @@ class TestCopyTreeWithIgnore:
 
         assert (dst / "file.txt").is_file()
         assert (dst / "sub/nested.txt").is_file()
+
+    def test_symlink_aliases_to_same_target_both_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        target = src / "target"
+        target.mkdir()
+        (target / "data.txt").write_text("data")
+        (src / "alias1").symlink_to("target", target_is_directory=True)
+        (src / "alias2").symlink_to("target", target_is_directory=True)
+
+        dst = tmp_path / "dst"
+        _copy_tree(src, dst)
+
+        assert (dst / "alias1/data.txt").read_text() == "data"
+        assert (dst / "alias2/data.txt").read_text() == "data"

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -247,3 +247,15 @@ class TestCopyTreeWithIgnore:
 
         assert (dst / "alias1/data.txt").read_text() == "data"
         assert (dst / "alias2/data.txt").read_text() == "data"
+
+    def test_symlinked_file_is_copied(self, tmp_path: pathlib.Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "real.txt").write_text("content")
+        (src / "link.txt").symlink_to("real.txt")
+
+        dst = tmp_path / "dst"
+        _copy_tree(src, dst)
+
+        assert (dst / "real.txt").read_text() == "content"
+        assert (dst / "link.txt").read_text() == "content"


### PR DESCRIPTION
## Summary

Fixes codeserver GHA build failures introduced by PR #3166: root-level `.dockerignore` patterns `ci/`, `bin/`, and `tests/` were applied at **every** directory depth during sandbox copies, stripping nested paths such as `code-server/ci/build/build-vscode.sh`. Builds then fail in `tweak-gha.sh` with:

```
sed: can't read ci/build/build-vscode.sh: No such file or directory
```

This change scopes those patterns to the **repository root only**, matching Docker's `dockerignore` semantics for unanchored directory patterns.

Relates to #3150.

## Changes

- `scripts/sandbox.py` — root-only ignore handling in `_copy_tree`
- `scripts/sandbox_tests.py` — regression tests for nested `ci/` preservation
- `.dockerignore` — comment clarifying root-only intent for `ci/`, `bin/`, `tests/`

## Test plan

- [x] `uv run pytest scripts/sandbox_tests.py`
- [ ] `build-notebooks-pr` codeserver amd64/arm64 jobs pass (no `tweak-gha.sh` / `build-vscode.sh` error)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox directory copying to correctly apply `.dockerignore` directory rules as either root-only (`name/`) or any-depth (`**/name/`), reducing incorrect pruning.
  * Refined sandbox traversal to better handle symlinks without hangs and preserve expected directory contents.
* **Documentation**
  * Clarified `.dockerignore` behavior for root-relative vs any-depth patterns, including limitations of the sandbox rule parser.
* **Tests**
  * Updated and expanded sandbox tests to validate the new ignore-scope behavior and traversal safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->