### PR TITLE
#3970: fix check-payload FIPS scan auth failure on forks

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -627,6 +627,8 @@ jobs:
         run: |
           set -Eeuxo pipefail
           PODMAN="$(which podman)"
+          # Pull via the CONTAINER_HOST remote client (has GHCR auth); sudo podman runs as root and lacks credentials
+          "${PODMAN}" pull "${CHECK_PAYLOAD_IMAGE}"
           IMAGE_MOUNT_DIR=$(sudo "${PODMAN}" image mount "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}")
           sudo "${PODMAN}" run --rm --user=0 \
             -v "${IMAGE_MOUNT_DIR}:${IMAGE_MOUNT_DIR}:ro,z" \


### PR DESCRIPTION
## Summary

Fixes the `Check image with check-payload for FIPS compliance` step failing on all
RHOAI builds in the `red-hat-data-services/notebooks` fork since PR #3974 merged (June 29).

## Root cause

PR #3974 switched check-payload from `go tool` (compiled locally) to a pre-built
container image at `ghcr.io/${{ github.repository }}/check-payload:0.3.16`.
The scan step runs `sudo podman run` to execute the scanner, but:

1. The `docker/login-action` stores GHCR credentials for the **runner user**
   (`$HOME/.config/containers/auth.json`).
2. `sudo podman run` runs as **root**, which has its own credential store —
   **no GHCR auth token**.
3. On `opendatahub-io/notebooks`, the check-payload GHCR package is **public**,
   so the unauthenticated pull succeeds and the problem is invisible.
4. On `red-hat-data-services/notebooks`, GHCR packages are **private by default**,
   so the pull fails: `unable to retrieve auth token: invalid username/password: unauthorized`.

The non-sudo `podman` commands work because `CONTAINER_HOST` is set — podman acts
as a remote client that forwards auth to the rootful podman server. But `sudo podman`
bypasses the remote client entirely and runs directly as root, losing the auth context.

## Impact

Every push build on `red-hat-data-services/notebooks` `main` has had all RHOAI FIPS
checks failing since June 29 (10+ days). PR CI is also affected (e.g.
[PR #2486](https://github.com/red-hat-data-services/notebooks/pull/2486)).

## Fix

Add `"${PODMAN}" pull "${CHECK_PAYLOAD_IMAGE}"` (without `sudo`) before the
`sudo podman run` line. The non-sudo podman uses the `CONTAINER_HOST` remote client
which has GHCR credentials and pulls the image into the rootful storage. The subsequent
`sudo podman run` then finds the image locally and doesn't need to authenticate.

This is a no-op on opendatahub-io (image is already pullable without auth) and fixes
the fork where the image is private.

## Test plan

- [ ] Verify FIPS check passes on a PR build in this repo (no regression)
- [ ] Cherry-pick to `red-hat-data-services/notebooks` and verify FIPS check passes there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FIPS compliance checks in notebook builds by ensuring the required image is downloaded through the authenticated container connection.
  * Prevented credential-related failures during image access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->