### PR TITLE
fix(ci): select odh vs rhoai in TEMPLATE self-test by repository

### DIFF
--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -36,5 +36,8 @@ jobs:
       python: "3.12"
       github: ${{ toJson(github) }}
       platform: linux/amd64
-      subscription: false
+      # ODH midstream vs RHDS downstream: avoid exercising stale odh lockfiles on RHDS.
+      product: ${{ github.repository == 'red-hat-data-services/notebooks' && 'rhoai' || 'odh' }}
+      # jupyter-minimal PDF deps need RHEL AppStream on RHDS (RHAIENG-2345 / #2310).
+      subscription: ${{ github.repository == 'red-hat-data-services/notebooks' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Make the TEMPLATE self-test pick product by repository: `odh` on `opendatahub-io/notebooks`, `rhoai` (+ subscription) on `red-hat-data-services/notebooks`.
- Stops RHDS from exercising midstream (`prefetch-input/odh`) lockfiles that can go stale (e.g. CentOS Stream RPM 404s during hermeto prefetch).

## Test plan
- [ ] TEMPLATE self-test on this PR runs as **odh** on ODH
- [ ] Prefetch uses `prefetch-input/odh`
- [ ] No unrelated workflow changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved notebook template build workflows to automatically detect repository context and set the correct `product` value.
  * Updated dependency subscription handling to use a conditional setting based on the repository, ensuring PDF-related package requirements are supported.
  * Added clarifying documentation about lockfile behavior across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->