### PR TITLE
ISSUE#3949: fix(ci): reliability improvements for Playwright tests

### DIFF
--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -95,6 +95,9 @@ runs:
           podman network reload --all
         fi
 
+    - run: podman system info
+      shell: bash
+
     - name: Show error logs (on failure)
       if: ${{ failure() }}
       shell: bash

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -465,6 +465,29 @@ jobs:
 
       # endregion
 
+      # region TypeScript (browser) image tests
+
+      # opendatahub-io/notebooks/issues/3949: podman transient_store seems unreliable
+      #  faccessat .../storage/overlay/d43b43566b744...: no such file or directory
+      # therefore, run this first thing in the job
+
+      # https://playwright.dev/docs/ci
+      # https://playwright.dev/docs/docker
+      # we leave little free disk space after we mount LVM for podman storage
+      # not enough to install playwright; running playwright in podman uses the space we have
+      - name: Run Playwright tests
+        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
+        uses: ./.github/actions/playwright-test
+        with:
+          test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
+          podman-socket: /var/run/podman/podman.sock
+          upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
+          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
+          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
+          grep-pattern: '@codeserver'
+
+      # endregion
+
       # region Pytest image tests
 
       - name: Run Testcontainers container tests (in PyTest)
@@ -663,25 +686,6 @@ jobs:
         env:
           GOCACHE: /home/runner/.cache/go-build
           GOMODCACHE: /home/runner/go/pkg/mod
-
-      # endregion
-
-      # region TypeScript (browser) image tests
-
-      # https://playwright.dev/docs/ci
-      # https://playwright.dev/docs/docker
-      # we leave little free disk space after we mount LVM for podman storage
-      # not enough to install playwright; running playwright in podman uses the space we have
-      - name: Run Playwright tests
-        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
-        uses: ./.github/actions/playwright-test
-        with:
-          test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
-          podman-socket: /var/run/podman/podman.sock
-          upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
-          artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
-          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
-          grep-pattern: '@codeserver'
 
       # endregion
 

--- a/ci/cached-builds/storage.conf
+++ b/ci/cached-builds/storage.conf
@@ -7,9 +7,11 @@
 driver = "overlay"
 
 graphroot = "/home/runner/.local/share/containers/storage"
-runroot = "/home/runner/.local/share/containers/storage"
+# keep runroot= on the default tmpfs-backed path, otherwise transient_store is kind of pointless
 
 # https://www.redhat.com/en/blog/speed-containers-podman-raspberry-pi
+# opendatahub-io/notebooks/issues/3949: transient_store can be buggy when unmounting:
+#  faccessat .../storage/overlay/d43b43566b744...: no such file or directory
 transient_store = true
 
 [storage.options]


### PR DESCRIPTION
GHA run
* https://github.com/opendatahub-io/notebooks/actions/runs/28287838876

This PR includes reliability improvements for Playwright tests and CI/CD configurations.

Recent changes:
- ISSUE#3949: fix(ci): relocate FIPS tests block to avoid transient store issue
- ISSUE#3919: chore(gha): add `podman system info` to install-podman-action for debugging
- ISSUE#3949: fix(ci): update storage.conf to have runroot= on a tmpfs
- fix(scripts): scope sandbox ci/ ignore to repo root only
- fix: _copy_tree respects .dockerignore patterns to avoid OSError on long paths

Addresses ISSUE#1123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI and notebook build validation by running the browser image tests earlier in the pipeline (before the FIPS compliance check).
  * Added an extra Podman diagnostic step to surface container setup issues via `podman system info`.
* **Documentation**
  * Clarified cached build storage configuration guidance to keep `runroot` on the default tmpfs-backed path so transient storage remains effective.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->