### PR TITLE
NO-JIRA: refactor(scripts): simplify digest BASE_IMAGE index resolution

### DIFF
--- a/scripts/index_url_resolver.py
+++ b/scripts/index_url_resolver.py
@@ -40,12 +40,9 @@ class ResolvedIndexConfig:
 _RHOAI_INDEX_PATH_RE = re.compile(
     r"/rhoai/(?P<release>[^/]+)/(?P<accelerator>[^/]+)-ubi9(?:-test)?/simple/?$",
 )
-# Tag form:  quay.io/aipcc/base-images/cpu:3.5.0-1782270118
-# Digest form (RHDS pins): quay.io/aipcc/base-images/cpu@sha256:…
-# The image name must stop at ':' or '@' so digests are not misparsed as
-# image="cpu@sha256", tag="<hex>" (which breaks parse_accelerator).
+# Accepts tag (:3.5.0-…) or digest (@sha256:…) refs; image name stops at : or @.
 _BASE_IMAGE_RE = re.compile(
-    r"^quay\.io/aipcc/base-images/(?P<image>[^:@]+)(?::(?P<tag>[^@]+)|@(?P<digest>sha256:[0-9a-f]+))$",
+    r"^quay\.io/aipcc/base-images/(?P<image>[^:@]+)(?::(?P<tag>[^@]+)|@sha256:[0-9a-f]+)$",
 )
 _RELEASE_OVERRIDE_RE = re.compile(r"^(?P<minor>\d+\.\d+)(?:-EA(?P<ea>\d+))?$")
 _ACCELERATOR_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -107,13 +104,15 @@ def parse_accelerator(image_name: str, conf_file: Path) -> str:
     raise IndexResolutionError(f"Unsupported BASE_IMAGE accelerator in {conf_file}: {image_name}")
 
 
+def _format_release(minor: str, ea: str | None) -> str:
+    return minor if ea is None else f"{minor}-EA{int(ea)}"
+
+
 def parse_release(tag: str, conf_file: Path) -> str:
     match = _TAG_RE.fullmatch(tag)
     if match is None:
         raise IndexResolutionError(f"Unsupported BASE_IMAGE tag in {conf_file}: {tag}")
-    release = match.group("minor")
-    ea = match.group("ea")
-    return release if ea is None else f"{release}-EA{int(ea)}"
+    return _format_release(match.group("minor"), match.group("ea"))
 
 
 def parse_release_override(release: str, conf_file: Path) -> str:
@@ -121,9 +120,7 @@ def parse_release_override(release: str, conf_file: Path) -> str:
     match = _RELEASE_OVERRIDE_RE.fullmatch(release)
     if match is None:
         raise IndexResolutionError(f"Unsupported RELEASE in {conf_file}: {release}")
-    minor = match.group("minor")
-    ea = match.group("ea")
-    return minor if ea is None else f"{minor}-EA{int(ea)}"
+    return _format_release(match.group("minor"), match.group("ea"))
 
 
 def build_rhoai_index_url(*, release: str, accelerator: str) -> str:
@@ -311,7 +308,7 @@ def _resolve_from_label(
     )
 
 
-def _resolve_from_base_image_tag(
+def _resolve_from_base_image_ref(
     base_image: str,
     conf_file: Path,
     *,
@@ -328,7 +325,6 @@ def _resolve_from_base_image_tag(
     if tag is not None:
         release = parse_release(tag, conf_file)
     elif release_override:
-        # Digest pins have no tag; fall back to RELEASE written beside BASE_IMAGE.
         release = parse_release_override(release_override, conf_file)
     else:
         raise IndexResolutionError(
@@ -402,7 +398,7 @@ def resolve_index_config(
     ):
         return resolved
 
-    return _resolve_from_base_image_tag(
+    return _resolve_from_base_image_ref(
         base_image,
         conf_file,
         flavor=flavor,

--- a/tests/unit/scripts/test_index_url_resolver.py
+++ b/tests/unit/scripts/test_index_url_resolver.py
@@ -36,6 +36,23 @@ def make_skopeo_label_stub(label_url: str):
     return stub
 
 
+def make_skopeo_inspect_fail_stub():
+    """Stub inspect_base_image_index_url to force the tag/digest fallback path."""
+
+    def stub(base_image: str) -> str:
+        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
+
+    return stub
+
+
+DIGEST_PINNED_CPU = (
+    "quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585"
+)
+DIGEST_PINNED_CUDA = (
+    "quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c"
+)
+
+
 def assert_skopeo_inspect_cmd(cmd: list[str], base_image: str) -> None:
     assert cmd[:3] == ["skopeo", "inspect", "--retry-times"], f"unexpected skopeo prefix: {cmd}"
     assert cmd[-1] == f"docker://{base_image}", f"expected docker://{base_image}, got {cmd[-1]!r}"
@@ -314,61 +331,39 @@ def test_resolve_falls_back_to_tag_when_label_missing(
     assert resolved.index_url == label_url, f"expected tag-derived index {label_url}, got {resolved.index_url}"
 
 
+@pytest.mark.parametrize(
+    ("conf_name", "base_image", "flavor", "accelerator"),
+    [
+        ("konflux.cpu.conf", DIGEST_PINNED_CPU, "cpu", "cpu"),
+        ("konflux.cuda.conf", DIGEST_PINNED_CUDA, "cuda", "cuda13.0"),
+    ],
+)
 def test_resolve_digest_pinned_base_image_uses_release_when_label_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    conf_name: str,
+    base_image: str,
+    flavor: str,
+    accelerator: str,
 ) -> None:
     """Digest pins (no tag) must fall back via RELEASE, not misparse image as cpu@sha256."""
     conf_file = write_conf(
         tmp_path,
-        "konflux.cpu.conf",
+        conf_name,
         [
-            "BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585",
-            "PYLOCK_FLAVOR=cpu",
+            f"BASE_IMAGE={base_image}",
+            f"PYLOCK_FLAVOR={flavor}",
             "PRODUCT=rhoai",
             "RELEASE=3.5",
         ],
     )
-    label_url = prod_index_url(release="3.5", accelerator="cpu")
-
-    def stub_no_label(base_image: str) -> str:
-        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
-
-    monkeypatch.setattr(resolver, "inspect_base_image_index_url", stub_no_label)
+    label_url = prod_index_url(release="3.5", accelerator=accelerator)
+    monkeypatch.setattr(resolver, "inspect_base_image_index_url", make_skopeo_inspect_fail_stub())
     monkeypatch.setattr(resolver, "index_url_exists", lambda url: url == label_url)
 
     resolved = resolver.resolve_index_config(conf_file)
 
-    assert resolved.accelerator == "cpu", f"expected accelerator cpu, got {resolved.accelerator}"
-    assert resolved.release == "3.5", f"expected release 3.5, got {resolved.release}"
-    assert resolved.index_url == label_url, f"expected index {label_url}, got {resolved.index_url}"
-
-
-def test_resolve_digest_pinned_cuda_base_image_uses_release_when_label_missing(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    conf_file = write_conf(
-        tmp_path,
-        "konflux.cuda.conf",
-        [
-            "BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c",
-            "PYLOCK_FLAVOR=cuda",
-            "PRODUCT=rhoai",
-            "RELEASE=3.5",
-        ],
-    )
-    label_url = prod_index_url(release="3.5", accelerator="cuda13.0")
-
-    def stub_no_label(base_image: str) -> str:
-        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
-
-    monkeypatch.setattr(resolver, "inspect_base_image_index_url", stub_no_label)
-    monkeypatch.setattr(resolver, "index_url_exists", lambda url: url == label_url)
-
-    resolved = resolver.resolve_index_config(conf_file)
-
-    assert resolved.accelerator == "cuda13.0", f"expected accelerator cuda13.0, got {resolved.accelerator}"
+    assert resolved.accelerator == accelerator, f"expected accelerator {accelerator}, got {resolved.accelerator}"
     assert resolved.release == "3.5", f"expected release 3.5, got {resolved.release}"
     assert resolved.index_url == label_url, f"expected index {label_url}, got {resolved.index_url}"
 
@@ -381,16 +376,12 @@ def test_digest_pinned_base_image_requires_release_when_label_missing(
         tmp_path,
         "konflux.cpu.conf",
         [
-            "BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585",
+            f"BASE_IMAGE={DIGEST_PINNED_CPU}",
             "PYLOCK_FLAVOR=cpu",
             "PRODUCT=rhoai",
         ],
     )
-
-    def stub_no_label(base_image: str) -> str:
-        raise resolver.IndexResolutionError(f"skopeo inspect failed for {base_image}")
-
-    monkeypatch.setattr(resolver, "inspect_base_image_index_url", stub_no_label)
+    monkeypatch.setattr(resolver, "inspect_base_image_index_url", make_skopeo_inspect_fail_stub())
 
     with pytest.raises(resolver.IndexResolutionError, match="requires RELEASE"):
         resolver.resolve_index_config(conf_file)


### PR DESCRIPTION
## Summary
- Follow-up to [#4132](https://github.com/opendatahub-io/notebooks/pull/4132) (merged): `/simplify` cleanups on the digest-pin index resolver.
- Share `_format_release()` between tag and `RELEASE` parsers, drop unused digest capture, rename `_resolve_from_base_image_tag` → `_resolve_from_base_image_ref`, and parametrize digest-pin unit tests.

## Test plan
- [x] `uv run pytest tests/unit/scripts/test_index_url_resolver.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)