### PR TITLE
docs: correct npm init -y lockfile claim in browser test scripts README

### DIFF
--- a/tests/browser/scripts/README.md
+++ b/tests/browser/scripts/README.md
@@ -29,7 +29,7 @@ Install **Node.js + npm**:
 
 ----------
 
-# 3️⃣ Initialize the project (creates package.json **and** package-lock.json)
+# 3️⃣ Initialize the project (creates package.json)
 
 From the repo root:
 

--- a/tests/browser/scripts/README.md
+++ b/tests/browser/scripts/README.md
@@ -38,7 +38,8 @@ From the repo root:
 This generates:
 
 -   `package.json` — declares dependencies and scripts
--   `package-lock.json` — _locks_ exact dependency versions for reproducible installs
+
+> **Note:** `npm init -y` creates only `package.json`. The `package-lock.json` file is generated later, by the first `npm install` step below.
 
 ----------
 


### PR DESCRIPTION
## What

Fixes the setup instructions in `tests/browser/scripts/README.md`, which incorrectly stated that `npm init -y` creates both `package.json` **and** `package-lock.json`.

In reality, `npm init -y` only creates `package.json`. The `package-lock.json` file is generated later, during the first `npm install` (e.g. `npm install playwright`, already documented in the next section).

## Changes

- Updated the "3️⃣ Initialize the project" heading so it no longer claims `npm init -y` creates `package-lock.json`.
- Removed `package-lock.json` from the "This generates" list under `npm init -y`, and added a note clarifying that it is produced by the first `npm install` step.

Closes #4043


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `npm init -y` creates only `package.json`.
  * Added a note explaining that `package-lock.json` is generated during the first `npm install`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->