### PR TITLE
RHAIENG-5879: (util) add cluster manifest apply/revert utility for ODH and RHOAI replicates old DevFlags

### DIFF
--- a/docs/manifest-cluster-dev-testing.md
+++ b/docs/manifest-cluster-dev-testing.md
@@ -1,0 +1,146 @@
+# Testing notebook manifest changes on a cluster (ODH / RHOAI)
+
+Apply local ImageStream manifest edits to a dev/test cluster using
+`scripts/apply-manifests-dev.sh`. The same script and workflow work for
+**Open Data Hub (ODH)** upstream and **Red Hat OpenShift AI (RHOAI)** downstream;
+only the `--platform` flag and default namespaces differ.
+
+**Not for production.** This bypasses the operator’s normal release path. It is a replacment for the recently deprecation of `devFlags` provided by the operator. 
+Changes may be
+overwritten on operator upgrade or workbenches reconcile.
+
+For how manifests are normally consumed, see [manifests/README.md](../manifests/README.md).
+
+## When to use this
+
+- You changed ImageStream YAML, annotations, tags, or `.env` files under
+  `manifests/odh/base/` or `manifests/rhoai/base/` and want to validate on a
+  cluster before opening a PR.
+- A colleague needs to repeat the same check on their cluster.
+
+## Prerequisites
+
+- `oc` logged in with permission to edit ImageStreams in the target namespace(s).
+- `kustomize` installed locally.
+- A checkout of this repo with your manifest edits.
+- ODH or RHOAI operator running with workbenches **Managed**.
+
+If you changed `kustomization.yaml` or added/removed ImageStreams, regenerate first:
+
+```bash
+# ODH
+uv run manifests/tools/generate_kustomization.py manifests/odh/base
+
+# RHOAI
+uv run manifests/tools/generate_kustomization.py manifests/rhoai/base
+```
+
+## Quick start
+
+Run from the **repo root**:
+
+### Examples
+
+```bash
+# ODH 
+./scripts/apply-manifests-dev.sh --platform odh apply
+# RHOAI 
+./scripts/apply-manifests-dev.sh --platform rhoai apply
+
+# Both
+./scripts/apply-manifests-dev.sh apply --target both
+
+# Revert (platform read from snapshot if omitted)
+./scripts/apply-manifests-dev.sh revert --clean-test
+./scripts/apply-manifests-dev.sh --platform odh revert --clean-test
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `apply` | Snapshot operator baseline, build manifests with real image digests, apply, restart dashboard |
+| `revert` | Re-apply saved operator baseline |
+| `preview` | Print `kustomize build` output (no cluster changes) |
+| `snapshot` | Save operator baseline only |
+
+```bash
+./scripts/apply-manifests-dev.sh --help
+```
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--platform odh\|rhoai` | `rhoai` | Select manifest tree and cluster defaults |
+| `--target applications` | yes | Apply to applications/dashboard namespace |
+| `--target workbench` | | Apply to DSC `workbenchNamespace` |
+| `--target both` | | Apply to both |
+| `--clean-test` | | With `revert`: delete ImageStreams added by the last `apply` |
+| `--dry-run` | | Client-side dry-run only |
+| `--no-restart-dashboard` | | Skip dashboard rollout after apply |
+| `--revert-dir DIR` | platform-specific | Snapshot directory |
+| `--operator-ns NS` | see table above | Operator namespace |
+| `--applications-ns NS` | see table above | Dashboard namespace |
+
+
+## Verify after apply
+
+```bash
+# ODH
+oc get imagestreams -n opendatahub -l opendatahub.io/component=true
+oc get route -n opendatahub | grep -i dashboard
+
+# RHOAI
+oc get imagestreams -n redhat-ods-applications -l opendatahub.io/component=true
+oc get route -n redhat-ods-applications | grep -i dashboard
+```
+
+Open the dashboard route → **Workbenches** and confirm images/tags. Hard-refresh if needed.
+
+## Revert notes
+
+- `revert` restores ImageStream **content** to the operator baseline from the last `apply`.
+- ImageStreams **remain visible** after revert — expected. Use `--clean-test` to remove
+  ImageStreams your apply added that were not in the operator bundle.
+- Snapshots live in `/tmp/odh-manifests-revert` or `/tmp/rhoai-manifests-revert`.
+
+
+## Platform defaults
+
+| | **ODH** (`--platform odh`) | **RHOAI** (`--platform rhoai`, default) |
+|---|---------------------------|----------------------------------------|
+| Local manifests | `manifests/odh/base/` | `manifests/rhoai/base/` |
+| Operator namespace | `opendatahub-operator` | `redhat-ods-operator` |
+| Operator pod label | `name=opendatahub-operator` | `name=rhods-operator` |
+| Applications / dashboard NS | `opendatahub` | `redhat-ods-applications` |
+| Dashboard deployment | `odh-dashboard` | `rhods-dashboard` |
+| Default workbench NS | `opendatahub` | `rhods-notebooks` (if set in DSC) |
+| Revert snapshot dir | `/tmp/odh-manifests-revert` | `/tmp/rhoai-manifests-revert` |
+
+Override namespaces when your install differs:
+
+```bash
+./scripts/apply-manifests-dev.sh --platform odh \
+  --operator-ns openshift-operators apply
+```
+
+Use `--target applications` for dashboard UI testing (default). Use `--target both`
+to apply to the applications namespace and the DSC `workbenchNamespace`.
+
+## Troubleshooting
+
+| Symptom | Action |
+|---------|--------|
+| `Workbenches must be Managed` | Set `managementState: Managed` on DSC workbenches |
+| `No operator pod` | Omit `--operator-ns` (auto-discovered). RHOAI default: `redhat-ods-operator`; ODH: `opendatahub-operator` |
+| Dashboard shows old images | Use `--target applications`; hard-refresh browser |
+| `No revert snapshot` | Run `apply` first (snapshots automatically) |
+| ImageStreams still visible after revert | Pre-existing cluster ImageStreams are expected |
+| Wrong platform on revert | Pass `--platform` or use matching `--revert-dir` |
+
+## Related
+
+- [manifests/README.md](../manifests/README.md) — manifest layout and operator pipeline
+- [opendatahub-operator custom manifests](https://github.com/opendatahub-io/opendatahub-operator/blob/main/hack/component-dev/README.md)
+- [rhods-operator custom manifests](https://github.com/red-hat-data-services/rhods-operator/blob/main/hack/component-dev/README.md)

--- a/scripts/apply-manifests-dev.sh
+++ b/scripts/apply-manifests-dev.sh
@@ -1,0 +1,525 @@
+#!/usr/bin/env bash
+#
+# Apply or revert local notebook ImageStream manifests on an ODH or RHOAI dev cluster.
+#
+# See docs/manifest-cluster-dev-testing.md for usage.
+#
+# Usage:
+#   scripts/apply-manifests-dev.sh [--platform odh|rhoai] apply [--target applications|workbench|both]
+#   scripts/apply-manifests-dev.sh [--platform odh|rhoai] revert [--clean-test]
+#   scripts/apply-manifests-dev.sh [--platform odh|rhoai] preview
+#   scripts/apply-manifests-dev.sh [--platform odh|rhoai] snapshot
+#
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PLATFORM="rhoai"
+TARGET="applications"
+REVERT_DIR=""
+OPERATOR_NS=""
+OPERATOR_NS_EXPLICIT=false
+RESOLVED_OPERATOR_POD=""
+APPLICATIONS_NS=""
+DRY_RUN=false
+CLEAN_TEST=false
+RESTART_DASHBOARD=true
+
+MANIFESTS_DIR=""
+MANIFESTS_VARIANT=""
+OPERATOR_POD_LABEL=""
+OPERATOR_MANIFESTS_TAR_DIR=""
+DASHBOARD_DEPLOY=""
+
+usage() {
+  cat <<'EOF'
+Apply or revert local notebook ImageStream manifests on an ODH or RHOAI dev cluster.
+
+Usage:
+  scripts/apply-manifests-dev.sh [--platform odh|rhoai] <command> [options]
+
+Commands:
+  apply     Snapshot operator baseline, build manifests, apply to cluster
+  revert    Restore operator baseline; use --clean-test to remove extras
+  preview   Build and print manifests (no cluster changes)
+  snapshot  Save operator baseline for later revert
+
+Options:
+  --platform PLATFORM   odh (upstream) or rhoai (default: rhoai)
+  --target TARGET       applications (default), workbench, or both
+  --revert-dir DIR      Snapshot directory (default: /tmp/<platform>-manifests-revert)
+  --operator-ns NS      Override operator namespace (auto-discovered if wrong or omitted)
+  --applications-ns NS  Override dashboard/applications namespace
+  --dry-run             Client-side dry-run only (apply/revert)
+  --no-restart-dashboard  Skip dashboard rollout after apply
+  --clean-test          On revert, delete ImageStreams added by the last apply
+  -h, --help            Show this help
+
+Platform defaults:
+  odh   operator: opendatahub-operator (pod label name=opendatahub-operator)
+        applications: opendatahub, manifests: manifests/odh/base, dashboard: odh-dashboard
+  rhoai operator: redhat-ods-operator (pod label name=rhods-operator)
+        applications: redhat-ods-applications, manifests: manifests/rhoai/base, dashboard: rhods-dashboard
+EOF
+}
+
+log() { printf '[apply-notebook-manifests-dev] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+configure_platform() {
+  case "${PLATFORM}" in
+    odh)
+      MANIFESTS_VARIANT="odh"
+      MANIFESTS_DIR="${REPO_ROOT}/manifests/odh/base"
+      OPERATOR_POD_LABEL="name=opendatahub-operator"
+      DASHBOARD_DEPLOY="odh-dashboard"
+      OPERATOR_NS="${OPERATOR_NS:-opendatahub-operator}"
+      APPLICATIONS_NS="${APPLICATIONS_NS:-opendatahub}"
+      REVERT_DIR="${REVERT_DIR:-/tmp/odh-manifests-revert}"
+      ;;
+    rhoai)
+      MANIFESTS_VARIANT="rhoai"
+      MANIFESTS_DIR="${REPO_ROOT}/manifests/rhoai/base"
+      OPERATOR_POD_LABEL="name=rhods-operator"
+      DASHBOARD_DEPLOY="rhods-dashboard"
+      OPERATOR_NS="${OPERATOR_NS:-redhat-ods-operator}"
+      APPLICATIONS_NS="${APPLICATIONS_NS:-redhat-ods-applications}"
+      REVERT_DIR="${REVERT_DIR:-/tmp/rhoai-manifests-revert}"
+      ;;
+    *)
+      die "--platform must be odh or rhoai (got: ${PLATFORM})"
+      ;;
+  esac
+  OPERATOR_MANIFESTS_TAR_DIR="/opt/manifests/workbenches/notebooks/${MANIFESTS_VARIANT}"
+  OPERATOR_MANIFESTS_PATH="${OPERATOR_MANIFESTS_TAR_DIR}/base"
+}
+
+parse_args() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --platform)
+        PLATFORM="${2:?}"
+        shift 2
+        ;;
+      --target)
+        TARGET="${2:?}"
+        shift 2
+        ;;
+      --revert-dir)
+        REVERT_DIR="${2:?}"
+        shift 2
+        ;;
+      --operator-ns)
+        OPERATOR_NS="${2:?}"
+        OPERATOR_NS_EXPLICIT=true
+        shift 2
+        ;;
+      --applications-ns)
+        APPLICATIONS_NS="${2:?}"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --no-restart-dashboard)
+        RESTART_DASHBOARD=false
+        shift
+        ;;
+      --clean-test)
+        CLEAN_TEST=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      apply | revert | preview | snapshot)
+        COMMAND="$1"
+        shift
+        break
+        ;;
+      *)
+        die "Unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "${COMMAND:-}" ]] || die "Missing command (apply, revert, preview, snapshot)"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target)
+        TARGET="${2:?}"
+        shift 2
+        ;;
+      --revert-dir)
+        REVERT_DIR="${2:?}"
+        shift 2
+        ;;
+      --operator-ns)
+        OPERATOR_NS="${2:?}"
+        OPERATOR_NS_EXPLICIT=true
+        shift 2
+        ;;
+      --applications-ns)
+        APPLICATIONS_NS="${2:?}"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --no-restart-dashboard)
+        RESTART_DASHBOARD=false
+        shift
+        ;;
+      --clean-test)
+        CLEAN_TEST=true
+        shift
+        ;;
+      *)
+        die "Unknown argument: $1"
+        ;;
+    esac
+  done
+
+  case "${COMMAND}" in
+    apply | revert | preview | snapshot) ;;
+    *)
+      die "Unknown command: ${COMMAND}"
+      ;;
+  esac
+
+  case "${TARGET}" in
+    applications | workbench | both) ;;
+    *)
+      die "--target must be applications, workbench, or both"
+      ;;
+  esac
+
+  if [[ "${COMMAND}" == "revert" && -z "${REVERT_DIR}" ]]; then
+    if [[ -f /tmp/rhoai-manifests-revert/platform.txt ]]; then
+      REVERT_DIR=/tmp/rhoai-manifests-revert
+    elif [[ -f /tmp/odh-manifests-revert/platform.txt ]]; then
+      REVERT_DIR=/tmp/odh-manifests-revert
+    fi
+  fi
+
+  if [[ -n "${REVERT_DIR}" && -f "${REVERT_DIR}/platform.txt" ]]; then
+    PLATFORM="$(tr -d '[:space:]' < "${REVERT_DIR}/platform.txt")"
+  fi
+
+  configure_platform
+}
+
+save_revert_metadata() {
+  printf '%s\n' "${PLATFORM}" > "${REVERT_DIR}/platform.txt"
+  printf '%s\n' "${OPERATOR_NS}" > "${REVERT_DIR}/operator-ns.txt"
+}
+
+check_prerequisites() {
+  need_cmd oc
+  need_cmd kustomize
+  [[ -d "${MANIFESTS_DIR}" ]] || die "Manifest directory not found: ${MANIFESTS_DIR}"
+
+  oc whoami >/dev/null 2>&1 || die "Not logged in to OpenShift (oc whoami failed)"
+
+  local wb_state
+  wb_state="$(oc get datasciencecluster default-dsc \
+    -o jsonpath='{.spec.components.workbenches.managementState}' 2>/dev/null || true)"
+  [[ "${wb_state}" == "Managed" ]] || die "Workbenches must be Managed (got: ${wb_state:-<unset>})"
+}
+
+operator_pod_labels_for_platform() {
+  case "${PLATFORM}" in
+    rhoai) printf '%s\n' "name=rhods-operator" "name=opendatahub-operator" ;;
+    odh) printf '%s\n' "name=opendatahub-operator" "name=rhods-operator" ;;
+  esac
+}
+
+operator_candidate_namespaces() {
+  if [[ "${OPERATOR_NS_EXPLICIT}" == true && -n "${OPERATOR_NS}" ]]; then
+    printf '%s\n' "${OPERATOR_NS}"
+    return
+  fi
+  case "${PLATFORM}" in
+    rhoai)
+      printf '%s\n' "redhat-ods-operator" "openshift-operators" "opendatahub-operator"
+      ;;
+    odh)
+      printf '%s\n' "opendatahub-operator" "openshift-operators" "redhat-ods-operator"
+      ;;
+  esac
+}
+
+resolve_operator() {
+  local ns label pod
+  local -a tried=()
+  local explicit_ns=""
+  if [[ "${OPERATOR_NS_EXPLICIT}" == true ]]; then
+    explicit_ns="${OPERATOR_NS}"
+  fi
+
+  while IFS= read -r ns; do
+    [[ -n "${ns}" ]] || continue
+    while IFS= read -r label; do
+      [[ -n "${label}" ]] || continue
+      tried+=("${ns} (${label})")
+      pod="$(oc get po -l "${label}" -n "${ns}" \
+        -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null | awk '{print $1}')"
+      if [[ -n "${pod}" ]]; then
+        OPERATOR_NS="${ns}"
+        OPERATOR_POD_LABEL="${label}"
+        RESOLVED_OPERATOR_POD="${pod}"
+        if [[ -n "${explicit_ns}" && "${explicit_ns}" != "${ns}" ]]; then
+          log "Operator not in ${explicit_ns}; using ${OPERATOR_NS}/${RESOLVED_OPERATOR_POD} (${OPERATOR_POD_LABEL})"
+        else
+          log "Using operator pod ${OPERATOR_NS}/${RESOLVED_OPERATOR_POD} (${OPERATOR_POD_LABEL})"
+        fi
+        return 0
+      fi
+    done < <(operator_pod_labels_for_platform)
+  done < <(operator_candidate_namespaces)
+
+  if [[ -n "${explicit_ns}" ]]; then
+    log "No running operator pod in ${explicit_ns}; searching other namespaces..."
+    OPERATOR_NS_EXPLICIT=false
+    resolve_operator
+    return $?
+  fi
+
+  die "Could not find a running operator pod. Tried: ${tried[*]}"
+}
+
+ensure_operator_resolved() {
+  if [[ -z "${RESOLVED_OPERATOR_POD}" ]]; then
+    resolve_operator
+  fi
+}
+
+workbench_namespace() {
+  oc get workbenches default-workbenches \
+    -o jsonpath='{.spec.workbenchNamespace}' 2>/dev/null \
+    || die "Workbenches CR default-workbenches not found"
+}
+
+imagestream_names_from_build() {
+  local dir="$1"
+  kustomize build "${dir}" | awk '
+    /^kind: ImageStream$/ { is=1; next }
+    is && /^  name: / { print $2; is=0 }
+  ' | sort -u
+}
+
+target_namespaces() {
+  local wb_ns
+  wb_ns="$(workbench_namespace)"
+  case "${TARGET}" in
+    applications) printf '%s\n' "${APPLICATIONS_NS}" ;;
+    workbench) printf '%s\n' "${wb_ns}" ;;
+    both)
+      printf '%s\n' "${APPLICATIONS_NS}"
+      if [[ "${wb_ns}" != "${APPLICATIONS_NS}" ]]; then
+        printf '%s\n' "${wb_ns}"
+      fi
+      ;;
+  esac
+}
+
+snapshot_baseline() {
+  local pod="$1"
+  mkdir -p "${REVERT_DIR}"
+  save_revert_metadata
+  log "Platform: ${PLATFORM} — snapshotting operator baseline to ${REVERT_DIR}/base"
+
+  oc exec -n "${OPERATOR_NS}" "${pod}" -- \
+    tar cf - -C "${OPERATOR_MANIFESTS_TAR_DIR}" base \
+    | tar xf - -C "${REVERT_DIR}"
+
+  kustomize build "${REVERT_DIR}/base" > "${REVERT_DIR}/rendered-before.yaml"
+  imagestream_names_from_build "${REVERT_DIR}/base" > "${REVERT_DIR}/baseline-imagestream-names.txt"
+
+  local ns
+  while IFS= read -r ns; do
+    oc get imagestreams -n "${ns}" -l opendatahub.io/component=true -o yaml \
+      > "${REVERT_DIR}/imagestreams-${ns}-before.yaml" 2>/dev/null || true
+  done < <(target_namespaces)
+
+  date -u +"%Y-%m-%dT%H:%M:%SZ" > "${REVERT_DIR}/snapshot-time.txt"
+  log "Baseline snapshot complete ($(wc -l < "${REVERT_DIR}/baseline-imagestream-names.txt") ImageStreams)"
+}
+
+build_workdir() {
+  local pod="$1"
+  local workdir
+  workdir="$(mktemp -d)"
+  cp -r "${MANIFESTS_DIR}/." "${workdir}/"
+
+  oc exec -n "${OPERATOR_NS}" "${pod}" -- \
+    cat "${OPERATOR_MANIFESTS_PATH}/params-latest.env" > "${workdir}/params-latest.env"
+  oc exec -n "${OPERATOR_NS}" "${pod}" -- \
+    cat "${OPERATOR_MANIFESTS_PATH}/commit-latest.env" > "${workdir}/commit-latest.env"
+
+  printf '%s' "${workdir}"
+}
+
+apply_to_namespace() {
+  local ns="$1"
+  local rendered="$2"
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    log "[dry-run] Would apply to namespace ${ns}"
+    oc apply --dry-run=client -n "${ns}" -f "${rendered}"
+  else
+    log "Applying to namespace ${ns}"
+    oc apply -n "${ns}" -f "${rendered}"
+  fi
+}
+
+cmd_snapshot() {
+  check_prerequisites
+  ensure_operator_resolved
+  snapshot_baseline "${RESOLVED_OPERATOR_POD}"
+}
+
+cmd_preview() {
+  check_prerequisites
+  local workdir
+  ensure_operator_resolved
+  workdir="$(build_workdir "${RESOLVED_OPERATOR_POD}")"
+
+  log "Previewing ${PLATFORM} kustomize build from ${MANIFESTS_DIR}"
+  kustomize build "${workdir}"
+  log "Resource counts:"
+  kustomize build "${workdir}" | awk '/^kind: / { counts[$2]++ } END { for (k in counts) print counts[k], k }' | sort -rn
+
+  rm -rf "${workdir}"
+}
+
+cmd_apply() {
+  check_prerequisites
+  local workdir rendered
+  ensure_operator_resolved
+  workdir="$(build_workdir "${RESOLVED_OPERATOR_POD}")"
+  rendered="$(mktemp)"
+
+  snapshot_baseline "${RESOLVED_OPERATOR_POD}"
+
+  kustomize build "${workdir}" > "${rendered}"
+  imagestream_names_from_build "${workdir}" > "${REVERT_DIR}/applied-imagestream-names.txt"
+  target_namespaces > "${REVERT_DIR}/applied-namespaces.txt"
+
+  log "Build summary:"
+  awk '/^kind: / { counts[$2]++ } END { for (k in counts) print "  ", counts[k], k }' "${rendered}" | sort -rn >&2
+
+  while IFS= read -r ns; do
+    [[ -n "${ns}" ]] || continue
+    apply_to_namespace "${ns}" "${rendered}"
+  done < "${REVERT_DIR}/applied-namespaces.txt"
+
+  if [[ "${DRY_RUN}" == false && "${RESTART_DASHBOARD}" == true ]]; then
+    if oc get deploy "${DASHBOARD_DEPLOY}" -n "${APPLICATIONS_NS}" >/dev/null 2>&1; then
+      log "Restarting ${DASHBOARD_DEPLOY}"
+      oc rollout restart "deploy/${DASHBOARD_DEPLOY}" -n "${APPLICATIONS_NS}"
+    fi
+  fi
+
+  rm -rf "${workdir}"
+  rm -f "${rendered}"
+
+  log "Done. Revert with: ${SCRIPT_DIR}/$(basename "$0") --platform ${PLATFORM} revert --clean-test"
+  log "Snapshot saved in ${REVERT_DIR}"
+}
+
+delete_test_added_imagestreams() {
+  local baseline="${REVERT_DIR}/baseline-imagestream-names.txt"
+  local applied="${REVERT_DIR}/applied-imagestream-names.txt"
+  local ns_file="${REVERT_DIR}/applied-namespaces.txt"
+  [[ -f "${baseline}" && -f "${applied}" ]] \
+    || die "Missing snapshot files in ${REVERT_DIR}; run apply or snapshot first"
+  [[ -f "${ns_file}" ]] || die "Missing ${ns_file}; run apply first"
+
+  local ns name
+  while IFS= read -r ns; do
+    [[ -n "${ns}" ]] || continue
+    while IFS= read -r name; do
+      [[ -n "${name}" ]] || continue
+      if grep -qx "${name}" "${baseline}"; then
+        continue
+      fi
+      if oc get imagestream "${name}" -n "${ns}" >/dev/null 2>&1; then
+        log "Deleting test-added ImageStream ${ns}/${name}"
+        if [[ "${DRY_RUN}" == true ]]; then
+          log "[dry-run] Would delete imagestream ${name} -n ${ns}"
+        else
+          oc delete imagestream "${name}" -n "${ns}"
+        fi
+      fi
+    done < "${applied}"
+  done < "${ns_file}"
+}
+
+cmd_revert() {
+  check_prerequisites
+  [[ -f "${REVERT_DIR}/rendered-before.yaml" ]] \
+    || die "No revert snapshot at ${REVERT_DIR}/rendered-before.yaml — run apply or snapshot first"
+
+  local ns wb_ns
+  if [[ -f "${REVERT_DIR}/applied-namespaces.txt" ]]; then
+    while IFS= read -r ns; do
+      [[ -n "${ns}" ]] || continue
+      log "Restoring baseline in ${ns}"
+      if [[ "${DRY_RUN}" == true ]]; then
+        oc apply --dry-run=client -n "${ns}" -f "${REVERT_DIR}/rendered-before.yaml"
+      else
+        oc apply -n "${ns}" -f "${REVERT_DIR}/rendered-before.yaml"
+      fi
+    done < "${REVERT_DIR}/applied-namespaces.txt"
+  else
+    log "Restoring baseline in ${APPLICATIONS_NS}"
+    if [[ "${DRY_RUN}" == true ]]; then
+      oc apply --dry-run=client -n "${APPLICATIONS_NS}" -f "${REVERT_DIR}/rendered-before.yaml"
+    else
+      oc apply -n "${APPLICATIONS_NS}" -f "${REVERT_DIR}/rendered-before.yaml"
+    fi
+    wb_ns="$(workbench_namespace)"
+    if [[ "${wb_ns}" != "${APPLICATIONS_NS}" ]]; then
+      log "Restoring baseline in ${wb_ns}"
+      if [[ "${DRY_RUN}" == true ]]; then
+        oc apply --dry-run=client -n "${wb_ns}" -f "${REVERT_DIR}/rendered-before.yaml"
+      else
+        oc apply -n "${wb_ns}" -f "${REVERT_DIR}/rendered-before.yaml"
+      fi
+    fi
+  fi
+
+  if [[ "${CLEAN_TEST}" == true ]]; then
+    log "Removing ImageStreams not in operator baseline"
+    delete_test_added_imagestreams
+  fi
+
+  log "Revert complete. ImageStreams from before your test may still exist — that is expected."
+}
+
+main() {
+  parse_args "$@"
+  case "${COMMAND}" in
+    snapshot) cmd_snapshot ;;
+    preview) cmd_preview ;;
+    apply) cmd_apply ;;
+    revert) cmd_revert ;;
+  esac
+}
+
+main "$@"

--- a/scripts/apply-manifests-dev.sh
+++ b/scripts/apply-manifests-dev.sh
@@ -16,6 +16,7 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 PLATFORM="rhoai"
+PLATFORM_EXPLICIT=false
 TARGET="applications"
 REVERT_DIR=""
 OPERATOR_NS=""
@@ -92,7 +93,7 @@ configure_platform() {
       REVERT_DIR="${REVERT_DIR:-/tmp/rhoai-manifests-revert}"
       ;;
     *)
-      die "--platform must be odh or rhoai (got: ${PLATFORM})"
+      die "${PLATFORM} is not supported; use odh or rhoai"
       ;;
   esac
   OPERATOR_MANIFESTS_TAR_DIR="/opt/manifests/workbenches/notebooks/${MANIFESTS_VARIANT}"
@@ -109,6 +110,7 @@ parse_args() {
     case "$1" in
       --platform)
         PLATFORM="${2:?}"
+        PLATFORM_EXPLICIT=true
         shift 2
         ;;
       --target)
@@ -209,14 +211,24 @@ parse_args() {
   esac
 
   if [[ "${COMMAND}" == "revert" && -z "${REVERT_DIR}" ]]; then
-    if [[ -f /tmp/rhoai-manifests-revert/platform.txt ]]; then
-      REVERT_DIR=/tmp/rhoai-manifests-revert
-    elif [[ -f /tmp/odh-manifests-revert/platform.txt ]]; then
-      REVERT_DIR=/tmp/odh-manifests-revert
+    local primary_revert_dir secondary_revert_dir
+    if [[ "${PLATFORM}" == "odh" ]]; then
+      primary_revert_dir=/tmp/odh-manifests-revert
+      secondary_revert_dir=/tmp/rhoai-manifests-revert
+    else
+      primary_revert_dir=/tmp/rhoai-manifests-revert
+      secondary_revert_dir=/tmp/odh-manifests-revert
+    fi
+
+    if [[ -f "${primary_revert_dir}/platform.txt" ]]; then
+      REVERT_DIR="${primary_revert_dir}"
+    elif [[ -f "${secondary_revert_dir}/platform.txt" ]]; then
+      REVERT_DIR="${secondary_revert_dir}"
     fi
   fi
 
-  if [[ -n "${REVERT_DIR}" && -f "${REVERT_DIR}/platform.txt" ]]; then
+  if [[ "${COMMAND}" == "revert" && "${PLATFORM_EXPLICIT}" == false \
+        && -n "${REVERT_DIR}" && -f "${REVERT_DIR}/platform.txt" ]]; then
     PLATFORM="$(tr -d '[:space:]' < "${REVERT_DIR}/platform.txt")"
   fi
 
@@ -228,10 +240,8 @@ save_revert_metadata() {
   printf '%s\n' "${OPERATOR_NS}" > "${REVERT_DIR}/operator-ns.txt"
 }
 
-check_prerequisites() {
+check_cluster_prerequisites() {
   need_cmd oc
-  need_cmd kustomize
-  [[ -d "${MANIFESTS_DIR}" ]] || die "Manifest directory not found: ${MANIFESTS_DIR}"
 
   oc whoami >/dev/null 2>&1 || die "Not logged in to OpenShift (oc whoami failed)"
 
@@ -239,6 +249,12 @@ check_prerequisites() {
   wb_state="$(oc get datasciencecluster default-dsc \
     -o jsonpath='{.spec.components.workbenches.managementState}' 2>/dev/null || true)"
   [[ "${wb_state}" == "Managed" ]] || die "Workbenches must be Managed (got: ${wb_state:-<unset>})"
+}
+
+check_build_prerequisites() {
+  check_cluster_prerequisites
+  need_cmd kustomize
+  [[ -d "${MANIFESTS_DIR}" ]] || die "Manifest directory not found: ${MANIFESTS_DIR}"
 }
 
 operator_pod_labels_for_platform() {
@@ -323,12 +339,17 @@ imagestream_names_from_build() {
 }
 
 target_namespaces() {
-  local wb_ns
-  wb_ns="$(workbench_namespace)"
+  local wb_ns=""
   case "${TARGET}" in
     applications) printf '%s\n' "${APPLICATIONS_NS}" ;;
-    workbench) printf '%s\n' "${wb_ns}" ;;
+    workbench)
+      wb_ns="$(workbench_namespace)"
+      [[ -n "${wb_ns}" ]] || die "Workbench namespace is unset"
+      printf '%s\n' "${wb_ns}"
+      ;;
     both)
+      wb_ns="$(workbench_namespace)"
+      [[ -n "${wb_ns}" ]] || die "Workbench namespace is unset"
       printf '%s\n' "${APPLICATIONS_NS}"
       if [[ "${wb_ns}" != "${APPLICATIONS_NS}" ]]; then
         printf '%s\n' "${wb_ns}"
@@ -350,11 +371,15 @@ snapshot_baseline() {
   kustomize build "${REVERT_DIR}/base" > "${REVERT_DIR}/rendered-before.yaml"
   imagestream_names_from_build "${REVERT_DIR}/base" > "${REVERT_DIR}/baseline-imagestream-names.txt"
 
+  target_namespaces > "${REVERT_DIR}/snapshot-namespaces.txt"
   local ns
   while IFS= read -r ns; do
     oc get imagestreams -n "${ns}" -l opendatahub.io/component=true -o yaml \
       > "${REVERT_DIR}/imagestreams-${ns}-before.yaml" 2>/dev/null || true
-  done < <(target_namespaces)
+    oc get imagestreams -n "${ns}" -l opendatahub.io/component=true \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+      > "${REVERT_DIR}/imagestreams-${ns}-before.txt" 2>/dev/null || true
+  done < "${REVERT_DIR}/snapshot-namespaces.txt"
 
   date -u +"%Y-%m-%dT%H:%M:%SZ" > "${REVERT_DIR}/snapshot-time.txt"
   log "Baseline snapshot complete ($(wc -l < "${REVERT_DIR}/baseline-imagestream-names.txt") ImageStreams)"
@@ -388,13 +413,13 @@ apply_to_namespace() {
 }
 
 cmd_snapshot() {
-  check_prerequisites
+  check_build_prerequisites
   ensure_operator_resolved
   snapshot_baseline "${RESOLVED_OPERATOR_POD}"
 }
 
 cmd_preview() {
-  check_prerequisites
+  check_build_prerequisites
   local workdir
   ensure_operator_resolved
   workdir="$(build_workdir "${RESOLVED_OPERATOR_POD}")"
@@ -404,11 +429,11 @@ cmd_preview() {
   log "Resource counts:"
   kustomize build "${workdir}" | awk '/^kind: / { counts[$2]++ } END { for (k in counts) print counts[k], k }' | sort -rn
 
-  rm -rf "${workdir}"
+  cleanup_temp_files "${workdir}" ""
 }
 
 cmd_apply() {
-  check_prerequisites
+  check_build_prerequisites
   local workdir rendered
   ensure_operator_resolved
   workdir="$(build_workdir "${RESOLVED_OPERATOR_POD}")"
@@ -435,27 +460,26 @@ cmd_apply() {
     fi
   fi
 
-  rm -rf "${workdir}"
-  rm -f "${rendered}"
-
-  log "Done. Revert with: ${SCRIPT_DIR}/$(basename "$0") --platform ${PLATFORM} revert --clean-test"
+  log "Done. Revert with: ${SCRIPT_DIR}/$(basename "$0") revert --clean-test (active plat: ${PLATFORM})"
   log "Snapshot saved in ${REVERT_DIR}"
+  cleanup_temp_files "${workdir}" "${rendered}"
 }
 
 delete_test_added_imagestreams() {
-  local baseline="${REVERT_DIR}/baseline-imagestream-names.txt"
   local applied="${REVERT_DIR}/applied-imagestream-names.txt"
   local ns_file="${REVERT_DIR}/applied-namespaces.txt"
-  [[ -f "${baseline}" && -f "${applied}" ]] \
+  [[ -f "${applied}" ]] \
     || die "Missing snapshot files in ${REVERT_DIR}; run apply or snapshot first"
   [[ -f "${ns_file}" ]] || die "Missing ${ns_file}; run apply first"
 
-  local ns name
+  local ns name before_names
   while IFS= read -r ns; do
     [[ -n "${ns}" ]] || continue
+    before_names="${REVERT_DIR}/imagestreams-${ns}-before.txt"
+    [[ -f "${before_names}" ]] || die "Missing ${before_names}; cannot safely clean test ImageStreams"
     while IFS= read -r name; do
       [[ -n "${name}" ]] || continue
-      if grep -qx "${name}" "${baseline}"; then
+      if grep -Fxq -- "${name}" "${before_names}"; then
         continue
       fi
       if oc get imagestream "${name}" -n "${ns}" >/dev/null 2>&1; then
@@ -471,12 +495,14 @@ delete_test_added_imagestreams() {
 }
 
 cmd_revert() {
-  check_prerequisites
+  check_cluster_prerequisites
   [[ -f "${REVERT_DIR}/rendered-before.yaml" ]] \
     || die "No revert snapshot at ${REVERT_DIR}/rendered-before.yaml — run apply or snapshot first"
 
-  local ns wb_ns
-  if [[ -f "${REVERT_DIR}/applied-namespaces.txt" ]]; then
+  local ns ns_file wb_ns
+  ns_file="${REVERT_DIR}/applied-namespaces.txt"
+  [[ -f "${ns_file}" ]] || ns_file="${REVERT_DIR}/snapshot-namespaces.txt"
+  if [[ -f "${ns_file}" ]]; then
     while IFS= read -r ns; do
       [[ -n "${ns}" ]] || continue
       log "Restoring baseline in ${ns}"
@@ -485,7 +511,7 @@ cmd_revert() {
       else
         oc apply -n "${ns}" -f "${REVERT_DIR}/rendered-before.yaml"
       fi
-    done < "${REVERT_DIR}/applied-namespaces.txt"
+    done < "${ns_file}"
   else
     log "Restoring baseline in ${APPLICATIONS_NS}"
     if [[ "${DRY_RUN}" == true ]]; then
@@ -510,6 +536,18 @@ cmd_revert() {
   fi
 
   log "Revert complete. ImageStreams from before your test may still exist — that is expected."
+}
+
+cleanup_temp_files() {
+  local workdir="${1:-}"
+  local rendered="${2:-}"
+
+  if [[ -n "${workdir}" ]]; then
+    rm -rf -- "${workdir}"
+  fi
+  if [[ -n "${rendered}" ]]; then
+    rm -f -- "${rendered}"
+  fi
 }
 
 main() {


### PR DESCRIPTION
Related to: https://redhat.atlassian.net/browse/RHAIENG-5879 

ODH/RHOAI operator **no longer use `devFlags`** to inject custom notebook manifests, so validating ImageStream changes on a dev cluster previously using the below code block on the DSC it doesn't work anymore (https://redhat-internal.slack.com/archives/C064Z5S84F3/p1782722415209109): 
```
workbenches:
  devFlags:
    manifests:
      - contextDir: manifests
        sourcePath: ''
        uri: 'https://github.com/<your-github-name>/notebooks/archive/<branch-name>.tar.gz'
  managementState: Managed
```

So in order to be able to check manifest changes before merge them on a cluster with installed RHOAI, this script developed: `scripts/apply-manifests-dev.sh`. It patches the operator with the set of manifests that we want to test, applies local manifests (from your working notebooks repo) . 

It snapshots the operator bundle, pull live params from the running operator pod, apply local manifests (from working notebooks repo) to the dashboard/applications namespace, restart the dashboard, and revert (with optional cleanup of test-added ImageStreams). 
Supports both ODH and RHOAI with operator auto-discovery when namespace overrides are wrong or omitted.

How to use the util is documented here: [docs/manifest-cluster-dev-testing.md](https://github.com/atheo89/notebooks/blob/manifest-apply-dev-on-cluster/docs/manifest-cluster-dev-testing.md) for repeatable cluster testing before opening PRs.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Make some changes (versions, new tags whatever) on the manifest files and run :
`./scripts/apply-manifests-dev.sh --platform [rhoai|odh] apply`

once you test/validate the updates on your cluster you can revert the state by 
`./scripts/apply-manifests-dev.sh revert --clean-test`



Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a developer testing workflow for applying, previewing, snapshotting, and reverting local manifest changes on ODH and RHOAI clusters.
  - Added support for platform-specific defaults, namespace overrides, dry runs, and optional dashboard restarts.

- **Documentation**
  - Published setup, usage, verification, revert, and troubleshooting guidance for the new workflow.
  - Included platform notes, prerequisites, and quick-start examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->