### PR TITLE
RHAIENG-5858: feat(manifests) Keep 2025.2 runtime images for 3.5 GA

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -30,7 +30,7 @@ if [ "${KONFLUX:-no}" = 'yes' ]; then
     # This value needs to be updated everytime we deliberately change number of the
     # images we want to have in the `params.env` or `params-latest.env` file.
     EXPECTED_COMMIT_NUM_RECORDS=43
-    EXPECTED_PARAMS_NUM_RECORDS=50
+    EXPECTED_PARAMS_NUM_RECORDS=57
 else
     _MANIFESTS_VARIANT="odh"
     # This value needs to be updated everytime we deliberately change number of the
@@ -601,6 +601,48 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             expected_commitref="main"
             expected_build_name="konflux"
             expected_img_size=5859
+            ;;
+        odh-pipeline-runtime-datascience-cpu-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=1015
+            ;;
+        odh-pipeline-runtime-minimal-cpu-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=595
+            ;;
+        odh-pipeline-runtime-pytorch-cuda-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=8768
+            ;;
+        odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=8723
+            ;;
+        odh-pipeline-runtime-pytorch-rocm-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=8725
+            ;;
+        odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=8206
+            ;;
+        odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-2025-2)
+            expected_name="rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9"
+            expected_commitref="main"
+            expected_build_name="konflux"
+            expected_img_size=6614
             ;;
         *)
             echo "Unimplemented variable name: '${image_variable}'"

--- a/ci/expected-image-metadata.yaml
+++ b/ci/expected-image-metadata.yaml
@@ -595,3 +595,62 @@ odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-3-4:
   variants:
     - odh
     - rhoai
+
+# --- py312 2025-2 pipeline runtime entries (RHOAI only) ---
+
+odh-pipeline-runtime-datascience-cpu-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 1015
+  variants:
+    - rhoai
+odh-pipeline-runtime-minimal-cpu-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 595
+  variants:
+    - rhoai
+odh-pipeline-runtime-pytorch-cuda-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 8768
+  variants:
+    - rhoai
+odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 8723
+  variants:
+    - rhoai
+odh-pipeline-runtime-pytorch-rocm-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 8725
+  variants:
+    - rhoai
+odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 8206
+  variants:
+    - rhoai
+odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-2025-2:
+  name:
+    rhoai: rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+  commitref: main
+  build_name: konflux
+  size_mb: 6614
+  variants:
+    - rhoai

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -20,6 +20,13 @@ resources:
   - runtime-rocm-tensorflow-imagestream.yaml
   - runtime-tensorflow-imagestream.yaml
   - runtime-pytorch-llmcompressor-imagestream.yaml
+  - runtime-datascience-imagestream-2025-2.yaml
+  - runtime-minimal-imagestream-2025-2.yaml
+  - runtime-pytorch-imagestream-2025-2.yaml
+  - runtime-pytorch-llmcompressor-imagestream-2025-2.yaml
+  - runtime-rocm-pytorch-imagestream-2025-2.yaml
+  - runtime-rocm-tensorflow-imagestream-2025-2.yaml
+  - runtime-tensorflow-imagestream-2025-2.yaml
 
 configMapGenerator:
   - envs:
@@ -1247,4 +1254,95 @@ replacements:
           group: image.openshift.io
           kind: ImageStream
           name: runtime-pytorch-llmcompressor
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-datascience-cpu-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-datascience-2025-2
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-minimal-cpu-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-minimal-2025-2
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-pytorch-cuda-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-pytorch-2025-2
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-pytorch-llmcompressor-2025-2
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-pytorch-rocm-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-rocm-pytorch-2025-2
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-rocm-tensorflow-2025-2
+          version: v1
+  - source:
+      fieldPath: data.odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-2025-2
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: runtime-tensorflow-2025-2
           version: v1

--- a/manifests/rhoai/base/params.env
+++ b/manifests/rhoai/base/params.env
@@ -22,6 +22,14 @@ odh-workbench-jupyter-trustyai-cpu-py312-ubi9-2025-2=registry.redhat.io/rhoai/od
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:8a82997a29741ecf41492c7aa5c9ee57aa0e7c3bcda1fc854c1ae8686632a36f
 odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:3e8f45e17ec6d8ad6150835d8566a611de83fde0a45c56ce09efa02b1074c480
 
+odh-pipeline-runtime-datascience-cpu-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:22ea9fc4352ec427a240fb983afb0ad3e7c1b2f2dc97bce4587695777f23ef07
+odh-pipeline-runtime-minimal-cpu-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:d3d4d82d0685feb25ec91cf8928dc5c5859436f44a21cd93b5d2ce7c1869a603
+odh-pipeline-runtime-pytorch-cuda-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:8b059881d8d7ef85883c7672a4464368ae564f2ce6104d54ebb03ac5d152d536
+odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:7c2ce6c9e93266a11cbfdef8b3abbeb9ffd13f983b9fb3a091607d1065d597e0
+odh-pipeline-runtime-pytorch-rocm-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384
+odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
+odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-2025-2=registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
+
 odh-workbench-jupyter-minimal-cpu-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py311-rhel9@sha256:2b00a5b676b07d4fd6ab894d5dcaeb5bf88ef35bde76cbf3b4c0951987e5aad6
 odh-workbench-jupyter-minimal-cuda-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py311-rhel9@sha256:481c5f3749efb85300ed6076a5b05ca5be1ceda17518791db3a67c7b1fa24941
 odh-workbench-jupyter-pytorch-cuda-py311-ubi9-2025-1=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py311-rhel9@sha256:384f2ea2df8ccf1978ba633a0b32332e12a4c8d026967ff93e7b8fb0928c8265

--- a/manifests/rhoai/base/runtime-datascience-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-datascience-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+  name: runtime-datascience-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | Datascience | CPU | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "datascience-2025.2"
+                ],
+                "display_name": "Runtime | Datascience | CPU | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-datascience-cpu-py312-ubi9-2025-2_PLACEHOLDER
+      name: "datascience-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/runtime-minimal-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-minimal-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+  name: runtime-minimal-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | Minimal | CPU | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "minimal-2025.2"
+                ],
+                "display_name": "Runtime | Minimal | CPU | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-minimal-cpu-py312-ubi9-2025-2_PLACEHOLDER
+      name: "minimal-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/runtime-pytorch-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | Pytorch | CUDA | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | Pytorch | CUDA | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "pytorch-2025.2"
+                ],
+                "display_name": "Runtime | Pytorch | CUDA | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-pytorch-cuda-py312-ubi9-2025-2_PLACEHOLDER
+      name: "pytorch-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/runtime-pytorch-llmcompressor-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-llmcompressor-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-pytorch-llmcompressor-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "pytorch-2025.2"
+                ],
+                "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-2025-2_PLACEHOLDER
+      name: "pytorch-llmcompressor-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/runtime-rocm-pytorch-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-rocm-pytorch-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | Pytorch | ROCm | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-rocm-pytorch-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | Pytorch | ROCm | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "rocm-pytorch-2025.2"
+                ],
+                "display_name": "Runtime | Pytorch | ROCm | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-pytorch-rocm-py312-ubi9-2025-2_PLACEHOLDER
+      name: "rocm-pytorch-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/runtime-rocm-tensorflow-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-rocm-tensorflow-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-rocm-tensorflow-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | TensorFlow | ROCm | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "rocm-tensorflow-2025.2"
+                ],
+                "display_name": "Runtime | TensorFlow | ROCm | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-2025-2_PLACEHOLDER
+      name: "rocm-tensorflow-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/runtime-tensorflow-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-tensorflow-imagestream-2025-2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/runtime-image: "true"
+  annotations:
+    opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+  name: runtime-tensorflow-2025-2
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        # language=json
+        opendatahub.io/runtime-image-metadata: |
+          [
+            {
+              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12 | 2025.2",
+              "metadata": {
+                "tags": [
+                  "tensorflow-2025.2"
+                ],
+                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12 | 2025.2",
+                "pull_policy": "IfNotPresent"
+              },
+              "schema_name": "runtime-image"
+            }
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+      from:
+        kind: DockerImage
+        name: odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-2025-2_PLACEHOLDER
+      name: "tensorflow-2025-2"
+      referencePolicy:
+        type: Source

--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -64,9 +64,10 @@ class Workbench:
 
 @dataclass
 class Runtime:
-    """A runtime image: single tag (N), params replacement only."""
+    """A runtime image: single tag, params replacement only."""
 
-    param_key: str
+    base_key: str
+    suffix: str
     imagestream: str
     resource_file: str
 
@@ -191,7 +192,7 @@ def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[st
 
         if full_key.startswith("odh-pipeline-runtime-"):
             res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
-            runtimes.append(Runtime(base_key, istream, res_file))
+            runtimes.append(Runtime(base_key, suffix, istream, res_file))
             if res_file not in runtime_resource_files:
                 runtime_resource_files.append(res_file)
         else:
@@ -336,9 +337,9 @@ def _workbench_commit_replacements(wb: Workbench) -> list[str]:
 
 
 def _runtime_params_replacement(rt: Runtime) -> str:
-    """Single image-params replacement for a runtime (N only)."""
+    """Single image-params replacement for a runtime."""
     return _replacement_block(
-        f"{rt.param_key}-n",
+        f"{rt.base_key}{rt.suffix}",
         "notebook-image-params",
         "spec.tags.0.from.name",
         rt.imagestream,
@@ -362,7 +363,7 @@ def generate(base_dir: Path) -> str:
     for wb in workbenches:
         replacement_blocks.extend(_workbench_commit_replacements(wb))
 
-    # 3) Runtime image-params (N only) for all runtimes
+    # 3) Runtime image-params for all runtimes
     for rt in runtimes:
         replacement_blocks.append(_runtime_params_replacement(rt))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://redhat.atlassian.net/browse/RHAIENG-5878 

## Description
<!--- Describe your changes in detail -->

Add new ImageStream manifests under manifests/rhoai/base/ to support the 2025.2 workbenches and their corresponding runtime images, ensuring that pipeline runtime images remain available and selectable in JupyterLab.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

 Manifest validation success check:  `kustomize build manifests/rhoai/base > rhoai-manifests.yaml` executed without errors, placeholer on imagestreams assigned the proper image hashes 
 
 On cluster:
 
<img width="703" height="609" alt="Screenshot 2026-06-29 at 11 56 00" src="https://github.com/user-attachments/assets/fdea9767-681f-4345-8e3b-dde940cbac25" />


`pipeline-runtime-images` ConfigMap generated by the notebook-controller

```
kind: ConfigMap
apiVersion: v1
metadata:
  name: pipeline-runtime-images
  namespace: atheo
  labels:
    opendatahub.io/managed-by: workbenches
  managedFields:{}
data:
  runtime-pytorch-rocm-python-3.12.json: '{"display_name":"Runtime | Pytorch | ROCm | Python 3.12","metadata":{"display_name":"Runtime | Pytorch | ROCm | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:9fdc288e50e3c3dd794fe68d765add6fbf619fa8032599fc969c49273956d3f6","pull_policy":"IfNotPresent","tags":["rocm-pytorch"]},"schema_name":"runtime-image"}'
  runtime-pytorch-cuda-python-3.12-2025.2.json: '{"display_name":"Runtime | Pytorch | CUDA | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | Pytorch | CUDA | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:8b059881d8d7ef85883c7672a4464368ae564f2ce6104d54ebb03ac5d152d536","pull_policy":"IfNotPresent","tags":["pytorch-2025.2"]},"schema_name":"runtime-image"}'
  runtime-datascience-cpu-python-3.12-2025.2.json: '{"display_name":"Runtime | Datascience | CPU | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | Datascience | CPU | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:22ea9fc4352ec427a240fb983afb0ad3e7c1b2f2dc97bce4587695777f23ef07","pull_policy":"IfNotPresent","tags":["datascience-2025.2"]},"schema_name":"runtime-image"}'
  runtime-tensorflow-cuda-python-3.12-2025.2.json: '{"display_name":"Runtime | TensorFlow | CUDA | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | TensorFlow | CUDA | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686","pull_policy":"IfNotPresent","tags":["tensorflow-2025.2"]},"schema_name":"runtime-image"}'
  runtime-minimal-cpu-python-3.12-2025.2.json: '{"display_name":"Runtime | Minimal | CPU | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | Minimal | CPU | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:d3d4d82d0685feb25ec91cf8928dc5c5859436f44a21cd93b5d2ce7c1869a603","pull_policy":"IfNotPresent","tags":["minimal-2025.2"]},"schema_name":"runtime-image"}'
  runtime-pytorch-llm-compressor-cuda-python-3.12-2025.2.json: '{"display_name":"Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:7c2ce6c9e93266a11cbfdef8b3abbeb9ffd13f983b9fb3a091607d1065d597e0","pull_policy":"IfNotPresent","tags":["pytorch-2025.2"]},"schema_name":"runtime-image"}'
  runtime-pytorch-llm-compressor-cuda-python-3.12.json: '{"display_name":"Runtime | PyTorch LLM Compressor | CUDA | Python 3.12","metadata":{"display_name":"Runtime | PyTorch LLM Compressor | CUDA | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:bb82e65682c3e36fe1397fb30272ebc56b2f23301015e4ac8977a814ba72e9b9","pull_policy":"IfNotPresent","tags":["pytorch"]},"schema_name":"runtime-image"}'
  runtime-minimal-cpu-python-3.12.json: '{"display_name":"Runtime | Minimal | CPU | Python 3.12","metadata":{"display_name":"Runtime | Minimal | CPU | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:eac5691f55bf797fc5992a1b45b4a21e743296d5d37a234eb112dca30e2e1b7c","pull_policy":"IfNotPresent","tags":["minimal"]},"schema_name":"runtime-image"}'
  runtime-tensorflow-cuda-python-3.12.json: '{"display_name":"Runtime | TensorFlow | CUDA | Python 3.12","metadata":{"display_name":"Runtime | TensorFlow | CUDA | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:e8c44fcdc152a69c38014106428a5f1de8c70dad0ec8c06f3a2f782dfa9d25fa","pull_policy":"IfNotPresent","tags":["tensorflow"]},"schema_name":"runtime-image"}'
  runtime-datascience-cpu-python-3.12.json: '{"display_name":"Runtime | Datascience | CPU | Python 3.12","metadata":{"display_name":"Runtime | Datascience | CPU | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:b0b8427da8303c46f0879b6064ded1aee2de143c756f9211ceb631f05a1c4919","pull_policy":"IfNotPresent","tags":["datascience"]},"schema_name":"runtime-image"}'
  runtime-pytorch-cuda-python-3.12.json: '{"display_name":"Runtime | Pytorch | CUDA | Python 3.12","metadata":{"display_name":"Runtime | Pytorch | CUDA | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:ff10b6182910bdcf5018358ff884c4960c76d2536472da9966f797a98dbe6a9a","pull_policy":"IfNotPresent","tags":["pytorch"]},"schema_name":"runtime-image"}'
  runtime-pytorch-rocm-python-3.12-2025.2.json: '{"display_name":"Runtime | Pytorch | ROCm | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | Pytorch | ROCm | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384","pull_policy":"IfNotPresent","tags":["rocm-pytorch-2025.2"]},"schema_name":"runtime-image"}'
  runtime-tensorflow-rocm-python-3.12-2025.2.json: '{"display_name":"Runtime | TensorFlow | ROCm | Python 3.12 | 2025.2","metadata":{"display_name":"Runtime | TensorFlow | ROCm | Python 3.12 | 2025.2","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47","pull_policy":"IfNotPresent","tags":["rocm-tensorflow-2025.2"]},"schema_name":"runtime-image"}'
  runtime-tensorflow-rocm-python-3.12.json: '{"display_name":"Runtime | TensorFlow | ROCm | Python 3.12","metadata":{"display_name":"Runtime | TensorFlow | ROCm | Python 3.12","image_name":"registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:d3c7ea1c6c8c3c8c29525a7146e066d49722d155dcf719f12e75cc7c041b6207","pull_policy":"IfNotPresent","tags":["rocm-tensorflow"]},"schema_name":"runtime-image"}'

```
 

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new `2025-2` runtime image set across multiple notebook/runtime options, including Data Science, Minimal, PyTorch, ROCm, TensorFlow, and PyTorch LLM Compressor.
  * Updated image references so these runtimes can be selected with the latest `ubi9-2025-2` images and digests.
  * Added matching image streams and configuration entries so the new runtime variants are available in the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->