### PR TITLE
[RHAIENG-5878] chore(tags) Update runtime naming separation between latest and 2025.2 

### DIFF
--- a/manifests/odh/base/runtime-datascience-imagestream.yaml
+++ b/manifests/odh/base/runtime-datascience-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
   name: runtime-datascience
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Datascience | CPU | Python 3.12",
+              "display_name": "Runtime | Datascience | CPU | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "datascience"
                 ],
-                "display_name": "Runtime | Datascience | CPU | Python 3.12",
+                "display_name": "Runtime | Datascience | CPU | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/odh/base/runtime-minimal-imagestream.yaml
+++ b/manifests/odh/base/runtime-minimal-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
   name: runtime-minimal
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Minimal | CPU | Python 3.12",
+              "display_name": "Runtime | Minimal | CPU | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "minimal"
                 ],
-                "display_name": "Runtime | Minimal | CPU | Python 3.12",
+                "display_name": "Runtime | Minimal | CPU | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/odh/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/odh/base/runtime-pytorch-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Pytorch | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Pytorch | CUDA | Python 3.12",
+              "display_name": "Runtime | PyTorch | CUDA | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "pytorch"
                 ],
-                "display_name": "Runtime | Pytorch | CUDA | Python 3.12",
+                "display_name": "Runtime | PyTorch | CUDA | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/odh/base/runtime-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/odh/base/runtime-pytorch-llmcompressor-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch-llmcompressor
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12",
+              "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "pytorch"
                 ],
-                "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12",
+                "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/odh/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/odh/base/runtime-rocm-pytorch-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Pytorch | ROCm | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-pytorch
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Pytorch | ROCm | Python 3.12",
+              "display_name": "Runtime | PyTorch | ROCm | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "rocm-pytorch"
                 ],
-                "display_name": "Runtime | Pytorch | ROCm | Python 3.12",
+                "display_name": "Runtime | PyTorch | ROCm | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/odh/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/odh/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-tensorflow
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | TensorFlow | ROCm | Python 3.12",
+              "display_name": "Runtime | TensorFlow | ROCm | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "rocm-tensorflow"
                 ],
-                "display_name": "Runtime | TensorFlow | ROCm | Python 3.12",
+                "display_name": "Runtime | TensorFlow | ROCm | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/odh/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/odh/base/runtime-tensorflow-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-tensorflow
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "tensorflow"
                 ],
-                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-datascience-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-datascience-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
   name: runtime-datascience
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Datascience | CPU | Python 3.12",
+              "display_name": "Runtime | Datascience | CPU | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "datascience"
                 ],
-                "display_name": "Runtime | Datascience | CPU | Python 3.12",
+                "display_name": "Runtime | Datascience | CPU | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-minimal-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-minimal-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
   name: runtime-minimal
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Minimal | CPU | Python 3.12",
+              "display_name": "Runtime | Minimal | CPU | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "minimal"
                 ],
-                "display_name": "Runtime | Minimal | CPU | Python 3.12",
+                "display_name": "Runtime | Minimal | CPU | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-pytorch-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-imagestream-2025-2.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Pytorch | CUDA | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12 | 2025.2"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch-2025-2
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Pytorch | CUDA | Python 3.12 | 2025.2",
+              "display_name": "Runtime | PyTorch | CUDA | Python 3.12 | 2025.2",
               "metadata": {
                 "tags": [
                   "pytorch-2025.2"
                 ],
-                "display_name": "Runtime | Pytorch | CUDA | Python 3.12 | 2025.2",
+                "display_name": "Runtime | PyTorch | CUDA | Python 3.12 | 2025.2",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Pytorch | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Pytorch | CUDA | Python 3.12",
+              "display_name": "Runtime | PyTorch | CUDA | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "pytorch"
                 ],
-                "display_name": "Runtime | Pytorch | CUDA | Python 3.12",
+                "display_name": "Runtime | PyTorch | CUDA | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-llmcompressor-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-pytorch-llmcompressor
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12",
+              "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "pytorch"
                 ],
-                "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12",
+                "display_name": "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-rocm-pytorch-imagestream-2025-2.yaml
+++ b/manifests/rhoai/base/runtime-rocm-pytorch-imagestream-2025-2.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Pytorch | ROCm | Python 3.12 | 2025.2"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12 | 2025.2"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-pytorch-2025-2
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Pytorch | ROCm | Python 3.12 | 2025.2",
+              "display_name": "Runtime | PyTorch | ROCm | Python 3.12 | 2025.2",
               "metadata": {
                 "tags": [
                   "rocm-pytorch-2025.2"
                 ],
-                "display_name": "Runtime | Pytorch | ROCm | Python 3.12 | 2025.2",
+                "display_name": "Runtime | PyTorch | ROCm | Python 3.12 | 2025.2",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-rocm-pytorch-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | Pytorch | ROCm | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-pytorch
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | Pytorch | ROCm | Python 3.12",
+              "display_name": "Runtime | PyTorch | ROCm | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "rocm-pytorch"
                 ],
-                "display_name": "Runtime | Pytorch | ROCm | Python 3.12",
+                "display_name": "Runtime | PyTorch | ROCm | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-rocm-tensorflow
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | TensorFlow | ROCm | Python 3.12",
+              "display_name": "Runtime | TensorFlow | ROCm | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "rocm-tensorflow"
                 ],
-                "display_name": "Runtime | TensorFlow | ROCm | Python 3.12",
+                "display_name": "Runtime | TensorFlow | ROCm | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"

--- a/manifests/rhoai/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-tensorflow-imagestream.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/runtime-image: "true"
   annotations:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
-    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12"
+    opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
   name: runtime-tensorflow
 spec:
@@ -18,12 +18,12 @@ spec:
         opendatahub.io/runtime-image-metadata: |
           [
             {
-              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+              "display_name": "Runtime | TensorFlow | CUDA | Python 3.12 | Latest",
               "metadata": {
                 "tags": [
                   "tensorflow"
                 ],
-                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12",
+                "display_name": "Runtime | TensorFlow | CUDA | Python 3.12 | Latest",
                 "pull_policy": "IfNotPresent"
               },
               "schema_name": "runtime-image"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
related to: https://redhat.atlassian.net/browse/RHAIENG-5878 

## Description
<!--- Describe your changes in detail -->
After discussion with Kezia decided to use (Latest) for the latest runtimes as well for better visibility on the UI

- Updated runtime image names and displayed labels for Data Science, Minimal, PyTorch, TensorFlow, and ROCm variants to consistently use “Latest”.
- Standardized PyTorch capitalization across runtime labels for clearer, more consistent naming.
- Applied the updated naming across both Open Data Hub and RHOAI runtime image listings.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**on cluster:**
in local dev repo run: `./scripts/apply-manifests-dev.sh --platform rhoai apply` to test the changes on cluster
once finish: `./scripts/apply-manifests-dev.sh revert --clean-test`


<img width="610" height="624" alt="Screenshot 2026-07-02 at 11 47 39" src="https://github.com/user-attachments/assets/bd8528db-97d9-487b-bcfa-04112f3f84f4" />



Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated runtime image names and displayed labels for Data Science, Minimal, PyTorch, TensorFlow, and ROCm variants to consistently use **“Latest”**.
  * Standardized PyTorch capitalization across runtime labels for clearer, more consistent naming.
  * Applied the updated naming across both Open Data Hub and RHOAI runtime image listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->