### PR TITLE
test: trigger codeserver CI build

### DIFF
--- a/codeserver/ubi9-python-3.12/README.md
+++ b/codeserver/ubi9-python-3.12/README.md
@@ -1,3 +1,4 @@
+# Test
 # codeserver/ubi9-python-3.12
 
 Code-server (VS Code in the browser) image with Python 3.12 on UBI 9, built


### PR DESCRIPTION
## Summary
- Minimal README change on `codeserver/ubi9-python-3.12` to trigger CI and validate the codeserver image build.

## Test plan
- [ ] Confirm codeserver GHA/Konflux builds run and pass on this PR
- [ ] Revert or close after validation if no lasting change is needed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Test” section heading to the Python 3.12 code server documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->