### PR TITLE
NO-JIRA: chore(.github): use pre-built buildinputs image instead of compiling Go on every runner

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -151,12 +151,11 @@ jobs:
           SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
           SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 
-      # for bin/buildinputs in scripts/sandbox.py and check-payload FIPS scan
+      # for check-payload FIPS scan
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "stable"
           cache-dependency-path: |
-            scripts/buildinputs/go.mod
             scripts/check-payload/go.mod
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -84,11 +84,6 @@ jobs:
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version: "stable"
-          cache-dependency-path: "scripts/buildinputs/go.mod"
-
       # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -83,11 +83,6 @@ jobs:
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version: "stable"
-          cache-dependency-path: "scripts/buildinputs/go.mod"
-
       # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -28,11 +28,6 @@ jobs:
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version: "stable"
-          cache-dependency-path: "scripts/buildinputs/go.mod"
-
       - name: Check if PR is from a fork
         id: fork-check
         env:

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -40,11 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version: "stable"
-          cache-dependency-path: "scripts/buildinputs/go.mod"
-
       - name: Determine targets to build (we want to build everything on push)
         run: |
           set -x

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -73,12 +73,6 @@ jobs:
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version-file: scripts/buildinputs/go.mod
-          cache-dependency-path: scripts/buildinputs/go.mod
-
       - name: Run make refresh-lock-files
         run: |
           make refresh-lock-files INDEX_MODE="$INDEX_MODE"

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,11 @@ endef
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
 skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files sync-build-args-from-versions sync-commit-env-files update-imagestream-annotations refresh-imagestream-metadata scan-image-vulnerabilities print-release
+# CI uses the pre-built container image via buildinputs_runner.py instead
+ifneq ($(CI),true)
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
 $(SELF): bin/buildinputs
+endif
 endif
 
 bin/buildinputs: scripts/buildinputs/buildinputs.go scripts/buildinputs/go.mod scripts/buildinputs/go.sum

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -13,9 +13,11 @@ import unittest
 import unittest.mock
 from typing import Literal, cast
 
-from scripts.buildinputs_runner import Platform, buildinputs
-
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.buildinputs_runner import Platform, buildinputs  # noqa: E402
+
 MAKE = shutil.which("gmake") or shutil.which("make") or "make"
 
 

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -8,9 +8,13 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
+import unittest.mock
 from typing import Literal
+
+from scripts.buildinputs_runner import buildinputs
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
 MAKE = shutil.which("gmake") or shutil.which("make") or "make"
@@ -156,25 +160,19 @@ def should_build_target(changed_files: list[str], target_directory: str) -> str:
     # detect change in any of the files outside
     dockerfiles = find_dockerfiles(target_directory)
     for dockerfile in dockerfiles:
-        stdout = subprocess.check_output(
-            args=[
-                PROJECT_ROOT / "bin/buildinputs",
-                *["-build-arg=BASE_IMAGE=fake-image"],
-                target_directory + "/" + dockerfile,
-            ],
-            env={
-                "TARGETPLATFORM": f"linux/{get_go_arch()}",
-                **os.environ,
-            },  # TODO(jdanek): still not ideal for qemu-user
-            text=True,
-            cwd=PROJECT_ROOT,
+        dependencies = _resolve_symlinks(
+            [
+                str(path)
+                for path in buildinputs(
+                    target_directory + "/" + dockerfile,
+                    platform=f"linux/{get_go_arch()}",
+                    build_args={"BASE_IMAGE": "fake-image"},
+                )
+            ]
         )
-        logging.debug(f"{target_directory=} {dockerfile=} {stdout=}")
-        if stdout == "\n":
-            # no dependencies
+        logging.debug(f"{target_directory=} {dockerfile=} {dependencies=}")
+        if not dependencies:
             continue
-        dependencies: list[str] = json.loads(stdout)
-        dependencies = _resolve_symlinks(dependencies)
         for dependency in dependencies:
             for changed_file in changed_files:
                 if _is_file_in_directory(changed_file, dependency):
@@ -236,7 +234,18 @@ class TestSelf(unittest.TestCase):
         assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm"
 
     def test_should_build_target(self):
-        assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.12")
+        current_module = sys.modules[__name__]
+        with unittest.mock.patch.object(current_module, "buildinputs", return_value=[]):
+            assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.12")
+
+    def test_should_build_target_dependency_change(self):
+        fake_return = [pathlib.Path("jupyter/datascience/ubi9-python-3.12/helper.txt")]
+        current_module = sys.modules[__name__]
+        with unittest.mock.patch.object(current_module, "buildinputs", return_value=fake_return):
+            assert should_build_target(
+                ["jupyter/datascience/ubi9-python-3.12/helper.txt"],
+                "jupyter/datascience/ubi9-python-3.12",
+            ) == "jupyter/datascience/ubi9-python-3.12/helper.txt"
 
     def test_resolve_symlinks_no_symlinks(self):
         """No symlinks in input paths -> returned unchanged."""

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -1,6 +1,5 @@
 import fnmatch
 import functools
-import json
 import logging
 import os
 import pathlib
@@ -12,9 +11,9 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
-from typing import Literal
+from typing import Literal, cast
 
-from scripts.buildinputs_runner import buildinputs
+from scripts.buildinputs_runner import Platform, buildinputs
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
 MAKE = shutil.which("gmake") or shutil.which("make") or "make"
@@ -165,7 +164,7 @@ def should_build_target(changed_files: list[str], target_directory: str) -> str:
                 str(path)
                 for path in buildinputs(
                     target_directory + "/" + dockerfile,
-                    platform=f"linux/{get_go_arch()}",
+                    platform=cast("Platform", f"linux/{get_go_arch()}"),
                     build_args={"BASE_IMAGE": "fake-image"},
                 )
             ]
@@ -242,10 +241,13 @@ class TestSelf(unittest.TestCase):
         fake_return = [pathlib.Path("jupyter/datascience/ubi9-python-3.12/helper.txt")]
         current_module = sys.modules[__name__]
         with unittest.mock.patch.object(current_module, "buildinputs", return_value=fake_return):
-            assert should_build_target(
-                ["jupyter/datascience/ubi9-python-3.12/helper.txt"],
-                "jupyter/datascience/ubi9-python-3.12",
-            ) == "jupyter/datascience/ubi9-python-3.12/helper.txt"
+            assert (
+                should_build_target(
+                    ["jupyter/datascience/ubi9-python-3.12/helper.txt"],
+                    "jupyter/datascience/ubi9-python-3.12",
+                )
+                == "jupyter/datascience/ubi9-python-3.12/helper.txt"
+            )
 
     def test_resolve_symlinks_no_symlinks(self):
         """No symlinks in input paths -> returned unchanged."""

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -203,7 +203,7 @@ CI now runs the published helper image from GHCR instead of compiling the tool o
 ```shell
 podman run --rm \
   -e TARGETPLATFORM=linux/amd64 \
-  -v "$PWD:$PWD:ro" \
+  -v "$PWD:$PWD:ro,z" \
   -w "$PWD" \
   ghcr.io/opendatahub-io/notebooks/buildinputs:main \
   -build-arg=BASE_IMAGE=fake-image \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -194,8 +194,23 @@ python scripts/cve/cve_due_dates.py --summary
 
 CLI tool written in Go that computes the list of input files required to build a Dockerfile.
 This is useful to determine what images need to be built on CI when testing a GitHub Pull Request.
+CI now runs the published helper image from GHCR instead of compiling the tool on every runner.
 
 ### Examples
+
+**Podman run**:
+
+```shell
+podman run --rm \
+  -e TARGETPLATFORM=linux/amd64 \
+  -v "$PWD:$PWD:ro" \
+  -w "$PWD" \
+  ghcr.io/opendatahub-io/notebooks/buildinputs:main \
+  -build-arg=BASE_IMAGE=fake-image \
+  jupyter/datascience/ubi9-python-3.11/Dockerfile
+```
+
+**Native local binary**:
 
 ```shell
 make bin/buildinputs

--- a/scripts/buildinputs_runner.py
+++ b/scripts/buildinputs_runner.py
@@ -9,7 +9,6 @@ import shutil
 import subprocess
 from typing import Literal
 
-
 ROOT_DIR = pathlib.Path(__file__).parent.parent.resolve()
 MAKE = shutil.which("gmake") or shutil.which("make")
 
@@ -27,7 +26,7 @@ def _repository_slug() -> str:
             cwd=ROOT_DIR,
             text=True,
         ).strip()
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except FileNotFoundError, subprocess.CalledProcessError:
         return "opendatahub-io/notebooks"
 
     if match := re.search(r"[:/]([^/]+/[^/]+?)(?:\.git)?$", origin):
@@ -83,26 +82,29 @@ def containarized_buildinputs(
     stdout = subprocess.check_output(command, text=True, cwd=ROOT_DIR)
     return stdout
 
+
 def local_buildinputs(
     dockerfile: pathlib.Path | str,
     platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64",
-    build_args: dict[str, str] | None = None
+    build_args: dict[str, str] | None = None,
 ) -> str:
     if not (ROOT_DIR / "bin/buildinputs").exists():
         subprocess.check_call([MAKE, "bin/buildinputs"], cwd=ROOT_DIR)
     if not build_args:
         build_args = {}
-    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs",
-                                      *[f"-build-arg={k}={v}" for k, v in build_args.items()],
-                                      str(dockerfile)],
-                                     text=True, cwd=ROOT_DIR,
-                                     env={**os.environ, "TARGETPLATFORM": platform})
+    stdout = subprocess.check_output(
+        [ROOT_DIR / "bin/buildinputs", *[f"-build-arg={k}={v}" for k, v in build_args.items()], str(dockerfile)],
+        text=True,
+        cwd=ROOT_DIR,
+        env={**os.environ, "TARGETPLATFORM": platform},
+    )
     return stdout
+
 
 def buildinputs(
     dockerfile: pathlib.Path | str,
     platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64",
-    build_args: dict[str, str] | None = None
+    build_args: dict[str, str] | None = None,
 ) -> list[pathlib.Path]:
 
     if "CI" in os.environ and os.environ["CI"] == "true":

--- a/scripts/buildinputs_runner.py
+++ b/scripts/buildinputs_runner.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import functools
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+from typing import Literal
+
+
+ROOT_DIR = pathlib.Path(__file__).parent.parent.resolve()
+MAKE = shutil.which("gmake") or shutil.which("make")
+
+Platform = Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+
+
+@functools.lru_cache
+def _repository_slug() -> str:
+    if repository := os.environ.get("GITHUB_REPOSITORY"):
+        return repository.lower()
+
+    try:
+        origin = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            cwd=ROOT_DIR,
+            text=True,
+        ).strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "opendatahub-io/notebooks"
+
+    if match := re.search(r"[:/]([^/]+/[^/]+?)(?:\.git)?$", origin):
+        return match.group(1).lower()
+    return "opendatahub-io/notebooks"
+
+
+def buildinputs_image() -> str:
+    if image := os.environ.get("BUILDINPUTS_IMAGE"):
+        return image
+    return f"ghcr.io/{_repository_slug()}/buildinputs:main"
+
+
+def _container_runtime() -> str:
+    if runtime := os.environ.get("BUILDINPUTS_RUNTIME"):
+        return runtime
+
+    for candidate in ("podman", "docker"):
+        if shutil.which(candidate):
+            return candidate
+    raise RuntimeError("need podman or docker to run the buildinputs image")
+
+
+def containarized_buildinputs(
+    dockerfile: pathlib.Path | str,
+    platform: Platform = "linux/amd64",
+    build_args: dict[str, str] | None = None,
+) -> str:
+    if build_args is None:
+        build_args = {}
+
+    dockerfile_path = pathlib.Path(dockerfile)
+    if not dockerfile_path.is_absolute():
+        dockerfile_path = (ROOT_DIR / dockerfile_path).resolve()
+    else:
+        dockerfile_path = dockerfile_path.resolve()
+
+    command = [
+        _container_runtime(),
+        "run",
+        "--rm",
+        "-e",
+        f"TARGETPLATFORM={platform}",
+        "-v",
+        f"{ROOT_DIR}:{ROOT_DIR}:ro,z",
+        "-w",
+        str(ROOT_DIR),
+        buildinputs_image(),
+        *[f"-build-arg={key}={value}" for key, value in build_args.items()],
+        str(dockerfile_path),
+    ]
+
+    stdout = subprocess.check_output(command, text=True, cwd=ROOT_DIR)
+    return stdout
+
+def local_buildinputs(
+    dockerfile: pathlib.Path | str,
+    platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64",
+    build_args: dict[str, str] | None = None
+) -> str:
+    if not (ROOT_DIR / "bin/buildinputs").exists():
+        subprocess.check_call([MAKE, "bin/buildinputs"], cwd=ROOT_DIR)
+    if not build_args:
+        build_args = {}
+    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs",
+                                      *[f"-build-arg={k}={v}" for k, v in build_args.items()],
+                                      str(dockerfile)],
+                                     text=True, cwd=ROOT_DIR,
+                                     env={**os.environ, "TARGETPLATFORM": platform})
+    return stdout
+
+def buildinputs(
+    dockerfile: pathlib.Path | str,
+    platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64",
+    build_args: dict[str, str] | None = None
+) -> list[pathlib.Path]:
+
+    if "CI" in os.environ and os.environ["CI"] == "true":
+        stdout = containarized_buildinputs(dockerfile, platform, build_args)
+    else:
+        stdout = local_buildinputs(dockerfile, platform, build_args)
+
+    prereqs = list(dict.fromkeys(pathlib.Path(file) for file in json.loads(stdout)))
+    print(f"{prereqs=}")
+    return prereqs

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -2,10 +2,8 @@
 
 import argparse
 import glob
-import json
 import os
 import pathlib
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -14,9 +12,9 @@ from typing import cast, Literal
 import structlog
 
 from ci.logging_config import configure_logging
+from scripts.buildinputs_runner import buildinputs
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
-MAKE = shutil.which("gmake") or shutil.which("make")
 
 log = structlog.get_logger()
 
@@ -73,25 +71,6 @@ def extract_build_args(remaining: list[str]) -> dict[str, str]:
         key, value = arg.split("=", 1)
         build_args[key] = value
     return build_args
-
-
-def buildinputs(
-        dockerfile: pathlib.Path | str,
-        platform: Literal["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"] = "linux/amd64",
-        build_args: dict[str, str] | None = None
-) -> list[pathlib.Path]:
-    if not (ROOT_DIR / "bin/buildinputs").exists():
-        subprocess.check_call([MAKE, "bin/buildinputs"], cwd=ROOT_DIR)
-    if not build_args:
-        build_args = {}
-    stdout = subprocess.check_output([ROOT_DIR / "bin/buildinputs",
-                                      *[f"-build-arg={k}={v}" for k, v in build_args.items()],
-                                      str(dockerfile)],
-                                     text=True, cwd=ROOT_DIR,
-                                     env={**os.environ, "TARGETPLATFORM": platform})
-    prereqs = list(dict.fromkeys(pathlib.Path(file) for file in json.loads(stdout)))
-    print(f"{prereqs=}")
-    return prereqs
 
 
 def _load_dockerignore(root: pathlib.Path) -> list[str]:

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -4,6 +4,7 @@ import argparse
 import glob
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
 import tempfile

--- a/scripts/test_buildinputs_runner.py
+++ b/scripts/test_buildinputs_runner.py
@@ -5,10 +5,11 @@ import pathlib
 from scripts import buildinputs_runner
 
 
-def test_buildinputs_image_uses_repository_slug(monkeypatch):
+def test_buildinputs_image_uses_repository_slug(monkeypatch, request):
     monkeypatch.delenv("BUILDINPUTS_IMAGE", raising=False)
     monkeypatch.setenv("GITHUB_REPOSITORY", "Example/Repo")
     buildinputs_runner._repository_slug.cache_clear()
+    request.addfinalizer(buildinputs_runner._repository_slug.cache_clear)
 
     assert buildinputs_runner.buildinputs_image() == "ghcr.io/example/repo/buildinputs:main"
 

--- a/scripts/test_buildinputs_runner.py
+++ b/scripts/test_buildinputs_runner.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pathlib
+
+from scripts import buildinputs_runner
+
+
+def test_buildinputs_image_uses_repository_slug(monkeypatch):
+    monkeypatch.delenv("BUILDINPUTS_IMAGE", raising=False)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "Example/Repo")
+    buildinputs_runner._repository_slug.cache_clear()
+
+    assert buildinputs_runner.buildinputs_image() == "ghcr.io/example/repo/buildinputs:main"
+
+
+def test_containarized_buildinputs(monkeypatch):
+    captured = {}
+
+    def fake_check_output(command, text, cwd):
+        captured["command"] = command
+        captured["cwd"] = cwd
+        assert text is True
+        return '["foo.txt", "bar/baz.txt"]\n'
+
+    monkeypatch.setenv("BUILDINPUTS_RUNTIME", "podman")
+    monkeypatch.setenv("BUILDINPUTS_IMAGE", "ghcr.io/example/buildinputs:main")
+    monkeypatch.setattr(buildinputs_runner.subprocess, "check_output", fake_check_output)
+
+    stdout = buildinputs_runner.containarized_buildinputs(
+        pathlib.Path("jupyter/example/Dockerfile"),
+        platform="linux/arm64",
+        build_args={"BASE_IMAGE": "fake-image"},
+    )
+
+    assert stdout == '["foo.txt", "bar/baz.txt"]\n'
+    assert captured["cwd"] == buildinputs_runner.ROOT_DIR
+    assert captured["command"] == [
+        "podman",
+        "run",
+        "--rm",
+        "-e",
+        "TARGETPLATFORM=linux/arm64",
+        "-v",
+        f"{buildinputs_runner.ROOT_DIR}:{buildinputs_runner.ROOT_DIR}:ro,z",
+        "-w",
+        str(buildinputs_runner.ROOT_DIR),
+        "ghcr.io/example/buildinputs:main",
+        "-build-arg=BASE_IMAGE=fake-image",
+        str((buildinputs_runner.ROOT_DIR / "jupyter/example/Dockerfile").resolve()),
+    ]
+
+
+def test_local_buildinputs(monkeypatch, tmp_path):
+    captured = {}
+
+    fake_binary = tmp_path / "bin" / "buildinputs"
+    fake_binary.parent.mkdir()
+    fake_binary.touch()
+
+    def fake_check_output(command, text, cwd, env=None):
+        captured["command"] = command
+        captured["cwd"] = cwd
+        captured["env"] = env
+        assert text is True
+        return '["foo.txt"]\n'
+
+    monkeypatch.setattr(buildinputs_runner, "ROOT_DIR", tmp_path)
+    monkeypatch.setattr(buildinputs_runner.subprocess, "check_output", fake_check_output)
+
+    stdout = buildinputs_runner.local_buildinputs(
+        "jupyter/example/Dockerfile",
+        platform="linux/amd64",
+        build_args={"BASE_IMAGE": "fake-image"},
+    )
+
+    assert stdout == '["foo.txt"]\n'
+    assert captured["command"] == [
+        fake_binary,
+        "-build-arg=BASE_IMAGE=fake-image",
+        "jupyter/example/Dockerfile",
+    ]
+    assert captured["env"]["TARGETPLATFORM"] == "linux/amd64"
+
+
+def test_buildinputs_dispatches_to_container_in_ci(monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setattr(
+        buildinputs_runner, "containarized_buildinputs", lambda *a, **kw: '["a.txt"]\n'
+    )
+
+    result = buildinputs_runner.buildinputs("Dockerfile")
+    assert result == [pathlib.Path("a.txt")]
+
+
+def test_buildinputs_dispatches_to_local_outside_ci(monkeypatch):
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(
+        buildinputs_runner, "local_buildinputs", lambda *a, **kw: '["b.txt"]\n'
+    )
+
+    result = buildinputs_runner.buildinputs("Dockerfile")
+    assert result == [pathlib.Path("b.txt")]


### PR DESCRIPTION
## Summary
- Add `scripts/buildinputs_runner.py` that runs the GHCR-published buildinputs container image via podman/docker, replacing the pattern of compiling the Go binary on every CI runner
- Remove `actions/setup-go` steps from 6 GHA workflows (TEMPLATE, pr, pr-aipcc, pr-rhel, push, piplock-renewal)
- In CI (`CI=true`), use the container image; locally, build the Go binary on demand via `local_buildinputs()`
- Move `buildinputs()` out of `sandbox.py` into dedicated module with SELinux `:z` mount label, `lru_cache` on repo slug lookup
- Replace `globals()` monkeypatch with `unittest.mock.patch.object` in `gha_pr_changed_files.py` tests

Follows up on #3968 which published the buildinputs image to GHCR.

## Test plan
- [x] `scripts/test_buildinputs_runner.py` — 5 tests covering container command, local binary, CI/local dispatch
- [x] `ci/cached-builds/gha_pr_changed_files.py` — monkepatched tests pass with `mock.patch.object`
- [ ] CI workflows no longer install Go for buildinputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now generates dependency information using a prebuilt helper image, with container execution in CI and local execution outside CI.
* **Bug Fixes**
  * Improved dependency discovery logic for build-target selection.
  * Workflows and CI builds skip unnecessary Go setup; CI builds avoid compiling the Go helper.
* **Documentation**
  * Updated helper documentation with container (podman) and local usage examples.
* **Tests**
  * Added a focused test suite for the helper runner behavior (container vs local, image selection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->