### PR TITLE
RHAIENG-6002: ci(.tekton): route amd64 Konflux builds to linux/x86_64 and size build steps

### DIFF
--- a/.tekton/multiarch-odh-main-combined-pipeline.yaml
+++ b/.tekton/multiarch-odh-main-combined-pipeline.yaml
@@ -84,7 +84,7 @@ spec:
     name: additional-tags
     type: array
   - default:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array

--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -48,6 +48,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -61,42 +61,46 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -56,42 +56,46 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -36,7 +36,7 @@ spec:
     - latest
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -43,6 +43,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
@@ -54,50 +54,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
@@ -49,6 +49,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
@@ -41,6 +41,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
@@ -30,7 +30,7 @@ spec:
     value: base-images/build-args/cuda12.9.conf
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
   - name: path-context
     value: .

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
@@ -46,50 +46,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
@@ -54,50 +54,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
@@ -49,6 +49,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-push.yaml
@@ -41,6 +41,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-push.yaml
@@ -46,50 +46,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
@@ -48,6 +48,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: base-images/rocm/7.14/c9s-python-3.12/Dockerfile.rocm
   - name: build-args-file

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
@@ -53,11 +53,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
@@ -53,50 +53,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-base-image-rocm-py312-c9s:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: base-images/rocm/7.14/c9s-python-3.12/Dockerfile.rocm
   - name: build-args-file

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
@@ -45,11 +45,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
@@ -45,50 +45,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
@@ -40,6 +40,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -94,9 +94,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -94,14 +94,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -113,7 +117,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -100,9 +100,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -100,18 +100,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -131,7 +131,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -87,9 +87,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -87,18 +87,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -118,7 +118,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -94,9 +94,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -101,7 +101,11 @@ spec:
           ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -117,7 +121,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -108,10 +108,10 @@ spec:
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -139,7 +139,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -100,9 +100,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -96,10 +96,10 @@ spec:
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -127,7 +127,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -88,9 +88,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -85,14 +85,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -104,7 +108,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -83,11 +83,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -90,18 +90,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -90,9 +90,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -85,18 +85,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -116,7 +116,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -85,9 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -85,27 +85,27 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -83,11 +83,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -90,18 +90,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -90,9 +90,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -85,18 +85,18 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
@@ -116,7 +116,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -85,9 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9:odh-stable
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: dockerfile
     value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -93,18 +93,26 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -93,11 +93,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -93,9 +93,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -89,19 +89,19 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -89,9 +89,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -89,11 +89,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -85,19 +85,19 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -85,11 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -85,9 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -30,7 +30,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -85,27 +85,27 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -83,11 +83,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -98,9 +98,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -98,19 +98,19 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       requests:
@@ -129,7 +129,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -85,9 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -85,19 +85,19 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       requests:
@@ -116,7 +116,11 @@ spec:
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -84,27 +84,27 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       limits:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -84,11 +84,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -82,11 +82,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9:odh-stable
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: dockerfile
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -89,19 +89,19 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -89,9 +89,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -89,11 +89,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -84,9 +84,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -84,11 +84,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -84,11 +84,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
@@ -100,11 +100,11 @@ spec:
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       requests:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -204,6 +204,16 @@ spec:
         memory: 32Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -43,7 +43,7 @@ spec:
     - 3.6_ea1-v1.47
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -197,50 +197,58 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:
         requests:
-          cpu: '16'
-          memory: 32Gi
-          ephemeral-storage: 160Gi
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
-          ephemeral-storage: 160Gi
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -207,12 +207,12 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '4'
-          memory: 8Gi
+          cpu: '16'
+          memory: 32Gi
           ephemeral-storage: 160Gi
         limits:
-          cpu: '4'
-          memory: 8Gi
+          cpu: '16'
+          memory: 32Gi
           ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   - name: build-platforms
     value:
     # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -216,12 +216,12 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '4'
-          memory: 8Gi
+          cpu: '16'
+          memory: 32Gi
           ephemeral-storage: 160Gi
         limits:
-          cpu: '4'
-          memory: 8Gi
+          cpu: '16'
+          memory: 32Gi
           ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -206,50 +206,58 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:
         requests:
-          cpu: '16'
-          memory: 32Gi
-          ephemeral-storage: 160Gi
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
-          ephemeral-storage: 160Gi
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -213,6 +213,16 @@ spec:
         memory: 32Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -48,7 +48,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -209,6 +209,16 @@ spec:
         memory: 32Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -202,50 +202,58 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: build
       computeResources:
         requests:
-          cpu: '16'
-          memory: 32Gi
-          ephemeral-storage: 160Gi
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
-          ephemeral-storage: 160Gi
+          cpu: '8'
+          memory: 16Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -212,12 +212,12 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '4'
-          memory: 8Gi
+          cpu: '16'
+          memory: 32Gi
           ephemeral-storage: 160Gi
         limits:
-          cpu: '4'
-          memory: 8Gi
+          cpu: '16'
+          memory: 32Gi
           ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -87,11 +87,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -61,50 +61,58 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -82,6 +82,16 @@ spec:
         memory: 32Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -75,11 +75,11 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: build
@@ -87,27 +87,27 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
@@ -115,11 +115,19 @@ spec:
 
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -62,50 +62,58 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -88,11 +88,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-mxlarge/amd64
+    - linux/x86_64
     - linux-mxlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -81,11 +81,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -55,29 +55,29 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
@@ -90,11 +90,19 @@ spec:
           ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -98,11 +98,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -72,29 +72,29 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
@@ -109,18 +109,18 @@ spec:
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -74,29 +74,29 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
@@ -114,11 +114,19 @@ spec:
 
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -100,11 +100,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -37,7 +37,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -55,46 +55,54 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -81,11 +81,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -96,11 +96,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -70,55 +70,55 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -74,39 +74,39 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
@@ -114,11 +114,19 @@ spec:
 
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -100,11 +100,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -37,7 +37,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -82,11 +82,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9:odh-stable
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -56,46 +56,54 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -95,11 +95,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -69,55 +69,55 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -60,7 +60,7 @@ spec:
     - '{{target_branch}}-{{revision}}'
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -65,50 +65,58 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -91,11 +91,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -85,11 +85,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -59,46 +59,54 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -76,55 +76,55 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -48,7 +48,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -102,11 +102,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -105,11 +105,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -71,11 +71,11 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-shell-check
     computeResources:
       requests:
@@ -89,40 +89,48 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -40,7 +40,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -83,11 +83,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -57,46 +57,54 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -70,50 +70,54 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -65,6 +65,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -63,44 +63,56 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:
         memory: 8Gi
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -79,11 +79,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -84,11 +84,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -86,18 +86,26 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -86,11 +86,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9:odh-stable
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -77,11 +77,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -72,6 +72,16 @@ spec:
         memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -77,11 +77,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
@@ -101,11 +101,11 @@ spec:
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -90,11 +90,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -88,11 +88,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -90,19 +90,19 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
       limits:
-        cpu: '4'
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -31,7 +31,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -26,7 +26,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -94,9 +94,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -76,36 +76,44 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
   - name: dockerfile
     value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -77,34 +77,34 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
       limits:
-        cpu: '4'
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
@@ -121,7 +121,11 @@ spec:
 
   - pipelineTaskName: prefetch-dependencies
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -72,6 +72,16 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -30,7 +30,7 @@ spec:
       value: 5d
     - name: build-platforms
       value:
-        - linux-d160-m4xlarge/amd64
+        - linux/x86_64
         - linux-d160-m4xlarge/arm64
     - name: dockerfile
       value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -81,9 +81,11 @@ spec:
             requests:
               cpu: '4'
               memory: 8Gi
+              ephemeral-storage: 160Gi
             limits:
               cpu: '4'
               memory: 8Gi
+              ephemeral-storage: 160Gi
     - pipelineTaskName: clair-scan
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -63,36 +63,36 @@ spec:
         - name: prepare-sboms
           computeResources:
             requests:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
             limits:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
         - name: sbom-syft-generate
           computeResources:
             requests:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
             limits:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
         - name: build
           computeResources:
             requests:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 160Gi
+              ephemeral-storage: 64Gi
             limits:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 160Gi
+              ephemeral-storage: 64Gi
     - pipelineTaskName: clair-scan
       computeResources:
         requests:
-          cpu: '4'
+          cpu: '8'
           memory: 8Gi
         limits:
-          cpu: '4'
+          cpu: '8'
           memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:
@@ -108,7 +108,11 @@ spec:
           memory: 8Gi
     - pipelineTaskName: prefetch-dependencies
       computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
         limits:
+          cpu: '4'
           memory: 8Gi
     - pipelineTaskName: clamav-scan
       computeResources:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -93,11 +93,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -95,11 +95,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9:odh-stable
+  - name: build-platforms
+    value:
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: build-args-file

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -67,46 +67,54 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
-        memory: 32Gi
+        cpu: '8'
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
   - name: dockerfile
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
   - name: path-context

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -65,55 +65,55 @@ spec:
   - pipelineTaskName: prefetch-dependencies
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: build-images
     stepSpecs:
     - name: prepare-sboms
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: sbom-syft-generate
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - name: build
       computeResources:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 160Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
       limits:
         cpu: '8'
-        memory: 32Gi
+        memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
       limits:
-        cpu: '8'
-        memory: 32Gi
+        cpu: '4'
+        memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -91,11 +91,13 @@ spec:
     - name: build
       computeResources:
         requests:
-          cpu: '8'
-          memory: 16Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
         limits:
-          cpu: '16'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 160Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -93,11 +93,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -88,11 +88,11 @@ spec:
             requests:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 64Gi
+              ephemeral-storage: 80Gi
             limits:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 64Gi
+              ephemeral-storage: 80Gi
     - pipelineTaskName: clair-scan
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -52,7 +52,7 @@ spec:
           requirements_files: [requirements.rocm.txt]
     - name: build-platforms
       value:
-        - linux-d160-m4xlarge/amd64
+        - linux/x86_64
     - name: additional-tags
       value:
         - '{{target_branch}}-{{revision}}'

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -60,55 +60,55 @@ spec:
     - pipelineTaskName: prefetch-dependencies
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: prepare-sboms
           computeResources:
             requests:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
             limits:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
         - name: sbom-syft-generate
           computeResources:
             requests:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
             limits:
-              cpu: '8'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
         - name: build
           computeResources:
             requests:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 160Gi
+              ephemeral-storage: 64Gi
             limits:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 160Gi
+              ephemeral-storage: 64Gi
     - pipelineTaskName: clair-scan
       computeResources:
         requests:
           cpu: '8'
-          memory: 32Gi
+          memory: 8Gi
         limits:
           cpu: '8'
-          memory: 32Gi
+          memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       computeResources:
         requests:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
         limits:
-          cpu: '8'
-          memory: 32Gi
+          cpu: '4'
+          memory: 8Gi
     - pipelineTaskName: sast-unicode-check
       computeResources:
         limits:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -86,11 +86,13 @@ spec:
         - name: build
           computeResources:
             requests:
-              cpu: '8'
-              memory: 16Gi
+              cpu: '4'
+              memory: 8Gi
+              ephemeral-storage: 160Gi
             limits:
-              cpu: '16'
-              memory: 32Gi
+              cpu: '4'
+              memory: 8Gi
+              ephemeral-storage: 160Gi
     - pipelineTaskName: clair-scan
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:odh-stable
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -105,11 +105,19 @@ spec:
           ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
+      requests:
+        cpu: '4'
+        memory: 8Gi
       limits:
+        cpu: '4'
         memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -98,9 +98,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: clair-scan
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -104,6 +104,16 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
+    - name: build
+      computeResources:
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
+        limits:
+          cpu: '4'
+          memory: 8Gi
+          ephemeral-storage: 64Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -173,7 +173,11 @@ spec:
 
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -121,9 +121,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
         limits:
           cpu: '4'
           memory: 8Gi
+          ephemeral-storage: 64Gi
   - pipelineTaskName: rpms-signature-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -169,7 +169,11 @@ spec:
 
   - pipelineTaskName: clair-scan
     computeResources:
+      requests:
+        cpu: '8'
+        memory: 8Gi
       limits:
+        cpu: '8'
         memory: 8Gi
   - pipelineTaskName: clamav-scan
     computeResources:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -44,7 +44,7 @@ spec:
     value: quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/docs/architecture/decisions/0016-route-amd64-konflux-builds-to-in-cluster-x86-64.md
+++ b/docs/architecture/decisions/0016-route-amd64-konflux-builds-to-in-cluster-x86-64.md
@@ -1,0 +1,188 @@
+# 16. Route amd64 Konflux builds to in-cluster `linux/x86_64` pods (reversing the amd64 VM-pool era)
+
+Date: 2026-08-07
+
+## Status
+
+Proposed
+
+## Context
+
+Konflux's multi-platform build pipelines take a `build-platforms` parameter per architecture leg.
+For the amd64 leg, that parameter can point at either:
+
+- **In-cluster `linux/x86_64`** — the multi-platform-controller schedules the `build-images`
+  TaskRun as a normal pod (`build.appstudio.redhat.com/assigned-host: localhost`). The pod's
+  `stepSpecs.computeResources` are real cgroup requests/limits: undersizing causes OOM
+  (`exit 137`); the ephemeral-storage limit is a real cap that can trigger `PodEvicted`.
+- **Dedicated amd64 VM machine pool** (`linux-d160-m4xlarge/amd64` and similar flavors) — the
+  multi-platform-controller provisions a per-build VM and runs buildah there
+  (`assigned-host: i-<instance-id>`). The same `stepSpecs.computeResources` are, in practice,
+  **a no-op**: buildah is not confined to that cgroup, so a build "succeeding under 4 CPU / 8Gi"
+  on a VM proves nothing about the build's actual resource use.
+
+This repository has gone back and forth between these two choices, and this ADR records that
+history so the next round-trip has the evidence in one place.
+
+### Era 0 — in-cluster `linux/x86_64` by default (pre-Dec 2025)
+
+Konflux's stock `multiarch-*-pipeline.yaml` templates default `build-platforms` to
+`linux/x86_64`; this was also the long-standing OpenShift CI default for these images. Even at
+this stage, `BuildPodEvicted: ephemeral-storage` failures on ROCm/CUDA images were already a
+known, recurring problem — reported in Slack in
+[Jul 2024](https://redhat-internal.slack.com/archives/C05TTTYG599/p1722350681659399) and
+[Jul/Aug 2024](https://redhat-internal.slack.com/archives/C05TTTYG599/p1723213317185749)
+(`#forum-ai-notebooks-server-and-extensions`), tied to
+[RHOAIENG-3466](https://issues.redhat.com/browse/RHOAIENG-3466). This establishes that
+ephemeral-storage exhaustion on heavy images predates Konflux and is a property of the image
+sizes involved, not of any particular platform choice.
+
+### Era 1 — move to dedicated amd64 VM machine pools
+
+[RHAIENG-2460](https://redhat.atlassian.net/browse/RHAIENG-2460) (reported/assigned Vath Sok,
+Dec 2025, Closed) states the rationale directly:
+
+> Based on a discussion with the Konflux team, it appears that only one linux/x86\_64 is
+> currently available, while linux/amd64 offers a wider range of options. Unfortunately, the
+> build process on x86\_64 often results in OOM errors, preventing us from upgrading to a larger
+> resource. Therefore, we should transition from linux/x86\_64 to linux/amd64 to take advantage
+> of the available larger resources.
+
+This landed via [PR #2778](https://github.com/opendatahub-io/notebooks/pull/2778)
+("Update x86\_64 to amd64", merged), synced downstream via
+[odh-konflux-central#95](https://github.com/opendatahub-io/odh-konflux-central/pull/95). It was
+followed by several rounds of VM-flavor and `stepSpecs` tuning while still on VMs:
+
+- [PR #2854](https://github.com/opendatahub-io/notebooks/pull/2854) — fixed a wrong platform
+  flavor name that caused a Kueue `resource … unavailable` error.
+- [PR #3081](https://github.com/opendatahub-io/notebooks/pull/3081) — applied a larger VM
+  platform to the ROCm minimal image build.
+- [PR #3160](https://github.com/opendatahub-io/notebooks/pull/3160) /
+  [KONFLUX-12587](https://issues.redhat.com/browse/KONFLUX-12587) — "Update konflux resource
+  stepSpecs to avoid OOM"; the author reported "no more OOMKilled" after the bump, across more
+  than 20 successful builds.
+- RHDS [#1751](https://github.com/red-hat-data-services/notebooks/pull/1751) /
+  [#1811](https://github.com/red-hat-data-services/notebooks/pull/1811)
+  ([RHAIENG-2344](https://redhat.atlassian.net/browse/RHAIENG-2344)) — bumped tensorflow to a
+  larger `linux-d160-m4xlarge/arm64` VM flavor (same pattern, arm64 side).
+
+Because `stepSpecs.computeResources` do not bind on VM builders, every one of these "fixes" was
+really a VM **flavor** change (more vCPU/RAM/disk on the dedicated machine), not a resource
+*request* that Kubernetes could reason about, schedule against, or enforce.
+
+### Era 2 — reverse back to in-cluster `linux/x86_64`
+
+[RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002) is titled "Fix Konflux build
+failure: bind-mount base-images/utils directory for dnf-helper.sh" and its description is about
+an unrelated buildah bug
+([buildah#6631](https://github.com/containers/buildah/issues/6631)) where
+`RUN --mount=type=bind` rejects a file-level source. That fix shipped separately via
+[PR #4004](https://github.com/opendatahub-io/notebooks/pull/4004) (merged) and its RHDS
+cherry-pick [red-hat-data-services/notebooks#2432](https://github.com/red-hat-data-services/notebooks/pull/2432).
+
+The amd64-platform-routing and resource-sizing work described in the rest of this ADR is
+**opportunistic follow-on work bundled into the same ticket/PR-branch**
+(`fix/dnf-helper-directory-bind-mount`,
+[PR #3994](https://github.com/opendatahub-io/notebooks/pull/3994)), not a separately chartered
+decision. Readers should not assume RHAIENG-6002 itself is a platform-migration ticket.
+
+PR #3994's commits, in order:
+
+| Commit | Date | Summary |
+|---|---|---|
+| `2d415b78` | 2026-07-02 | Route ODH PR Konflux builds' amd64 leg to `linux/x86_64` |
+| `3aeec900` | 2026-08-05 | Extend to push/ci-push pipelines and the multiarch default |
+| `aa7753a9` | 2026-08-05 | Set `linux/x86_64` explicitly on ROCm ci-push (was relying on the default) |
+| `dee382d1` | 2026-08-05 | Size `build` stepSpecs: Guaranteed 4 CPU / 8Gi + ephemeral-storage 64Gi/160Gi, now that limits actually bind |
+| `08fe2d53` | 2026-08-06 | Codeserver OOM'd (`exit 137`) at 4.6/8Gi &rarr; bumped to 16 CPU / 32Gi / 160Gi |
+| `9bfbe6f8` | 2026-08-06 | Peak-align: dropped most steps from "32Gi folklore" to ~8Gi Guaranteed based on live peaks; codeserver 16/32/160&rarr;8/16/80 |
+| `e9a17a3d` | 2026-08-06 | tensorflow-rocm `PodEvicted` at 64Gi ephemeral &rarr; raised to 80Gi |
+| `c8abe913` | 2026-08-07 | pytorch-rocm + rocm-7-14 base also `PodEvicted` at 64Gi &rarr; raised to 80Gi (same class) |
+
+The pattern across the last five commits is consistent: switching to in-cluster pods made
+resource requests real for the first time, which immediately surfaced undersized requests that
+VM builders had been silently absorbing (OOM on codeserver, `PodEvicted` on two ROCm-class
+images), each requiring its own follow-up commit to fix.
+
+### Evidence on whether the reversal delivers the assumed benefit
+
+Live monitoring during this PR's `/build-konflux` runs (recorded in
+[the PR's own comment thread](https://github.com/opendatahub-io/notebooks/pull/3994#issuecomment-5215422266))
+gives two results that matter for this decision:
+
+1. **Resource control works.** On tip `c8abe9133e0c`, the full fleet went green (22/22 Konflux
+   checks). Guaranteed peak-aligned sizing (8 CPU / 16Gi / 80Gi for codeserver and ROCm build
+   steps) held under real load — this validates the *resource-control* rationale for pods: real
+   cgroup caps that can actually be sized from observed peaks.
+2. **Build speed does not reliably improve.** Among 15 multi-arch components on that tip,
+   in-cluster `x86_64` finished sooner than every other architecture in only **7/15 (47%)**, and
+   was measurably slower than sibling arm64 VM builds by 2-4 minutes on heavy CUDA images. A
+   14-day historical sample from the prior VM-pool era showed almost the same spread (amd64-VM
+   finished first in 43% of multi-arch PLRs, last in 35%) — wall-clock finish order was already
+   close to a coin flip against arm64 *before* this change, and moving amd64 to pods did not
+   change that outcome. It only made the resource *requests* real; it did not make the *builds*
+   faster.
+
+## Decision
+
+Reverse the amd64 build-platform leg from dedicated VM machine pools back to in-cluster
+`linux/x86_64`, across pull-request, push, and ci-push PipelineRuns, and the
+`multiarch-odh-main-combined-pipeline.yaml` default. Size the `build` step (and the
+resource-heavy post-build steps: `sbom-syft-generate`, `prepare-sboms`, `clair-scan`,
+`ecosystem-cert-preflight-checks`) with Guaranteed-QoS `computeResources`
+(`requests == limits`) and an explicit `ephemeral-storage` limit, derived from live Prometheus
+peaks observed on in-cluster builds rather than from historical VM-era success (which never
+exercised these limits as real caps).
+
+We do this specifically *because* VM builders make `stepSpecs.computeResources` a no-op: only
+on in-cluster pods does sizing this correctly do anything — protect against noisy-neighbor
+scheduling, make quota usage predictable, and catch OOM/eviction before it happens instead of
+after.
+
+## Consequences
+
+- **Real, enforceable, auditable resource requests.** For the first time, `build`,
+  `sbom-syft-generate`, `prepare-sboms`, `clair-scan`, and `ecosystem-cert-preflight-checks`
+  have `stepSpecs.computeResources` that are actually binding on the amd64 leg.
+- **Caught real problems the VM era had been hiding.** Two `ephemeral-storage`-class
+  `PodEvicted` failures (tensorflow-rocm, then pytorch-rocm/rocm-7-14-base) and one OOM
+  (codeserver, `exit 137`) surfaced only once amd64 moved to pods, and were fixed in follow-up
+  commits within the same PR.
+- **Build finish time is not consistently improved.** Do not present this migration as a
+  performance win: on both the new in-cluster tip and the prior VM era, amd64 finished before
+  every sibling architecture only in the 43-47% range, and was routinely a few minutes behind
+  arm64 VMs on the heaviest CUDA images. The benefit is resource *control*, not build *speed*.
+- **Per-image sizing is now an ongoing cost.** Every image family with unusual build behavior
+  (codeserver's `npm`/vscode build, ROCm's large unpacked layers) needs its own sizing pass;
+  this PR alone took five follow-up commits over about 36 hours to reach a stable, peak-aligned
+  set of limits. Future new images should expect the same trial-and-error unless sized from
+  live peaks up front.
+- **`container_fs_usage_bytes` under-reports buildah's real ephemeral-storage usage.**
+  `PodEvicted`, not the Prometheus filesystem metric, remains the only reliable signal for
+  ephemeral-storage sizing; this should be assumed for any future image added to the fleet.
+- **Follow-up:** [`docs/konflux.md`](../../konflux.md)'s "Pipeline resource overrides" section
+  still documents older, VM-era `stepSpecs` numbers ("32Gi folklore"). It should be refreshed to
+  the peak-aligned numbers from this PR once #3994 merges, so the doc does not silently
+  contradict the checked-in `.tekton/*.yaml` files.
+
+## References
+
+- [RHAIENG-2460](https://redhat.atlassian.net/browse/RHAIENG-2460) — original decision to move
+  amd64 from `linux/x86_64` to VM machine pools, for larger resources / to avoid OOM.
+- [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002) — dnf-helper bind-mount bug
+  ticket that this PR's branch grew out of; not itself a platform-migration ticket.
+- [KONFLUX-12587](https://issues.redhat.com/browse/KONFLUX-12587) — VM-era `stepSpecs` OOM fix.
+- [RHOAIENG-3466](https://issues.redhat.com/browse/RHOAIENG-3466) — earlier OpenShift CI
+  ephemeral-storage eviction issue, cited as prior art for the same failure class.
+- [buildah#6631](https://github.com/containers/buildah/issues/6631) — root cause of the
+  dnf-helper bind-mount failure.
+- PRs: [#2778](https://github.com/opendatahub-io/notebooks/pull/2778),
+  [#2854](https://github.com/opendatahub-io/notebooks/pull/2854),
+  [#3081](https://github.com/opendatahub-io/notebooks/pull/3081),
+  [#3160](https://github.com/opendatahub-io/notebooks/pull/3160),
+  [#3994](https://github.com/opendatahub-io/notebooks/pull/3994) (this decision) and its
+  [resource/timing analysis comment](https://github.com/opendatahub-io/notebooks/pull/3994#issuecomment-5215422266).
+- [`docs/konflux.md`](../../konflux.md) — operational Konflux reference; VM `host-config` and
+  pipeline resource override sections should stay consistent with this ADR.
+- ADR [0011](0011-abandon-pull-request-target-for-pr-builds.md) — closest existing ADR
+  precedent for a CI-platform-routing decision (style/format template for this ADR).


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-6002

## Description

Route Konflux **amd64** builds from machine-pool platforms (`linux-*/amd64`) to in-cluster **`linux/x86_64`**, and set real `build` `stepSpecs.computeResources` now that those limits bind as cgroup caps.

**Context:** On VM builders (`linux-d160-…/amd64`), `computeResources` on the build step are effectively a noop (buildah runs on the dedicated VM). On `linux/x86_64` (`assigned-host: localhost`), the same requests/limits are hard caps — undersizing causes OOM (exit 137); oversized concurrent ephemeral requests can hit `ExceededResourceQuota`.

**Changes (`.tekton/` only):**
- Pull-request, push, and ci-push PipelineRuns: amd64 `build-platforms` → `linux/x86_64` (other arches unchanged)
- Default in `multiarch-odh-main-combined-pipeline.yaml` → `linux/x86_64`
- `build` stepSpecs: Guaranteed-style **4 CPU / 8Gi** + ephemeral-storage (**64Gi** light / **160Gi** heavy); add missing `build` stepSpecs where needed
- Codeserver: **16 CPU / 32Gi** / 160Gi ephemeral (previously OOM’d under 8Gi on `linux/x86_64`)

> Note: The original dnf-helper directory bind-mount fix already landed on `main` via other PRs. This PR retains the [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002) tracker for the follow-on Konflux platform/resource work.

## How Has This Been Tested?

- [x] `/build-konflux` on this tip (`08fe2d539`) against `open-data-hub-tenant`
- [x] Confirmed live pods pick up stepSpecs (`step-build` limits 4/8 or 16/32 + ephemeral)
- [x] Live Prometheus (console tenancy): e.g. rocm base mem peak ~7 Gi under 8 Gi; `runtime-minimal` / `jupyter-minimal-cuda` Succeeded under 4/8
- [ ] Full PR Konflux matrix green (some TaskRuns still `ExceededResourceQuota` under concurrent large ephemeral reservations; codeserver 16/32 not fully exercised yet)

Self checklist:
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — N/A for `.tekton`-only change
- [x] Konflux PipelineRun edits are intentional on this branch for validation; durable sync should go through konflux-central as usual

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work (partial — monitoring in progress)

[RHAIENG-6002]: https://redhat.atlassian.net/browse/RHAIENG-6002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Standardized x86 builds on `linux/x86_64` while retaining ARM64 support where configured.
  * Added explicit CPU, memory, and temporary-storage capacity for image builds, including up to 80 GiB of ephemeral storage.
  * Tuned resource allocations for dependency preparation, SBOM generation, security scanning, and certification checks to improve build reliability and efficiency.

* **Documentation**
  * Documented the updated build platform strategy, resource sizing, monitoring results, and operational guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->