### PR TITLE
GHA: Update ODH rpms.lock.yaml lock files

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/1e1ca9c1c5b65df87c451d93e5de1cfc4f3796d9483f220e0e7046d1b2f21b91-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/c82914d0aab149cf507542e7beb411fb34d7d097df87cbabe103e35b0b396e3a-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8702
-    checksum: sha256:1e1ca9c1c5b65df87c451d93e5de1cfc4f3796d9483f220e0e7046d1b2f21b91
+    checksum: sha256:c82914d0aab149cf507542e7beb411fb34d7d097df87cbabe103e35b0b396e3a
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/fdeb604d8f3d7a8b9b0e23244c3c503bdbf0a3ffb7aadca7beb9ec5920f541c6-modules.yaml.xz
     repoid: appstream
     size: 16488
@@ -14583,10 +14583,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/68849442e37c84b1351518d76eadc7e1ca34ec4fa4f30a4f920002e7c883512a-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/2b5c52ccffb55fec2ec09451ccab9e517123e373ad6b72b7774faaeaebd980d6-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8491
-    checksum: sha256:68849442e37c84b1351518d76eadc7e1ca34ec4fa4f30a4f920002e7c883512a
+    checksum: sha256:2b5c52ccffb55fec2ec09451ccab9e517123e373ad6b72b7774faaeaebd980d6
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/56f71a495a6d36a569c1e07a997ff0b942fd390237353fdf4e7bf0361f30b48d-modules.yaml.xz
     repoid: appstream
     size: 16436


### PR DESCRIPTION
Automated regeneration of `rpms.lock.yaml` from `rpms.in.yaml` for the **ODH** variant.

Updated paths:
- `prefetch-input/odh/rpms.lock.yaml`
- `codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata for UBI9 Python 3.12 prefetch inputs on both `aarch64` and `x86_64`.
  * Refreshed package source details and checksums to match current upstream content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->