### PR TITLE
RHAIENG-5649: fix: pin Konflux BASE_IMAGE references by digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,12 +123,14 @@
         "/(jupyter|codeserver|runtimes)/.+/build-args/konflux\\..+\\.conf$/",
       ],
       "matchStrings": [
-        "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>\\S+)",
+        "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?",
       ],
       // Renovate's auto-replace locates the full match (replaceString) first, then
       // substitutes with this template.  Without it the default template may not
       // reconstruct the BASE_IMAGE=… line correctly.
-      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}",
+      // {{{newDigest}}} is populated when pinDigests is enabled on the matching
+      // packageRule — it resolves the tag to its registry manifest digest.
+      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}@{{{newDigest}}}",
       "datasourceTemplate": "docker",
       // Stable tags become [major, minor, patch, timestamp].
       // EA tags keep [major, minor, patch] and encode ea_version + timestamp in
@@ -195,6 +197,7 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["/^quay\\.io\\/aipcc\\//"],
       "groupName": "konflux BASE_IMAGE {{{depNameSanitized}}}",
+      "pinDigests": true,
       "recreateWhen": "always",
       "semanticCommits": "enabled",
     },
@@ -276,6 +279,7 @@
       // https://docs.renovatebot.com/configuration-options/#matchpackagenames
       "matchPackageNames": ["/^registry\\.redhat\\.io\\/rhai\\//"],
       "groupName": "Red Hat registry base images",
+      "pinDigests": true,
       "semanticCommits": "enabled",
     },
     {


### PR DESCRIPTION
## Summary

Enable `pinDigests: true` in Renovate/MintMaker configuration so that `BASE_IMAGE` references in `*/build-args/konflux.*.conf` files are cryptographically pinned with `@sha256:` digests (FIND-008, CWE-1357).

Upstream counterpart to https://github.com/red-hat-data-services/notebooks/pull/2365 — this change belongs in ODH first per contributing guidelines, then syncs downstream.

Changes to `.github/renovate.json5`:
- Update the custom.regex `matchStrings` to capture an optional existing `@sha256:` digest via `(?:@(?<currentDigest>\S+))?`, so Renovate can parse conf files that already have digests appended.
- Update `autoReplaceStringTemplate` to include `{{{newDigest}}}` so replacement strings include the resolved digest.
- Add `pinDigests: true` to the `quay.io/aipcc` and `registry.redhat.io/rhai` package rules so Renovate resolves and appends digests on every update.

On its next run, MintMaker/Renovate on ODH `main` will open PRs to append `@sha256:…` digests to all konflux conf files. Future tag updates will automatically include the digest.

## How Has This Been Tested?

- `./uv run python scripts/ci/validate_renovate_config.py` — semantic validation passes
- `./uv run pytest tests/test_renovate_config.py tests/unit/scripts/ci/test_validate_renovate_config.py` — unit tests pass

## Test plan

- [ ] CI `validate-renovate-config` / `pytest-tests` pass
- [ ] After merge, confirm MintMaker opens pin-digest PRs for konflux conf files on ODH `main`
- [ ] Sync downstream to RHDS release branches


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated handling of digest-pinned `BASE_IMAGE` entries so image updates keep digest references consistent when pinning is enabled.
  * Enabled digest pinning for two additional automated image update rules, making base image references more precise and stable during update cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->