### PR TITLE
RHAIENG-6163: fix(ci): disable digest pinning for golangci-lint uses-with dep

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -177,13 +177,17 @@
       // github-actions manager extracts golangci/golangci-lint from the version:
       // input of golangci/golangci-lint-action (depType uses-with). pinDigests
       // cannot apply to a plain version string, so the grouped branch fails.
+      //
       // Do not add matchDepTypes here. A dry-run with matchDepTypes: ["uses-with"]
       // still emitted pinDigest for golangci/golangci-lint and the grouped branch
-      // failed; Cilium's fix uses package name + pinDigests: false only.
-      description: "Do not pin digest for golangci-lint uses-with dep",
+      // failed; Cilium's package-name-only pinDigests:false also did not stop
+      // pinDigest generation in our Renovate 43 dry-run — disable the update
+      // type explicitly instead.
+      description: "Disable pinDigest for golangci-lint uses-with dep",
       matchManagers: ["github-actions"],
       matchPackageNames: ["golangci/golangci-lint"],
-      pinDigests: false,
+      matchUpdateTypes: ["pinDigest"],
+      enabled: false,
     },
     {
       // astral-sh/setup-uv uses exact version tags (v8.0.0), not major tags (v8).

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -278,6 +278,15 @@
       "groupName": "Red Hat registry base images",
       "semanticCommits": "enabled",
     },
+    {
+      // uses-with dep from golangci-lint-action version: input; see cilium/cilium@4127ed6
+      description: "Do not pin digest for golangci-lint uses-with dep",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["golangci/golangci-lint"],
+      // matchDepTypes: ["uses-with"],  // do NOT add — PR dry-runs still hit branch
+      // update failure with this set; Cilium uses package name + pinDigests only
+      pinDigests: false,
+    },
   ],
 
   "forkProcessing": "enabled",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -174,6 +174,15 @@
       pinDigests: true,
     },
     {
+      // github-actions manager extracts golangci/golangci-lint from the version:
+      // input of golangci/golangci-lint-action (depType uses-with). pinDigests
+      // cannot apply to a plain version string, so the grouped branch fails.
+      description: "Do not pin digest for golangci-lint uses-with dep",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["golangci/golangci-lint"],
+      pinDigests: false,
+    },
+    {
       // astral-sh/setup-uv uses exact version tags (v8.0.0), not major tags (v8).
       "description": "Track exact versions for setup-uv (no major tags published)",
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -179,6 +179,7 @@
       // cannot apply to a plain version string, so the grouped branch fails.
       description: "Do not pin digest for golangci-lint uses-with dep",
       matchManagers: ["github-actions"],
+      matchDepTypes: ["uses-with"],
       matchPackageNames: ["golangci/golangci-lint"],
       pinDigests: false,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -178,15 +178,20 @@
       // input of golangci/golangci-lint-action (depType uses-with). pinDigests
       // cannot apply to a plain version string, so the grouped branch fails.
       //
-      // Do not add matchDepTypes here. A dry-run with matchDepTypes: ["uses-with"]
-      // still emitted pinDigest for golangci/golangci-lint and the grouped branch
-      // failed; Cilium's package-name-only pinDigests:false also did not stop
-      // pinDigest generation in our Renovate 43 dry-run — disable the update
-      // type explicitly instead.
-      description: "Disable pinDigest for golangci-lint uses-with dep",
+      // Do NOT add matchDepTypes: ["uses-with"] — dry-run
+      // https://github.com/opendatahub-io/notebooks/actions/runs/29012903496
+      // still emitted pinDigest and the grouped branch failed. CodeRabbit
+      // suggested matchDepTypes for "tighter scope"; that broke the fix.
+      //
+      // Also insufficient in Renovate 43 dry-runs:
+      // - pinDigests: false alone (Cilium-style)
+      // - matchUpdateTypes: ["pinDigest"] + enabled: false
+      // Both still left isPinDigest:true on golangci/golangci-lint.
+      // Disable the whole github-actions extraction of this package instead;
+      // keep managing `version:` in code-quality.yaml manually / via pinact.
+      description: "Disable github-actions extraction of golangci-lint version input",
       matchManagers: ["github-actions"],
       matchPackageNames: ["golangci/golangci-lint"],
-      matchUpdateTypes: ["pinDigest"],
       enabled: false,
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -177,9 +177,11 @@
       // github-actions manager extracts golangci/golangci-lint from the version:
       // input of golangci/golangci-lint-action (depType uses-with). pinDigests
       // cannot apply to a plain version string, so the grouped branch fails.
+      // Do not add matchDepTypes here. A dry-run with matchDepTypes: ["uses-with"]
+      // still emitted pinDigest for golangci/golangci-lint and the grouped branch
+      // failed; Cilium's fix uses package name + pinDigests: false only.
       description: "Do not pin digest for golangci-lint uses-with dep",
       matchManagers: ["github-actions"],
-      matchDepTypes: ["uses-with"],
       matchPackageNames: ["golangci/golangci-lint"],
       pinDigests: false,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -170,23 +170,8 @@
     {
       description: "Group GitHub Actions digest updates into a single PR",
       matchManagers: ["github-actions"],
-      // Exclude uses-with golangci/golangci-lint: pinDigests cannot apply to
-      // version: vX.Y.Z and aborts the whole group (RHAIENG-6163).
-      // Do NOT rely on a later packageRule with pinDigests:false / enabled:false
-      // alone — Renovate 43 dry-runs still emitted isPinDigest for this dep.
-      // Do NOT add matchDepTypes: ["uses-with"] on an exception rule either;
-      // that also failed to stop pinDigest (CodeRabbit suggested it).
-      matchPackageNames: ["!golangci/golangci-lint"],
       groupName: "github-actions",
       pinDigests: true,
-    },
-    {
-      // Keep version bumps for the uses-with dep, but never pinDigests (nowhere
-      // to store a SHA on `version: vX.Y.Z`). Separate from the group above.
-      description: "golangci-lint uses-with: version bumps only, no digest pin",
-      matchManagers: ["github-actions"],
-      matchPackageNames: ["golangci/golangci-lint"],
-      pinDigests: false,
     },
     {
       // astral-sh/setup-uv uses exact version tags (v8.0.0), not major tags (v8).

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -170,29 +170,23 @@
     {
       description: "Group GitHub Actions digest updates into a single PR",
       matchManagers: ["github-actions"],
+      // Exclude uses-with golangci/golangci-lint: pinDigests cannot apply to
+      // version: vX.Y.Z and aborts the whole group (RHAIENG-6163).
+      // Do NOT rely on a later packageRule with pinDigests:false / enabled:false
+      // alone — Renovate 43 dry-runs still emitted isPinDigest for this dep.
+      // Do NOT add matchDepTypes: ["uses-with"] on an exception rule either;
+      // that also failed to stop pinDigest (CodeRabbit suggested it).
+      matchPackageNames: ["!golangci/golangci-lint"],
       groupName: "github-actions",
       pinDigests: true,
     },
     {
-      // github-actions manager extracts golangci/golangci-lint from the version:
-      // input of golangci/golangci-lint-action (depType uses-with). pinDigests
-      // cannot apply to a plain version string, so the grouped branch fails.
-      //
-      // Do NOT add matchDepTypes: ["uses-with"] — dry-run
-      // https://github.com/opendatahub-io/notebooks/actions/runs/29012903496
-      // still emitted pinDigest and the grouped branch failed. CodeRabbit
-      // suggested matchDepTypes for "tighter scope"; that broke the fix.
-      //
-      // Also insufficient in Renovate 43 dry-runs:
-      // - pinDigests: false alone (Cilium-style)
-      // - matchUpdateTypes: ["pinDigest"] + enabled: false
-      // Both still left isPinDigest:true on golangci/golangci-lint.
-      // Disable the whole github-actions extraction of this package instead;
-      // keep managing `version:` in code-quality.yaml manually / via pinact.
-      description: "Disable github-actions extraction of golangci-lint version input",
+      // Keep version bumps for the uses-with dep, but never pinDigests (nowhere
+      // to store a SHA on `version: vX.Y.Z`). Separate from the group above.
+      description: "golangci-lint uses-with: version bumps only, no digest pin",
       matchManagers: ["github-actions"],
       matchPackageNames: ["golangci/golangci-lint"],
-      enabled: false,
+      pinDigests: false,
     },
     {
       // astral-sh/setup-uv uses exact version tags (v8.0.0), not major tags (v8).

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -121,11 +121,12 @@ jobs:
         with:
           go-version-file: scripts/buildinputs/go.mod
 
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
-        with:
-          version: v2.12.2
-          working-directory: scripts/buildinputs
+        run: golangci-lint run
+        working-directory: scripts/buildinputs
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -121,12 +121,11 @@ jobs:
         with:
           go-version-file: scripts/buildinputs/go.mod
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
-
       - name: golangci-lint
-        run: golangci-lint run
-        working-directory: scripts/buildinputs
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+        with:
+          version: v2.12.2
+          working-directory: scripts/buildinputs
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -121,7 +121,7 @@ jobs:
         with:
           go-version-file: scripts/buildinputs/go.mod
 
-      - name: golangci-lint
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.12.2

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -121,7 +121,7 @@ jobs:
         with:
           go-version-file: scripts/buildinputs/go.mod
 
-      - name: Run golangci-lint
+      - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.12.2


### PR DESCRIPTION
## Problem

Renovate self-hosted runs find GitHub Actions updates but fail to open the grouped PR on branch `konflux/mintmaker/main/github-actions`:

```
WARN: Error updating branch: update failure (branch=konflux/mintmaker/main/github-actions)
```

## Root cause

Renovate's `github-actions` manager auto-extracts the `version:` input of `golangci/golangci-lint-action` as a separate `uses-with` dependency (`golangci/golangci-lint`, `currentValue: v2.12.2` in `.github/workflows/code-quality.yaml`). With grouped `pinDigests: true` in `.github/renovate.json5`, Renovate tries to pin that plain `version: vX.Y.Z` string to a commit SHA, but there is nowhere to store a digest — `foundValue: undefined` — and the entire grouped branch fails.

**Ruled out during investigation:** renaming the workflow step `golangci-lint` does not help (tested in commit `e9884a30f`; Renovate dry-run on `main` still failed).

**Prior art:** [cilium/cilium@4127ed6](https://github.com/cilium/cilium/commit/4127ed6c6966dd8ff45176978ddb248f61ef9e55)

## Summary

- Add a `packageRules` entry to `.github/renovate.json5` setting `pinDigests: false` for `golangci/golangci-lint` under the `github-actions` manager
- Unblocks the grouped `konflux/mintmaker/main/github-actions` Renovate branch (~12 stale GHA pins since ~May 2025)

## Jira

https://redhat.atlassian.net/browse/RHAIENG-6163

## Test plan

- [ ] Merge this PR
- [ ] Re-run Renovate (self-hosted) on `main` — dry-run first (`dry_run=true`, `dry_run_mode=full`, `log_level=debug`)
- [ ] Confirm no `update failure` on `konflux/mintmaker/main/github-actions`
- [ ] Re-run Renovate for real and verify grouped GHA PR is created
- [ ] If `aquasecurity/trivy` upgrade collision in `security.yaml` persists, resolve separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings for GitHub Actions workflows to better handle updates to a Go linting tool.
  * Adjusted the update behavior to avoid digest pinning for that specific linting-tool rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->