### PR TITLE
RHAIENG-6193: chore(.tekton/): pin git-clone-oci-ta to 0.2.4 for git-lfs

### DIFF
--- a/.tekton/multiarch-odh-main-combined-pipeline.yaml
+++ b/.tekton/multiarch-odh-main-combined-pipeline.yaml
@@ -232,7 +232,8 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e5ba1f8549e6a0f043629ef00bea7511957121e05304b688f40ff12304560f38
+        # 0.2.4 includes git-lfs (task-runner 2.1.0); floating 0.2 tag is stale and does not track 0.2.z
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.4@sha256:df3c42d78223f07b40a84dd29e5c8860d14777ffdf150ea08c738770f51216dc
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

Pin `git-clone-oci-ta` from floating `0.2` to `0.2.4` so Konflux clones smudge Git LFS again.

After `git-clone` moved to `build-pipeline-tasks`, the floating `0.2` Quay tag is no longer updated when `0.2.z` releases ship. We stayed on a pre-`git-lfs` digest (`sha256:e5ba1f85…`), so codeserver builds still get LFS pointer stubs for `utils/*.vsix` — now caught immediately by the fail-fast check from #4055.

`0.2.4` includes `konflux-build-cli` on `task-runner` 2.1.0 with `git-lfs` ([changelog](https://github.com/konflux-ci/build-pipeline-tasks/blob/main/task/git-clone-oci-ta/CHANGELOG.md)).

See [RHAIENG-6193](https://redhat.atlassian.net/browse/RHAIENG-6193) and the [forum-konflux-developer thread](https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1783344941320529).

## How Has This Been Tested?

- Resolved Quay tag `0.2.4` → `sha256:df3c42d78223f07b40a84dd29e5c8860d14777ffdf150ea08c738770f51216dc`
- Confirmed floating `0.2` still resolves to the stale digest we were on
- After merge: confirm Konflux codeserver PR/push builds pass clone + `require_valid_vsix` (no LFS pointer error)

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

[RHAIENG-6193]: https://redhat.atlassian.net/browse/RHAIENG-6193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the repository cloning step to a newer task bundle.
  * Added support for Git Large File Storage (Git LFS) during repository cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->