### PR TITLE
RHAIENG-4895: feat(manifests/tools): add ImageStream tag rollout for ODH and RHOAI

### DIFF
--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -258,12 +258,23 @@ def _discover_param_pairs_from_imagestreams(
         document = yaml.safe_load(resource_path.read_text())
         if not isinstance(document, dict):
             continue
-        imagestream_name = document.get("metadata", {}).get("name")
-        tags = document.get("spec", {}).get("tags", [])
+        metadata = document.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        imagestream_name = metadata.get("name")
+        spec = document.get("spec")
+        if not isinstance(spec, dict):
+            continue
+        tags = spec.get("tags")
         if not isinstance(imagestream_name, str) or not isinstance(tags, list):
             continue
         for tag in tags:
-            from_name = tag.get("from", {}).get("name")
+            if not isinstance(tag, dict):
+                continue
+            from_block = tag.get("from")
+            if not isinstance(from_block, dict):
+                continue
+            from_name = from_block.get("name")
             if isinstance(from_name, str) and from_name.endswith("_PLACEHOLDER"):
                 pairs.append((from_name.removesuffix("_PLACEHOLDER"), imagestream_name))
     return pairs

--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -26,6 +26,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
 from manifests.tools.commit_env_refs import parse_env_file
 from ntb.strings import process_template_with_indents
 
@@ -64,10 +65,9 @@ class Workbench:
 
 @dataclass
 class Runtime:
-    """A runtime image: single tag, params replacement only."""
+    """A runtime image: single tag (N), params replacement only."""
 
-    base_key: str
-    suffix: str
+    param_key: str
     imagestream: str
     resource_file: str
 
@@ -129,82 +129,99 @@ def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[st
     imagestream_to_resource = _build_imagestream_to_resource(base_dir, all_resources)
 
     # 2) Collect all param keys from .env files
-    param_keys = set(parse_env_file(base_dir / "params.env").keys()) | set(parse_env_file(base_dir / "params-latest.env").keys())
+    param_keys = set(parse_env_file(base_dir / "params.env").keys()) | set(
+        parse_env_file(base_dir / "params-latest.env").keys()
+    )
 
-    # 3) Parse param keys into (base_key, suffix) pairs.
-    #    e.g. "odh-workbench-...-ubi9-n"      -> ("odh-workbench-...-ubi9", "-n")
-    #         "odh-workbench-...-ubi9-2025-2"  -> ("odh-workbench-...-ubi9", "-2025-2")
-    #    We group by imagestream because different py versions share the same imagestream.
-
-    # First, figure out which resource file each param key belongs to by matching
-    # against the kustomization.yaml replacement blocks.  We do this by reading the
-    # existing file structure.
-    #
-    # Simpler approach: parse the existing kustomization.yaml replacements section
-    # to extract the ordered (key, imagestream) pairs.  This gives us exact ordering.
-
+    # 3) Read existing replacement blocks to preserve workbench/runtime ordering,
+    # then resolve version chains from ImageStream tag placeholders so newly
+    # rolled-out keys (for example ``-3-4``) are included in the correct tag order.
     replacements_text = kustomization[kustomization.index("replacements:"):]
     field_path_pattern = re.compile(r"fieldPath: data\.(\S+)")
     imagestream_pattern = re.compile(r"kind: ImageStream\n\s+name: (\S+)")
 
-    # Extract pairs of (fieldPath_key, imagestream_name) from replacement blocks
     field_paths = field_path_pattern.findall(replacements_text)
     imagestreams = imagestream_pattern.findall(replacements_text)
     assert len(field_paths) == len(imagestreams), (
         f"Mismatch: {len(field_paths)} fieldPaths vs {len(imagestreams)} imagestreams"
     )
 
-    # Split into params and commit blocks
-    replacement_params_pairs: list[tuple[str, str]] = []  # (full_key, imagestream)
+    replacement_params_pairs: list[tuple[str, str]] = []
     for key, istream in zip(field_paths, imagestreams, strict=True):
         if "-commit-" not in key:
             replacement_params_pairs.append((key, istream))
 
-    replacement_param_keys = {full_key for full_key, _imagestream in replacement_params_pairs}
-    missing_param_keys = sorted(param_keys - replacement_param_keys)
+    yaml_pairs = _discover_param_pairs_from_imagestreams(base_dir, all_resources)
+    yaml_keys_by_imagestream: dict[str, list[str]] = {}
+    for full_key, istream in yaml_pairs:
+        yaml_keys_by_imagestream.setdefault(istream, []).append(full_key)
+
+    discovered_param_keys = {full_key for full_key, _istream in yaml_pairs if full_key in param_keys}
+    missing_param_keys = sorted(param_keys - discovered_param_keys)
     assert not missing_param_keys, (
-        "Missing imagestream replacement for params key(s): "
-        + ", ".join(missing_param_keys)
+        "Missing imagestream replacement for params key(s): " + ", ".join(missing_param_keys)
     )
 
-    # Keep only keys that still exist in params*.env.
-    #
-    # This lets the generator recover after tag removals where stale replacements
-    # still exist in kustomization.yaml (the script should remove those blocks).
-    params_pairs = [
-        (full_key, istream) for full_key, istream in replacement_params_pairs if full_key in param_keys
-    ]
+    workbench_imagestream_order: list[str] = []
+    seen_workbench_imagestreams: set[str] = set()
+    for _key, istream in replacement_params_pairs:
+        if _key.startswith("odh-pipeline-runtime-"):
+            continue
+        if istream not in seen_workbench_imagestreams:
+            workbench_imagestream_order.append(istream)
+            seen_workbench_imagestreams.add(istream)
+    for istream in yaml_keys_by_imagestream:
+        if istream not in seen_workbench_imagestreams and not istream.startswith("runtime-"):
+            workbench_imagestream_order.append(istream)
+            seen_workbench_imagestreams.add(istream)
 
-    # 5) Build workbenches and runtimes from the params pairs
+    runtime_imagestream_order: list[str] = []
+    seen_runtime_imagestreams: set[str] = set()
+    for _key, istream in replacement_params_pairs:
+        if not _key.startswith("odh-pipeline-runtime-"):
+            continue
+        if istream not in seen_runtime_imagestreams:
+            runtime_imagestream_order.append(istream)
+            seen_runtime_imagestreams.add(istream)
+    for istream in yaml_keys_by_imagestream:
+        if istream.startswith("runtime-") and istream not in seen_runtime_imagestreams:
+            runtime_imagestream_order.append(istream)
+            seen_runtime_imagestreams.add(istream)
+
+    # 5) Build workbenches and runtimes from ImageStream tag order
     workbench_resource_files: list[str] = []
     runtime_resource_files: list[str] = []
     workbenches: list[Workbench] = []
     runtimes: list[Runtime] = []
 
-    # Track which imagestreams we've seen to group versions
-    seen_workbench_imagestreams: dict[str, Workbench] = {}
+    for istream in workbench_imagestream_order:
+        res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
+        wb = Workbench(istream, res_file)
+        for full_key in yaml_keys_by_imagestream.get(istream, []):
+            if full_key not in param_keys:
+                continue
+            m = _PARAM_KEY_RE.match(full_key)
+            assert m, f"Could not parse param key: {full_key}"
+            wb.versions.append((m.group(1), m.group(2)))
+        workbenches.append(wb)
+        if res_file not in workbench_resource_files:
+            workbench_resource_files.append(res_file)
 
-    for full_key, istream in params_pairs:
+    for istream in runtime_imagestream_order:
+        runtime_keys = [
+            full_key
+            for full_key in yaml_keys_by_imagestream.get(istream, [])
+            if full_key in param_keys and full_key.startswith("odh-pipeline-runtime-")
+        ]
+        if not runtime_keys:
+            continue
+        full_key = runtime_keys[0]
         m = _PARAM_KEY_RE.match(full_key)
         assert m, f"Could not parse param key: {full_key}"
-        base_key = m.group(1)
-        suffix = m.group(2)
-
-        if full_key.startswith("odh-pipeline-runtime-"):
-            res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
-            runtimes.append(Runtime(base_key, suffix, istream, res_file))
-            if res_file not in runtime_resource_files:
-                runtime_resource_files.append(res_file)
-        else:
-            if istream not in seen_workbench_imagestreams:
-                res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
-                wb = Workbench(istream, res_file)
-                seen_workbench_imagestreams[istream] = wb
-                workbenches.append(wb)
-                if res_file not in workbench_resource_files:
-                    workbench_resource_files.append(res_file)
-            wb = seen_workbench_imagestreams[istream]
-            wb.versions.append((base_key, suffix))
+        res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
+        runtimes.append(Runtime(m.group(1), istream, res_file))
+        if res_file not in runtime_resource_files:
+            runtime_resource_files.append(res_file)
 
     # 6) Collect non-imagestream resources (buildconfigs, etc.) that are in
     #    the resource list but not matched to any workbench/runtime
@@ -219,6 +236,31 @@ def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[st
     ordered_resources = _order_resources(all_resources)
 
     return ordered_resources, workbenches, runtime_resource_files, runtimes
+
+
+def _discover_param_pairs_from_imagestreams(
+    base_dir: Path,
+    all_resources: list[str],
+) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for resource in all_resources:
+        if not resource.endswith("-imagestream.yaml"):
+            continue
+        resource_path = base_dir / resource
+        if not resource_path.exists():
+            continue
+        document = yaml.safe_load(resource_path.read_text())
+        if not isinstance(document, dict):
+            continue
+        imagestream_name = document.get("metadata", {}).get("name")
+        tags = document.get("spec", {}).get("tags", [])
+        if not isinstance(imagestream_name, str) or not isinstance(tags, list):
+            continue
+        for tag in tags:
+            from_name = tag.get("from", {}).get("name")
+            if isinstance(from_name, str) and from_name.endswith("_PLACEHOLDER"):
+                pairs.append((from_name.removesuffix("_PLACEHOLDER"), imagestream_name))
+    return pairs
 
 
 def _build_imagestream_to_resource(base_dir: Path, all_resources: list[str]) -> dict[str, str]:
@@ -337,9 +379,9 @@ def _workbench_commit_replacements(wb: Workbench) -> list[str]:
 
 
 def _runtime_params_replacement(rt: Runtime) -> str:
-    """Single image-params replacement for a runtime."""
+    """Single image-params replacement for a runtime (N only)."""
     return _replacement_block(
-        f"{rt.base_key}{rt.suffix}",
+        f"{rt.param_key}-n",
         "notebook-image-params",
         "spec.tags.0.from.name",
         rt.imagestream,
@@ -363,7 +405,7 @@ def generate(base_dir: Path) -> str:
     for wb in workbenches:
         replacement_blocks.extend(_workbench_commit_replacements(wb))
 
-    # 3) Runtime image-params for all runtimes
+    # 3) Runtime image-params (N only) for all runtimes
     for rt in runtimes:
         replacement_blocks.append(_runtime_params_replacement(rt))
 

--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -65,9 +65,10 @@ class Workbench:
 
 @dataclass
 class Runtime:
-    """A runtime image: single tag (N), params replacement only."""
+    """A runtime image: single tag, params replacement only."""
 
-    param_key: str
+    base_key: str
+    suffix: str
     imagestream: str
     resource_file: str
 
@@ -219,7 +220,7 @@ def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[st
         m = _PARAM_KEY_RE.match(full_key)
         assert m, f"Could not parse param key: {full_key}"
         res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
-        runtimes.append(Runtime(m.group(1), istream, res_file))
+        runtimes.append(Runtime(m.group(1), m.group(2), istream, res_file))
         if res_file not in runtime_resource_files:
             runtime_resource_files.append(res_file)
 
@@ -238,13 +239,18 @@ def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[st
     return ordered_resources, workbenches, runtime_resource_files, runtimes
 
 
+def _is_imagestream_resource(resource: str) -> bool:
+    """Return True for ImageStream manifest files, including versioned variants."""
+    return "-imagestream" in resource and resource.endswith(".yaml")
+
+
 def _discover_param_pairs_from_imagestreams(
     base_dir: Path,
     all_resources: list[str],
 ) -> list[tuple[str, str]]:
     pairs: list[tuple[str, str]] = []
     for resource in all_resources:
-        if not resource.endswith("-imagestream.yaml"):
+        if not _is_imagestream_resource(resource):
             continue
         resource_path = base_dir / resource
         if not resource_path.exists():
@@ -379,9 +385,9 @@ def _workbench_commit_replacements(wb: Workbench) -> list[str]:
 
 
 def _runtime_params_replacement(rt: Runtime) -> str:
-    """Single image-params replacement for a runtime (N only)."""
+    """Single image-params replacement for a runtime."""
     return _replacement_block(
-        f"{rt.param_key}-n",
+        f"{rt.base_key}{rt.suffix}",
         "notebook-image-params",
         "spec.tags.0.from.name",
         rt.imagestream,
@@ -405,7 +411,7 @@ def generate(base_dir: Path) -> str:
     for wb in workbenches:
         replacement_blocks.extend(_workbench_commit_replacements(wb))
 
-    # 3) Runtime image-params (N only) for all runtimes
+    # 3) Runtime image-params for all runtimes
     for rt in runtimes:
         replacement_blocks.append(_runtime_params_replacement(rt))
 

--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -895,7 +895,7 @@ def main(argv: list[str] | None = None) -> int:
     changed_paths.extend(imagestream_changed_paths)
     step_index += 1
 
-    if not args.dry_run and imagestream_changed_paths:
+    if imagestream_changed_paths:
         if "odh" in variants:
             params_changed_paths, released_images = run_odh_params_step(
                 root / "manifests" / "odh" / "base",

--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -26,8 +26,8 @@ from pathlib import Path
 from threading import Lock
 from typing import Any, Callable, Iterator
 
-from consolio import Consolio
 import yaml
+from rich.console import Console
 from manifests.tools.commit_env_refs import commit_field_key, parse_env_file
 from manifests.tools.generate_kustomization import generate as generate_kustomization
 from ruamel.yaml import YAML
@@ -72,19 +72,14 @@ class ReleasedImage:
 class StepReporter:
     def __init__(self, stream: Any | None = None) -> None:
         self.stream = sys.stdout if stream is None else stream
-        self.is_tty = bool(getattr(self.stream, "isatty", lambda: False)())
-        self.console = Consolio(
-            spinner_type="dots",
-            no_colors=not self.is_tty,
-            no_animation=not self.is_tty,
-        )
+        self.console = Console(file=self.stream)
+        self.is_tty = self.console.is_terminal
 
     def print_step(self, message: str) -> None:
         if not self.is_tty:
             print(message, file=self.stream, flush=True)
             return
-        self.console.reset_indent()
-        self.console.print("cmp", message)
+        self.console.print(f"[bold green]✓[/bold green] {message}")
 
     @contextmanager
     def running_step(
@@ -104,7 +99,7 @@ class StepReporter:
                 completed += 1
                 detail = f"[{completed}/{total}] {message}"
                 if self.is_tty:
-                    self.console.print(1, "inf", detail)
+                    self.console.print(f"  [bold cyan]i[/bold cyan] {detail}")
                 else:
                     print(f"  {detail}", file=self.stream, flush=True)
                 self.stream.flush()
@@ -127,9 +122,9 @@ class StepReporter:
                 self.print_step(done_message)
             return
 
-        with self.console.spinner(start_message, inline=True):
+        with self.console.status(start_message, spinner="dots"):
             yield None
-        self.console.print("cmp", done_message)
+        self.print_step(done_message)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -1,0 +1,958 @@
+#!/usr/bin/env -S uv run --project=../..
+"""Roll workbench ImageStream tags forward from ``versions_config.yml``.
+
+This updates workbench ImageStream YAML files under ``manifests/<variant>/base``.
+Runtime ImageStreams are skipped. For ODH, the tool also synchronizes released
+``params.env`` / ``commit.env`` entries and regenerates ``kustomization.yaml``.
+ODH keeps exactly two tags (``N`` and ``N-1``). RHOAI prepends a new ``N`` tag,
+preserves existing ImageStream history, and synchronizes ``params.env`` /
+``commit.env`` for the new ``N-1`` tag using digest refs from
+``red-hat-data-services/RHOAI-Build-Config``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib
+import re
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Any, Callable, Iterator
+
+from consolio import Consolio
+import yaml
+from manifests.tools.commit_env_refs import commit_field_key, parse_env_file
+from manifests.tools.generate_kustomization import generate as generate_kustomization
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString, SingleQuotedScalarString
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parents[1]
+
+_RECOMMENDED_KEY = "opendatahub.io/workbench-image-recommended"
+_OUTDATED_KEY = "opendatahub.io/image-tag-outdated"
+_COMMIT_KEY = "opendatahub.io/notebook-build-commit"
+_PLACEHOLDER_RE = re.compile(r"^(?P<prefix>.+?)(?P<suffix>-(?:n|\d+(?:-\d+)*))_PLACEHOLDER$")
+_VERSIONED_KEY_RE = re.compile(r"^(?P<base>.+?)(?P<suffix>-(?:n|\d+(?:-\d+)*))$")
+_ODH_RELEASE_FAMILY_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)$")
+_ODH_GA_BUILD_TAG_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)-v\d+\.(?P<build>\d+)$")
+_RHOAI_WORKBENCH_BASE_KEY_RE = re.compile(
+    r"^odh-workbench-(?P<middle>.+)-py(?P<pyver>\d+)-(?P<platform>ubi9|c9s)$"
+)
+_RHOAI_BUILD_CONFIG_REPO = "red-hat-data-services/RHOAI-Build-Config"
+_RHOAI_BUILD_CONFIG_CSV_PATH = "bundle/manifests/rhods-operator.clusterserviceversion.yaml"
+_SKOPEO_INSPECT = importlib.import_module("manifests.tools.skopeo_inspect")
+
+
+@dataclass(frozen=True)
+class ReleasedImage:
+    base_key: str
+    released_suffix: str
+    released_param_key: str
+    released_commit_key: str
+    digest_ref: str
+    commit_sha: str
+    repository: str = ""
+    published_tag: str = ""
+    release_tag: str = ""
+    source_url: str = ""
+
+    def progress_message(self) -> str:
+        digest = self.digest_ref.rsplit("@", 1)[-1]
+        return f"{self.base_key} commit={self.commit_sha} digest={digest}"
+
+
+class StepReporter:
+    def __init__(self, stream: Any | None = None) -> None:
+        self.stream = sys.stdout if stream is None else stream
+        self.is_tty = bool(getattr(self.stream, "isatty", lambda: False)())
+        self.console = Consolio(
+            spinner_type="dots",
+            no_colors=not self.is_tty,
+            no_animation=not self.is_tty,
+        )
+
+    def print_step(self, message: str) -> None:
+        if not self.is_tty:
+            print(message, file=self.stream, flush=True)
+            return
+        self.console.reset_indent()
+        self.console.print("cmp", message)
+
+    @contextmanager
+    def running_step(
+        self,
+        start_message: str,
+        done_message: str,
+        *,
+        animate: bool = False,
+        total: int | None = None,
+    ) -> Iterator[Callable[[str], None] | None]:
+        if total is not None:
+            self.print_step(start_message)
+            completed = 0
+
+            def track_item(message: str) -> None:
+                nonlocal completed
+                completed += 1
+                detail = f"[{completed}/{total}] {message}"
+                if self.is_tty:
+                    self.console.print(1, "inf", detail)
+                else:
+                    print(f"  {detail}", file=self.stream, flush=True)
+                self.stream.flush()
+
+            try:
+                yield track_item
+            except Exception:
+                raise
+            else:
+                self.print_step(done_message)
+            return
+
+        if not self.is_tty or not animate:
+            self.print_step(start_message)
+            try:
+                yield None
+            except Exception:
+                raise
+            else:
+                self.print_step(done_message)
+            return
+
+        with self.console.spinner(start_message, inline=True):
+            yield None
+        self.console.print("cmp", done_message)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=ROOT_DIR,
+        help="Repository root containing versions_config.yml and manifests/ (default: repo root)",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to versions_config.yml (default: <root>/versions_config.yml)",
+    )
+    parser.add_argument(
+        "--target",
+        choices=("all", "odh", "rhoai"),
+        default="all",
+        help="Roll out only one manifests base directory (default: all)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Compute updates without writing files")
+    return parser.parse_args(argv)
+
+
+def load_release_tag(config_path: Path) -> str:
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    full_version = data["release"]["full_version"]
+    parts = full_version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"Expected semantic release.full_version, got {full_version!r}")
+    major, minor, _patch = parts
+    return f"{int(major)}.{int(minor)}"
+
+
+def build_yaml() -> YAML:
+    yml = YAML()
+    yml.preserve_quotes = True
+    yml.width = 1024 * 1024
+    yml.explicit_start = True
+    yml.indent(mapping=2, sequence=4, offset=2)
+    return yml
+
+
+def iter_workbench_imagestream_paths(base_dir: Path) -> Iterator[Path]:
+    yield from sorted(
+        path
+        for path in base_dir.glob("*-imagestream.yaml")
+        if not path.name.startswith("runtime-")
+    )
+
+
+def update_tag_placeholders(tag: dict[str, Any], suffix: str) -> None:
+    annotations = tag.setdefault("annotations", {})
+    from_block = tag.setdefault("from", {})
+
+    from_name = from_block.get("name")
+    if not isinstance(from_name, str):
+        raise ValueError(f"Missing DockerImage placeholder in tag: {tag!r}")
+    match = _PLACEHOLDER_RE.match(from_name)
+    if match is None:
+        raise ValueError(f"Unsupported placeholder format: {from_name!r}")
+    from_block["name"] = f"{match.group('prefix')}{suffix}_PLACEHOLDER"
+
+    commit_value = annotations.get(_COMMIT_KEY)
+    if commit_value is None:
+        return
+    if not isinstance(commit_value, str):
+        raise ValueError(f"Unexpected commit placeholder type: {commit_value!r}")
+    match = _PLACEHOLDER_RE.match(commit_value)
+    if match is None:
+        raise ValueError(f"Unsupported placeholder format: {commit_value!r}")
+    annotations[_COMMIT_KEY] = f"{match.group('prefix')}{suffix}_PLACEHOLDER"
+
+
+def _odh_ga_tag_sort_key(tag: str) -> tuple[int, str]:
+    match = _ODH_GA_BUILD_TAG_RE.fullmatch(tag)
+    if match is None:
+        raise ValueError(f"Unsupported ODH GA build tag format: {tag!r}")
+    return (int(match.group("build")), tag)
+
+
+def select_latest_matching_odh_tag(tags: list[str], release_family: str) -> str:
+    match = _ODH_RELEASE_FAMILY_RE.fullmatch(release_family)
+    if match is None:
+        raise ValueError(f"Unsupported ODH release family: {release_family!r}")
+    target_major = int(match.group("major"))
+    target_minor = int(match.group("minor"))
+
+    matches: list[tuple[tuple[int, str], str]] = []
+    for tag in tags:
+        tag_match = _ODH_GA_BUILD_TAG_RE.fullmatch(tag)
+        if tag_match is None:
+            continue
+        if int(tag_match.group("major")) != target_major or int(tag_match.group("minor")) != target_minor:
+            continue
+        matches.append((_odh_ga_tag_sort_key(tag), tag))
+
+    if not matches:
+        raise ValueError(
+            f"No published ODH GA tag found for family '{release_family}' "
+            "(expected format like '3.4-v1.43'; early-access tags are ignored)"
+        )
+    return max(matches, key=lambda item: item[0])[1]
+
+
+def repository_from_image_ref(image_ref: str) -> str:
+    repository = image_ref.split("@", 1)[0]
+    last_colon = repository.rfind(":")
+    last_slash = repository.rfind("/")
+    if last_colon > last_slash:
+        return repository[:last_colon]
+    return repository
+
+
+def extract_short_vcs_ref(config_payload: dict[str, Any], image_ref: str) -> str:
+    labels = config_payload.get("config", {}).get("Labels")
+    if not isinstance(labels, dict):
+        labels = config_payload.get("Labels")
+    if not isinstance(labels, dict):
+        raise ValueError(f"skopeo inspect returned invalid labels for {image_ref}")
+    vcs_ref = labels.get("vcs-ref")
+    if not isinstance(vcs_ref, str) or len(vcs_ref) < 7:
+        raise ValueError(f"skopeo inspect returned invalid vcs-ref for {image_ref}")
+    return vcs_ref[:7]
+
+
+def _list_repository_tags_cached(
+    repository: str,
+    tag_cache: dict[str, tuple[str, ...]],
+    tag_cache_lock: Lock,
+) -> tuple[str, ...]:
+    with tag_cache_lock:
+        cached = tag_cache.get(repository)
+    if cached is not None:
+        return cached
+
+    resolved_tags = _SKOPEO_INSPECT.list_repository_tags(repository)
+    with tag_cache_lock:
+        tag_cache.setdefault(repository, resolved_tags)
+        return tag_cache[repository]
+
+
+def _resolve_odh_released_image(
+    path: Path,
+    params_latest: dict[str, str],
+    *,
+    tag_cache: dict[str, tuple[str, ...]],
+    tag_cache_lock: Lock,
+) -> ReleasedImage:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    tags = data["spec"]["tags"]
+    if len(tags) < 2:
+        raise ValueError(f"{path.name} must have at least two tags to sync ODH env files")
+
+    released_placeholder = tags[1]["from"]["name"]
+    if not isinstance(released_placeholder, str):
+        raise ValueError(f"{path.name} tag 1 missing from.name placeholder")
+    match = _PLACEHOLDER_RE.match(released_placeholder)
+    if match is None:
+        raise ValueError(f"{path.name} tag 1 placeholder has unexpected format: {released_placeholder!r}")
+
+    base_key = match.group("prefix")
+    released_suffix = match.group("suffix")
+    latest_key = f"{base_key}-n"
+    latest_ref = params_latest.get(latest_key)
+    if latest_ref is None:
+        raise ValueError(f"Missing params-latest.env entry for {latest_key}")
+
+    repository = repository_from_image_ref(latest_ref)
+    repository_name = repository.rsplit("/", 1)[1]
+    if repository_name != base_key:
+        raise ValueError(
+            f"params-latest.env value for {latest_key} does not match key base {base_key!r}: {latest_ref!r}"
+        )
+
+    release_family = str(tags[1]["name"])
+    published_tags = list(_list_repository_tags_cached(repository, tag_cache, tag_cache_lock))
+    published_tag = select_latest_matching_odh_tag(published_tags, release_family)
+    inspected = _SKOPEO_INSPECT.inspect_image(f"{repository}:{published_tag}")
+    digest_ref = f"{repository}@{inspected.digest}"
+    commit_sha = extract_short_vcs_ref(inspected.payload, digest_ref)
+    return ReleasedImage(
+        base_key=base_key,
+        released_suffix=released_suffix,
+        released_param_key=released_placeholder.removesuffix("_PLACEHOLDER"),
+        released_commit_key=commit_field_key(base_key, released_suffix),
+        digest_ref=digest_ref,
+        commit_sha=commit_sha,
+        repository=repository,
+        published_tag=published_tag,
+        release_tag=release_family,
+    )
+
+
+def resolve_odh_released_images(
+    base_dir: Path,
+    *,
+    paths: list[Path] | None = None,
+    on_item: Callable[[str], None] | None = None,
+) -> list[ReleasedImage]:
+    params_latest = parse_env_file(base_dir / "params-latest.env")
+    imagestream_paths = list(paths if paths is not None else iter_workbench_imagestream_paths(base_dir))
+    tag_cache: dict[str, tuple[str, ...]] = {}
+    tag_cache_lock = Lock()
+    released_images: list[ReleasedImage | None] = [None] * len(imagestream_paths)
+    worker_count = min(8, len(imagestream_paths) or 1)
+
+    def resolve_at(index: int, path: Path) -> tuple[int, ReleasedImage]:
+        return index, _resolve_odh_released_image(
+            path,
+            params_latest,
+            tag_cache=tag_cache,
+            tag_cache_lock=tag_cache_lock,
+        )
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [
+            executor.submit(resolve_at, index, path) for index, path in enumerate(imagestream_paths)
+        ]
+        for future in as_completed(futures):
+            index, released_image = future.result()
+            released_images[index] = released_image
+            if on_item is not None:
+                on_item(released_image.progress_message())
+
+    return [image for image in released_images if image is not None]
+
+
+def related_image_env_name(base_key: str) -> str | None:
+    match = _RHOAI_WORKBENCH_BASE_KEY_RE.fullmatch(base_key)
+    if match is None or match.group("pyver") != "312" or match.group("platform") != "ubi9":
+        return None
+    middle = match.group("middle").upper().replace("-", "_")
+    return f"RELATED_IMAGE_ODH_WORKBENCH_{middle}_PY312_IMAGE"
+
+
+def rhoai_build_config_branch_candidates(release_tag: str) -> tuple[str, ...]:
+    return (f"rhoai-{release_tag}", f"rhoai-{release_tag}-ea.2")
+
+
+def rhoai_build_config_source_url(branch: str) -> str:
+    return f"https://github.com/{_RHOAI_BUILD_CONFIG_REPO}/blob/{branch}/{_RHOAI_BUILD_CONFIG_CSV_PATH}"
+
+
+def fetch_rhoai_build_config(branch: str, *, urlopen: Callable[..., Any] | None = None) -> str:
+    url = f"https://raw.githubusercontent.com/{_RHOAI_BUILD_CONFIG_REPO}/{branch}/{_RHOAI_BUILD_CONFIG_CSV_PATH}"
+    opener = urllib.request.urlopen if urlopen is None else urlopen
+    with opener(url, timeout=60) as response:
+        return response.read().decode("utf-8")
+
+
+def resolve_rhoai_build_config_source(
+    release_tag: str,
+    *,
+    urlopen: Callable[..., Any] | None = None,
+) -> tuple[str, str]:
+    last_error: urllib.error.HTTPError | None = None
+    for branch in rhoai_build_config_branch_candidates(release_tag):
+        try:
+            fetch_rhoai_build_config(branch, urlopen=urlopen)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                last_error = exc
+                continue
+            raise
+        else:
+            return branch, rhoai_build_config_source_url(branch)
+    raise ValueError(
+        f"No RHOAI-Build-Config branch found for release {release_tag!r} "
+        f"(tried {', '.join(rhoai_build_config_branch_candidates(release_tag))})"
+    ) from last_error
+
+
+def parse_workbench_related_images(csv_text: str) -> dict[str, str]:
+    data = yaml.safe_load(csv_text)
+    related: dict[str, str] = {}
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            name = node.get("name")
+            value = node.get("value")
+            if (
+                isinstance(name, str)
+                and name.startswith("RELATED_IMAGE_ODH_WORKBENCH_")
+                and isinstance(value, str)
+            ):
+                related[name] = value.strip('"')
+            for child in node.values():
+                walk(child)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(data)
+    return related
+
+
+def load_rhoai_workbench_related_images(
+    release_tag: str,
+    cache: dict[str, dict[str, str]],
+    source_urls: dict[str, str],
+    *,
+    urlopen: Callable[..., Any] | None = None,
+) -> dict[str, str]:
+    if release_tag in cache:
+        return cache[release_tag]
+
+    branch, source_url = resolve_rhoai_build_config_source(release_tag, urlopen=urlopen)
+    cache[release_tag] = parse_workbench_related_images(fetch_rhoai_build_config(branch, urlopen=urlopen))
+    source_urls[release_tag] = source_url
+    return cache[release_tag]
+
+
+def _resolve_rhoai_released_image(
+    path: Path,
+    related_images_cache: dict[str, dict[str, str]],
+    source_urls: dict[str, str],
+    *,
+    urlopen: Callable[..., Any] | None = None,
+) -> ReleasedImage | None:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    tags = data["spec"]["tags"]
+    if len(tags) < 2:
+        raise ValueError(f"{path.name} must have at least two tags to sync RHOAI env files")
+
+    released_placeholder = tags[1]["from"]["name"]
+    if not isinstance(released_placeholder, str):
+        raise ValueError(f"{path.name} tag 1 missing from.name placeholder")
+    match = _PLACEHOLDER_RE.match(released_placeholder)
+    if match is None:
+        raise ValueError(f"{path.name} tag 1 placeholder has unexpected format: {released_placeholder!r}")
+
+    base_key = match.group("prefix")
+    related_image_name = related_image_env_name(base_key)
+    if related_image_name is None:
+        return None
+
+    release_tag = str(tags[1]["name"])
+    related_images = load_rhoai_workbench_related_images(
+        release_tag,
+        related_images_cache,
+        source_urls,
+        urlopen=urlopen,
+    )
+    digest_ref = related_images.get(related_image_name)
+    if digest_ref is None:
+        raise ValueError(
+            f"No {related_image_name} entry in RHOAI-Build-Config for release {release_tag!r}"
+        )
+
+    config_payload = _SKOPEO_INSPECT.inspect_config(digest_ref)
+    commit_sha = extract_short_vcs_ref(config_payload, digest_ref)
+    released_suffix = match.group("suffix")
+    return ReleasedImage(
+        base_key=base_key,
+        released_suffix=released_suffix,
+        released_param_key=released_placeholder.removesuffix("_PLACEHOLDER"),
+        released_commit_key=commit_field_key(base_key, released_suffix),
+        digest_ref=digest_ref,
+        commit_sha=commit_sha,
+        release_tag=release_tag,
+        source_url=source_urls[release_tag],
+    )
+
+
+def resolve_rhoai_released_images(
+    base_dir: Path,
+    *,
+    paths: list[Path] | None = None,
+    on_item: Callable[[str], None] | None = None,
+    urlopen: Callable[..., Any] | None = None,
+) -> list[ReleasedImage]:
+    imagestream_paths = list(paths if paths is not None else iter_workbench_imagestream_paths(base_dir))
+    related_images_cache: dict[str, dict[str, str]] = {}
+    source_urls: dict[str, str] = {}
+    released_images: list[ReleasedImage] = []
+
+    for path in imagestream_paths:
+        released_image = _resolve_rhoai_released_image(
+            path,
+            related_images_cache,
+            source_urls,
+            urlopen=urlopen,
+        )
+        if released_image is None:
+            continue
+        released_images.append(released_image)
+        if on_item is not None:
+            on_item(released_image.progress_message())
+
+    return released_images
+
+
+def rhoai_env_todo_header(release_tag: str, source_url: str) -> str:
+    return (
+        f"# TODO: Update the hashes after {release_tag} official release, these values fetched from\n"
+        f"# {source_url}\n"
+    )
+
+
+def sync_rhoai_env_entries(
+    path: Path,
+    desired_entries: dict[str, str],
+    *,
+    release_tag: str,
+    source_url: str,
+    dry_run: bool = False,
+) -> bool:
+    if not desired_entries:
+        return False
+
+    current_entries = parse_env_file(path)
+    desired_keys = set(desired_entries)
+    unchanged_entries = [(key, value) for key, value in current_entries.items() if key not in desired_keys]
+
+    released_block = rhoai_env_todo_header(release_tag, source_url) + "".join(
+        f"{key}={desired_entries[key]}\n" for key in sorted(desired_entries)
+    )
+    unchanged_body = "".join(f"{key}={value}\n" for key, value in unchanged_entries)
+    updated_text = f"{released_block}\n{unchanged_body}" if unchanged_body else released_block
+
+    current_text = path.read_text(encoding="utf-8")
+    if updated_text == current_text:
+        return False
+    if not dry_run:
+        path.write_text(updated_text, encoding="utf-8")
+    return True
+
+
+def sync_managed_env_file(
+    path: Path,
+    desired_entries_by_base: dict[str, tuple[str, str]],
+    *,
+    managed_prefix: str,
+    dry_run: bool = False,
+) -> bool:
+    current_entries = parse_env_file(path)
+    updated_entries: list[tuple[str, str]] = []
+    seen_bases: set[str] = set()
+
+    for key, value in current_entries.items():
+        match = _VERSIONED_KEY_RE.match(key)
+        if match is None:
+            updated_entries.append((key, value))
+            continue
+
+        base_key = match.group("base")
+        if base_key in desired_entries_by_base:
+            if base_key in seen_bases:
+                continue
+            updated_entries.append(desired_entries_by_base[base_key])
+            seen_bases.add(base_key)
+            continue
+
+        if key.startswith(managed_prefix):
+            continue
+        updated_entries.append((key, value))
+
+    for base_key, entry in desired_entries_by_base.items():
+        if base_key not in seen_bases:
+            updated_entries.append(entry)
+
+    updated_text = "".join(f"{key}={value}\n" for key, value in updated_entries)
+    current_text = path.read_text(encoding="utf-8")
+    if updated_text == current_text:
+        return False
+    if not dry_run:
+        path.write_text(updated_text, encoding="utf-8")
+    return True
+
+
+def sync_odh_params_env(base_dir: Path, released_images: list[ReleasedImage], *, dry_run: bool = False) -> bool:
+    desired_entries_by_base = {
+        released_image.base_key: (released_image.released_param_key, released_image.digest_ref)
+        for released_image in released_images
+    }
+    return sync_managed_env_file(
+        base_dir / "params.env",
+        desired_entries_by_base,
+        managed_prefix="odh-workbench-",
+        dry_run=dry_run,
+    )
+
+
+def sync_odh_commit_env(base_dir: Path, released_images: list[ReleasedImage], *, dry_run: bool = False) -> bool:
+    desired_entries_by_base = {
+        f"{released_image.base_key}-commit": (released_image.released_commit_key, released_image.commit_sha)
+        for released_image in released_images
+    }
+    return sync_managed_env_file(
+        base_dir / "commit.env",
+        desired_entries_by_base,
+        managed_prefix="odh-workbench-",
+        dry_run=dry_run,
+    )
+
+
+def sync_rhoai_params_env(base_dir: Path, released_images: list[ReleasedImage], *, dry_run: bool = False) -> bool:
+    if not released_images:
+        return False
+    release_tag = released_images[0].release_tag
+    source_url = released_images[0].source_url
+    desired_entries = {image.released_param_key: image.digest_ref for image in released_images}
+    return sync_rhoai_env_entries(
+        base_dir / "params.env",
+        desired_entries,
+        release_tag=release_tag,
+        source_url=source_url,
+        dry_run=dry_run,
+    )
+
+
+def sync_rhoai_commit_env(base_dir: Path, released_images: list[ReleasedImage], *, dry_run: bool = False) -> bool:
+    if not released_images:
+        return False
+    release_tag = released_images[0].release_tag
+    source_url = released_images[0].source_url
+    desired_entries = {image.released_commit_key: image.commit_sha for image in released_images}
+    return sync_rhoai_env_entries(
+        base_dir / "commit.env",
+        desired_entries,
+        release_tag=release_tag,
+        source_url=source_url,
+        dry_run=dry_run,
+    )
+
+
+def regenerate_kustomization(base_dir: Path, *, dry_run: bool = False) -> bool:
+    path = base_dir / "kustomization.yaml"
+    generated_text = generate_kustomization(base_dir)
+    current_text = path.read_text(encoding="utf-8")
+    if generated_text == current_text:
+        return False
+    if not dry_run:
+        path.write_text(generated_text, encoding="utf-8")
+    return True
+
+
+def normalize_rollout_state(tag: dict[str, Any], index: int) -> None:
+    annotations = tag.setdefault("annotations", {})
+    if index == 0:
+        annotations[_RECOMMENDED_KEY] = SingleQuotedScalarString("true")
+        annotations.pop(_OUTDATED_KEY, None)
+        return
+    if index == 1:
+        annotations[_RECOMMENDED_KEY] = SingleQuotedScalarString("false")
+        annotations.pop(_OUTDATED_KEY, None)
+        return
+    annotations.pop(_RECOMMENDED_KEY, None)
+    annotations[_OUTDATED_KEY] = SingleQuotedScalarString("true")
+
+
+def rollout_tag_sequence(tags: Any, target_tag_name: str, *, keep_history: bool) -> bool:
+    if not tags:
+        return False
+    if str(tags[0].get("name")) == target_tag_name:
+        return False
+
+    historical_tags = [copy.deepcopy(tag) for tag in tags]
+    new_latest = copy.deepcopy(tags[0])
+    new_latest["name"] = DoubleQuotedScalarString(target_tag_name)
+
+    rolled_tags = [new_latest, *historical_tags]
+    for index, tag in enumerate(rolled_tags):
+        suffix = "-n" if index == 0 else "-" + str(tag["name"]).replace(".", "-")
+        update_tag_placeholders(tag, suffix)
+        normalize_rollout_state(tag, index)
+
+    if not keep_history:
+        del rolled_tags[2:]
+
+    tags.clear()
+    tags.extend(rolled_tags)
+    return True
+
+
+def rollout_imagestream_file(path: Path, target_tag_name: str, *, keep_history: bool, dry_run: bool, yml: YAML) -> bool:
+    with path.open("r", encoding="utf-8") as handle:
+        docs = list(yml.load_all(handle))
+    if not docs:
+        return False
+
+    document = docs[0]
+    tags = document.get("spec", {}).get("tags")
+    if tags is None:
+        raise ValueError(f"ImageStream has no spec.tags: {path}")
+
+    changed = rollout_tag_sequence(tags, target_tag_name, keep_history=keep_history)
+    if changed and not dry_run:
+        with path.open("w", encoding="utf-8") as handle:
+            if len(docs) > 1:
+                yml.dump_all(docs, handle)
+            else:
+                yml.dump(document, handle)
+    return changed
+
+
+def rollout_variant_imagestreams(root: Path, variant: str, target_tag_name: str, *, dry_run: bool = False) -> list[Path]:
+    base_dir = root / "manifests" / variant / "base"
+    keep_history = variant == "rhoai"
+    yml = build_yaml()
+    changed_paths: list[Path] = []
+
+    for path in iter_workbench_imagestream_paths(base_dir):
+        if rollout_imagestream_file(path, target_tag_name, keep_history=keep_history, dry_run=dry_run, yml=yml):
+            changed_paths.append(path)
+    return changed_paths
+
+
+def run_imagestream_rollout_step(
+    root: Path,
+    variants: tuple[str, ...],
+    target_tag_name: str,
+    *,
+    dry_run: bool,
+    reporter: StepReporter,
+    step_index: int,
+    step_total: int,
+) -> list[Path]:
+    with reporter.running_step(
+        f"{step_index}/{step_total} Updating imagestreams with new tag",
+        f"{step_index}/{step_total} Imagestreams updated",
+    ):
+        changed_paths: list[Path] = []
+        for variant in variants:
+            changed_paths.extend(rollout_variant_imagestreams(root, variant, target_tag_name, dry_run=dry_run))
+        return changed_paths
+
+
+def run_odh_params_step(
+    base_dir: Path,
+    *,
+    dry_run: bool,
+    reporter: StepReporter,
+    step_index: int,
+    step_total: int,
+) -> tuple[list[Path], list[ReleasedImage]]:
+    changed_paths: list[Path] = []
+    imagestream_paths = list(iter_workbench_imagestream_paths(base_dir))
+    worker_count = min(8, len(imagestream_paths) or 1)
+    with reporter.running_step(
+        f"{step_index}/{step_total} Updating the ODH params.env file "
+        f"({len(imagestream_paths)} images, {worker_count} concurrent skopeo workers)",
+        f"{step_index}/{step_total} ODH params.env file updated",
+        total=len(imagestream_paths),
+    ) as track_item:
+        released_images = resolve_odh_released_images(
+            base_dir,
+            paths=imagestream_paths,
+            on_item=track_item,
+        )
+        if sync_odh_params_env(base_dir, released_images, dry_run=dry_run):
+            changed_paths.append(base_dir / "params.env")
+    return changed_paths, released_images
+
+
+def run_odh_commit_step(
+    base_dir: Path,
+    released_images: list[ReleasedImage],
+    *,
+    dry_run: bool,
+    reporter: StepReporter,
+    step_index: int,
+    step_total: int,
+) -> list[Path]:
+    changed_paths: list[Path] = []
+    with reporter.running_step(
+        f"{step_index}/{step_total} Updating the ODH commit.env and kustomization.yaml files",
+        f"{step_index}/{step_total} ODH commit.env and kustomization.yaml updated",
+    ):
+        if sync_odh_commit_env(base_dir, released_images, dry_run=dry_run):
+            changed_paths.append(base_dir / "commit.env")
+        if regenerate_kustomization(base_dir, dry_run=dry_run):
+            changed_paths.append(base_dir / "kustomization.yaml")
+    return changed_paths
+
+
+def run_rhoai_params_step(
+    base_dir: Path,
+    *,
+    dry_run: bool,
+    reporter: StepReporter,
+    step_index: int,
+    step_total: int,
+    urlopen: Callable[..., Any] | None = None,
+) -> tuple[list[Path], list[ReleasedImage]]:
+    changed_paths: list[Path] = []
+    imagestream_paths = list(iter_workbench_imagestream_paths(base_dir))
+    with reporter.running_step(
+        f"{step_index}/{step_total} Updating the RHOAI params.env file ({len(imagestream_paths)} images)",
+        f"{step_index}/{step_total} RHOAI params.env file updated",
+        total=len(imagestream_paths),
+    ) as track_item:
+        released_images = resolve_rhoai_released_images(
+            base_dir,
+            paths=imagestream_paths,
+            on_item=track_item,
+            urlopen=urlopen,
+        )
+        if sync_rhoai_params_env(base_dir, released_images, dry_run=dry_run):
+            changed_paths.append(base_dir / "params.env")
+    return changed_paths, released_images
+
+
+def run_rhoai_commit_step(
+    base_dir: Path,
+    released_images: list[ReleasedImage],
+    *,
+    dry_run: bool,
+    reporter: StepReporter,
+    step_index: int,
+    step_total: int,
+) -> list[Path]:
+    changed_paths: list[Path] = []
+    with reporter.running_step(
+        f"{step_index}/{step_total} Updating the RHOAI commit.env and kustomization.yaml files",
+        f"{step_index}/{step_total} RHOAI commit.env and kustomization.yaml updated",
+    ):
+        if sync_rhoai_commit_env(base_dir, released_images, dry_run=dry_run):
+            changed_paths.append(base_dir / "commit.env")
+        if regenerate_kustomization(base_dir, dry_run=dry_run):
+            changed_paths.append(base_dir / "kustomization.yaml")
+    return changed_paths
+
+
+def variant_needs_rollout(root: Path, variant: str, target_tag_name: str) -> bool:
+    base_dir = root / "manifests" / variant / "base"
+    for path in iter_workbench_imagestream_paths(base_dir):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        tags = data["spec"]["tags"]
+        if tags and str(tags[0].get("name")) != target_tag_name:
+            return True
+    return False
+
+
+def rollout_step_total(variants: tuple[str, ...]) -> int:
+    return 1 + (2 if "odh" in variants else 0) + (2 if "rhoai" in variants else 0)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = args.root.resolve()
+    config_path = args.config.resolve() if args.config is not None else root / "versions_config.yml"
+    target_tag_name = load_release_tag(config_path)
+    variants = ("odh", "rhoai") if args.target == "all" else (args.target,)
+
+    reporter = StepReporter()
+    changed_paths: list[Path] = []
+    rollout_needed = any(variant_needs_rollout(root, variant, target_tag_name) for variant in variants)
+    if not rollout_needed and not args.dry_run:
+        print("Rollout files already match the requested state.")
+        return 0
+
+    step_total = rollout_step_total(variants)
+    step_index = 1
+
+    imagestream_changed_paths = run_imagestream_rollout_step(
+        root,
+        variants,
+        target_tag_name,
+        dry_run=args.dry_run,
+        reporter=reporter,
+        step_index=step_index,
+        step_total=step_total,
+    )
+    changed_paths.extend(imagestream_changed_paths)
+    step_index += 1
+
+    if not args.dry_run and imagestream_changed_paths:
+        if "odh" in variants:
+            params_changed_paths, released_images = run_odh_params_step(
+                root / "manifests" / "odh" / "base",
+                dry_run=args.dry_run,
+                reporter=reporter,
+                step_index=step_index,
+                step_total=step_total,
+            )
+            changed_paths.extend(params_changed_paths)
+            step_index += 1
+            changed_paths.extend(
+                run_odh_commit_step(
+                    root / "manifests" / "odh" / "base",
+                    released_images,
+                    dry_run=args.dry_run,
+                    reporter=reporter,
+                    step_index=step_index,
+                    step_total=step_total,
+                )
+            )
+            step_index += 1
+
+        if "rhoai" in variants:
+            params_changed_paths, released_images = run_rhoai_params_step(
+                root / "manifests" / "rhoai" / "base",
+                dry_run=args.dry_run,
+                reporter=reporter,
+                step_index=step_index,
+                step_total=step_total,
+            )
+            changed_paths.extend(params_changed_paths)
+            step_index += 1
+            changed_paths.extend(
+                run_rhoai_commit_step(
+                    root / "manifests" / "rhoai" / "base",
+                    released_images,
+                    dry_run=args.dry_run,
+                    reporter=reporter,
+                    step_index=step_index,
+                    step_total=step_total,
+                )
+            )
+
+    if not changed_paths:
+        if not args.dry_run:
+            print("Rollout files already match the requested state.")
+            return 0
+        print("ImageStream files already match the requested rollout.")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/manifests/tools/skopeo_inspect.py
+++ b/manifests/tools/skopeo_inspect.py
@@ -1,0 +1,102 @@
+"""Shared synchronous skopeo helpers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+_INSPECT_BASE_ARGS = (
+    "skopeo",
+    "inspect",
+    "--retry-times",
+    "3",
+    "--no-tags",
+    "--override-arch",
+    "amd64",
+    "--override-os",
+    "linux",
+)
+
+
+@dataclass(frozen=True)
+class InspectedImage:
+    digest: str
+    payload: dict[str, Any]
+
+
+def _run_json(command: list[str], *, target: str, operation: str) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError(f"skopeo is required to run {operation}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"skopeo {operation} timed out for {target}") from exc
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
+        raise ValueError(f"skopeo {operation} failed for {target}: {detail}")
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"skopeo {operation} returned invalid JSON for {target}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"skopeo {operation} returned invalid JSON object for {target}")
+    return payload
+
+
+def list_repository_tags(
+    repository: str,
+    *,
+    tag_cache: dict[str, tuple[str, ...]] | None = None,
+) -> tuple[str, ...]:
+    if tag_cache is not None and repository in tag_cache:
+        return tag_cache[repository]
+
+    payload = _run_json(
+        ["skopeo", "list-tags", "--retry-times", "3", f"docker://{repository}"],
+        target=repository,
+        operation="list-tags",
+    )
+    tags = payload.get("Tags")
+    if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+        raise ValueError(f"skopeo list-tags returned invalid tags for {repository}")
+
+    resolved_tags = tuple(tags)
+    if tag_cache is not None:
+        tag_cache[repository] = resolved_tags
+    return resolved_tags
+
+
+def inspect_image(image_ref: str) -> InspectedImage:
+    """Return digest and inspect payload in one registry round trip."""
+    payload = _run_json(
+        [*_INSPECT_BASE_ARGS, f"docker://{image_ref}"],
+        target=image_ref,
+        operation="inspect",
+    )
+    digest = payload.get("Digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError(f"skopeo inspect returned invalid digest for {image_ref}")
+    return InspectedImage(digest=digest, payload=payload)
+
+
+def inspect_digest(image_ref: str) -> str:
+    return inspect_image(image_ref).digest
+
+
+def inspect_config(image_ref: str) -> dict[str, Any]:
+    return _run_json(
+        [*_INSPECT_BASE_ARGS, "--config", f"docker://{image_ref}"],
+        target=image_ref,
+        operation="inspect --config",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dev = [
     # rich powers the local live progress table in ci/check-image-availability.py
     "rich>=14.3.2",
     "inline-snapshot>=0.34.1",
-    "consolio>=0.1.15",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     # rich powers the local live progress table in ci/check-image-availability.py
     "rich>=14.3.2",
     "inline-snapshot>=0.34.1",
+    "consolio>=0.1.15",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ required-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-29T13:30:10.758732Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -295,6 +295,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "consolio"
+version = "0.1.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/38/2605162816a9172fe7f46dba9fd17916978913834406f1844b3e9c5ea8ba/consolio-0.1.15.tar.gz", hash = "sha256:17d723468e4f8545d06fd8e1ae21c752549fb0e99c27c20429fd692b8b28c7aa", size = 10443, upload-time = "2025-10-08T22:35:40.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a8/e089e0d5a112a9a3f9b8da77eeda269ad939ea75962df0d6ac4efbe22144/consolio-0.1.15-py3-none-any.whl", hash = "sha256:70910195cf61dec564e08564dc02c61b733e86b82f3f37aa9783d95e88c0a158", size = 9601, upload-time = "2025-10-08T22:35:39.75Z" },
 ]
 
 [[package]]
@@ -984,6 +993,7 @@ dev = [
     { name = "allure-pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "authlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "consolio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "inline-snapshot", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "keyring", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1016,6 +1026,7 @@ dev = [
     { name = "allure-pytest" },
     { name = "authlib", specifier = ">=1.6.12" },
     { name = "certifi" },
+    { name = "consolio", specifier = ">=0.1.15" },
     { name = "docker" },
     { name = "inline-snapshot", specifier = ">=0.34.1" },
     { name = "keyring" },

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ required-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T13:30:10.758732Z"
+exclude-newer = "2026-06-29T14:55:22.740511Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -295,15 +295,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
-]
-
-[[package]]
-name = "consolio"
-version = "0.1.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/38/2605162816a9172fe7f46dba9fd17916978913834406f1844b3e9c5ea8ba/consolio-0.1.15.tar.gz", hash = "sha256:17d723468e4f8545d06fd8e1ae21c752549fb0e99c27c20429fd692b8b28c7aa", size = 10443, upload-time = "2025-10-08T22:35:40.997Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/a8/e089e0d5a112a9a3f9b8da77eeda269ad939ea75962df0d6ac4efbe22144/consolio-0.1.15-py3-none-any.whl", hash = "sha256:70910195cf61dec564e08564dc02c61b733e86b82f3f37aa9783d95e88c0a158", size = 9601, upload-time = "2025-10-08T22:35:39.75Z" },
 ]
 
 [[package]]
@@ -993,7 +984,6 @@ dev = [
     { name = "allure-pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "authlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "consolio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "inline-snapshot", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "keyring", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1026,7 +1016,6 @@ dev = [
     { name = "allure-pytest" },
     { name = "authlib", specifier = ">=1.6.12" },
     { name = "certifi" },
-    { name = "consolio", specifier = ">=0.1.15" },
     { name = "docker" },
     { name = "inline-snapshot", specifier = ">=0.34.1" },
     { name = "keyring" },


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4895 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add `rollout_tag_on_imagestreams.py` to roll workbench ImageStream tags (tag, fetched from versions_config.yml). 
ODH keeps two tags and resolves N-1 digests via skopeo; RHOAI preserves tag history and syncs params.env/commit.env from RHOAI-Build-Config. Extend generate_kustomization.py to discover new rollout keys from ImageStream placeholders. Add shared skopeo_inspect helpers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rollout utility to update image stream tags and synchronize release metadata automatically.
  * Added target selection (all/ODH/RHOAI) and a dry-run mode.
  * Added improved release image inspection and tag lookup helpers for release-related workflows.
* **Bug Fixes**
  * Improved automatic kustomization/config generation to ensure newly released parameters are discovered and ordered correctly.
  * Preserves existing rollout order while extending version chains using imagestream manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->