### PR TITLE
RHAIENG-5136: chore(ci) Add fail_ci_if_error to Codecov actions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -78,6 +78,7 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   go-tests:
     runs-on: ubuntu-26.04
@@ -120,6 +121,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: scripts/buildinputs/junit-go.xml
+          fail_ci_if_error: false
 
   code-static-analysis:
     runs-on: ubuntu-26.04


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C096ZR053RQ/p1782756956346059

## Description
<!--- Describe your changes in detail -->
Greenify push CI on rhoai-3.5 by fixing the Code static analysis workflow 

pytest-tests failures ([example run](https://github.com/red-hat-data-services/notebooks/actions/runs/28377434702/job/84114767675)):
gen_gha_matrix_jobs tests failed because buildinputs_runner.py tried to podman run ghcr.io/.../buildinputs:main without podman/GHCR auth (exit 125).
Fix: build bin/buildinputs locally in the job and set CI: 'false' so tests use the local binary (same as local dev).
Codecov upload noise on protected branches:

codecov/test-results-action failed with Token required because branch is protected even when tests passed.
Fix: add fail_ci_if_error: false to both Python and Go test-results upload steps (matching coverage upload behavior).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/mtchoum1/notebooks/actions/runs/28391710484/job/84120186161

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work