### PR TITLE
fix(ci): add conditional GHCR login for buildinputs image pulls

### DIFF
--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -66,6 +66,9 @@ jobs:
     name: Generate job matrix
     needs: [authorize]
     if: needs.authorize.outputs.authorized == 'true'
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-26.04
     # rhds/notebooks builds from AIPCC bases and requires pull_request_target trigger
     outputs:
@@ -83,6 +86,14 @@ jobs:
         if: ${{ github.event_name != 'pull_request_target' }}
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository != 'opendatahub-io/notebooks' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -66,6 +66,9 @@ jobs:
     name: Generate job matrix
     needs: [authorize]
     if: needs.authorize.outputs.authorized == 'true'
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
@@ -82,6 +85,14 @@ jobs:
         if: ${{ github.event_name != 'pull_request_target' }}
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository != 'opendatahub-io/notebooks' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # RHAIENG-3914: use env vars to prevent GitHub Actions expression injection
       - name: Determine targets to build based on changed files

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -18,6 +18,7 @@ jobs:
     name: Generate job matrix
     permissions:
       contents: read
+      packages: read
     runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
@@ -27,6 +28,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository != 'opendatahub-io/notebooks' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if PR is from a fork
         id: fork-check

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -28,6 +28,9 @@ permissions:
 jobs:
   gen:
     name: Generate job matrix
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-26.04
     # for odh-io/notebooks and rhds/notebooks, allow only main, rhoai-*, release-*
     if: ${{ github.event_name == 'workflow_dispatch' ||
@@ -39,6 +42,14 @@ jobs:
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository != 'opendatahub-io/notebooks' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine targets to build (we want to build everything on push)
         run: |

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -38,12 +38,23 @@ jobs:
           fi
 
   pytest-tests:
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Full history so tests/test_pylock_downgrade.py can `git show origin/main:…/pylock.toml`.
           fetch-depth: 0
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository != 'opendatahub-io/notebooks' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -45,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
           # Full history so tests/test_pylock_downgrade.py can `git show origin/main:…/pylock.toml`.
           fetch-depth: 0
 

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -51,6 +51,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: read  # checkout only; push and PR creation use the PAT
+      packages: read
     env:
       BRANCH: ${{ github.event.inputs.branch || 'main' }}
       INDEX_MODE: ${{ github.event.inputs.index_mode || 'auto' }}
@@ -93,6 +94,14 @@ jobs:
         run: |
           uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant odh
           uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant rhoai
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository != 'opendatahub-io/notebooks' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate manifests (make test)
         run: make test


### PR DESCRIPTION
Related to [RHAIENG-3914](https://redhat.atlassian.net/browse/RHAIENG-3914) (the evaluation ticket) and cross-referencing [RHAIENG-4290](https://redhat.atlassian.net/browse/RHAIENG-4290).

## Summary
- Grant `packages: read` on CI jobs that invoke `buildinputs()` (matrix generation, `pytest-tests`, lockfile renewal validation).
- Add conditional `docker/login-action` for `ghcr.io` on non-ODH repos so private `buildinputs` images can be pulled after #3969.
- Skip GHCR login on `opendatahub-io/notebooks` where the package is publicly pullable.

Fixes RHDS CI breakage synced from #3969 (`Generate job matrix` and `pytest-tests` failing with `ghcr.io/red-hat-data-services/notebooks/buildinputs:main` unauthorized).

## Test plan
- [ ] ODH PR: `pytest-tests` and `Generate job matrix` pass without running the login step.
- [ ] After sync to RHDS: `pytest-tests` and `Generate job matrix` pull `buildinputs:main` successfully on PRs touching `Dockerfile.konflux.*`.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — workflow-only change
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work — logic mirrors existing `build-notebooks-TEMPLATE.yaml` login; RHDS validation pending post-sync.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional GitHub Container Registry login to several workflows, improving package access during builds and checks.
  * Expanded workflow permissions to allow read access for GitHub Packages where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->