### PR TITLE
NO-JIRA: fix(semgrep): harden shell-unquoted-var-in-dangerous-cmd

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1867,7 +1867,9 @@ rules:
       Remediation: Always quote variables in file operations:
         rm "$FILE"         # correct
         rm $FILE           # dangerous
-    pattern-regex: '(rm|cp|mv|eval|chmod|chown|kill|pkill)\s+[^|;]*(?<!["''\\])\$(?:\{[A-Za-z_][A-Za-z0-9_]*(?:[:\-\+\?=][^}]*)?\}|[A-Za-z_][A-Za-z0-9_]*)'
+    # Word boundaries avoid matching substrings (e.g. "rm" in "--platform").
+    # [^\n|;&]* keeps the match on one logical command (stops at |, ||, ;, &, &&).
+    pattern-regex: '(?<![\w-])(rm|cp|mv|eval|chmod|chown|kill|pkill)(?![\w-])[ \t]+[^\n|;&]*(?<!["''\\])\$(?:\{[A-Za-z_][A-Za-z0-9_]*(?:[:\-\+\?=][^}]*)?\}|[A-Za-z_][A-Za-z0-9_]*)'
     metadata:
       cwe: "CWE-78"
       category: "security"

--- a/tests/unit/test_semgrep_shell_unquoted.py
+++ b/tests/unit/test_semgrep_shell_unquoted.py
@@ -1,0 +1,60 @@
+"""Regression coverage for shell-unquoted-var-in-dangerous-cmd in semgrep.yaml."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SEMGREP_YAML = ROOT / "semgrep.yaml"
+RULE_ID = "shell-unquoted-var-in-dangerous-cmd"
+
+
+def _dangerous_cmd_pattern() -> re.Pattern[str]:
+    doc = yaml.safe_load(SEMGREP_YAML.read_text())
+    for rule in doc["rules"]:
+        if rule.get("id") == RULE_ID:
+            return re.compile(rule["pattern-regex"])
+    raise AssertionError(f"{RULE_ID} not found in {SEMGREP_YAML}")
+
+
+@pytest.fixture(scope="module")
+def pattern() -> re.Pattern[str]:
+    return _dangerous_cmd_pattern()
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "rm $FILE",
+        "rm ${FILE}",
+        "cp $SRC $DST",
+        "rm $FILE && echo ok",
+        "rm $FILE || echo ok",
+        "echo ok && rm $FILE",
+        "echo ok || rm $OTHER",
+    ],
+)
+def test_flags_unquoted_var_in_dangerous_cmd(pattern: re.Pattern[str], line: str) -> None:
+    assert pattern.search(line), f"expected match for {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        'rm "$FILE"',
+        "rm '$FILE'",
+        "python pylock_version.py --platform x86_64",
+        # Quoted rm must not match $OTHER after shell command separators.
+        'rm "$FILE" && echo $OTHER',
+        'rm "$FILE" || echo $OTHER',
+        'rm "$FILE"; echo $OTHER',
+        'rm "$FILE" | echo $OTHER',
+        'rm "$FILE" & echo $OTHER',
+    ],
+)
+def test_ignores_safe_or_other_command_vars(pattern: re.Pattern[str], line: str) -> None:
+    assert not pattern.search(line), f"unexpected match for {line!r}"

--- a/tests/unit/test_semgrep_shell_unquoted.py
+++ b/tests/unit/test_semgrep_shell_unquoted.py
@@ -30,6 +30,7 @@ def pattern() -> re.Pattern[str]:
     "line",
     [
         "rm $FILE",
+        "rm\t$FILE",
         "rm ${FILE}",
         "cp $SRC $DST",
         "rm $FILE && echo ok",
@@ -47,7 +48,8 @@ def test_flags_unquoted_var_in_dangerous_cmd(pattern: re.Pattern[str], line: str
     [
         'rm "$FILE"',
         "rm '$FILE'",
-        "python pylock_version.py --platform x86_64",
+        "rmdir $FILE",
+        'rm "$FILE"\necho $OTHER',
         # Quoted rm must not match $OTHER after shell command separators.
         'rm "$FILE" && echo $OTHER',
         'rm "$FILE" || echo $OTHER',


### PR DESCRIPTION
## Description

Semgrep OSS failed on [#4055](https://github.com/opendatahub-io/notebooks/pull/4055) with `shell-unquoted-var-in-dangerous-cmd` on `setup-offline-binaries.sh`. Root cause: the rule regex used `[^|;]*`, which also matches newlines, so a correctly quoted `cp "${f}"` could span across `chmod`/`echo` lines and flag `${NODE_ARCH}` later on the same logical block.

### What changed in this PR

The first revision only added `\n` to the exclusion class and rewrote nearby comments to drop `${NODE_ARCH}`. Review compared that with an existing fix already on `rhoai-2.25` ([`045652529`](https://github.com/red-hat-data-services/notebooks/commit/045652529)) and replaced the branch diff with a cherry-pick (`-x`) of that commit instead — it is a stronger fix and does not need shell-script comment edits.

**Current changes** (cherry-picked from `rhoai-2.25`):

- Harden `shell-unquoted-var-in-dangerous-cmd` in `semgrep.yaml`:
  - word boundaries around dangerous commands (e.g. avoid matching `rm` inside `--platform`)
  - `[ \t]+` instead of `\s+` (no newline crossing via whitespace)
  - stop argument span at `|`, `||`, `;`, `&`, and `&&` (`[^\n|;&]*`)
- Add `tests/unit/test_semgrep_shell_unquoted.py` regression coverage for the rule regex

No runtime or image behavior changes.

## How Has This Been Tested?

- `uv run pytest tests/unit/test_semgrep_shell_unquoted.py` — 15 passed
- `semgrep scan --config semgrep.yaml codeserver/ubi9-python-3.12/prefetch-input/patches/setup-offline-binaries.sh` — 0 findings
- Confirmed the hardened regex has no match on the original `setup-offline-binaries.sh` (without comment rewrites)

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — targeted unit tests run; full `make test` not required for semgrep-regex-only change
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for detecting unquoted variables in dangerous shell commands.
  * Added validation to ensure quoted variables are not flagged and that quoting prevents matches across common shell operators and separators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->