### PR TITLE
feat: RHOAI manifests for universal JupyterLab (keystone)

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -29,8 +29,8 @@ if [ "${PRODUCT:-odh}" = 'rhoai' ]; then
     _MANIFESTS_VARIANT="rhoai"
     # This value needs to be updated everytime we deliberately change number of the
     # images we want to have in the `params.env` or `params-latest.env` file.
-    EXPECTED_COMMIT_NUM_RECORDS=43
-    EXPECTED_PARAMS_NUM_RECORDS=57
+    EXPECTED_COMMIT_NUM_RECORDS=44
+    EXPECTED_PARAMS_NUM_RECORDS=58
 else
     _MANIFESTS_VARIANT="odh"
     # This value needs to be updated everytime we deliberately change number of the

--- a/manifests/rhoai/base/commit-latest.env
+++ b/manifests/rhoai/base/commit-latest.env
@@ -8,4 +8,5 @@ odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-n=8e73cac
 odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-n=8e73cac
 odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-n=06da715
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-n=06703a3
+odh-workbench-jupyter-universal-cpu-py312-ubi9-commit-n=b7c78ba
 odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-n=8e73cac

--- a/manifests/rhoai/base/jupyter-universal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-universal-notebook-imagestream.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/universal/ubi9-python-3.12"
+    opendatahub.io/notebook-image-name: "JupyterLab | Universal | CPU | Python 3.12"
+    opendatahub.io/notebook-image-desc: "Universal JupyterLab image: interactive workbench (when NOTEBOOK_ARGS is set) or AI Pipelines runtime (when command is overridden). Python packages from PyPI."
+    opendatahub.io/notebook-image-order: "24"
+  name: jupyter-universal-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # N Version of the image
+    - annotations:
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "JupyterLab", "version": "4.4"},
+            {"name": "Python", "version": "v3.12"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "ipykernel", "version": "7.3"},
+            {"name": "papermill", "version": "2.7"},
+            {"name": "jupyterlab-git", "version": "0.56"},
+            {"name": "nbgitpuller", "version": "1.2"}
+          ]
+        openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-universal-cpu-py312-rhel9
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: odh-workbench-jupyter-universal-cpu-py312-ubi9-commit-n_PLACEHOLDER
+      from:
+        kind: DockerImage
+        name: odh-workbench-jupyter-universal-cpu-py312-ubi9-n_PLACEHOLDER
+      name: "3.5"
+      referencePolicy:
+        type: Source

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - jupyter-tensorflow-notebook-imagestream.yaml
   - jupyter-trustyai-notebook-imagestream.yaml
   - code-server-notebook-imagestream.yaml
+  - jupyter-universal-notebook-imagestream.yaml
   - jupyter-rocm-minimal-notebook-imagestream.yaml
   - jupyter-rocm-pytorch-notebook-imagestream.yaml
   - jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -606,6 +607,19 @@ replacements:
           name: jupyter-pytorch-llmcompressor
           version: v1
   - source:
+      fieldPath: data.odh-workbench-jupyter-universal-cpu-py312-ubi9-n
+      kind: ConfigMap
+      name: notebook-image-params
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.from.name
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-universal-notebook
+          version: v1
+  - source:
       fieldPath: data.odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-n
       kind: ConfigMap
       name: notebook-image-commithash
@@ -1163,6 +1177,19 @@ replacements:
           group: image.openshift.io
           kind: ImageStream
           name: jupyter-pytorch-llmcompressor
+          version: v1
+  - source:
+      fieldPath: data.odh-workbench-jupyter-universal-cpu-py312-ubi9-commit-n
+      kind: ConfigMap
+      name: notebook-image-commithash
+      version: v1
+    targets:
+      - fieldPaths:
+          - spec.tags.0.annotations.[opendatahub.io/notebook-build-commit]
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: jupyter-universal-notebook
           version: v1
   - source:
       fieldPath: data.odh-pipeline-runtime-minimal-cpu-py312-ubi9-n

--- a/manifests/rhoai/base/params-latest.env
+++ b/manifests/rhoai/base/params-latest.env
@@ -9,6 +9,7 @@ odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-n=dummy
 odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-n=dummy
 odh-workbench-jupyter-trustyai-cpu-py312-ubi9-n=dummy
 odh-workbench-codeserver-datascience-cpu-py312-ubi9-n=dummy
+odh-workbench-jupyter-universal-cpu-py312-ubi9-n=dummy
 odh-pipeline-runtime-minimal-cpu-py312-ubi9-n=dummy
 odh-pipeline-runtime-datascience-cpu-py312-ubi9-n=dummy
 odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n=dummy


### PR DESCRIPTION
## Summary
- Keystone follow-up to #4110: add RHOAI ImageStream / params / commit env for the universal JupyterLab image
- Holds the RHOAI catalog entry until the ODH image + manifests land ([Keystone Interface](https://www.martinfowler.com/bliki/KeystoneInterface.html))
- Does **not** include `konflux.cpu.conf` (that stays on #4110 for builds)

## Test plan
- [ ] Stacked on #4110 — merge that first (or retarget this PR to `main` after #4110 merges)
- [ ] `ci/check-params-env.sh` RHOAI counts 43→44 / 57→58
- [ ] `uv run manifests/tools/generate_kustomization.py --target rhoai` is clean
- [ ] ImageStream uses `registry.redhat.io/rhoai/` prefix
