### PR TITLE
RHAIENG-5164: build: use Dockerfile.konflux.* in .tekton and Makefile

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+    value: runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+    value: runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+    value: runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+    value: runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: event-type

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m2xlarge/amd64
   - name: dockerfile
-    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+    value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+    value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context
     value: .
   - name: event-type

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+    value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m2xlarge/amd64
   - name: dockerfile
-    value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+    value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9:odh-stable
   - name: dockerfile
-    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m2xlarge/amd64
   - name: dockerfile
-    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+    value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:odh-stable
   - name: dockerfile
-    value: codeserver/ubi9-python-3.12/Dockerfile.cpu
+    value: codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: codeserver/ubi9-python-3.12/build-args/cpu.conf
   - name: hermetic

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
   - name: dockerfile
-    value: codeserver/ubi9-python-3.12/Dockerfile.cpu
+    value: codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -36,7 +36,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:{{revision}}
   - name: dockerfile
-    value: codeserver/ubi9-python-3.12/Dockerfile.cpu
+    value: codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: codeserver/ubi9-python-3.12/build-args/cpu.conf
   - name: hermetic

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -36,7 +36,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9:{{revision}}
   - name: dockerfile
-    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -50,7 +50,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -42,7 +42,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -33,7 +33,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: build-args-file
     value: jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+    value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
       value:
         - linux-d160-m4xlarge/amd64
     - name: dockerfile
-      value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+      value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
     - name: build-args-file
       value: jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
     - name: path-context

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     value:
     - linux-d160-m4xlarge/amd64
   - name: dockerfile
-    value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+    value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     - name: output-image
       value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9:{{revision}}
     - name: dockerfile
-      value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+      value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
     - name: build-args-file
       value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
     - name: path-context

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:odh-stable
   - name: dockerfile
-    value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -56,7 +56,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -49,7 +49,7 @@ spec:
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile
-    value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+    value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: build-args-file
     value: jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
   - name: path-context

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CONTAINER_BUILD_SECURITY_ARGS ?= $(if $(filter podman,$(CONTAINER_ENGINE)),--sec
 PUSH_IMAGES ?= yes
 # INDEX_MODE: auto (default), public-index, or rh-index - controls lock file generation
 INDEX_MODE ?= auto
-# KONFLUX: whether to build images from Dockerfile.konflux.* (default: no)
+# KONFLUX: select RHOAI build-args (konflux.*.conf) vs ODH (default: no)
 KONFLUX ?= no
 
 
@@ -149,8 +149,8 @@ endef
 # PUSH_IMAGES: allows skipping podman push
 define image
 	$(eval BUILD_DIRECTORY := $(shell echo $(2) | sed 's/\/Dockerfile.*//'))
-	$(eval VARIANT := $(shell echo $(notdir $(2)) | cut -d. -f2))
-	$(eval DOCKERFILE := $(BUILD_DIRECTORY)/Dockerfile$(if $(KONFLUX:no=),.konflux,$(empty)).$(VARIANT))
+	$(eval VARIANT := $(shell echo $(notdir $(2)) | awk -F. '{print $$NF}'))
+	$(eval DOCKERFILE := $(BUILD_DIRECTORY)/Dockerfile.konflux.$(VARIANT))
 	$(if $(strip $(DOCKERFILE)),,$(error Dockerfile not found for variant '$(VARIANT)' in '$(BUILD_DIRECTORY)'))
 
 	$(eval CONF_FILE := $(BUILD_DIRECTORY)/build-args/$(if $(KONFLUX:no=),konflux.,$(empty))$(shell echo $(VARIANT)).conf)
@@ -187,76 +187,76 @@ bin/buildinputs: scripts/buildinputs/buildinputs.go scripts/buildinputs/go.mod s
 
 .PHONY: jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: jupyter-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,jupyter/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: cuda-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: cuda-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: cuda-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/trustyai/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,jupyter/trustyai/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: runtime-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,runtimes/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: runtime-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,runtimes/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,runtimes/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,runtimes/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,runtimes/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: codeserver-ubi9-python-$(RELEASE_PYTHON_VERSION)
 codeserver-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,codeserver/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,codeserver/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 ####################################### Buildchain for AMD Python using UBI9 #######################################
 .PHONY: rocm-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/rocm/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,jupyter/rocm/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/rocm/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,jupyter/rocm/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/rocm-pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,runtimes/rocm-pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/rocm-tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,runtimes/rocm-tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 ####################################### Deployments #######################################
 

--- a/Makefile
+++ b/Makefile
@@ -151,16 +151,13 @@ define image
 	$(eval BUILD_DIRECTORY := $(shell echo $(2) | sed 's/\/Dockerfile.*//'))
 	$(eval VARIANT := $(shell echo $(notdir $(2)) | awk -F. '{print $$NF}'))
 	$(eval DOCKERFILE := $(BUILD_DIRECTORY)/Dockerfile.konflux.$(VARIANT))
-	$(if $(strip $(DOCKERFILE)),,$(error Dockerfile not found for variant '$(VARIANT)' in '$(BUILD_DIRECTORY)'))
+	$(if $(wildcard $(DOCKERFILE)),,$(error Dockerfile not found for variant '$(VARIANT)' in '$(BUILD_DIRECTORY)'))
 
 	$(eval CONF_FILE := $(BUILD_DIRECTORY)/build-args/$(if $(KONFLUX:no=),konflux.,$(empty))$(shell echo $(VARIANT)).conf)
 	$(info #*# Image build Dockerfile: <$(DOCKERFILE)> #(MACHINE-PARSED LINE)#*#...)
 	$(info #*# Image build directory: <$(BUILD_DIRECTORY)> #(MACHINE-PARSED LINE)#*#...)
 
-	# realpath dereferences symlinks — podman API rejects symlinks with "must be a regular file"
-	$(eval DOCKERFILE_BUILD := $(realpath $(DOCKERFILE)))
-	$(if $(strip $(DOCKERFILE_BUILD)),,$(error Resolved Dockerfile path is empty for '$(DOCKERFILE)' — file missing or broken symlink))
-	$(call build_image,$(1),$(DOCKERFILE_BUILD),$(CONF_FILE))
+	$(call build_image,$(1),$(DOCKERFILE),$(CONF_FILE))
 
 	$(if $(PUSH_IMAGES:no=),
 		$(call push_image,$(1))

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -232,7 +232,7 @@ class TestSelf(unittest.TestCase):
 
     def test_get_build_dockerfile(self):
         dockerfile = get_build_dockerfile("rocm-jupyter-pytorch-ubi9-python-3.12")
-        assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm"
+        assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm"
 
     def test_should_build_target(self):
         current_module = sys.modules[__name__]

--- a/ci/cached-builds/makefile_helper.py
+++ b/ci/cached-builds/makefile_helper.py
@@ -68,6 +68,8 @@ class TestMakefile:
     def test_makefile__build_image__konflux(self):
         import ntb  # noqa: PLC0415 `import` should be at the top-level of a file
 
+        minimal_image_dir = "jupyter/minimal/ubi9-python-3.12/"
+
         konflux_default = dry_run_makefile(target=self.MINIMAL_IMAGE, makefile_dir=PROJECT_ROOT)
         konflux_yes = dry_run_makefile(target=self.MINIMAL_IMAGE, makefile_dir=PROJECT_ROOT, env={"KONFLUX": "yes"})
 
@@ -75,28 +77,25 @@ class TestMakefile:
             {
                 "VARIANT": "cpu",
                 "DOCKERFILE_NAME": "Dockerfile.konflux.cpu",
-                "CONF_FILE": "jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf",
+                "CONF_FILE": (minimal_image_dir + "build-args/cpu.conf"),
             },
             _extract_assignments(konflux_default),
         )
+        assert f"--file '{minimal_image_dir + 'Dockerfile.konflux.cpu'}'" in konflux_default
+        assert f"with {minimal_image_dir + 'build-args/cpu.conf'}" in konflux_default
+        assert "--build-arg 'PRODUCT=odh'" in konflux_default
 
         ntb.assert_subdict(
             {
                 "VARIANT": "cpu",
                 "DOCKERFILE_NAME": "Dockerfile.konflux.cpu",
-                "CONF_FILE": "jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf",
+                "CONF_FILE": (minimal_image_dir + "build-args/konflux.cpu.conf"),
             },
             _extract_assignments(konflux_yes),
         )
-
-        assert (
-            "#*# Image build Dockerfile: <jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu>"
-            in konflux_default
-        )
-        assert (
-            "#*# Image build Dockerfile: <jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu>"
-            in konflux_yes
-        )
+        assert f"--file '{minimal_image_dir + 'Dockerfile.konflux.cpu'}'" in konflux_yes
+        assert f"with {minimal_image_dir + 'build-args/konflux.cpu.conf'}" in konflux_yes
+        assert "--build-arg 'PRODUCT=rhoai'" in konflux_yes
 
 
 def _extract_assignments(makefile_output: str) -> dict[str, str]:

--- a/ci/cached-builds/makefile_helper.py
+++ b/ci/cached-builds/makefile_helper.py
@@ -74,7 +74,7 @@ class TestMakefile:
         ntb.assert_subdict(
             {
                 "VARIANT": "cpu",
-                "DOCKERFILE_NAME": "Dockerfile.cpu",
+                "DOCKERFILE_NAME": "Dockerfile.konflux.cpu",
                 "CONF_FILE": "jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf",
             },
             _extract_assignments(konflux_default),
@@ -89,8 +89,14 @@ class TestMakefile:
             _extract_assignments(konflux_yes),
         )
 
-        assert "--file 'jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu'" in konflux_default
-        assert "--file 'jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu'" in konflux_yes
+        assert (
+            "#*# Image build Dockerfile: <jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu>"
+            in konflux_default
+        )
+        assert (
+            "#*# Image build Dockerfile: <jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu>"
+            in konflux_yes
+        )
 
 
 def _extract_assignments(makefile_output: str) -> dict[str, str]:

--- a/manifests/tools/update_imagestream_annotations_from_pylock.py
+++ b/manifests/tools/update_imagestream_annotations_from_pylock.py
@@ -61,7 +61,7 @@ from tests.manifests import (  # noqa: E402
 logger = logging.getLogger(__name__)
 
 # Force accelerator flavor when resolving ImageStream paths. ``extract_metadata_from_path`` may
-# infer "cuda" from Dockerfile.cuda even for the CPU ImageStream (same tree builds both).
+# infer "cuda" from Dockerfile.konflux.cuda even for the CPU ImageStream (same tree builds both).
 _ACCELERATOR_OVERRIDE_FOR_RESOURCE: dict[str, str | None] = {
     "jupyter-minimal-notebook-imagestream.yaml": None,
     "jupyter-minimal-gpu-notebook-imagestream.yaml": "cuda",

--- a/tests/manifests.py
+++ b/tests/manifests.py
@@ -117,11 +117,12 @@ def extract_metadata_from_path(directory: Path) -> NotebookMetadata:
         accelerator_flavor = "rocm"
     elif "cuda" in notebook_identity_parts:
         accelerator_flavor = "cuda"
-    # The shell script has an implicit rule for pytorch being cuda. We can
-    # replicate this by checking for a specific Dockerfile.
-    elif (directory / "Dockerfile.cuda").exists():
+    # jupyter/pytorch has no "cuda" in the path; papermill treats jupyter-pytorch-* as cuda
+    # via name matching (_get_accelerator_flavor in test_jupyter_with_papermill.sh).
+    # When inferring from a directory path, detect cuda/rocm from Dockerfile.konflux.* variants.
+    elif (directory / "Dockerfile.konflux.cuda").exists():
         accelerator_flavor = "cuda"
-    elif (directory / "Dockerfile.rocm").exists():
+    elif (directory / "Dockerfile.konflux.rocm").exists():
         accelerator_flavor = "rocm"
 
     return NotebookMetadata(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -494,13 +494,11 @@ def test_files_that_should_be_same_are_same(subtests: pytest_subtests.plugin.Sub
 
 @allure.issue("RHOAIENG-42632")
 def test_rhds_pipelines_use_rhds_args(subtests: pytest_subtests.plugin.SubTests):
-    r"""Pipelines under .tekton/ that build `^Dockerfile\.konflux.*` dockerfiles have to use
-    `^konflux\..*` args files. For example, this would be a violation of the rule:
+    r"""RHDS pipelines (output-image under quay.io/rhoai/) must pair Dockerfile.konflux.*
+    with konflux.* build-args conf files.
 
-    - name: dockerfile
-      value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
-    - name: build-args-file
-      value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+    ODH pipelines publish to quay.io/opendatahub/ and use build-args/<variant>.conf even
+    when building Dockerfile.konflux.* — that pairing is valid and not checked here.
     """
     for file in PROJECT_ROOT.glob(".tekton/*.yaml"):
         with subtests.test(msg="checking tekton pipeline", pipeline=file):
@@ -521,19 +519,27 @@ def test_rhds_pipelines_use_rhds_args(subtests: pytest_subtests.plugin.SubTests)
 
             dockerfile_param = None
             build_args_file_param = None
+            output_image_param = None
 
             for param in pipeline["spec"]["params"]:
                 if param["name"] == "dockerfile":
                     dockerfile_param = pathlib.Path(param["value"])
                 if param["name"] == "build-args-file":
                     build_args_file_param = pathlib.Path(param["value"])
+                if param["name"] == "output-image":
+                    output_image_param = param["value"]
+
+            if not output_image_param or not str(output_image_param).startswith("quay.io/rhoai/"):
+                continue
 
             assert dockerfile_param is not None, (
                 f"Pipeline {file.relative_to(PROJECT_ROOT)} is missing the required 'dockerfile' parameter"
             )
 
-            if not dockerfile_param.name.startswith("Dockerfile.konflux"):
-                continue
+            assert dockerfile_param.name.startswith("Dockerfile.konflux"), (
+                f"Pipeline {file.relative_to(PROJECT_ROOT)} publishes to quay.io/rhoai/ "
+                f"but does not use a Dockerfile.konflux.* ({dockerfile_param.name})"
+            )
 
             assert build_args_file_param is not None, (
                 f"Pipeline {file.relative_to(PROJECT_ROOT)} builds a konflux Dockerfile ({dockerfile_param.name}) "


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5164

## Summary

- Update 54 ODH `.tekton` pipeline files to reference `Dockerfile.konflux.cpu|cuda|rocm` instead of symlink names (`Dockerfile.cpu|cuda|rocm`).
- Make `Makefile` always resolve `Dockerfile.konflux.*` for local builds; `KONFLUX` now only selects build-args conf files (`cpu.conf` vs `konflux.cpu.conf`).
- Update accelerator detection in `tests/manifests.py` and align CI helper tests; gate `test_rhds_pipelines_use_rhds_args` on `quay.io/rhoai/` output-image so ODH pipelines are not required to use konflux conf files.

Symlink files (`Dockerfile.cpu` etc.) are intentionally retained for a follow-up removal PR.

## Test plan

- [x] `pytest tests/test_main.py::test_rhds_pipelines_use_rhds_args ci/cached-builds/makefile_helper.py ci/cached-builds/gha_pr_changed_files.py`
- [x] `scripts/check_dockerfile_alignment.sh`
- [x] Verified 18 symlinks still present under `jupyter/`, `runtimes/`, `codeserver/`
- [x] Verified 8 `base-images/` `.tekton` pipelines unchanged (real `Dockerfile.cpu|cuda|rocm`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build pipelines to use the newer Konflux Dockerfile variants for multiple runtime and workbench images.
  * Standardized image build selection for CPU, CUDA, and ROCm variants so push and pull-request builds follow the same build inputs.
  * Improved build-related checks to match the updated Dockerfile naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->