### PR TITLE
NO-JIRA: fix(scripts): resolve RH index from digest-pinned BASE_IMAGE

### DIFF
--- a/scripts/index_url_resolver.py
+++ b/scripts/index_url_resolver.py
@@ -40,9 +40,14 @@ class ResolvedIndexConfig:
 _RHOAI_INDEX_PATH_RE = re.compile(
     r"/rhoai/(?P<release>[^/]+)/(?P<accelerator>[^/]+)-ubi9(?:-test)?/simple/?$",
 )
+# Tag form:  quay.io/aipcc/base-images/cpu:3.5.0-1782270118
+# Digest form (RHDS pins): quay.io/aipcc/base-images/cpu@sha256:…
+# The image name must stop at ':' or '@' so digests are not misparsed as
+# image="cpu@sha256", tag="<hex>" (which breaks parse_accelerator).
 _BASE_IMAGE_RE = re.compile(
-    r"^quay\.io/aipcc/base-images/(?P<image>[^:]+):(?P<tag>[^:]+)$",
+    r"^quay\.io/aipcc/base-images/(?P<image>[^:@]+)(?::(?P<tag>[^@]+)|@(?P<digest>sha256:[0-9a-f]+))$",
 )
+_RELEASE_OVERRIDE_RE = re.compile(r"^(?P<minor>\d+\.\d+)(?:-EA(?P<ea>\d+))?$")
 _ACCELERATOR_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^cpu$"), "cpu"),
     (re.compile(r"^cuda-(?P<version>\d+\.\d+)-el\d+(?:\.\d+)?$"), "cuda"),
@@ -109,6 +114,16 @@ def parse_release(tag: str, conf_file: Path) -> str:
     release = match.group("minor")
     ea = match.group("ea")
     return release if ea is None else f"{release}-EA{int(ea)}"
+
+
+def parse_release_override(release: str, conf_file: Path) -> str:
+    """Normalize RELEASE from a build-args conf (used for digest-pinned BASE_IMAGE)."""
+    match = _RELEASE_OVERRIDE_RE.fullmatch(release)
+    if match is None:
+        raise IndexResolutionError(f"Unsupported RELEASE in {conf_file}: {release}")
+    minor = match.group("minor")
+    ea = match.group("ea")
+    return minor if ea is None else f"{minor}-EA{int(ea)}"
 
 
 def build_rhoai_index_url(*, release: str, accelerator: str) -> str:
@@ -302,13 +317,24 @@ def _resolve_from_base_image_tag(
     *,
     flavor: str,
     product: str,
+    release_override: str | None = None,
 ) -> ResolvedIndexConfig:
     match = _BASE_IMAGE_RE.fullmatch(base_image)
     if match is None:
         raise IndexResolutionError(f"Unsupported BASE_IMAGE format in {conf_file}: {base_image}")
 
     accelerator = parse_accelerator(match.group("image"), conf_file)
-    release = parse_release(match.group("tag"), conf_file)
+    tag = match.group("tag")
+    if tag is not None:
+        release = parse_release(tag, conf_file)
+    elif release_override:
+        # Digest pins have no tag; fall back to RELEASE written beside BASE_IMAGE.
+        release = parse_release_override(release_override, conf_file)
+    else:
+        raise IndexResolutionError(
+            f"Digest-pinned BASE_IMAGE in {conf_file} requires RELEASE for index "
+            f"resolution fallback: {base_image}"
+        )
     release_candidates = [release]
     if accelerator.startswith("rocm"):
         stable = stable_rhoai_release(release)
@@ -381,6 +407,7 @@ def resolve_index_config(
         conf_file,
         flavor=flavor,
         product=product,
+        release_override=entries.get("RELEASE"),
     )
 
 

--- a/tests/unit/scripts/test_index_url_resolver.py
+++ b/tests/unit/scripts/test_index_url_resolver.py
@@ -314,6 +314,88 @@ def test_resolve_falls_back_to_tag_when_label_missing(
     assert resolved.index_url == label_url, f"expected tag-derived index {label_url}, got {resolved.index_url}"
 
 
+def test_resolve_digest_pinned_base_image_uses_release_when_label_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Digest pins (no tag) must fall back via RELEASE, not misparse image as cpu@sha256."""
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cpu.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585",
+            "PYLOCK_FLAVOR=cpu",
+            "PRODUCT=rhoai",
+            "RELEASE=3.5",
+        ],
+    )
+    label_url = prod_index_url(release="3.5", accelerator="cpu")
+
+    def stub_no_label(base_image: str) -> str:
+        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
+
+    monkeypatch.setattr(resolver, "inspect_base_image_index_url", stub_no_label)
+    monkeypatch.setattr(resolver, "index_url_exists", lambda url: url == label_url)
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.accelerator == "cpu", f"expected accelerator cpu, got {resolved.accelerator}"
+    assert resolved.release == "3.5", f"expected release 3.5, got {resolved.release}"
+    assert resolved.index_url == label_url, f"expected index {label_url}, got {resolved.index_url}"
+
+
+def test_resolve_digest_pinned_cuda_base_image_uses_release_when_label_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cuda.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c",
+            "PYLOCK_FLAVOR=cuda",
+            "PRODUCT=rhoai",
+            "RELEASE=3.5",
+        ],
+    )
+    label_url = prod_index_url(release="3.5", accelerator="cuda13.0")
+
+    def stub_no_label(base_image: str) -> str:
+        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
+
+    monkeypatch.setattr(resolver, "inspect_base_image_index_url", stub_no_label)
+    monkeypatch.setattr(resolver, "index_url_exists", lambda url: url == label_url)
+
+    resolved = resolver.resolve_index_config(conf_file)
+
+    assert resolved.accelerator == "cuda13.0", f"expected accelerator cuda13.0, got {resolved.accelerator}"
+    assert resolved.release == "3.5", f"expected release 3.5, got {resolved.release}"
+    assert resolved.index_url == label_url, f"expected index {label_url}, got {resolved.index_url}"
+
+
+def test_digest_pinned_base_image_requires_release_when_label_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf_file = write_conf(
+        tmp_path,
+        "konflux.cpu.conf",
+        [
+            "BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585",
+            "PYLOCK_FLAVOR=cpu",
+            "PRODUCT=rhoai",
+        ],
+    )
+
+    def stub_no_label(base_image: str) -> str:
+        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
+
+    monkeypatch.setattr(resolver, "inspect_base_image_index_url", stub_no_label)
+
+    with pytest.raises(resolver.IndexResolutionError, match="requires RELEASE"):
+        resolver.resolve_index_config(conf_file)
+
+
 def test_error_when_label_missing_and_tag_unusable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     conf_file = write_conf(
         tmp_path,


### PR DESCRIPTION
## Summary
- After [#4124](https://github.com/opendatahub-io/notebooks/pull/4124) pinned RHDS `BASE_IMAGE` refs to `@sha256:…`, index resolution fails whenever skopeo label lookup is unavailable and the tag-fallback path runs.
- The broken regex misparsed digests as `image=cuda-13.0-el9.6@sha256` (same for `cpu@sha256`), then `parse_accelerator` raised.
- Seen in two places on [#4126](https://github.com/opendatahub-io/notebooks/pull/4126):
  - [`check-generated-code` / pylocks_generator](https://github.com/opendatahub-io/notebooks/actions/runs/29853567857/job/88712210062)
  - [`Prefetch hermetic build dependencies` / `index_url_resolver.py index-url`](https://github.com/opendatahub-io/notebooks/actions/runs/29853568076/job/88712296314) (Build Notebooks)
- Fix: parse digest refs correctly and use `RELEASE` from the konflux build-args conf when no tag is present; add unit coverage.

## Test plan
- [x] `uv run pytest tests/unit/scripts/test_index_url_resolver.py`
- [x] Forced skopeo failure: all `konflux.*.conf` files resolve via `RELEASE`
- [x] `PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto codeserver/ubi9-python-3.12`
- [ ] CI `check-generated-code` green
- [ ] Build Notebooks prefetch step no longer fails on digest-pinned BASE_IMAGE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of digest-pinned base images during index resolution.
  * Correctly uses the configured release value when image metadata cannot be inspected.
  * Provides a clear error when a required release value is missing.
  * Supports release values with optional EA suffixes.

* **Tests**
  * Added coverage for CPU and CUDA digest-pinned image scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->