### PR TITLE
Fix agent-browser postinstall for s390x hermetic builds

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/apply-patch.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/apply-patch.sh
@@ -96,6 +96,29 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" || "$ARCH" == "ppc64le" || "$ARCH
         echo "WARNING: ripgrep postinstall not found at ${RIPGREP_PATCHED}"
     fi
 
+    # [AGENT-BROWSER] Overwrite agent-browser postinstall in the cached npm tarball.
+    # The npm tarball bundles native binaries for linux-x64/arm64 only; ppc64le/s390x
+    # are missing. Upstream postinstall then downloads from GitHub releases (not npm),
+    # which fails in hermetic builds. arm64/amd64 succeed because the bundled binary
+    # is found before any download is attempted.
+    AGENT_BROWSER_PATCHED="${CODESERVER_SOURCE_PREFETCH}/agent-browser/postinstall.js"
+    AGENT_BROWSER_TGZ=$(find /cachi2/output/deps/npm -name "agent-browser-*.tgz" -type f 2>/dev/null | head -1)
+    if [[ -n "${AGENT_BROWSER_TGZ}" && -f "${AGENT_BROWSER_PATCHED}" ]]; then
+        echo "Patching agent-browser: overwrite with ${AGENT_BROWSER_PATCHED}"
+        tmpdir=$(mktemp -d)
+        tar xzf "${AGENT_BROWSER_TGZ}" -C "$tmpdir"
+        cp "${AGENT_BROWSER_PATCHED}" "$tmpdir/package/scripts/postinstall.js"
+        tar czf "${AGENT_BROWSER_TGZ}" -C "$tmpdir" package
+        rm -rf "$tmpdir"
+        jq 'del(.packages["node_modules/agent-browser"].integrity)' \
+            lib/vscode/package-lock.json > /tmp/lock-agent-browser.json \
+            && mv /tmp/lock-agent-browser.json lib/vscode/package-lock.json
+    elif [[ -z "${AGENT_BROWSER_TGZ}" ]]; then
+        echo "WARNING: agent-browser tarball not found in /cachi2/output/deps/npm/"
+    elif [[ ! -f "${AGENT_BROWSER_PATCHED}" ]]; then
+        echo "WARNING: agent-browser postinstall not found at ${AGENT_BROWSER_PATCHED}"
+    fi
+
     if [[ "$ARCH" == "ppc64le" || "$ARCH" == "s390x" ]]; then
         # Try to patch the cached tarball (remove postinstall from its package.json)
         VSCE_TGZ=$(find /cachi2/output/deps/npm -name "*vsce-sign*.tgz" -type f 2>/dev/null | head -1)

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/agent-browser/postinstall.js
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/agent-browser/postinstall.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * Offline-safe postinstall for agent-browser.
+ *
+ * The npm tarball ships native binaries for x64/arm64/darwin/win32 only.
+ * ppc64le/s390x are not bundled; upstream postinstall then tries to download
+ * from GitHub releases, which fails in hermetic Konflux builds (network
+ * blocked) and crashes on unlink. This script chmods a bundled binary when
+ * present, otherwise exits 0 and uses the Node.js CLI fallback.
+ */
+
+import { existsSync, chmodSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { platform, arch } from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const binDir = join(projectRoot, 'bin');
+
+const platformKey = `${platform()}-${arch()}`;
+const ext = platform() === 'win32' ? '.exe' : '';
+const binaryName = `agent-browser-${platformKey}${ext}`;
+const binaryPath = join(binDir, binaryName);
+
+if (existsSync(binaryPath)) {
+	if (platform() !== 'win32') {
+		chmodSync(binaryPath, 0o755);
+	}
+	console.log(`Native binary ready: ${binaryName}`);
+	process.exit(0);
+}
+
+console.log(
+	`No bundled native binary for ${platformKey}; using Node.js CLI fallback`,
+);
+process.exit(0);


### PR DESCRIPTION
## Summary

Cherry-picks the agent-browser fix from [red-hat-data-services/notebooks#2484](https://github.com/red-hat-data-services/notebooks/pull/2484) onto ODH main.

VS Code 1.112 (code-server v4.112.0, merged via #4022) adds `agent-browser` as a devDependency. Its upstream postinstall downloads platform-specific native binaries from GitHub releases — not the npm registry — so cachi2 prefetch alone is insufficient. On s390x/ppc64le the npm tarball has no bundled binary, the download is blocked in hermetic Konflux builds, and npm fails.

This PR patches the cached `agent-browser` npm tarball during `apply-patch.sh` (same pattern as `@vscode/ripgrep`) with an offline-safe postinstall that exits cleanly and falls back to the Node.js CLI.

- Adds `prefetch-input/patches/code-server-v4.112.0/agent-browser/postinstall.js`
- Extends `apply-patch.sh` to overwrite the tarball and strip lockfile integrity

## Test plan

- [ ] Konflux codeserver multi-arch build passes on s390x (and ppc64le)
- [ ] amd64/arm64 builds still succeed (bundled native binary path unchanged)
- [ ] `/build-codeserver` on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline installation of the agent-browser dependency.
  * Prevented installation failures when native binaries are unavailable by using a Node.js fallback.
  * Ensured bundled native binaries are correctly prepared for supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->