### PR TITLE
RHAIENG-4343: fix CodeServer culling redirects by using proxy_pass

### DIFF
--- a/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template_nbprefix
@@ -21,12 +21,7 @@ location = ${NB_PREFIX}/api/kernels {
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 ${NB_PREFIX}/api/kernels/;
-    access_log  off;
-}
-
-location /api/kernels/ {
-  proxy_pass http://127.0.0.1:8080;
+  proxy_pass http://127.0.0.1:8080/api/kernels/;
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This PR aims to simple a redirect in CodeServer's culling configuration by removing an endless loop.

## Description

The `${NB_PREFIX}/api/kernels/` location was redirecting to itself, while the working `proxy_pass` block was only on the unprefixed `/api/kernels/` path. Prefixed culler requests never reached httpd.

More information can be see in https://redhat.atlassian.net/browse/RHAIENG-4343

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
