### PR TITLE
fix: correct typo 'overriden' to 'overridden' in docs/workbenches-naming.md

### DIFF
--- a/docs/workbenches-naming.md
+++ b/docs/workbenches-naming.md
@@ -57,7 +57,7 @@ Example:
 ## Split of params
 
 Konflux would be help with build of workbenches. Konflux patch the sha of the built image into params file as a process of nudging.
-To keep this file not getting overriden, we have split the params file into 2 files.
+To keep this file not getting overridden, we have split the params file into 2 files.
 - params-latest.env: Any workbench images that represent the image version N (the latest one).
 - params.env: Rest of the workbench images that represent the n-1 and extras.
 


### PR DESCRIPTION
Fixes a spelling typo in `docs/workbenches-naming.md`: replaces 'overriden' with the correct spelling 'overridden'. Closes #4035.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the “Split of params” documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->