### PR TITLE
RHAIENG-4344: fix culling heartbeat for CodeServer

### DIFF
--- a/codeserver/ubi9-python-3.12/httpd/httpd.conf
+++ b/codeserver/ubi9-python-3.12/httpd/httpd.conf
@@ -4,8 +4,8 @@ Listen 8080
 
 # Load modules
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule unixd_module modules/mod_unixd.so
 LoadModule authz_core_module modules/mod_authz_core.so
-LoadModule mime_module modules/mod_mime.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule cgi_module modules/mod_cgi.so
 LoadModule rewrite_module modules/mod_rewrite.so
@@ -17,6 +17,7 @@ LoadModule rewrite_module modules/mod_rewrite.so
 # Server configuration
 ServerAdmin root@localhost
 ServerName localhost
+PidFile /var/run/httpd/httpd.pid
 
 # Document root
 DocumentRoot "/opt/app-root"
@@ -29,11 +30,22 @@ DocumentRoot "/opt/app-root"
 
 <Directory "/opt/app-root">
     AllowOverride None
+    Require all granted
+</Directory>
+
+# Culling probe only: SetHandler is core (no mod_mime). AddHandler would require mod_mime.
+<Directory "/opt/app-root/api/kernels">
+    AllowOverride None
     Options +ExecCGI
     Require all granted
-    AddHandler cgi-script .cgi
     DirectoryIndex access.cgi
 </Directory>
+
+<LocationMatch "^/api/kernels/">
+    SetHandler cgi-script
+    Options +ExecCGI
+    Require all granted
+</LocationMatch>
 
 # Error and access logs
 ErrorLog "/dev/stderr"

--- a/codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi
+++ b/codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi
@@ -1,14 +1,42 @@
 #!/bin/bash
+# CGI shim for the notebook controller culler.
+#
+# Code-Server has no Jupyter-compatible /api/kernels/ API. Apache (httpd) invokes
+# this script for that path; it polls code-server's /healthz heartbeat and returns
+# a single synthetic kernel record the culler can parse.
+#
+# Expected output shape (Jupyter kernels API):
+#   [{"id":"...","name":"...","last_activity":"<RFC3339>","execution_state":"busy|idle","connections":1}]
+
+# --- CGI response headers (required before any body output) ---
 echo "Status: 200"
 echo "Content-type: application/json"
 echo
-# Query the heartbeat endpoint
-HEALTHZ=$(curl -s http://localhost:8888/codeserver/healthz)
-# Extract last_activity | remove milliseconds
-LAST_ACTIVITY_EPOCH=$(echo $HEALTHZ | grep -Po 'lastHeartbeat":\K.*?(?=})' | awk '{ print substr( $0, 1, length($0)-3 ) }')
-# Convert to ISO8601 date format
-LAST_ACTIVITY=$(date -d @$LAST_ACTIVITY_EPOCH -Iseconds)
-# Extract status and replace with terms expected by culler
-STATUS=$(sed 's/alive/busy/;s/expired/idle/' <<< $(echo $HEALTHZ | grep -Po 'status":"\K.*?(?=")'))
-# Export in format expected by the culling engine
-echo '[{"id":"code-server","name":"code-server","last_activity":"'$LAST_ACTIVITY'","execution_state":"'$STATUS'","connections":1}]'
+
+# --- Fetch code-server heartbeat ---
+# Poll through nginx on 8888 using the same probe path as notebook-controller:
+#   ${NB_PREFIX}/api  ->  ${NB_PREFIX}/codeserver/healthz/
+# A bare /codeserver/healthz curl fails when NB_PREFIX is set because nginx only
+# routes prefixed /codeserver/* to code-server. -L follows the probe redirect chain.
+NB_PREFIX="${NB_PREFIX:-}"
+HEALTHZ=$(curl -sL "http://localhost:8888${NB_PREFIX}/api")
+# Example HEALTHZ JSON: {"status":"alive","lastHeartbeat":1742345025123}
+
+# --- Derive last_activity (RFC3339 / ISO 8601) ---
+# lastHeartbeat is milliseconds since epoch. The culler expects seconds in ISO format.
+# On a fresh pod, code-server reports lastHeartbeat=0 until the first user interaction;
+# date -d @0 would work but misleads the culler, so we use the current time instead
+# (consistent with the initial entry written in run-code-server.sh).
+LAST_HEARTBEAT_MS=$(echo "$HEALTHZ" | grep -Po 'lastHeartbeat":\K[0-9]+')
+if [ -z "$LAST_HEARTBEAT_MS" ] || [ "$LAST_HEARTBEAT_MS" = "0" ]; then
+    LAST_ACTIVITY=$(date -Iseconds)
+else
+    LAST_ACTIVITY=$(date -d "@$((LAST_HEARTBEAT_MS / 1000))" -Iseconds)
+fi
+
+# --- Map code-server status to Jupyter execution_state ---
+# code-server uses alive/expired; the culler expects busy/idle (Jupyter kernel terms).
+STATUS=$(sed 's/alive/busy/;s/expired/idle/' <<< "$(echo "$HEALTHZ" | grep -Po 'status":"\K.*?(?=")')")
+
+# --- Emit synthetic kernel list (always one entry for the IDE session) ---
+echo '[{"id":"code-server","name":"code-server","last_activity":"'"$LAST_ACTIVITY"'","execution_state":"'"$STATUS"'","connections":1}]'

--- a/codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi
+++ b/codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi
@@ -19,7 +19,7 @@ echo
 # A bare /codeserver/healthz curl fails when NB_PREFIX is set because nginx only
 # routes prefixed /codeserver/* to code-server. -L follows the probe redirect chain.
 NB_PREFIX="${NB_PREFIX:-}"
-HEALTHZ=$(curl -sL "http://localhost:8888${NB_PREFIX}/api")
+HEALTHZ=$(curl -sLf --max-time 5 "http://localhost:8888${NB_PREFIX}/api")
 # Example HEALTHZ JSON: {"status":"alive","lastHeartbeat":1742345025123}
 
 # --- Derive last_activity (RFC3339 / ISO 8601) ---
@@ -37,6 +37,9 @@ fi
 # --- Map code-server status to Jupyter execution_state ---
 # code-server uses alive/expired; the culler expects busy/idle (Jupyter kernel terms).
 STATUS=$(sed 's/alive/busy/;s/expired/idle/' <<< "$(echo "$HEALTHZ" | grep -Po 'status":"\K.*?(?=")')")
+
+# Default to busy (safe: prevents premature culling when state is unknown)
+[ -z "$STATUS" ] || { [ "$STATUS" != "busy" ] && [ "$STATUS" != "idle" ]; } && STATUS="busy"
 
 # --- Emit synthetic kernel list (always one entry for the IDE session) ---
 echo '[{"id":"code-server","name":"code-server","last_activity":"'"$LAST_ACTIVITY"'","execution_state":"'"$STATUS"'","connections":1}]'

--- a/tests/containers/workbenches/culling_api_test.py
+++ b/tests/containers/workbenches/culling_api_test.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+import allure
+import pytest
+
+from tests import PROJECT_ROOT
+from tests.containers import conftest, docker_utils
+from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
+
+if TYPE_CHECKING:
+    import pytest_subtests
+
+ACCESS_CGI_PATH = PROJECT_ROOT / "codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi"
+
+# date -Iseconds output: 2026-03-18T01:23:45+00:00
+RFC3339_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$")
+
+
+def _codeserver_platform_env(project: str = "test-ns", notebook: str = "test-notebook") -> dict[str, str]:
+    """Env vars notebook-controller injects for a prefixed workbench route."""
+    nb_prefix = f"/notebook/{project}/{notebook}"
+    notebook_args = " ".join(
+        [
+            "--ServerApp.port=8888",
+            "--ServerApp.token=''",
+            "--ServerApp.password=''",
+            f"--ServerApp.base_url={nb_prefix}",
+            "--ServerApp.quit_button=False",
+        ]
+    )
+    return {
+        "NB_PREFIX": nb_prefix,
+        "NOTEBOOK_ARGS": notebook_args,
+    }
+
+
+def _wait_for_healthz(container: WorkbenchContainer, *, nb_prefix: str | None = None, timeout: float = 120) -> None:
+    """Poll code-server readiness via the platform probe path inside the container."""
+    probe_path = f"{nb_prefix}/api" if nb_prefix else "/api"
+    healthz_url = f"http://127.0.0.1:8888{probe_path}"
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        container.get_wrapped_container().reload()
+        assert container.get_wrapped_container().status != "exited", "codeserver container exited during startup"
+
+        exit_code, _ = container.exec(
+            ["curl", "-sS", "-f", "-L", "-o", "/dev/null", "--max-time", "2", healthz_url]
+        )
+        if exit_code == 0:
+            return
+        time.sleep(2)
+
+    raise TimeoutError(f"code-server healthz did not become ready at {healthz_url} within {timeout}s")
+
+
+def _install_access_cgi(container: WorkbenchContainer) -> None:
+    """Install the workspace access.cgi so tests exercise current source, not only a baked image."""
+    docker_utils.container_cp(
+        container.get_wrapped_container(),
+        str(ACCESS_CGI_PATH),
+        "/opt/app-root/api/kernels",
+        user=1001,
+        group=0,
+    )
+
+
+def _invoke_access_cgi(container: WorkbenchContainer, *, nb_prefix: str = "") -> list[dict[str, Any]]:
+    """Execute access.cgi directly (RHAIENG-3712 scope: CGI logic, not httpd/nginx routing)."""
+    exit_code, output = container.exec(
+        [
+            "bash",
+            "-c",
+            f"NB_PREFIX={nb_prefix!r} bash /opt/app-root/api/kernels/access.cgi | tail -1",
+        ]
+    )
+    assert exit_code == 0, f"access.cgi execution failed: {output.decode(errors='replace')}"
+    return json.loads(output.decode())
+
+
+def _assert_valid_kernel_record(kernel: dict[str, Any]) -> None:
+    assert kernel.get("id") == "code-server"
+    assert kernel.get("name") == "code-server"
+    assert kernel.get("connections") == 1
+
+    last_activity = kernel.get("last_activity")
+    assert isinstance(last_activity, str) and last_activity, "last_activity must be a non-empty RFC3339 timestamp"
+    assert RFC3339_PATTERN.match(last_activity), f"last_activity is not RFC3339: {last_activity!r}"
+
+    execution_state = kernel.get("execution_state")
+    assert execution_state in {"busy", "idle"}, f"execution_state must be busy or idle, got {execution_state!r}"
+
+
+@pytest.mark.codeserver
+class TestCullingApi:
+    """Regression tests for access.cgi /api/kernels/ shim (RHAIENG-3712)."""
+
+    @allure.issue("RHAIENG-3712")
+    @allure.description(
+        "With NB_PREFIX set, access.cgi must reach healthz via ${NB_PREFIX}/api (the platform probe path). "
+        "A hardcoded /codeserver/healthz leaves last_activity and execution_state empty."
+    )
+    def test_kernels_api_with_nb_prefix(self, codeserver_image: conftest.Image) -> None:
+        env = _codeserver_platform_env()
+        nb_prefix = env["NB_PREFIX"]
+
+        with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
+            for key, value in env.items():
+                container.with_env(key, value)
+            container.start(wait_for_readiness=False)
+            _wait_for_healthz(container, nb_prefix=nb_prefix)
+            _install_access_cgi(container)
+
+            kernels = _invoke_access_cgi(container, nb_prefix=nb_prefix)
+            assert len(kernels) == 1
+            _assert_valid_kernel_record(kernels[0])
+
+    @allure.issue("RHAIENG-3712")
+    @allure.description(
+        "On a fresh pod, code-server reports lastHeartbeat=0 until the first user interaction. "
+        "access.cgi must still emit a valid last_activity and execution_state."
+    )
+    def test_kernels_api_fresh_pod_last_heartbeat_zero(
+        self, subtests: pytest_subtests.SubTests, codeserver_image: conftest.Image
+    ) -> None:
+        platform_env = _codeserver_platform_env()
+        scenarios = [
+            ("without NB_PREFIX", "", {}),
+            ("with NB_PREFIX", platform_env["NB_PREFIX"], platform_env),
+        ]
+        for label, nb_prefix, env in scenarios:
+            with subtests.test(label):
+                with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
+                    for key, value in env.items():
+                        container.with_env(key, value)
+                    container.start(wait_for_readiness=False)
+                    _wait_for_healthz(container, nb_prefix=nb_prefix or None)
+                    _install_access_cgi(container)
+
+                    kernels = _invoke_access_cgi(container, nb_prefix=nb_prefix)
+                    assert len(kernels) == 1
+                    _assert_valid_kernel_record(kernels[0])
+
+    @allure.issue("RHAIENG-3712")
+    @allure.description("Without NB_PREFIX, the legacy /codeserver/healthz path must keep working.")
+    def test_kernels_api_without_nb_prefix(self, codeserver_image: conftest.Image) -> None:
+        with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
+            container.start(wait_for_readiness=False)
+            _wait_for_healthz(container)
+            _install_access_cgi(container)
+
+            kernels = _invoke_access_cgi(container)
+            assert len(kernels) == 1
+            _assert_valid_kernel_record(kernels[0])

--- a/tests/containers/workbenches/culling_api_test.py
+++ b/tests/containers/workbenches/culling_api_test.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import time
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import allure
@@ -13,12 +15,19 @@ from tests.containers import conftest, docker_utils
 from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
 
 if TYPE_CHECKING:
-    import pytest_subtests
+    from pytest import Subtests
 
-ACCESS_CGI_PATH = PROJECT_ROOT / "codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi"
+CODESERVER_ROOT = PROJECT_ROOT / "codeserver/ubi9-python-3.12"
+ACCESS_CGI_PATH = CODESERVER_ROOT / "nginx/api/kernels/access.cgi"
+HTTPD_CONF_PATH = CODESERVER_ROOT / "httpd/httpd.conf"
+PROXY_TEMPLATE_PATH = CODESERVER_ROOT / "nginx/serverconf/proxy.conf.template"
+PROXY_TEMPLATE_NBPREFIX_PATH = CODESERVER_ROOT / "nginx/serverconf/proxy.conf.template_nbprefix"
 
 # date -Iseconds output: 2026-03-18T01:23:45+00:00
 RFC3339_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$")
+
+# date -Iseconds has 1s resolution; allow 1s slack on each side of the CGI window.
+_LAST_ACTIVITY_WINDOW_SLACK_S = 1.0
 
 
 def _codeserver_platform_env(project: str = "test-ns", notebook: str = "test-notebook") -> dict[str, str]:
@@ -39,19 +48,21 @@ def _codeserver_platform_env(project: str = "test-ns", notebook: str = "test-not
     }
 
 
+def _healthz_url(*, nb_prefix: str | None = None) -> str:
+    probe_path = f"{nb_prefix}/api" if nb_prefix else "/api"
+    return f"http://127.0.0.1:8888{probe_path}"
+
+
 def _wait_for_healthz(container: WorkbenchContainer, *, nb_prefix: str | None = None, timeout: float = 120) -> None:
     """Poll code-server readiness via the platform probe path inside the container."""
-    probe_path = f"{nb_prefix}/api" if nb_prefix else "/api"
-    healthz_url = f"http://127.0.0.1:8888{probe_path}"
+    healthz_url = _healthz_url(nb_prefix=nb_prefix)
     deadline = time.monotonic() + timeout
 
     while time.monotonic() < deadline:
         container.get_wrapped_container().reload()
         assert container.get_wrapped_container().status != "exited", "codeserver container exited during startup"
 
-        exit_code, _ = container.exec(
-            ["curl", "-sS", "-f", "-L", "-o", "/dev/null", "--max-time", "2", healthz_url]
-        )
+        exit_code, _ = container.exec(["curl", "-sS", "-f", "-L", "-o", "/dev/null", "--max-time", "2", healthz_url])
         if exit_code == 0:
             return
         time.sleep(2)
@@ -59,34 +70,112 @@ def _wait_for_healthz(container: WorkbenchContainer, *, nb_prefix: str | None = 
     raise TimeoutError(f"code-server healthz did not become ready at {healthz_url} within {timeout}s")
 
 
-def _install_access_cgi(container: WorkbenchContainer) -> None:
-    """Install the workspace access.cgi so tests exercise current source, not only a baked image."""
+def _fetch_healthz(container: WorkbenchContainer, *, nb_prefix: str | None = None) -> dict[str, Any]:
+    """Return the parsed code-server healthz JSON from the platform probe path."""
+    healthz_url = _healthz_url(nb_prefix=nb_prefix)
+    exit_code, output = container.exec(["curl", "-sS", "-f", "-L", "--max-time", "5", healthz_url])
+    assert exit_code == 0, f"healthz fetch failed: {output.decode(errors='replace')}"
+    return json.loads(output.decode())
+
+
+def _install_culling_stack(container: WorkbenchContainer) -> None:
+    """Install workspace CGI + httpd + nginx proxy templates and reload the serving stack.
+
+    Baked images may lag workspace; tests must exercise current routing, not only CGI bash logic.
+    """
+    wrapped = container.get_wrapped_container()
+    docker_utils.container_cp(wrapped, str(ACCESS_CGI_PATH), "/opt/app-root/api/kernels", user=1001, group=0)
+    docker_utils.container_cp(wrapped, str(HTTPD_CONF_PATH), "/etc/httpd/conf", user=1001, group=0)
     docker_utils.container_cp(
-        container.get_wrapped_container(),
-        str(ACCESS_CGI_PATH),
-        "/opt/app-root/api/kernels",
-        user=1001,
-        group=0,
+        wrapped, str(PROXY_TEMPLATE_PATH), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
+    )
+    docker_utils.container_cp(
+        wrapped, str(PROXY_TEMPLATE_NBPREFIX_PATH), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
     )
 
-
-def _invoke_access_cgi(container: WorkbenchContainer, *, nb_prefix: str = "") -> list[dict[str, Any]]:
-    """Execute access.cgi directly (RHAIENG-3712 scope: CGI logic, not httpd/nginx routing)."""
+    # Mirror run-nginx.sh template selection, then reload nginx and httpd.
+    # Use `httpd -k start|graceful` (daemonizes) — NOT `httpd -D FOREGROUND &` under
+    # container.exec, which gets SIGTERM (exit 143) when the exec session ends.
     exit_code, output = container.exec(
         [
             "bash",
             "-c",
-            f"NB_PREFIX={nb_prefix!r} bash /opt/app-root/api/kernels/access.cgi | tail -1",
+            """
+set -euo pipefail
+if [ -z "${NB_PREFIX:-}" ]; then
+  cp /opt/app-root/etc/nginx.default.d/proxy.conf.template \\
+    /opt/app-root/etc/nginx.default.d/proxy.conf
+else
+  export BASE_URL=_
+  envsubst '${NB_PREFIX},${BASE_URL}' \\
+    < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix \\
+    > /opt/app-root/etc/nginx.default.d/proxy.conf
+fi
+nginx -s reload
+if pgrep httpd >/dev/null 2>&1; then
+  /usr/sbin/httpd -k graceful
+else
+  /usr/sbin/httpd -k start
+fi
+pgrep httpd >/dev/null
+""",
         ]
     )
-    assert exit_code == 0, f"access.cgi execution failed: {output.decode(errors='replace')}"
+    assert exit_code == 0, f"failed to reload nginx/httpd stack: {output.decode(errors='replace')}"
+
+
+def _container_epoch_s(container: WorkbenchContainer) -> float:
+    """Return the container's current Unix epoch seconds (avoids host/container clock skew)."""
+    exit_code, output = container.exec(["date", "+%s"])
+    assert exit_code == 0, f"date failed: {output.decode(errors='replace')}"
+    return float(output.decode().strip())
+
+
+def _get_kernels_via_http(
+    container: WorkbenchContainer, *, kernels_path: str
+) -> tuple[int, list[dict[str, Any]] | None]:
+    """GET the culling kernels URL through nginx→httpd (not a direct CGI bash invoke)."""
+    assert kernels_path.startswith("/"), f"kernels_path must be absolute, got {kernels_path!r}"
+    url = f"http://127.0.0.1:8888{kernels_path}"
+    # Body then a final line with the HTTP status code.
+    cmd = f"curl -sS -L --max-time 10 -w '\\n%{{http_code}}' {shlex.quote(url)}"
+    exit_code, output = container.exec(["bash", "-c", cmd])
+    text = output.decode(errors="replace")
+    assert exit_code == 0, f"kernels HTTP request failed for {url}: {text}"
+
+    body, _, status_str = text.rstrip("\n").rpartition("\n")
+    status = int(status_str)
+    if status != 200:
+        return status, None
+    return status, json.loads(body)
+
+
+def _invoke_access_cgi_with_healthz_stub(
+    container: WorkbenchContainer, *, healthz_payload: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Direct CGI invoke with a stubbed healthz body (HTTP path cannot inject curl stubs under httpd)."""
+    payload = shlex.quote(json.dumps(healthz_payload, separators=(",", ":")))
+    cmd = f"""
+set -euo pipefail
+STUBDIR=$(mktemp -d)
+printf '%s' {payload} > "$STUBDIR/healthz.json"
+cat > "$STUBDIR/curl" << 'EOF'
+#!/bin/bash
+cat "$(dirname "$0")/healthz.json"
+exit 0
+EOF
+chmod +x "$STUBDIR/curl"
+PATH="$STUBDIR:$PATH" bash /opt/app-root/api/kernels/access.cgi | tail -1
+"""
+    exit_code, output = container.exec(["bash", "-c", cmd])
+    assert exit_code == 0, f"access.cgi stub execution failed: {output.decode(errors='replace')}"
     return json.loads(output.decode())
 
 
 def _assert_valid_kernel_record(kernel: dict[str, Any]) -> None:
-    assert kernel.get("id") == "code-server"
-    assert kernel.get("name") == "code-server"
-    assert kernel.get("connections") == 1
+    assert kernel.get("id") == "code-server", f"expected id 'code-server', got {kernel.get('id')!r}"
+    assert kernel.get("name") == "code-server", f"expected name 'code-server', got {kernel.get('name')!r}"
+    assert kernel.get("connections") == 1, f"expected connections 1, got {kernel.get('connections')!r}"
 
     last_activity = kernel.get("last_activity")
     assert isinstance(last_activity, str) and last_activity, "last_activity must be a non-empty RFC3339 timestamp"
@@ -96,14 +185,25 @@ def _assert_valid_kernel_record(kernel: dict[str, Any]) -> None:
     assert execution_state in {"busy", "idle"}, f"execution_state must be busy or idle, got {execution_state!r}"
 
 
+def _assert_last_activity_within_window(last_activity: str, *, before: float, after: float) -> None:
+    """Assert last_activity is a current-time fallback within the CGI invocation window."""
+    ts = datetime.fromisoformat(last_activity).timestamp()
+    lo = before - _LAST_ACTIVITY_WINDOW_SLACK_S
+    hi = after + _LAST_ACTIVITY_WINDOW_SLACK_S
+    assert lo <= ts <= hi, (
+        f"last_activity {last_activity!r} (epoch {ts}) not within CGI window [{before}, {after}] "
+        f"(±{_LAST_ACTIVITY_WINDOW_SLACK_S}s)"
+    )
+
+
 @pytest.mark.codeserver
 class TestCullingApi:
     """Regression tests for access.cgi /api/kernels/ shim (RHAIENG-3712)."""
 
     @allure.issue("RHAIENG-3712")
     @allure.description(
-        "With NB_PREFIX set, access.cgi must reach healthz via ${NB_PREFIX}/api (the platform probe path). "
-        "A hardcoded /codeserver/healthz leaves last_activity and execution_state empty."
+        "With NB_PREFIX set, nginx must proxy ${NB_PREFIX}/api/kernels/ to httpd CGI. "
+        "Legacy /api/kernels/ is not registered in the prefixed nginx template."
     )
     def test_kernels_api_with_nb_prefix(self, codeserver_image: conftest.Image) -> None:
         env = _codeserver_platform_env()
@@ -114,46 +214,85 @@ class TestCullingApi:
                 container.with_env(key, value)
             container.start(wait_for_readiness=False)
             _wait_for_healthz(container, nb_prefix=nb_prefix)
-            _install_access_cgi(container)
+            _install_culling_stack(container)
 
-            kernels = _invoke_access_cgi(container, nb_prefix=nb_prefix)
-            assert len(kernels) == 1
+            status, kernels = _get_kernels_via_http(container, kernels_path=f"{nb_prefix}/api/kernels/")
+            assert status == 200, f"expected 200 for prefixed kernels URL, got {status}"
+            assert kernels is not None and len(kernels) == 1
             _assert_valid_kernel_record(kernels[0])
+
+            legacy_status, legacy_kernels = _get_kernels_via_http(container, kernels_path="/api/kernels/")
+            assert legacy_status == 404, f"expected 404 for legacy kernels URL under NB_PREFIX, got {legacy_status}"
+            assert legacy_kernels is None
 
     @allure.issue("RHAIENG-3712")
     @allure.description(
         "On a fresh pod, code-server reports lastHeartbeat=0 until the first user interaction. "
-        "access.cgi must still emit a valid last_activity and execution_state."
+        "access.cgi must fall back to current time for last_activity (same as when lastHeartbeat is absent)."
     )
     def test_kernels_api_fresh_pod_last_heartbeat_zero(
-        self, subtests: pytest_subtests.SubTests, codeserver_image: conftest.Image
+        self, subtests: Subtests, codeserver_image: conftest.Image
     ) -> None:
         platform_env = _codeserver_platform_env()
         scenarios = [
-            ("without NB_PREFIX", "", {}),
-            ("with NB_PREFIX", platform_env["NB_PREFIX"], platform_env),
+            ("without NB_PREFIX", "", "/api/kernels/", {}),
+            (
+                "with NB_PREFIX",
+                platform_env["NB_PREFIX"],
+                f"{platform_env['NB_PREFIX']}/api/kernels/",
+                platform_env,
+            ),
         ]
-        for label, nb_prefix, env in scenarios:
+        for label, nb_prefix, kernels_path, env in scenarios:
             with subtests.test(label):
                 with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
                     for key, value in env.items():
                         container.with_env(key, value)
                     container.start(wait_for_readiness=False)
                     _wait_for_healthz(container, nb_prefix=nb_prefix or None)
-                    _install_access_cgi(container)
+                    _install_culling_stack(container)
 
-                    kernels = _invoke_access_cgi(container, nb_prefix=nb_prefix)
-                    assert len(kernels) == 1
+                    healthz = _fetch_healthz(container, nb_prefix=nb_prefix or None)
+                    assert healthz.get("lastHeartbeat") == 0, f"expected fresh-pod lastHeartbeat 0, got {healthz!r}"
+
+                    before = _container_epoch_s(container)
+                    status, kernels = _get_kernels_via_http(container, kernels_path=kernels_path)
+                    after = _container_epoch_s(container)
+
+                    assert status == 200, f"expected 200 for {kernels_path}, got {status}"
+                    assert kernels is not None and len(kernels) == 1
                     _assert_valid_kernel_record(kernels[0])
+                    _assert_last_activity_within_window(kernels[0]["last_activity"], before=before, after=after)
+
+        with subtests.test("missing lastHeartbeat falls back to now"):
+            # Controlled healthz stub cannot be injected through httpd's CGI child PATH.
+            with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
+                container.start(wait_for_readiness=False)
+                docker_utils.container_cp(
+                    container.get_wrapped_container(),
+                    str(ACCESS_CGI_PATH),
+                    "/opt/app-root/api/kernels",
+                    user=1001,
+                    group=0,
+                )
+
+                before = _container_epoch_s(container)
+                kernels = _invoke_access_cgi_with_healthz_stub(container, healthz_payload={"status": "alive"})
+                after = _container_epoch_s(container)
+
+                assert len(kernels) == 1
+                _assert_valid_kernel_record(kernels[0])
+                _assert_last_activity_within_window(kernels[0]["last_activity"], before=before, after=after)
 
     @allure.issue("RHAIENG-3712")
-    @allure.description("Without NB_PREFIX, the legacy /codeserver/healthz path must keep working.")
+    @allure.description("Without NB_PREFIX, the legacy /api/kernels/ nginx→httpd path must keep working.")
     def test_kernels_api_without_nb_prefix(self, codeserver_image: conftest.Image) -> None:
         with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
             container.start(wait_for_readiness=False)
             _wait_for_healthz(container)
-            _install_access_cgi(container)
+            _install_culling_stack(container)
 
-            kernels = _invoke_access_cgi(container)
-            assert len(kernels) == 1
+            status, kernels = _get_kernels_via_http(container, kernels_path="/api/kernels/")
+            assert status == 200, f"expected 200 for legacy kernels URL, got {status}"
+            assert kernels is not None and len(kernels) == 1
             _assert_valid_kernel_record(kernels[0])


### PR DESCRIPTION
This PR aims to fix two issues with CodeServer's culling API:

- the `healthz` request is hardcoded to  `/codeserver/healthz` instead of using `${NB_PREFIX}/codeserver/healthz`;
- the `lastHeartbeat=0` case is truncated incorrectly, producing an empty timestamp on fresh pods before first user interaction

More details can be found on https://redhat.atlassian.net/browse/RHAIENG-4344

## Description

This PR did two changes basically:

#### 1. Add `NB_PREFIX` to HEALTHZ path:

The first change was to receive NB_PREFIX environment variable, that will come from the Notebooks Controller, and use it in the healthz endpoint, if there is any predefined value:

```cgi
NB_PREFIX="${NB_PREFIX:-}"
HEALTHZ=$(curl -sL "http://localhost:8888${NB_PREFIX}/api")
```

#### 2. Validate if the heartbeat is the first interaction

The second change was to add a conditional, because if the heartbeat happens without a first user interaction, then the heartbeat comes with `0` instead of the epoch:

```cgi
LAST_HEARTBEAT_MS=$(echo "$HEALTHZ" | grep -Po 'lastHeartbeat":\K[0-9]+')
if [ -z "$LAST_HEARTBEAT_MS" ] || [ "$LAST_HEARTBEAT_MS" = "0" ]; then
    LAST_ACTIVITY=$(date -Iseconds)
else
    LAST_ACTIVITY=$(date -d "@$((LAST_HEARTBEAT_MS / 1000))" -Iseconds)
fi
```

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook kernel status reporting for active and expired kernels.
  * Standardized activity timestamps in RFC3339 format, with current-time fallback when heartbeat data is unavailable.
  * Added support for URL-prefixed deployments while preserving legacy routing.
  * Improved kernel API and CGI handling for more reliable notebook integration.

* **Tests**
  * Added regression coverage for prefixed and non-prefixed deployments, fresh environments, and missing heartbeat data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->