### PR TITLE
RHAIENG-6018: feat(scripts): pin BASE_IMAGE to sha256 digests in version sync

### DIFF
--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -5,9 +5,10 @@
 This flow validates the root config, scans managed image-tree ``build-args``
 files, rewrites managed ``BASE_IMAGE`` and ``RELEASE`` assignments plus the
 root ``Makefile`` release defaults, resolves newer RHDS ``channel: fast``
-releases to the highest already-published phase per target repository, and
-uses ``skopeo`` to select the latest build in the chosen release-and-phase
-family.
+releases to the highest already-published phase per target repository, uses
+``skopeo`` to select the latest build in the chosen release-and-phase family,
+and pins each resolved ``BASE_IMAGE`` to an immutable ``repository@sha256:…``
+reference.
 """
 
 from __future__ import annotations
@@ -613,11 +614,131 @@ def collect_conf_targets(root_dir: Path) -> list[ConfTarget]:
     return targets
 
 
+def image_reference_is_digest(ref: str) -> bool:
+    return ref.startswith("sha256:")
+
+
 def split_image_ref(image: str) -> tuple[str, str]:
+    if "@" in image:
+        repository, ref = image.rsplit("@", 1)
+        if not ref:
+            raise ValueError(f"Image reference is missing a digest: {image}")
+        if ":" in repository:
+            repository = repository.rsplit(":", 1)[0]
+        return repository, ref
+
     name, separator, tag = image.rpartition(":")
     if not separator:
         raise ValueError(f"Image reference is missing a tag: {image}")
     return name, tag
+
+
+def inspect_image_manifest(
+    image: str,
+    *,
+    warning_color: str | None = None,
+) -> dict[str, Any] | None:
+    try:
+        result = subprocess.run(
+            [
+                "skopeo",
+                "inspect",
+                "--retry-times",
+                "3",
+                "--override-arch",
+                "amd64",
+                "--override-os",
+                "linux",
+                f"docker://{image}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        log_warning("Could not inspect image manifest for %s: %s", image, exc, color=warning_color)
+        return None
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
+        log_warning("skopeo inspect failed for %s: %s", image, detail, color=warning_color)
+        return None
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        log_warning("skopeo inspect returned invalid JSON for %s: %s", image, exc, color=warning_color)
+        return None
+
+    if not isinstance(payload, dict):
+        log_warning("skopeo inspect returned unexpected payload for %s", image, color=warning_color)
+        return None
+    return payload
+
+
+def cached_inspect_image_manifest(
+    image: str,
+    manifest_cache: dict[str, dict[str, Any]] | None,
+    *,
+    warning_color: str | None = None,
+) -> dict[str, Any] | None:
+    if manifest_cache is not None and image in manifest_cache:
+        return manifest_cache[image]
+
+    payload = inspect_image_manifest(image, warning_color=warning_color)
+    if payload is not None and manifest_cache is not None:
+        manifest_cache[image] = payload
+    return payload
+
+
+def image_tag_from_reference(
+    image: str,
+    manifest_cache: dict[str, dict[str, Any]] | None = None,
+) -> str:
+    _repository, ref = split_image_ref(image)
+    if not image_reference_is_digest(ref):
+        return ref
+
+    payload = cached_inspect_image_manifest(image, manifest_cache)
+    if payload is None:
+        raise ValueError(f"Cannot determine tag for digested image {image}")
+
+    name = payload.get("Name")
+    if isinstance(name, str) and ":" in name:
+        return name.rsplit(":", 1)[1]
+
+    repo_tags = payload.get("RepoTags")
+    if isinstance(repo_tags, list):
+        for tag in repo_tags:
+            if isinstance(tag, str):
+                return tag
+
+    raise ValueError(f"Cannot determine tag for digested image {image}")
+
+
+def resolve_image_digest(
+    image: str,
+    digest_cache: dict[str, str] | None = None,
+) -> str:
+    repository, ref = split_image_ref(image)
+    if image_reference_is_digest(ref):
+        return image if "@" in image else f"{repository}@{ref}"
+
+    if digest_cache is not None and image in digest_cache:
+        return f"{repository}@{digest_cache[image]}"
+
+    payload = inspect_image_manifest(image)
+    if payload is None:
+        raise ValueError(f"skopeo inspect failed while resolving digest for {image}")
+
+    digest = payload.get("Digest")
+    if not isinstance(digest, str) or not digest:
+        raise ValueError(f"skopeo inspect returned no digest for {image}")
+
+    if digest_cache is not None:
+        digest_cache[image] = digest
+    return f"{repository}@{digest}"
 
 
 def normalize_stream_version(version: str) -> str:
@@ -960,6 +1081,7 @@ def build_rhds_seed_tag(release_version: str, phase: str | None) -> str:
 def determine_rhds_fast_bundle_phase(
     states: list[TargetState],
     release: ReleaseConfig,
+    manifest_cache: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[bool, str | None]:
     target_version = parse_release_version(release.full_version)
     same_release_phases: set[str | None] = set()
@@ -970,7 +1092,7 @@ def determine_rhds_fast_bundle_phase(
         if peer_state.policy.mode != "fast":
             continue
 
-        _peer_repository, peer_tag = split_image_ref(peer_state.current_base_image)
+        peer_tag = image_tag_from_reference(peer_state.current_base_image, manifest_cache)
         match = RHDS_TAG_RE.fullmatch(peer_tag)
         if match is None:
             continue
@@ -1029,8 +1151,9 @@ def build_rhds_pinned_image(
     use_bundle_phase: bool = False,
     bundle_phase: str | None = None,
     forward_phase: str | None = "ea.1",
+    manifest_cache: dict[str, dict[str, Any]] | None = None,
 ) -> str:
-    _current_name, current_tag = split_image_ref(current_base_image)
+    current_tag = image_tag_from_reference(current_base_image, manifest_cache)
     repository = build_rhds_pinned_repository(accelerator, version, release)
     return f"{repository}:{build_rhds_pinned_tag(current_tag, target_release_version, use_bundle_phase=use_bundle_phase, bundle_phase=bundle_phase, forward_phase=forward_phase)}"
 
@@ -1085,6 +1208,7 @@ def resolve_rhds_base_image(
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
     stable_repo_overrides: dict[str, str] | None = None,
+    manifest_cache: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     target = state.target
     policy = state.policy
@@ -1119,9 +1243,8 @@ def resolve_rhds_base_image(
         use_release_bundle_phase=use_release_bundle_phase,
         rhds_bundle_phase=rhds_bundle_phase,
     )
-    repository, current_tag = build_rhds_pinned_repository(target.accelerator, policy.version, release), split_image_ref(
-        current_base_image
-    )[1]
+    repository = build_rhds_pinned_repository(target.accelerator, policy.version, release)
+    current_tag = image_tag_from_reference(current_base_image, manifest_cache)
 
     if RHDS_TAG_RE.fullmatch(current_tag) is None:
         stable_match = RHDS_STABLE_TAG_RE.fullmatch(current_tag)
@@ -1174,6 +1297,7 @@ def resolve_rhds_base_image(
             use_bundle_phase=rhds_bundle_phase_known and use_release_bundle_phase and target_version == current_version,
             bundle_phase=rhds_bundle_phase,
             forward_phase=forward_phase,
+            manifest_cache=manifest_cache,
         )
     return resolve_latest_published_rhds_image(candidate, tag_cache)
 
@@ -1199,6 +1323,7 @@ def build_target_base_image(
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
     stable_repo_overrides: dict[str, str] | None = None,
+    manifest_cache: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     match state.target.distribution:
         case "rhds":
@@ -1210,6 +1335,7 @@ def build_target_base_image(
                 rhds_bundle_phase_known,
                 rhds_bundle_phase,
                 stable_repo_overrides,
+                manifest_cache,
             )
         case "odh":
             return resolve_odh_base_image(state, release)
@@ -1299,6 +1425,8 @@ def plan_updates(
     states: list[TargetState] = []
     tag_cache: dict[str, tuple[str, ...]] = {}
     stable_acc_version_cache: dict[tuple[str, str], str | None | object] = {}
+    manifest_cache: dict[str, dict[str, Any]] = {}
+    digest_cache: dict[str, str] = {}
 
     for target in collect_conf_targets(root_dir):
         original_text = target.path.read_text(encoding="utf-8")
@@ -1321,18 +1449,26 @@ def plan_updates(
             )
         )
 
-    rhds_bundle_phase_known, rhds_bundle_phase = determine_rhds_fast_bundle_phase(states, config.release)
+    rhds_bundle_phase_known, rhds_bundle_phase = determine_rhds_fast_bundle_phase(
+        states,
+        config.release,
+        manifest_cache,
+    )
 
     updates: list[PlannedUpdate] = []
     for state in states:
-        resolved_base_image = build_target_base_image(
-            state,
-            config.release,
-            tag_cache,
-            stable_acc_version_cache,
-            rhds_bundle_phase_known,
-            rhds_bundle_phase,
-            stable_repo_overrides,
+        resolved_base_image = resolve_image_digest(
+            build_target_base_image(
+                state,
+                config.release,
+                tag_cache,
+                stable_acc_version_cache,
+                rhds_bundle_phase_known,
+                rhds_bundle_phase,
+                stable_repo_overrides,
+                manifest_cache,
+            ),
+            digest_cache,
         )
         updates.append(
             PlannedUpdate(

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -677,56 +677,104 @@ def inspect_image_manifest(
     return payload
 
 
-def cached_inspect_image_manifest(
-    image: str,
-    manifest_cache: dict[str, dict[str, Any]] | None,
-    *,
-    warning_color: str | None = None,
-) -> dict[str, Any] | None:
-    if manifest_cache is not None and image in manifest_cache:
-        return manifest_cache[image]
+def rhds_tag_sort_key(tag: str) -> tuple[tuple[int, int, int], int, int] | tuple[int, str]:
+    match = RHDS_TAG_RE.fullmatch(tag)
+    if match is None:
+        return (0, tag)
+    return (
+        parse_release_version(match.group("version")),
+        rank_rhds_phase(match.group("phase")),
+        int(match.group("build")),
+    )
 
-    payload = inspect_image_manifest(image, warning_color=warning_color)
-    if payload is not None and manifest_cache is not None:
-        manifest_cache[image] = payload
-    return payload
+
+def select_best_matching_tag(matches: list[str]) -> str:
+    rhds_matches = [tag for tag in matches if RHDS_TAG_RE.fullmatch(tag)]
+    candidates = rhds_matches if rhds_matches else matches
+    return max(candidates, key=rhds_tag_sort_key)
+
+
+def _matching_tags_from_digest_cache(
+    repository: str,
+    digest_ref: str,
+    digest_cache: dict[str, str] | None,
+) -> list[str]:
+    if digest_cache is None:
+        return []
+
+    prefix = f"{repository}:"
+    return [
+        tagged_image.removeprefix(prefix)
+        for tagged_image, cached_digest in digest_cache.items()
+        if cached_digest == digest_ref and tagged_image.startswith(prefix)
+    ]
+
+
+def resolve_tag_for_digest_reference(
+    image: str,
+    *,
+    source_tag_by_digest: dict[str, str] | None = None,
+    digest_cache: dict[str, str] | None = None,
+    digest_to_tag_by_repository: dict[str, dict[str, str]] | None = None,
+) -> str | None:
+    if source_tag_by_digest is not None and image in source_tag_by_digest:
+        return source_tag_by_digest[image]
+
+    repository, digest_ref = split_image_ref(image)
+
+    if digest_to_tag_by_repository is not None:
+        repo_index = digest_to_tag_by_repository.get(repository)
+        if repo_index is not None and digest_ref in repo_index:
+            selected = repo_index[digest_ref]
+            if source_tag_by_digest is not None:
+                source_tag_by_digest[image] = selected
+            return selected
+
+    cached_matches = _matching_tags_from_digest_cache(repository, digest_ref, digest_cache)
+    if cached_matches:
+        selected = select_best_matching_tag(cached_matches)
+        if source_tag_by_digest is not None:
+            source_tag_by_digest[image] = selected
+        if digest_to_tag_by_repository is not None:
+            digest_to_tag_by_repository.setdefault(repository, {})[digest_ref] = selected
+        return selected
+
+    return None
 
 
 def image_tag_from_reference(
     image: str,
-    manifest_cache: dict[str, dict[str, Any]] | None = None,
-) -> str:
+    *,
+    source_tag_by_digest: dict[str, str] | None = None,
+    digest_cache: dict[str, str] | None = None,
+    digest_to_tag_by_repository: dict[str, dict[str, str]] | None = None,
+) -> str | None:
     _repository, ref = split_image_ref(image)
     if not image_reference_is_digest(ref):
         return ref
 
-    payload = cached_inspect_image_manifest(image, manifest_cache)
-    if payload is None:
-        raise ValueError(f"Cannot determine tag for digested image {image}")
-
-    name = payload.get("Name")
-    if isinstance(name, str) and ":" in name:
-        return name.rsplit(":", 1)[1]
-
-    repo_tags = payload.get("RepoTags")
-    if isinstance(repo_tags, list):
-        for tag in repo_tags:
-            if isinstance(tag, str):
-                return tag
-
-    raise ValueError(f"Cannot determine tag for digested image {image}")
+    return resolve_tag_for_digest_reference(
+        image,
+        source_tag_by_digest=source_tag_by_digest,
+        digest_cache=digest_cache,
+        digest_to_tag_by_repository=digest_to_tag_by_repository,
+    )
 
 
 def resolve_image_digest(
     image: str,
     digest_cache: dict[str, str] | None = None,
+    source_tag_by_digest: dict[str, str] | None = None,
 ) -> str:
     repository, ref = split_image_ref(image)
     if image_reference_is_digest(ref):
         return image if "@" in image else f"{repository}@{ref}"
 
     if digest_cache is not None and image in digest_cache:
-        return f"{repository}@{digest_cache[image]}"
+        pinned = f"{repository}@{digest_cache[image]}"
+        if source_tag_by_digest is not None:
+            source_tag_by_digest[pinned] = ref
+        return pinned
 
     payload = inspect_image_manifest(image)
     if payload is None:
@@ -738,7 +786,10 @@ def resolve_image_digest(
 
     if digest_cache is not None:
         digest_cache[image] = digest
-    return f"{repository}@{digest}"
+    pinned = f"{repository}@{digest}"
+    if source_tag_by_digest is not None:
+        source_tag_by_digest[pinned] = ref
+    return pinned
 
 
 def normalize_stream_version(version: str) -> str:
@@ -1081,7 +1132,10 @@ def build_rhds_seed_tag(release_version: str, phase: str | None) -> str:
 def determine_rhds_fast_bundle_phase(
     states: list[TargetState],
     release: ReleaseConfig,
-    manifest_cache: dict[str, dict[str, Any]] | None = None,
+    *,
+    source_tag_by_digest: dict[str, str] | None = None,
+    digest_cache: dict[str, str] | None = None,
+    digest_to_tag_by_repository: dict[str, dict[str, str]] | None = None,
 ) -> tuple[bool, str | None]:
     target_version = parse_release_version(release.full_version)
     same_release_phases: set[str | None] = set()
@@ -1092,7 +1146,14 @@ def determine_rhds_fast_bundle_phase(
         if peer_state.policy.mode != "fast":
             continue
 
-        peer_tag = image_tag_from_reference(peer_state.current_base_image, manifest_cache)
+        peer_tag = image_tag_from_reference(
+            peer_state.current_base_image,
+            source_tag_by_digest=source_tag_by_digest,
+            digest_cache=digest_cache,
+            digest_to_tag_by_repository=digest_to_tag_by_repository,
+        )
+        if peer_tag is None:
+            continue
         match = RHDS_TAG_RE.fullmatch(peer_tag)
         if match is None:
             continue
@@ -1151,9 +1212,18 @@ def build_rhds_pinned_image(
     use_bundle_phase: bool = False,
     bundle_phase: str | None = None,
     forward_phase: str | None = "ea.1",
-    manifest_cache: dict[str, dict[str, Any]] | None = None,
+    source_tag_by_digest: dict[str, str] | None = None,
+    digest_cache: dict[str, str] | None = None,
+    digest_to_tag_by_repository: dict[str, dict[str, str]] | None = None,
 ) -> str:
-    current_tag = image_tag_from_reference(current_base_image, manifest_cache)
+    current_tag = image_tag_from_reference(
+        current_base_image,
+        source_tag_by_digest=source_tag_by_digest,
+        digest_cache=digest_cache,
+        digest_to_tag_by_repository=digest_to_tag_by_repository,
+    )
+    if current_tag is None:
+        raise ValueError(f"Cannot determine RHDS tag for digested image {current_base_image}")
     repository = build_rhds_pinned_repository(accelerator, version, release)
     return f"{repository}:{build_rhds_pinned_tag(current_tag, target_release_version, use_bundle_phase=use_bundle_phase, bundle_phase=bundle_phase, forward_phase=forward_phase)}"
 
@@ -1208,7 +1278,9 @@ def resolve_rhds_base_image(
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
     stable_repo_overrides: dict[str, str] | None = None,
-    manifest_cache: dict[str, dict[str, Any]] | None = None,
+    source_tag_by_digest: dict[str, str] | None = None,
+    digest_cache: dict[str, str] | None = None,
+    digest_to_tag_by_repository: dict[str, dict[str, str]] | None = None,
 ) -> str:
     target = state.target
     policy = state.policy
@@ -1244,9 +1316,16 @@ def resolve_rhds_base_image(
         rhds_bundle_phase=rhds_bundle_phase,
     )
     repository = build_rhds_pinned_repository(target.accelerator, policy.version, release)
-    current_tag = image_tag_from_reference(current_base_image, manifest_cache)
+    current_tag = image_tag_from_reference(
+        current_base_image,
+        source_tag_by_digest=source_tag_by_digest,
+        digest_cache=digest_cache,
+        digest_to_tag_by_repository=digest_to_tag_by_repository,
+    )
 
-    if RHDS_TAG_RE.fullmatch(current_tag) is None:
+    if current_tag is None:
+        candidate = f"{repository}:{build_rhds_seed_tag(target_release_version, bundle_seed_phase)}"
+    elif RHDS_TAG_RE.fullmatch(current_tag) is None:
         stable_match = RHDS_STABLE_TAG_RE.fullmatch(current_tag)
         if MIDSTREAM_VERSION_RE.fullmatch(current_tag):
             current_minor = parse_minor_version(current_tag)
@@ -1297,7 +1376,9 @@ def resolve_rhds_base_image(
             use_bundle_phase=rhds_bundle_phase_known and use_release_bundle_phase and target_version == current_version,
             bundle_phase=rhds_bundle_phase,
             forward_phase=forward_phase,
-            manifest_cache=manifest_cache,
+            source_tag_by_digest=source_tag_by_digest,
+            digest_cache=digest_cache,
+            digest_to_tag_by_repository=digest_to_tag_by_repository,
         )
     return resolve_latest_published_rhds_image(candidate, tag_cache)
 
@@ -1323,7 +1404,9 @@ def build_target_base_image(
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
     stable_repo_overrides: dict[str, str] | None = None,
-    manifest_cache: dict[str, dict[str, Any]] | None = None,
+    source_tag_by_digest: dict[str, str] | None = None,
+    digest_cache: dict[str, str] | None = None,
+    digest_to_tag_by_repository: dict[str, dict[str, str]] | None = None,
 ) -> str:
     match state.target.distribution:
         case "rhds":
@@ -1335,7 +1418,9 @@ def build_target_base_image(
                 rhds_bundle_phase_known,
                 rhds_bundle_phase,
                 stable_repo_overrides,
-                manifest_cache,
+                source_tag_by_digest,
+                digest_cache,
+                digest_to_tag_by_repository,
             )
         case "odh":
             return resolve_odh_base_image(state, release)
@@ -1425,8 +1510,9 @@ def plan_updates(
     states: list[TargetState] = []
     tag_cache: dict[str, tuple[str, ...]] = {}
     stable_acc_version_cache: dict[tuple[str, str], str | None | object] = {}
-    manifest_cache: dict[str, dict[str, Any]] = {}
+    source_tag_by_digest: dict[str, str] = {}
     digest_cache: dict[str, str] = {}
+    digest_to_tag_by_repository: dict[str, dict[str, str]] = {}
 
     for target in collect_conf_targets(root_dir):
         original_text = target.path.read_text(encoding="utf-8")
@@ -1452,7 +1538,9 @@ def plan_updates(
     rhds_bundle_phase_known, rhds_bundle_phase = determine_rhds_fast_bundle_phase(
         states,
         config.release,
-        manifest_cache,
+        source_tag_by_digest=source_tag_by_digest,
+        digest_cache=digest_cache,
+        digest_to_tag_by_repository=digest_to_tag_by_repository,
     )
 
     updates: list[PlannedUpdate] = []
@@ -1466,9 +1554,12 @@ def plan_updates(
                 rhds_bundle_phase_known,
                 rhds_bundle_phase,
                 stable_repo_overrides,
-                manifest_cache,
+                source_tag_by_digest,
+                digest_cache,
+                digest_to_tag_by_repository,
             ),
             digest_cache,
+            source_tag_by_digest,
         )
         updates.append(
             PlannedUpdate(

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -1251,7 +1251,10 @@ def test_plan_updates_uses_published_ga_for_new_release_when_available(
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777921111")
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777921111"
+    )
+
 
 def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missing(
     tmp_path: Path,
@@ -1276,8 +1279,8 @@ def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missi
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert (
-        updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999")
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999"
     )
 
 
@@ -1351,8 +1354,8 @@ def test_plan_updates_builds_fast_rhds_candidate_before_latest_resolution(
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919771"]
-    assert (
-        updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999")
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"
     )
 
 
@@ -1532,7 +1535,7 @@ def test_plan_updates_allows_independent_mixed_rhds_channels(
 
     assert seen == ["quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771"]
     assert rendered["konflux.cpu.conf"] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000")
-    assert rendered["konflux.cuda.conf"] == pinned_base_image(rhds_gpu_stable_image('cuda'))
+    assert rendered["konflux.cuda.conf"] == pinned_base_image(rhds_gpu_stable_image("cuda"))
 
 
 def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
@@ -1566,8 +1569,10 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
     rendered = {update.target.path: update.updated_text.strip() for update in updates}
 
     assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771"]
-    assert rendered[minimal_conf] == pinned_base_image(rhds_gpu_stable_image('cuda'))
-    assert rendered[pytorch_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000")
+    assert rendered[minimal_conf] == pinned_base_image(rhds_gpu_stable_image("cuda"))
+    assert rendered[pytorch_conf] == pinned_base_image(
+        "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1639,7 +1644,9 @@ def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-midstream-rocm-base-8-0:latest")
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/opendatahub/odh-midstream-rocm-base-8-0:latest"
+    )
 
 
 def test_plan_updates_picks_rhds_stable_tag_matching_shared_acc_version_over_newer_build(
@@ -1680,7 +1687,7 @@ def test_plan_updates_picks_rhds_stable_tag_matching_shared_acc_version_over_new
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == pinned_base_image(rhds_gpu_stable_image('cuda', build='1780598175'))
+    assert updates[0].updated_text.strip() == pinned_base_image(rhds_gpu_stable_image("cuda", build="1780598175"))
 
 
 def test_inspect_image_config_warns_in_red_on_skopeo_failure(
@@ -1808,7 +1815,9 @@ def test_plan_updates_uses_odh_midstream_cpu_repo(tmp_path: Path) -> None:
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-midstream-python-base-3-11:latest")
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/opendatahub/odh-midstream-python-base-3-11:latest"
+    )
 
 
 def test_plan_updates_uses_odh_in_house_cpu_repo_from_release_python_version(tmp_path: Path) -> None:
@@ -1820,8 +1829,9 @@ def test_plan_updates_uses_odh_in_house_cpu_repo_from_release_python_version(tmp
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-base-image-cpu-py311-c9s:latest")
-
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/opendatahub/odh-base-image-cpu-py311-c9s:latest"
+    )
 
 
 def test_plan_updates_can_switch_odh_rocm_back_to_in_house_repo(tmp_path: Path) -> None:
@@ -1833,7 +1843,9 @@ def test_plan_updates_can_switch_odh_rocm_back_to_in_house_repo(tmp_path: Path) 
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0")
+    assert updates[0].updated_text.strip() == pinned_base_image(
+        "quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0"
+    )
 
 
 def test_plan_updates_rewrites_release_to_minor_version(

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -33,9 +33,34 @@ def completed_process(
 
 
 DEFAULT_GPU_MINIMAL_ACC_VERSION = {"cuda": "25.0", "rocm": "8.0"}
+TEST_IMAGE_DIGEST = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 RHDS_CPU_EA2_IMAGE = "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771"
 RHDS_CUDA_EA2_IMAGE = "quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-ea.2-1777919771"
 RHDS_ROCM_EA2_IMAGE = "quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-1777919771"
+
+
+def pin_image_for_test(tagged_image: str) -> str:
+    if "@" in tagged_image:
+        return tagged_image
+    repository, _tag = tagged_image.rsplit(":", 1)
+    return f"{repository}@{TEST_IMAGE_DIGEST}"
+
+
+def pinned_base_image(tagged_image: str) -> str:
+    return f"BASE_IMAGE={pin_image_for_test(tagged_image)}"
+
+
+def stub_image_digest_pinning(monkeypatch: pytest.MonkeyPatch, updater) -> None:
+    monkeypatch.setattr(
+        updater,
+        "resolve_image_digest",
+        lambda image, digest_cache=None: pin_image_for_test(image),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_image_digest_pinning(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_image_digest_pinning(monkeypatch, load_updater())
 
 
 def rhds_gpu_stable_image(
@@ -634,6 +659,60 @@ def test_collect_conf_targets_rejects_unknown_build_args_filename(tmp_path: Path
         updater.collect_conf_targets(tmp_path)
 
 
+def test_split_image_ref_accepts_tag_and_digest_references() -> None:
+    updater = load_updater()
+
+    assert updater.split_image_ref("quay.io/example/repo:3.5.0-ea.1-1") == (
+        "quay.io/example/repo",
+        "3.5.0-ea.1-1",
+    )
+    assert updater.split_image_ref(
+        "quay.io/example/repo@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    ) == (
+        "quay.io/example/repo",
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    )
+
+
+def test_resolve_image_digest_uses_skopeo_inspect(monkeypatch: pytest.MonkeyPatch) -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+    monkeypatch.setattr(
+        updater,
+        "inspect_image_manifest",
+        lambda image, warning_color=None: {"Digest": digest},
+    )
+
+    pinned = updater.resolve_image_digest("quay.io/aipcc/base-images/cpu:3.5.0-1782914735")
+
+    assert pinned == f"quay.io/aipcc/base-images/cpu@{digest}"
+
+
+def test_resolve_image_digest_keeps_already_pinned_reference() -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    image = f"quay.io/aipcc/base-images/cpu@{digest}"
+
+    assert updater.resolve_image_digest(image) == image
+
+
+def test_image_tag_from_reference_inspects_digested_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    image = f"quay.io/aipcc/base-images/cpu@{digest}"
+
+    monkeypatch.setattr(
+        updater,
+        "inspect_image_manifest",
+        lambda image, warning_color=None: {
+            "Name": "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771",
+        },
+    )
+
+    assert updater.image_tag_from_reference(image) == "3.5.0-ea.2-1777919771"
+
+
 def test_select_latest_matching_rhds_tag_prefers_highest_build_in_same_family() -> None:
     updater = load_updater()
 
@@ -970,8 +1049,8 @@ def test_plan_updates_infers_bundle_phase_for_stable_to_fast_target(
         "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-0",
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771",
     ]
-    assert rendered[target_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
-    assert rendered[peer_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+    assert rendered[target_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000")
+    assert rendered[peer_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001")
 
 
 def test_plan_updates_infers_ga_phase_for_stable_to_fast_target(
@@ -1003,8 +1082,8 @@ def test_plan_updates_infers_ga_phase_for_stable_to_fast_target(
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-0",
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777919771",
     ]
-    assert rendered[target_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000000"
-    assert rendered[peer_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000001"
+    assert rendered[target_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000000")
+    assert rendered[peer_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1780000001")
 
 
 def test_plan_updates_falls_back_to_ea1_without_any_bundle_fast_style_peers(
@@ -1034,8 +1113,8 @@ def test_plan_updates_falls_back_to_ea1_without_any_bundle_fast_style_peers(
         "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-0",
         "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-0",
     ]
-    assert rendered[first_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000"
-    assert rendered[second_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000"
+    assert rendered[first_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000")
+    assert rendered[second_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780000000")
 
 
 def test_plan_updates_uses_highest_observed_bundle_phase_for_existing_fast_targets(
@@ -1072,9 +1151,9 @@ def test_plan_updates_uses_highest_observed_bundle_phase_for_existing_fast_targe
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771",
         "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064",
     ]
-    assert rendered[rocm_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1780000002"
-    assert rendered[cuda_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
-    assert rendered[cpu_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780609999"
+    assert rendered[rocm_conf] == pinned_base_image("quay.io/aipcc/base-images/rocm-8.0-el9.6:3.5.0-ea.2-1780000002")
+    assert rendered[cuda_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001")
+    assert rendered[cpu_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780609999")
 
 
 def test_plan_updates_uses_forward_discovery_not_bundle_phase_for_lagging_target(
@@ -1111,8 +1190,8 @@ def test_plan_updates_uses_forward_discovery_not_bundle_phase_for_lagging_target
 
     assert "quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780600064" in seen
     assert "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780600064" not in seen
-    assert rendered[cpu_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780609999"
-    assert rendered[cuda_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001"
+    assert rendered[cpu_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.1-1780609999")
+    assert rendered[cuda_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000001")
 
 
 def test_plan_updates_starts_new_release_at_ea1_when_peers_are_older_release(
@@ -1145,8 +1224,8 @@ def test_plan_updates_starts_new_release_at_ea1_when_peers_are_older_release(
         "quay.io/aipcc/base-images/cpu:3.6.0-ea.1-0",
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919771",
     ]
-    assert rendered[target_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.6.0-ea.1-1780000000"
-    assert rendered[peer_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1780000001"
+    assert rendered[target_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.6.0-ea.1-1780000000")
+    assert rendered[peer_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1780000001")
 
 
 def test_plan_updates_uses_published_ga_for_new_release_when_available(
@@ -1172,8 +1251,7 @@ def test_plan_updates_uses_published_ga_for_new_release_when_available(
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777921111"
-
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-1777921111")
 
 def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missing(
     tmp_path: Path,
@@ -1199,7 +1277,7 @@ def test_plan_updates_uses_highest_published_phase_for_new_release_when_ga_missi
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert (
-        updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999"
+        updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919999")
     )
 
 
@@ -1226,7 +1304,7 @@ def test_plan_updates_stable_to_fast_forward_uses_highest_published_phase_for_ne
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919999"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919999")
 
 
 def test_plan_updates_new_release_without_published_tags_keeps_strict_failure(
@@ -1274,7 +1352,7 @@ def test_plan_updates_builds_fast_rhds_candidate_before_latest_resolution(
 
     assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777919771"]
     assert (
-        updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"
+        updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999")
     )
 
 
@@ -1299,7 +1377,7 @@ def test_plan_updates_rollback_targets_ga_family_for_older_release(
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert seen == ["quay.io/aipcc/base-images/cpu:3.4.0-1777919771"]
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cpu:3.4.0-1780000000")
 
 
 def test_plan_updates_uses_hard_coded_rhds_cpu_version_for_fast_channel(
@@ -1332,7 +1410,7 @@ def test_plan_updates_uses_hard_coded_rhds_cpu_version_for_fast_channel(
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert seen == ["quay.io/aipcc/base-images/cpu:3.4.0-1777919771"]
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cpu:3.4.0-1780000000")
 
 
 def test_plan_updates_rollback_ignores_newer_fast_peers(
@@ -1364,8 +1442,8 @@ def test_plan_updates_rollback_ignores_newer_fast_peers(
         "quay.io/aipcc/base-images/cpu:3.4.0-1780600064",
         "quay.io/aipcc/base-images/cuda-25.0-el9.6:3.4.0-1777919771",
     ]
-    assert rendered[cpu_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780609999"
-    assert rendered[cuda_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.4.0-1780000001"
+    assert rendered[cpu_conf] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.4.0-1780609999")
+    assert rendered[cuda_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.4.0-1780000001")
 
 
 def test_plan_updates_rollback_falls_back_to_highest_published_phase_when_ga_missing(
@@ -1391,7 +1469,7 @@ def test_plan_updates_rollback_falls_back_to_highest_published_phase_when_ga_mis
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1777919999"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cpu:3.4.0-ea.2-1777919999")
 
 
 def test_plan_updates_rollback_from_stable_target_uses_ga_seed(
@@ -1415,7 +1493,7 @@ def test_plan_updates_rollback_from_stable_target_uses_ga_seed(
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert seen == ["quay.io/aipcc/base-images/cpu:3.4.0-0"]
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.0-1780000000"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-images/cpu:3.4.0-1780000000")
 
 
 def test_plan_updates_allows_independent_mixed_rhds_channels(
@@ -1453,8 +1531,8 @@ def test_plan_updates_allows_independent_mixed_rhds_channels(
     rendered = {update.target.path.name: update.updated_text.strip() for update in updates}
 
     assert seen == ["quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771"]
-    assert rendered["konflux.cpu.conf"] == "BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000"
-    assert rendered["konflux.cuda.conf"] == f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}"
+    assert rendered["konflux.cpu.conf"] == pinned_base_image("quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1780000000")
+    assert rendered["konflux.cuda.conf"] == pinned_base_image(rhds_gpu_stable_image('cuda'))
 
 
 def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
@@ -1488,8 +1566,8 @@ def test_plan_updates_allows_cuda_minimal_stable_and_pytorch_fast(
     rendered = {update.target.path: update.updated_text.strip() for update in updates}
 
     assert seen == ["quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1777919771"]
-    assert rendered[minimal_conf] == f"BASE_IMAGE={rhds_gpu_stable_image('cuda')}"
-    assert rendered[pytorch_conf] == "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000"
+    assert rendered[minimal_conf] == pinned_base_image(rhds_gpu_stable_image('cuda'))
+    assert rendered[pytorch_conf] == pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.5.0-ea.2-1780000000")
 
 
 @pytest.mark.parametrize(
@@ -1522,7 +1600,7 @@ def test_plan_updates_uses_rhds_gpu_stable_repo(
     stub_matching_rhds_stable_acc_version(monkeypatch, updater)
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image(accelerator)}"
+    assert updates[0].updated_text.strip() == pinned_base_image(rhds_gpu_stable_image(accelerator))
 
 
 def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
@@ -1543,7 +1621,7 @@ def test_plan_updates_uses_rhds_cpu_stable_repo(tmp_path: Path) -> None:
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/aipcc/base-image-cpu-stable-ubi9:3.5"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/aipcc/base-image-cpu-stable-ubi9:3.5")
 
 
 def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
@@ -1561,7 +1639,7 @@ def test_plan_updates_uses_odh_midstream_rocm_repo(tmp_path: Path) -> None:
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-8-0:latest"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-midstream-rocm-base-8-0:latest")
 
 
 def test_plan_updates_picks_rhds_stable_tag_matching_shared_acc_version_over_newer_build(
@@ -1602,7 +1680,7 @@ def test_plan_updates_picks_rhds_stable_tag_matching_shared_acc_version_over_new
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == f"BASE_IMAGE={rhds_gpu_stable_image('cuda', build='1780598175')}"
+    assert updates[0].updated_text.strip() == pinned_base_image(rhds_gpu_stable_image('cuda', build='1780598175'))
 
 
 def test_inspect_image_config_warns_in_red_on_skopeo_failure(
@@ -1730,7 +1808,7 @@ def test_plan_updates_uses_odh_midstream_cpu_repo(tmp_path: Path) -> None:
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-midstream-python-base-3-11:latest"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-midstream-python-base-3-11:latest")
 
 
 def test_plan_updates_uses_odh_in_house_cpu_repo_from_release_python_version(tmp_path: Path) -> None:
@@ -1742,7 +1820,8 @@ def test_plan_updates_uses_odh_in_house_cpu_repo_from_release_python_version(tmp
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py311-c9s:latest"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-base-image-cpu-py311-c9s:latest")
+
 
 
 def test_plan_updates_can_switch_odh_rocm_back_to_in_house_repo(tmp_path: Path) -> None:
@@ -1754,7 +1833,7 @@ def test_plan_updates_can_switch_odh_rocm_back_to_in_house_repo(tmp_path: Path) 
 
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
-    assert updates[0].updated_text.strip() == "BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0"
+    assert updates[0].updated_text.strip() == pinned_base_image("quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v8.0")
 
 
 def test_plan_updates_rewrites_release_to_minor_version(
@@ -1786,7 +1865,7 @@ def test_plan_updates_rewrites_release_to_minor_version(
     updates = updater.plan_updates(tmp_path, updater.load_versions_config(tmp_path / "versions_config.yml"))
 
     assert updates[0].updated_text.splitlines() == [
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+        pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"),
         "PYLOCK_FLAVOR=cuda",
         "RELEASE=3.6",
     ]
@@ -1819,7 +1898,7 @@ def test_main_updates_base_image_and_release_lines(tmp_path: Path, monkeypatch: 
     assert updater.main(["--root", str(tmp_path), "--config", str(tmp_path / "versions_config.yml")]) == 0
     assert conf.read_text(encoding="utf-8").splitlines() == [
         "INDEX_URL=unchanged",
-        "BASE_IMAGE=quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999",
+        pinned_base_image("quay.io/aipcc/base-images/cuda-25.0-el9.6:3.6.0-ea.1-1777929999"),
         "PYLOCK_FLAVOR=cuda",
         "RELEASE=3.6",
     ]
@@ -1974,7 +2053,7 @@ def test_main_updates_cuda_stable_with_rhds_stable_repo_override(
     assert seen == ["quay.io/example/testing/cuda-el9.6"]
     assert conf.read_text(encoding="utf-8").splitlines() == [
         "INDEX_URL=unchanged",
-        "BASE_IMAGE=quay.io/example/testing/cuda-el9.6:3.5.0-stable-9999999999",
+        pinned_base_image("quay.io/example/testing/cuda-el9.6:3.5.0-stable-9999999999"),
         "PYLOCK_FLAVOR=cuda",
         "RELEASE=3.5",
     ]

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -54,12 +54,23 @@ def stub_image_digest_pinning(monkeypatch: pytest.MonkeyPatch, updater) -> None:
     monkeypatch.setattr(
         updater,
         "resolve_image_digest",
-        lambda image, digest_cache=None: pin_image_for_test(image),
+        lambda image, digest_cache=None, source_tag_by_digest=None: pin_image_for_test(image),
     )
 
 
+_RESOLVE_IMAGE_DIGEST_TESTS = frozenset(
+    {
+        "test_resolve_image_digest_uses_skopeo_inspect",
+        "test_resolve_image_digest_records_source_tag_for_digest_reference",
+        "test_resolve_image_digest_keeps_already_pinned_reference",
+    }
+)
+
+
 @pytest.fixture(autouse=True)
-def _stub_image_digest_pinning(monkeypatch: pytest.MonkeyPatch) -> None:
+def _stub_image_digest_pinning(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    if request.node.name in _RESOLVE_IMAGE_DIGEST_TESTS:
+        return
     stub_image_digest_pinning(monkeypatch, load_updater())
 
 
@@ -676,7 +687,29 @@ def test_split_image_ref_accepts_tag_and_digest_references() -> None:
 
 def test_resolve_image_digest_uses_skopeo_inspect(monkeypatch: pytest.MonkeyPatch) -> None:
     updater = load_updater()
+    digest = "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+
+    inspect_calls: list[str] = []
+
+    def fake_inspect(image: str, warning_color=None) -> dict[str, str]:
+        inspect_calls.append(image)
+        return {"Digest": digest}
+
+    monkeypatch.setattr(updater, "inspect_image_manifest", fake_inspect)
+
+    pinned = updater.resolve_image_digest("quay.io/aipcc/base-images/cpu:3.5.0-1782914735")
+
+    assert inspect_calls == ["quay.io/aipcc/base-images/cpu:3.5.0-1782914735"]
+    assert pinned == f"quay.io/aipcc/base-images/cpu@{digest}"
+    assert pinned != pin_image_for_test("quay.io/aipcc/base-images/cpu:3.5.0-1782914735")
+
+
+def test_resolve_image_digest_records_source_tag_for_digest_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = load_updater()
     digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    source_tag_by_digest: dict[str, str] = {}
 
     monkeypatch.setattr(
         updater,
@@ -684,9 +717,13 @@ def test_resolve_image_digest_uses_skopeo_inspect(monkeypatch: pytest.MonkeyPatc
         lambda image, warning_color=None: {"Digest": digest},
     )
 
-    pinned = updater.resolve_image_digest("quay.io/aipcc/base-images/cpu:3.5.0-1782914735")
+    pinned = updater.resolve_image_digest(
+        "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771",
+        source_tag_by_digest=source_tag_by_digest,
+    )
 
     assert pinned == f"quay.io/aipcc/base-images/cpu@{digest}"
+    assert source_tag_by_digest[pinned] == "3.5.0-ea.2-1777919771"
 
 
 def test_resolve_image_digest_keeps_already_pinned_reference() -> None:
@@ -697,20 +734,103 @@ def test_resolve_image_digest_keeps_already_pinned_reference() -> None:
     assert updater.resolve_image_digest(image) == image
 
 
-def test_image_tag_from_reference_inspects_digested_image(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_image_tag_from_reference_uses_source_tag_cache() -> None:
     updater = load_updater()
     digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     image = f"quay.io/aipcc/base-images/cpu@{digest}"
 
-    monkeypatch.setattr(
-        updater,
-        "inspect_image_manifest",
-        lambda image, warning_color=None: {
-            "Name": "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771",
-        },
+    assert (
+        updater.image_tag_from_reference(
+            image,
+            source_tag_by_digest={image: "3.5.0-ea.2-1777919771"},
+        )
+        == "3.5.0-ea.2-1777919771"
     )
 
-    assert updater.image_tag_from_reference(image) == "3.5.0-ea.2-1777919771"
+
+def test_image_tag_from_reference_returns_none_without_cached_tag_mapping() -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    image = f"quay.io/aipcc/base-images/cpu@{digest}"
+
+    assert updater.image_tag_from_reference(image) is None
+
+
+def test_image_tag_from_reference_matches_digest_from_digest_cache() -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    image = f"quay.io/aipcc/base-images/cpu@{digest}"
+
+    assert (
+        updater.image_tag_from_reference(
+            image,
+            digest_cache={
+                "quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771": digest,
+                "quay.io/aipcc/base-images/cpu:3.5.0-1777921111": "sha256:deadbeef",
+            },
+        )
+        == "3.5.0-ea.2-1777919771"
+    )
+
+
+def test_image_tag_from_reference_prefers_highest_semantic_match_from_digest_cache() -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    image = f"quay.io/aipcc/base-images/cpu@{digest}"
+
+    assert (
+        updater.image_tag_from_reference(
+            image,
+            digest_cache={
+                "quay.io/aipcc/base-images/cpu:3.9.0-ea.1-1": digest,
+                "quay.io/aipcc/base-images/cpu:3.10.0-ea.1-1": digest,
+            },
+        )
+        == "3.10.0-ea.1-1"
+    )
+
+
+def test_image_tag_from_reference_reuses_digest_to_tag_repository_cache() -> None:
+    updater = load_updater()
+    digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    image = f"quay.io/aipcc/base-images/cpu@{digest}"
+    digest_to_tag_by_repository = {
+        "quay.io/aipcc/base-images/cpu": {digest: "3.5.0-ea.2-1777919771"},
+    }
+
+    assert (
+        updater.image_tag_from_reference(
+            image,
+            digest_to_tag_by_repository=digest_to_tag_by_repository,
+        )
+        == "3.5.0-ea.2-1777919771"
+    )
+
+
+def test_select_best_matching_tag_prefers_higher_semantic_version() -> None:
+    updater = load_updater()
+
+    selected = updater.select_best_matching_tag(
+        [
+            "3.9.0-ea.1-1",
+            "3.10.0-ea.1-1",
+        ]
+    )
+
+    assert selected == "3.10.0-ea.1-1"
+
+
+def test_select_best_matching_tag_prefers_higher_build_number() -> None:
+    updater = load_updater()
+
+    selected = updater.select_best_matching_tag(
+        [
+            "3.5.0-ea.2-9",
+            "3.5.0-ea.2-10",
+        ]
+    )
+
+    assert selected == "3.5.0-ea.2-10"
 
 
 def test_select_latest_matching_rhds_tag_prefers_highest_build_in_same_family() -> None:


### PR DESCRIPTION
Resolve base images with the existing tag-selection logic, then use skopeo inspect to write immutable repository@sha256 references into managed build-args files. Support digest-pinned inputs for RHDS bundle-phase inference and add unit tests for digest parsing and resolution.

Related to: https://redhat.atlassian.net/browse/RHAIENG-6018

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Base image update logic now supports digest-based image references and emits digest-pinned `BASE_IMAGE` values.
  * Added digest↔tag resolution utilities to improve “current tag” determination.

* **Bug Fixes**
  * More reliable selection of the applicable tag when `BASE_IMAGE` is already digest-pinned.
  * Improved caching for digest and tag mappings to keep resolution consistent.

* **Tests**
  * Expanded unit coverage for digest parsing and digest↔tag selection.
  * Updated expectations to use deterministic digest-pinned base images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->