### PR TITLE
RHAIENG-6193: Switch git-clone-oci-ta back to 0.1

### DIFF
--- a/.tekton/multiarch-odh-main-combined-pipeline.yaml
+++ b/.tekton/multiarch-odh-main-combined-pipeline.yaml
@@ -232,7 +232,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:12cbcf0b408e906f84e7eb3c62c6cd618e2b1f78a40218e10940fbaf2c45455d
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
[RHAIENG-6193](https://redhat.atlassian.net/browse/RHAIENG-6193): Switch git-clone-oci-ta back to 0.1

## Description
(Konflux bot, Jul 9) bumped git-clone-oci-ta 0.1 → 0.2 in .tekton/multiarch-odh-main-combined-pipeline.yaml. Version 0.2 uses konflux-build-cli instead of the old git-clone image and does not smudge LFS files into the clone artifact.

Pin clone back to 0.1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


[RHAIENG-6193]: https://redhat.atlassian.net/browse/RHAIENG-6193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a pinned pipeline task reference to a different version for repository cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->