### PR TITLE
NO-JIRA: fix(ci): align Elyra ipython pin with RH packages index

### DIFF
--- a/ci/requirements-elyra.txt
+++ b/ci/requirements-elyra.txt
@@ -1,11 +1,11 @@
 # Downloaded from https://raw.githubusercontent.com/opendatahub-io/elyra/main/etc/generic/requirements-elyra.txt
 # Local changes synced with runtime pylocks (runtimes/*/ubi9-python-3.12/uv.lock.d/pylock.*.toml):
 #   ipykernel==7.2.0 (7.1.0 is not installable from PyPI for current pip index)
-#   ipython==9.14.0, requests==2.34.2, tornado==6.5.6, traitlets==5.15.1
+#   ipython==9.14.1, requests==2.34.2, tornado==6.5.6, traitlets==5.15.1
 
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
 ipykernel==7.2.0
-ipython==9.14.0
+ipython==9.14.1
 ipython-genutils==0.2.0
 jinja2==3.1.6
 jupyter-client==8.8.0


### PR DESCRIPTION
## Summary
- Bump `ipython` in `ci/requirements-elyra.txt` from `9.14.0` to `9.14.1`
- `validate-runtime-image` installs Elyra deps with `pip` inside the runtime container, which uses the configured `packages.redhat.com` PyPI index (not public PyPI)
- `ipython==9.14.0` is no longer available in that RH index (`8.36.0`, `9.14.1`, `9.15.0` are), which breaks Elyra runtime validation (e.g. `rocm-runtime-pytorch-ubi9-python-3.12`)
- `ipython==9.14.0` remains on [public PyPI](https://pypi.org/project/ipython/9.14.0/); this is an index/registry mismatch, not a PyPI yank

## Test plan
* https://github.com/opendatahub-io/notebooks/actions/runs/29101076522
- [x] `python3 -m pip install --dry-run -r ci/requirements-elyra.txt`
- [ ] CI `validate-runtime-image` passes for affected runtime images