### PR TITLE
RHAIENG-6193: fix(codeserver): fail fast on un-smudged Git LFS .vsix files

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
@@ -116,8 +116,6 @@ populate_vsix() {
         return
     fi
 
-    require_valid_vsix "${vsix_file}"
-
     echo "Extracting ${ext_name} from $(basename "${vsix_file}")..."
     local tmp_dir
     tmp_dir="$(mktemp -d /tmp/vsix-extract.XXXXXX)"

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh
@@ -56,6 +56,23 @@ fi
 export RIPGREP_BINARY_PATH
 echo "Using ripgrep from Python wheel: ${RIPGREP_BINARY_PATH}"
 
+# [RHAIENG-6193] .vsix files under utils/ are Git LFS objects. If the clone task did not
+# smudge LFS (regression in git-clone-oci-ta 0.2), these are ~130 byte pointer stubs, not
+# real ZIPs. Fail fast here instead of ~1h into the VS Code compile when the build later
+# tries (and fails) to download the extension from GitHub with no network access.
+require_valid_vsix() {
+    local f="$1"
+    if [[ ! -f "$f" ]]; then
+        echo "ERROR: ${f} not found" >&2
+        exit 1
+    fi
+    if ! unzip -tqq "$f" >/dev/null 2>&1; then
+        echo "ERROR: ${f} is not a valid .vsix zip (Git LFS pointer not materialized? see RHAIENG-6193)" >&2
+        head -c 200 "$f" >&2 || true
+        exit 1
+    fi
+}
+
 # Setup VSCode marketplace extensions and Node.js binaries from prefetched files.
 # VSCODE_OFFLINE_CACHE is already exported by codeserver-offline-env.sh.
 # Built-in .vsix (js-debug, etc.) are in repo at utils/ (COPY'd into image); not from cachi2.
@@ -63,9 +80,12 @@ mkdir -p "${VSCODE_OFFLINE_CACHE}"
 VSIX_UTILS="${CODESERVER_SOURCE_CODE}/utils"
 
 # Copy .vsix extension files from utils/ (git-tracked large files)
-cp "${VSIX_UTILS}/ms-vscode.js-debug-companion.1.1.3.vsix" "${VSCODE_OFFLINE_CACHE}/"
-cp "${VSIX_UTILS}/ms-vscode.js-debug.1.112.0.vsix" "${VSCODE_OFFLINE_CACHE}/"
-cp "${VSIX_UTILS}/ms-vscode.vscode-js-profile-table.1.0.10.vsix" "${VSCODE_OFFLINE_CACHE}/"
+for f in "${VSIX_UTILS}/ms-vscode.js-debug-companion.1.1.3.vsix" \
+         "${VSIX_UTILS}/ms-vscode.js-debug.1.112.0.vsix" \
+         "${VSIX_UTILS}/ms-vscode.vscode-js-profile-table.1.0.10.vsix"; do
+    require_valid_vsix "${f}"
+    cp "${f}" "${VSCODE_OFFLINE_CACHE}/"
+done
 
 # [HERMETIC] Pre-populate .build/node/ with system Node (like che-code) so gulp skips download.
 # build-vscode.sh is patched to build for current arch (vscode-reh-web-linux-${NODE_ARCH}).
@@ -96,10 +116,11 @@ populate_vsix() {
         return
     fi
 
+    require_valid_vsix "${vsix_file}"
+
     echo "Extracting ${ext_name} from $(basename "${vsix_file}")..."
-    local tmp_dir="/tmp/vsix-extract-$$"
-    rm -rf "${tmp_dir}"
-    mkdir -p "${tmp_dir}"
+    local tmp_dir
+    tmp_dir="$(mktemp -d /tmp/vsix-extract.XXXXXX)"
     # .vsix is a ZIP; the extension contents are in the extension/ subdirectory
     unzip -qo "${vsix_file}" "extension/*" -d "${tmp_dir}"
     rm -rf "${ext_dir}"


### PR DESCRIPTION
## Summary

- Konflux `git-clone-oci-ta` 0.2's `clone` step image (`konflux-build-cli`, based on `task-runner`) is missing the `git-lfs` package, so Git-LFS-tracked `.vsix` files under `codeserver/ubi9-python-3.12/utils/` arrive as ~130 byte pointer stubs instead of real archives.
- Previously this surfaced ~1h into the hermetic VS Code compile as a confusing `TypeError: fetch failed` while the build tried (and failed, no network) to download the extension from GitHub.
- This PR adds a fail-fast check in `setup-offline-binaries.sh` so a bad `.vsix` is caught immediately, with an error message that points straight at the root cause, instead of a cryptic network failure an hour later. Also fixes a CodeRabbit-flagged CWE-377 (predictable `/tmp` path) by switching to `mktemp -d`.

## What this PR deliberately does NOT do

- **Does not prefetch `.vsix` via cachi2.** An earlier version of this PR did this; reverted. `git-clone-oci-ta` is already pinned back to 0.1 in [#4047](https://github.com/opendatahub-io/notebooks/pull/4047), so this workaround isn't needed right now, and it would have papered over the real upstream bug instead of tracking it to resolution.
- **Does not add a `fetch-git-lfs` task to the shared `multiarch-odh-main-combined-pipeline.yaml`.** An earlier version of this PR did this too; reverted. Adding permanent pipeline machinery for every component just to work around a temporary upstream regression isn't worth the complexity, especially since a real fix already exists.

## Root cause and fix status (full writeup in [RHAIENG-6193](https://redhat.atlassian.net/browse/RHAIENG-6193))

- Root cause: `task-runner` migrated EL9->EL10 and dropped the `git-lfs` RPM; `konflux-build-cli` inherits this. Confirmed via direct image inspection and an A/B clone test against a real Git LFS repo.
- The fix is already built and published upstream: `konflux-build-cli@sha256:fddbb4c2edb01a3f0065321f84cf2e4d8e483b4149e3d6f78dd0c46e85e35aef` (built from `task-runner` 2.1.0, which added `git-lfs`) correctly smudges LFS content -- verified directly.
- The only missing piece is [konflux-ci/build-definitions#3653](https://github.com/konflux-ci/build-definitions/pull/3653), which bumps `git-clone-oci-ta`'s pinned `konflux-build-cli` digest to the fixed one. It's CI-green and mergeable, but has a "Do NOT merge" hold from a code owner (unrelated reorg reason, predates the LFS fix landing in that PR).
- Once #3653 merges and MintMaker proposes the new digest to us, we can go back to `git-clone-oci-ta` 0.2 directly -- no extra pipeline work needed on our side. This PR's fail-fast check stays as cheap permanent insurance against this class of regression.

## Test plan

- [ ] Merge and confirm `Red Hat Konflux / odh-workbench-codeserver-datascience-cpu-py312-ubi9-on-pull-request` passes on the PR (unaffected by this change since it's diagnostics-only and `git-clone-oci-ta` is on 0.1)

[RHAIENG-6193]: https://redhat.atlassian.net/browse/RHAIENG-6193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of offline extension packages before they are copied or extracted.
  * Added faster, clearer error messages with brief previews when packages are missing or invalid.
  * Reduced the risk of temporary-directory conflicts during extension processing by using a unique workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->