### PR TITLE
#3970: use pre-built check-payload image in TEMPLATE workflow

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -628,7 +628,7 @@ jobs:
           set -Eeuxo pipefail
           PODMAN="$(which podman)"
           IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}")
-          sudo "${PODMAN}" run --rm \
+          sudo "${PODMAN}" run --rm --user=0 \
             -v "${IMAGE_MOUNT_DIR}:${IMAGE_MOUNT_DIR}:ro,z" \
             -v "${PWD}/scripts/check-payload/config.toml:/config.toml:ro,z" \
             "${CHECK_PAYLOAD_IMAGE}" \

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -151,13 +151,6 @@ jobs:
           SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
           SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 
-      # for check-payload FIPS scan
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version: "stable"
-          cache-dependency-path: |
-            scripts/check-payload/go.mod
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
@@ -628,43 +621,21 @@ jobs:
 
       # region check-payload for FIPS compliance
 
-      # F0512 15:43:03.219076 21568 main.go:294] Error: exec: "oc": executable file not found in $PATH
-      - name: Install oc client
-        if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
-        run: |
-          # Install the oc client
-          curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/openshift-client-linux.tar.gz
-          tar -xzvf /tmp/openshift-client-linux.tar.gz oc
-          rm -f /tmp/openshift-client-linux.tar.gz
-          sudo mv ./oc /usr/local/bin
-
-      # perform `podman image mount` ourselves, and then follow the scenario from
-      # https://github.com/openshift/check-payload/pull/154, that is because
-      # `check-payload scan image --spec` insists on pulling the image, even if already present,
-      #  that causes trouble when checking PRs (image not pushed) and requires `podman login` as root
-      #  (we run podman as root in the GHA to reuse container storage in Kubernetes)
-      # use sudo to avoid
-      #  podman error (args=[image mount ghcr.io/...])
-      #  (stderr=Error: cannot use command "podman image mount" with the remote podman client
-      # and use --preserve-env=PATH to avoid
-      #  F0512 16:31:58.425584    9911 main.go:294] Error: exec: "podman": executable file not found in $PATH
       - name: Check image with check-payload for FIPS compliance
         id: fips-check
         if: ${{ !cancelled() && steps.make-target.outcome == 'success' }}
         run: |
           set -Eeuxo pipefail
-          # resolve podman under current user, not under sudo/root
           PODMAN="$(which podman)"
-          # mount the image
           IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}")
-          # run the check-payload scan
-          sudo --preserve-env=PATH,GOCACHE,GOMODCACHE go tool github.com/openshift/check-payload scan local --path "${IMAGE_MOUNT_DIR}"
-          # unmount the image
+          sudo "${PODMAN}" run --rm \
+            -v "${IMAGE_MOUNT_DIR}:${IMAGE_MOUNT_DIR}:ro,z" \
+            -v "${PWD}/scripts/check-payload/config.toml:/config.toml:ro,z" \
+            "${CHECK_PAYLOAD_IMAGE}" \
+            scan local --path "${IMAGE_MOUNT_DIR}" -c /config.toml
           sudo "${PODMAN}" image unmount --all
-        working-directory: scripts/check-payload
         env:
-          GOCACHE: /home/runner/.cache/go-build
-          GOMODCACHE: /home/runner/go/pkg/mod
+          CHECK_PAYLOAD_IMAGE: ghcr.io/${{ github.repository }}/check-payload:0.3.16
 
       # endregion
 


### PR DESCRIPTION
## Summary

- Remove `actions/setup-go` — the sole remaining Go dependency in the build pipeline
- Remove `install-oc` step — not needed for `scan local --path`
- Replace `go tool` invocation with `podman run` using `ghcr.io/{repo}/check-payload:0.3.16`

Follow-up to #3972 which built and published the check-payload image.

Resolves #3970

## Test plan

- [ ] FIPS check step passes on a real notebook build
- [ ] No `setup-go` or `oc` installation in the workflow logs
- [ ] check-payload scan output matches previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the notebook build workflow’s compliance validation to use a container-based scan, removing the prior Go tooling setup step.
  * The workflow now mounts the just-built image, runs the payload compliance check inside the scan container with the workflow configuration, and then cleans up mounts after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->