### PR TITLE
RHAIENG-6194: replace perl with perl-interpreter in ROCm Dockerfiles

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -24,7 +24,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    bash /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 
 # Create unversioned .so symlinks for ROCm libs (RHAIENG-2643)

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -51,7 +51,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    bash /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 
 ########################

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -57,7 +57,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    bash /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -20,7 +20,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    bash /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat compat-openssl11 openshift-clients
+    bash /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat compat-openssl11 openshift-clients
 
 
 USER 1001

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -20,7 +20,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    bash /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat compat-openssl11 openshift-clients
+    bash /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat compat-openssl11 openshift-clients
 
 
 USER 1001


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-6194

## Summary

Replace the `perl` meta-package with `perl-interpreter` in all 5 ROCm
Dockerfiles to resolve a DNF dependency conflict on the RHEL 9.6 EUS
ROCm base image.

## Problem

The `perl` meta-package pulls in `perl-devel`, which depends on
`redhat-rpm-config`, which in turn requires a newer `glibc` than is
available in the RHEL 9.6 EUS ROCm base image (`registry.redhat.io/aipcc/rocm-*-el9.6`).
This causes `dnf install` to fail with an unsatisfiable dependency error
during the container build.

The ROCm Dockerfiles only need the `perl` interpreter itself (used by some
build scripts), not the full development toolchain. `perl-interpreter`
provides exactly that without dragging in `perl-devel` or `redhat-rpm-config`.

## Changed files

- `jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm`
- `jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm`
- `jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm`
- `runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm`
- `runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm`

## Test plan

- [ ] ROCm image builds succeed (no DNF dependency conflict)
- [ ] FIPS check-payload passes on built images

Corresponding downstream PR: https://github.com/red-hat-data-services/notebooks/pull/2486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ROCm-based Python 3.12 images to install the appropriate Perl interpreter package.
  * Standardized package provisioning across Jupyter and runtime images for more reliable image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->