### PR TITLE
RHAIENG-6397: chore(ci): scope PR lock regen in check-generated-code

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,12 +18,8 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
-      - name: Fetch PR merge base for lock scoping
-        if: github.event_name == 'pull_request'
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: git fetch --no-tags --depth=1 origin "${PR_BASE_SHA}"
+        with:
+          fetch-depth: 0
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fetch PR merge base for lock scoping
+      - name: Resolve PR changed files for lock scoping
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,23 +34,9 @@ jobs:
             echo "::error::Could not resolve merge-base from GitHub compare API"
             exit 1
           fi
-          COMMITS_AHEAD="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${MERGE_BASE}...${PR_HEAD_SHA}" --jq '.ahead_by')"
-          git fetch --no-tags origin "${MERGE_BASE}"
-          if [[ "${COMMITS_AHEAD}" =~ ^[0-9]+$ ]] && [[ "${COMMITS_AHEAD}" -gt 0 ]]; then
-            git fetch --no-tags --deepen="${COMMITS_AHEAD}" origin "${PR_HEAD_SHA}"
-          fi
-          if ! git merge-base --is-ancestor "${MERGE_BASE}" HEAD 2>/dev/null; then
-            depth=0
-            while ! git merge-base --is-ancestor "${MERGE_BASE}" HEAD 2>/dev/null; do
-              depth=$((depth + 100))
-              if [[ "${depth}" -gt 5000 ]]; then
-                echo "::error::Could not connect merge-base ${MERGE_BASE} to HEAD after deepening ${depth} commits"
-                exit 1
-              fi
-              git fetch --no-tags --deepen=100 origin "${PR_HEAD_SHA}"
-            done
-          fi
+          jq -r '.files[].filename' <<<"${COMPARE_JSON}" > "${RUNNER_TEMP}/pr-changed-files.txt"
           echo "MERGE_BASE=${MERGE_BASE}" >> "${GITHUB_ENV}"
+          echo "PR_CHANGED_FILES=${RUNNER_TEMP}/pr-changed-files.txt" >> "${GITHUB_ENV}"
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
@@ -76,7 +62,8 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           MERGE_BASE: ${{ env.MERGE_BASE }}
-        run: bash ci/generate_code.sh --pr-base "${MERGE_BASE}"
+          PR_CHANGED_FILES: ${{ env.PR_CHANGED_FILES }}
+        run: bash ci/generate_code.sh --pr-base "${MERGE_BASE}" --pr-changed-files "${PR_CHANGED_FILES}"
 
       - name: Rerun all code generators we have (push)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -28,12 +28,28 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          MERGE_BASE="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${PR_BASE_SHA}...${PR_HEAD_SHA}" --jq '.merge_base_commit.sha')"
+          COMPARE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${PR_BASE_SHA}...${PR_HEAD_SHA}")"
+          MERGE_BASE="$(jq -r '.merge_base_commit.sha' <<<"${COMPARE_JSON}")"
           if [[ -z "${MERGE_BASE}" || "${MERGE_BASE}" == "null" ]]; then
             echo "::error::Could not resolve merge-base from GitHub compare API"
             exit 1
           fi
-          git fetch --no-tags --depth=1 origin "${MERGE_BASE}"
+          COMMITS_AHEAD="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${MERGE_BASE}...${PR_HEAD_SHA}" --jq '.ahead_by')"
+          git fetch --no-tags origin "${MERGE_BASE}"
+          if [[ "${COMMITS_AHEAD}" =~ ^[0-9]+$ ]] && [[ "${COMMITS_AHEAD}" -gt 0 ]]; then
+            git fetch --no-tags --deepen="${COMMITS_AHEAD}" origin "${PR_HEAD_SHA}"
+          fi
+          if ! git merge-base --is-ancestor "${MERGE_BASE}" HEAD 2>/dev/null; then
+            depth=0
+            while ! git merge-base --is-ancestor "${MERGE_BASE}" HEAD 2>/dev/null; do
+              depth=$((depth + 100))
+              if [[ "${depth}" -gt 5000 ]]; then
+                echo "::error::Could not connect merge-base ${MERGE_BASE} to HEAD after deepening ${depth} commits"
+                exit 1
+              fi
+              git fetch --no-tags --deepen=100 origin "${PR_HEAD_SHA}"
+            done
+          fi
           echo "MERGE_BASE=${MERGE_BASE}" >> "${GITHUB_ENV}"
 
       - name: Setup uv and Python

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+      - name: Fetch PR merge base for lock scoping
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "${PR_BASE_SHA}"
+
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
 
@@ -39,7 +45,14 @@ jobs:
           fi
           printf '%s' "${AIPCC_PASS}" | skopeo login --username "${AIPCC_USER}" --password-stdin quay.io
 
-      - name: Rerun all code generators we have
+      - name: Rerun all code generators we have (pr)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash ci/generate_code.sh --pr-base "${PR_BASE_SHA}"
+
+      - name: Rerun all code generators we have (push)
+        if: github.event_name != 'pull_request'
         run: bash ci/generate_code.sh
 
       - name: Check there aren't any modified files present

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -55,7 +55,8 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: bash ci/generate_code.sh --pr-base "origin/${BASE_REF}"
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: bash ci/generate_code.sh --pr-base "origin/${BASE_REF}" --pr-to-ref "${HEAD_REF}"
 
       - name: Rerun all code generators we have (push)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Fetch PR merge base for lock scoping
         if: github.event_name == 'pull_request'
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,22 +21,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve PR changed files for lock scoping
+      - name: Fetch base and head refs for lock scoping
         if: github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          COMPARE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${PR_BASE_SHA}...${PR_HEAD_SHA}")"
-          MERGE_BASE="$(jq -r '.merge_base_commit.sha' <<<"${COMPARE_JSON}")"
-          if [[ -z "${MERGE_BASE}" || "${MERGE_BASE}" == "null" ]]; then
-            echo "::error::Could not resolve merge-base from GitHub compare API"
-            exit 1
-          fi
-          jq -r '.files[].filename' <<<"${COMPARE_JSON}" > "${RUNNER_TEMP}/pr-changed-files.txt"
-          echo "MERGE_BASE=${MERGE_BASE}" >> "${GITHUB_ENV}"
-          echo "PR_CHANGED_FILES=${RUNNER_TEMP}/pr-changed-files.txt" >> "${GITHUB_ENV}"
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head:${HEAD_REF}"
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
@@ -61,9 +54,8 @@ jobs:
       - name: Rerun all code generators we have (pr)
         if: github.event_name == 'pull_request'
         env:
-          MERGE_BASE: ${{ env.MERGE_BASE }}
-          PR_CHANGED_FILES: ${{ env.PR_CHANGED_FILES }}
-        run: bash ci/generate_code.sh --pr-base "${MERGE_BASE}" --pr-changed-files "${PR_CHANGED_FILES}"
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: bash ci/generate_code.sh --pr-base "origin/${BASE_REF}"
 
       - name: Rerun all code generators we have (push)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,8 +18,20 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          fetch-depth: 0
+
+      - name: Fetch PR merge base for lock scoping
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MERGE_BASE="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${PR_BASE_SHA}...${PR_HEAD_SHA}" --jq '.merge_base_commit.sha')"
+          if [[ -z "${MERGE_BASE}" || "${MERGE_BASE}" == "null" ]]; then
+            echo "::error::Could not resolve merge-base from GitHub compare API"
+            exit 1
+          fi
+          git fetch --no-tags --depth=1 origin "${MERGE_BASE}"
+          echo "MERGE_BASE=${MERGE_BASE}" >> "${GITHUB_ENV}"
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
@@ -44,8 +56,8 @@ jobs:
       - name: Rerun all code generators we have (pr)
         if: github.event_name == 'pull_request'
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: bash ci/generate_code.sh --pr-base "${PR_BASE_SHA}"
+          MERGE_BASE: ${{ env.MERGE_BASE }}
+        run: bash ci/generate_code.sh --pr-base "${MERGE_BASE}"
 
       - name: Rerun all code generators we have (push)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Fetch PR merge base for lock scoping
         if: github.event_name == 'pull_request'

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -83,6 +83,11 @@ def _resolve_symlinks(paths: list[str]) -> list[str]:
     return sorted(expanded)
 
 
+def expand_changed_paths(paths: list[str]) -> list[str]:
+    """Expand a changed-file list with symlink logical paths (e.g. GitHub compare API)."""
+    return _resolve_symlinks(paths)
+
+
 def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     logging.debug("Getting list of changed files from git diff")
 

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -83,11 +83,6 @@ def _resolve_symlinks(paths: list[str]) -> list[str]:
     return sorted(expanded)
 
 
-def expand_changed_paths(paths: list[str]) -> list[str]:
-    """Expand a changed-file list with symlink logical paths (e.g. GitHub compare API)."""
-    return _resolve_symlinks(paths)
-
-
 def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     logging.debug("Getting list of changed files from git diff")
 

--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -5,14 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 PR_BASE=""
+PR_CHANGED_FILES=""
 
 usage() {
   cat <<'EOF'
-Usage: ci/generate_code.sh [--pr-base REF]
+Usage: ci/generate_code.sh [--pr-base REF] [--pr-changed-files FILE]
 
-  --pr-base REF   PR only: merge-base ref for lock scoping (pyproject.toml, pylock.toml,
-                  requirements.*.txt, or uv.lock.d/*). Locally: git merge-base <base> HEAD.
-                  Omit on push for full regen.
+  --pr-base REF            PR only: merge-base ref for lock scoping. Locally:
+                           git merge-base <base> HEAD. Omit on push for full regen.
+  --pr-changed-files FILE  PR only: changed paths (one per line). CI passes GitHub
+                           compare API files[].filename so git diff is not needed.
 EOF
 }
 
@@ -21,6 +23,11 @@ while [[ $# -gt 0 ]]; do
     --pr-base)
       [[ $# -ge 2 ]] || { echo "error: --pr-base requires a value" >&2; exit 1; }
       PR_BASE="$2"
+      shift 2
+      ;;
+    --pr-changed-files)
+      [[ $# -ge 2 ]] || { echo "error: --pr-changed-files requires a value" >&2; exit 1; }
+      PR_CHANGED_FILES="$2"
       shift 2
       ;;
     -h|--help) usage; exit 0 ;;
@@ -35,7 +42,11 @@ uv run scripts/dockerfile_fragments.py
 uv run manifests/tools/generate_kustomization.py
 
 if [[ -n "${PR_BASE}" ]]; then
-  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto --pr-base "${PR_BASE}"
+  pylocks_args=(auto --pr-base "${PR_BASE}")
+  if [[ -n "${PR_CHANGED_FILES}" ]]; then
+    pylocks_args+=(--pr-changed-files-file "${PR_CHANGED_FILES}")
+  fi
+  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py "${pylocks_args[@]}"
 else
   PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py
 fi

--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -5,15 +5,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 PR_BASE=""
+PR_TO_REF="HEAD"
 
 usage() {
   cat <<'EOF'
-Usage: ci/generate_code.sh [--pr-base REF]
+Usage: ci/generate_code.sh [--pr-base REF] [--pr-to-ref REF]
 
-  --pr-base REF   PR only: base ref for lock scoping (three-dot diff ref...HEAD).
-                  CI passes origin/<base-branch>; locally:
-                  git merge-base origin/main HEAD or origin/main.
-                  Omit on push for full regen.
+  --pr-base REF    PR only: base ref for lock scoping (three-dot diff base...head).
+                   CI passes origin/<base-branch>; locally: origin/main.
+  --pr-to-ref REF  PR only: head ref for lock scoping. CI passes the fetched PR branch;
+                   default HEAD for local runs.
+                   Omit --pr-base on push for full regen.
 EOF
 }
 
@@ -22,6 +24,11 @@ while [[ $# -gt 0 ]]; do
     --pr-base)
       [[ $# -ge 2 ]] || { echo "error: --pr-base requires a value" >&2; exit 1; }
       PR_BASE="$2"
+      shift 2
+      ;;
+    --pr-to-ref)
+      [[ $# -ge 2 ]] || { echo "error: --pr-to-ref requires a value" >&2; exit 1; }
+      PR_TO_REF="$2"
       shift 2
       ;;
     -h|--help) usage; exit 0 ;;
@@ -36,7 +43,7 @@ uv run scripts/dockerfile_fragments.py
 uv run manifests/tools/generate_kustomization.py
 
 if [[ -n "${PR_BASE}" ]]; then
-  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto --pr-base "${PR_BASE}"
+  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto --pr-base "${PR_BASE}" --pr-to-ref "${PR_TO_REF}"
 else
   PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py
 fi

--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -5,16 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 PR_BASE=""
-PR_CHANGED_FILES=""
 
 usage() {
   cat <<'EOF'
-Usage: ci/generate_code.sh [--pr-base REF] [--pr-changed-files FILE]
+Usage: ci/generate_code.sh [--pr-base REF]
 
-  --pr-base REF            PR only: merge-base ref for lock scoping. Locally:
-                           git merge-base <base> HEAD. Omit on push for full regen.
-  --pr-changed-files FILE  PR only: changed paths (one per line). CI passes GitHub
-                           compare API files[].filename so git diff is not needed.
+  --pr-base REF   PR only: base ref for lock scoping (three-dot diff ref...HEAD).
+                  CI passes origin/<base-branch>; locally:
+                  git merge-base origin/main HEAD or origin/main.
+                  Omit on push for full regen.
 EOF
 }
 
@@ -23,11 +22,6 @@ while [[ $# -gt 0 ]]; do
     --pr-base)
       [[ $# -ge 2 ]] || { echo "error: --pr-base requires a value" >&2; exit 1; }
       PR_BASE="$2"
-      shift 2
-      ;;
-    --pr-changed-files)
-      [[ $# -ge 2 ]] || { echo "error: --pr-changed-files requires a value" >&2; exit 1; }
-      PR_CHANGED_FILES="$2"
       shift 2
       ;;
     -h|--help) usage; exit 0 ;;
@@ -42,11 +36,7 @@ uv run scripts/dockerfile_fragments.py
 uv run manifests/tools/generate_kustomization.py
 
 if [[ -n "${PR_BASE}" ]]; then
-  pylocks_args=(auto --pr-base "${PR_BASE}")
-  if [[ -n "${PR_CHANGED_FILES}" ]]; then
-    pylocks_args+=(--pr-changed-files-file "${PR_CHANGED_FILES}")
-  fi
-  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py "${pylocks_args[@]}"
+  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto --pr-base "${PR_BASE}"
 else
   PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py
 fi

--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -10,8 +10,8 @@ usage() {
   cat <<'EOF'
 Usage: ci/generate_code.sh [--pr-base REF]
 
-  --pr-base REF   PR only: regenerate locks for image dirs whose lock chain changed
-                  (pyproject.toml, pylock.toml, requirements.*.txt, or uv.lock.d/*).
+  --pr-base REF   PR only: merge-base ref for lock scoping (pyproject.toml, pylock.toml,
+                  requirements.*.txt, or uv.lock.d/*). Locally: git merge-base <base> HEAD.
                   Omit on push for full regen.
 EOF
 }

--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -4,9 +4,38 @@ set -Eeuxo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+PR_BASE=""
+
+usage() {
+  cat <<'EOF'
+Usage: ci/generate_code.sh [--pr-base REF]
+
+  --pr-base REF   PR only: regenerate locks for image dirs whose lock chain changed
+                  (pyproject.toml, pylock.toml, requirements.*.txt, or uv.lock.d/*).
+                  Omit on push for full regen.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr-base)
+      [[ $# -ge 2 ]] || { echo "error: --pr-base requires a value" >&2; exit 1; }
+      PR_BASE="$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
 cd "${REPO_ROOT}"
 uv --version || pip install 'uv>=0.10,<0.12'
 
 uv run scripts/dockerfile_fragments.py
 uv run manifests/tools/generate_kustomization.py
-PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py
+
+if [[ -n "${PR_BASE}" ]]; then
+  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto --pr-base "${PR_BASE}"
+else
+  PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py
+fi

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -88,7 +88,10 @@ The `check-generated-code` job runs `ci/generate_code.sh`, then verifies a clean
   touched (`pyproject.toml`, `pylock.toml`, `requirements.*.txt`, or `uv.lock.d/*`). If the PR only changes
   unrelated files, `pylocks_generator` is skipped so external AIPCC index churn does not
   fail the job. Shared inputs (`dependencies/cve-constraints.txt`, lock generator scripts)
-  still trigger full lock regen. See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
+  still trigger full lock regen. CI resolves merge-base via `gh api compare/base...head`,
+  shallow-fetches that commit, then runs `pylocks_generator --pr-base` with a local
+  `git diff` for the file list. Locally: `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
+  See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
 - **Push** (`main`, `stable`, `rhoai-*`): full lock regen for all image dirs (unchanged).
 
 ## Frameworks and tools

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -89,10 +89,9 @@ The `check-generated-code` job runs `ci/generate_code.sh`, then verifies a clean
   unrelated files, `pylocks_generator` is skipped so external AIPCC index churn does not
   fail the job. Shared inputs (`dependencies/cve-constraints.txt`, lock generator scripts)
   still trigger full lock regen. CI fetches base and PR head refs (same pattern as
-  `build-notebooks-pr.yaml`), then runs `pylocks_generator --pr-base origin/<base-branch>`
-  with `gha_pr_changed_files.list_changed_files()` (`git diff` three-dot). Locally:
-  `bash ci/generate_code.sh --pr-base origin/main` or
-  `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
+  `build-notebooks-pr.yaml`), then runs `pylocks_generator --pr-base origin/<base-branch>
+  --pr-to-ref <pr-branch>` with `gha_pr_changed_files.list_changed_files()` (`git diff`
+  three-dot). Locally: `bash ci/generate_code.sh --pr-base origin/main` (default head: `HEAD`).
   See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
 - **Push** (`main`, `stable`, `rhoai-*`): full lock regen for all image dirs (unchanged).
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -89,8 +89,8 @@ The `check-generated-code` job runs `ci/generate_code.sh`, then verifies a clean
   unrelated files, `pylocks_generator` is skipped so external AIPCC index churn does not
   fail the job. Shared inputs (`dependencies/cve-constraints.txt`, lock generator scripts)
   still trigger full lock regen. CI resolves merge-base via `gh api compare/base...head`,
-  shallow-fetches that commit, then runs `pylocks_generator --pr-base` with a local
-  `git diff` for the file list. Locally: `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
+  fetches that commit, deepens the PR checkout until it is an ancestor of `HEAD`, then runs
+  `pylocks_generator --pr-base` with a local `git diff` for the file list. Locally: `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
   See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
 - **Push** (`main`, `stable`, `rhoai-*`): full lock regen for all image dirs (unchanged).
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -88,9 +88,10 @@ The `check-generated-code` job runs `ci/generate_code.sh`, then verifies a clean
   touched (`pyproject.toml`, `pylock.toml`, `requirements.*.txt`, or `uv.lock.d/*`). If the PR only changes
   unrelated files, `pylocks_generator` is skipped so external AIPCC index churn does not
   fail the job. Shared inputs (`dependencies/cve-constraints.txt`, lock generator scripts)
-  still trigger full lock regen. CI resolves merge-base via `gh api compare/base...head`,
-  fetches that commit, deepens the PR checkout until it is an ancestor of `HEAD`, then runs
-  `pylocks_generator --pr-base` with a local `git diff` for the file list. Locally: `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
+  still trigger full lock regen. CI resolves merge-base and changed paths via
+  `gh api compare/base...head` (`merge_base_commit` + `files[].filename`), then runs
+  `pylocks_generator --pr-base` with that file list (no shallow git deepen). Locally:
+  `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"` uses `git diff`. `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
   See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
 - **Push** (`main`, `stable`, `rhoai-*`): full lock regen for all image dirs (unchanged).
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -80,6 +80,17 @@ exposed as `make` targets:
 Closing this gap (moving inline CI logic into Makefile targets) is tracked in
 [#3174](https://github.com/opendatahub-io/notebooks/issues/3174).
 
+### `check-generated-code` (lock scoping)
+
+The `check-generated-code` job runs `ci/generate_code.sh`, then verifies a clean working tree with `git status --porcelain`.
+
+- **Pull requests:** lock regen is scoped to image directories whose lock chain the PR
+  touched (`pyproject.toml`, `pylock.toml`, `requirements.*.txt`, or `uv.lock.d/*`). If the PR only changes
+  unrelated files, `pylocks_generator` is skipped so external AIPCC index churn does not
+  fail the job. Shared inputs (`dependencies/cve-constraints.txt`, lock generator scripts)
+  still trigger full lock regen. See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
+- **Push** (`main`, `stable`, `rhoai-*`): full lock regen for all image dirs (unchanged).
+
 ## Frameworks and tools
 
 | Tool | Purpose |

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -88,10 +88,11 @@ The `check-generated-code` job runs `ci/generate_code.sh`, then verifies a clean
   touched (`pyproject.toml`, `pylock.toml`, `requirements.*.txt`, or `uv.lock.d/*`). If the PR only changes
   unrelated files, `pylocks_generator` is skipped so external AIPCC index churn does not
   fail the job. Shared inputs (`dependencies/cve-constraints.txt`, lock generator scripts)
-  still trigger full lock regen. CI resolves merge-base and changed paths via
-  `gh api compare/base...head` (`merge_base_commit` + `files[].filename`), then runs
-  `pylocks_generator --pr-base` with that file list (no shallow git deepen). Locally:
-  `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"` uses `git diff`. `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
+  still trigger full lock regen. CI fetches base and PR head refs (same pattern as
+  `build-notebooks-pr.yaml`), then runs `pylocks_generator --pr-base origin/<base-branch>`
+  with `gha_pr_changed_files.list_changed_files()` (`git diff` three-dot). Locally:
+  `bash ci/generate_code.sh --pr-base origin/main` or
+  `bash ci/generate_code.sh --pr-base "$(git merge-base origin/main HEAD)"`.
   See [RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397).
 - **Push** (`main`, `stable`, `rhoai-*`): full lock regen for all image dirs (unchanged).
 

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -295,7 +295,7 @@ def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
     it via the GitHub compare API; locally use ``git merge-base <base> HEAD``.
     """
     log.info(f"PR lock scoping from merge-base {pr_base}")
-    changed = _list_changed_files(pr_base)
+    changed = _list_changed_files(pr_base, "HEAD")
     all_dirs = discover_all_image_project_dirs()
 
     if any(_is_global_lock_input(path) for path in changed):

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -41,9 +41,7 @@ Usage:
 
   6. PR-scoped lock regen (CI only; skips dirs whose lock chain the PR did not touch)::
 
-       PYLOCKS_CI_CHECK=1 python pylocks_generator.py auto --pr-base <merge-base-sha>
-       PYLOCKS_CI_CHECK=1 python pylocks_generator.py auto --pr-base <merge-base-sha> \\
-           --pr-changed-files-file /path/to/changed-files.txt
+       PYLOCKS_CI_CHECK=1 python pylocks_generator.py auto --pr-base origin/main
 
 Reproducible CI checks (PYLOCKS_CI_CHECK):
   When ``PYLOCKS_CI_CHECK=1`` (set only by ``check-generated-code`` in CI),
@@ -252,17 +250,6 @@ def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
     return gha_pr_changed_files.list_changed_files(from_ref, to_ref)
 
 
-def _load_pr_changed_files(path: Path) -> list[str]:
-    """Load PR changed paths from a file (one repo-relative path per line)."""
-    cached_builds = ROOT_DIR / "ci" / "cached-builds"
-    if str(cached_builds) not in sys.path:
-        sys.path.insert(0, str(cached_builds))
-    import gha_pr_changed_files
-
-    files = [line.strip() for line in path.read_text().splitlines() if line.strip()]
-    return gha_pr_changed_files.expand_changed_paths(files)
-
-
 def _path_under(path: Path, prefix: Path) -> bool:
     return path.is_relative_to(prefix)
 
@@ -301,20 +288,14 @@ def _is_lock_chain_file(relative_to_project: Path) -> bool:
     return bool(relative_to_project.parts) and relative_to_project.parts[0] == "uv.lock.d"
 
 
-def resolve_pr_scoped_target_dirs(
-    pr_base: str,
-    log: LogBuffer,
-    *,
-    changed_files: list[str] | None = None,
-) -> list[Path]:
+def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
     """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed.
 
-    ``pr_base`` is the merge-base ref for a three-dot PR diff (``pr_base...HEAD``). CI resolves
-    it via the GitHub compare API; locally use ``git merge-base <base> HEAD``. When
-    ``changed_files`` is set (CI passes compare API ``files[].filename``), git diff is skipped.
+    ``pr_base`` is the base ref for a three-dot PR diff (``pr_base...HEAD``). CI passes
+    ``origin/<base-branch>`` after fetching refs; locally use ``origin/main`` or a merge-base SHA.
     """
-    log.info(f"PR lock scoping from merge-base {pr_base}")
-    changed = changed_files if changed_files is not None else _list_changed_files(pr_base, "HEAD")
+    log.info(f"PR lock scoping from {pr_base}")
+    changed = _list_changed_files(pr_base, "HEAD")
     all_dirs = discover_all_image_project_dirs()
 
     if any(_is_global_lock_input(path) for path in changed):
@@ -724,14 +705,7 @@ def main(
         str | None,
         typer.Option(
             "--pr-base",
-            help="Merge-base ref for PR scoping (three-dot diff pr_base...HEAD); CI passes compare API result",
-        ),
-    ] = None,
-    pr_changed_files_file: Annotated[
-        Path | None,
-        typer.Option(
-            "--pr-changed-files-file",
-            help="PR changed paths, one per line (CI: GitHub compare API files[].filename)",
+            help="Base ref for PR scoping (three-dot diff pr_base...HEAD); CI uses origin/<base-branch>",
         ),
     ] = None,
 ) -> None:
@@ -763,8 +737,7 @@ def main(
         if target_dir is not None:
             log.error("Cannot combine a specific target directory with --pr-base.")
             raise SystemExit(1)
-        changed_files = _load_pr_changed_files(pr_changed_files_file) if pr_changed_files_file else None
-        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log, changed_files=changed_files)
+        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log)
         if not target_dirs:
             log.ok("Skipped pylocks regeneration.")
             return

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -39,6 +39,10 @@ Usage:
        python pylocks_generator.py --requirements-only
        python pylocks_generator.py rh-index jupyter/minimal/ubi9-python-3.12 --requirements-only
 
+  6. PR-scoped lock regen (CI only; skips dirs whose lock chain the PR did not touch)::
+
+       PYLOCKS_CI_CHECK=1 python pylocks_generator.py auto --pr-base <merge-base-sha>
+
 Reproducible CI checks (PYLOCKS_CI_CHECK):
   When ``PYLOCKS_CI_CHECK=1`` (set only by ``check-generated-code`` in CI),
   ``uv pip compile`` always passes ``--exclude-newer`` parsed from the existing
@@ -83,6 +87,12 @@ CVE_CONSTRAINTS_FILE = ROOT_DIR / "dependencies" / "cve-constraints.txt"
 PYLOCK_TO_REQUIREMENTS = ROOT_DIR / "scripts" / "lockfile-generators" / "helpers" / "pylock-to-requirements.py"
 PUBLIC_INDEX = "--default-index=https://pypi.org/simple"
 MAIN_DIRS = ("jupyter", "runtimes", "codeserver")
+# Shared lock inputs: a PR touching any of these regenerates all image project locks.
+GLOBAL_LOCK_INPUTS: tuple[Path, ...] = (
+    Path("dependencies/cve-constraints.txt"),
+    Path("scripts/pylocks_generator.py"),
+    Path("scripts/index_url_resolver.py"),
+)
 UV_MIN_VERSION = (0, 4, 0)
 
 NO_EMIT_PACKAGES = (
@@ -207,6 +217,16 @@ def check_uv(log: LogBuffer) -> None:
         raise SystemExit(1)
 
 
+def discover_all_image_project_dirs() -> list[Path]:
+    """All image project directories under MAIN_DIRS (each contains pyproject.toml)."""
+    dirs: set[Path] = set()
+    for base_name in MAIN_DIRS:
+        base = ROOT_DIR / base_name
+        if base.is_dir():
+            dirs.update(p.parent for p in base.rglob("pyproject.toml"))
+    return sorted(dirs)
+
+
 def find_target_dirs(target_dir: Path | None, log: LogBuffer) -> list[Path]:
     """Find directories containing pyproject.toml."""
     if target_dir is not None:
@@ -217,12 +237,85 @@ def find_target_dirs(target_dir: Path | None, log: LogBuffer) -> list[Path]:
         return [candidate]
 
     log.info("Scanning main directories for Python projects...")
-    dirs: set[Path] = set()
-    for base_name in MAIN_DIRS:
-        base = ROOT_DIR / base_name
-        if base.is_dir():
-            dirs.update(p.parent for p in base.rglob("pyproject.toml"))
-    return sorted(dirs)
+    return discover_all_image_project_dirs()
+
+
+def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
+    """PR file diff via ci/cached-builds helper (symlink-aware three-dot diff)."""
+    cached_builds = ROOT_DIR / "ci" / "cached-builds"
+    if str(cached_builds) not in sys.path:
+        sys.path.insert(0, str(cached_builds))
+    import gha_pr_changed_files
+
+    return gha_pr_changed_files.list_changed_files(from_ref, to_ref)
+
+
+def _path_under(path: Path, prefix: Path) -> bool:
+    try:
+        path.relative_to(prefix)
+        return True
+    except ValueError:
+        return False
+
+
+def image_project_dir_for_repo_file(
+    repo_relative: str,
+    project_dirs: list[Path] | None = None,
+) -> Path | None:
+    """Map a repo-relative file path to its image project directory, if any."""
+    path = Path(repo_relative)
+    dirs = project_dirs if project_dirs is not None else discover_all_image_project_dirs()
+    matches = [
+        project_dir
+        for project_dir in dirs
+        if path == (rel := project_dir.relative_to(ROOT_DIR)) or _path_under(path, rel)
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda project_dir: len(project_dir.parts))
+
+
+def _is_global_lock_input(changed_path: str) -> bool:
+    normalized = changed_path.replace("\\", "/")
+    for global_path in GLOBAL_LOCK_INPUTS:
+        entry = global_path.as_posix()
+        if normalized == entry or normalized.startswith(f"{entry}/"):
+            return True
+    return False
+
+
+def _is_lock_chain_file(relative_to_project: Path) -> bool:
+    if relative_to_project.name in ("pyproject.toml", "pylock.toml"):
+        return True
+    if relative_to_project.name.startswith("requirements.") and relative_to_project.suffix == ".txt":
+        return True
+    return bool(relative_to_project.parts) and relative_to_project.parts[0] == "uv.lock.d"
+
+
+def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
+    """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed."""
+    changed = _list_changed_files(pr_base)
+    all_dirs = discover_all_image_project_dirs()
+
+    if any(_is_global_lock_input(path) for path in changed):
+        log.info("Global lock input changed in PR; regenerating all image project locks.")
+        return all_dirs
+
+    touched: set[Path] = set()
+    for repo_relative in changed:
+        project_dir = image_project_dir_for_repo_file(repo_relative, all_dirs)
+        if project_dir is None:
+            continue
+        inner = Path(repo_relative).relative_to(project_dir.relative_to(ROOT_DIR))
+        if _is_lock_chain_file(inner):
+            touched.add(project_dir)
+
+    if not touched:
+        log.info("No image lock-chain changes in PR; skipping pylocks regeneration.")
+        return []
+
+    log.info(f"PR lock-chain changes in {len(touched)} project director(ies).")
+    return sorted(touched)
 
 
 def detect_flavors(project_dir: Path) -> set[str]:
@@ -607,6 +700,13 @@ def main(
     requirements_only: Annotated[
         bool, typer.Option("--requirements-only", help="Only regenerate requirements.txt from existing pylock files, skip lock generation")
     ] = False,
+    pr_base: Annotated[
+        str | None,
+        typer.Option(
+            "--pr-base",
+            help="Merge-base ref for PR-scoped lock regen (only dirs whose lock chain changed)",
+        ),
+    ] = None,
 ) -> None:
     """Generate pylock.toml lock files for Python project directories."""
     log = LogBuffer(buffered=False)
@@ -632,10 +732,19 @@ def main(
         log.info("PYLOCKS_CI_CHECK=1: using pinned --exclude-newer from each lockfile header when present.")
 
     # TARGET DIRECTORIES
-    target_dirs = find_target_dirs(target_dir, log)
-    if not target_dirs:
-        log.error("No directories containing pyproject.toml were found.")
-        raise SystemExit(1)
+    if pr_base is not None:
+        if target_dir is not None:
+            log.error("Cannot combine a specific target directory with --pr-base.")
+            raise SystemExit(1)
+        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log)
+        if not target_dirs:
+            log.ok("Skipped pylocks regeneration.")
+            return
+    else:
+        target_dirs = find_target_dirs(target_dir, log)
+        if not target_dirs:
+            log.error("No directories containing pyproject.toml were found.")
+            raise SystemExit(1)
 
     # PARALLEL LOCK GENERATION
     success_dirs: list[Path] = []

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -240,22 +240,6 @@ def find_target_dirs(target_dir: Path | None, log: LogBuffer) -> list[Path]:
     return discover_all_image_project_dirs()
 
 
-def _merge_base_with_head(base_ref: str) -> str:
-    """Merge-base of the PR base branch tip and HEAD (for three-dot PR diffs)."""
-    result = subprocess.run(
-        ["git", "merge-base", base_ref, "HEAD"],
-        cwd=ROOT_DIR,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise SystemExit(
-            f"git merge-base {base_ref} HEAD failed: {result.stderr.strip() or result.returncode}"
-        )
-    return result.stdout.strip()
-
-
 def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
     """PR file diff via ci/cached-builds helper (symlink-aware three-dot diff)."""
     cached_builds = ROOT_DIR / "ci" / "cached-builds"
@@ -311,12 +295,11 @@ def _is_lock_chain_file(relative_to_project: Path) -> bool:
 def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
     """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed.
 
-    ``pr_base`` is the PR target branch tip (e.g. ``pull_request.base.sha``). The merge-base
-    with HEAD is computed before diffing so rebased or behind-main branches still work.
+    ``pr_base`` is the merge-base ref for a three-dot PR diff (``pr_base...HEAD``). CI resolves
+    it via the GitHub compare API; locally use ``git merge-base <base> HEAD``.
     """
-    merge_base = _merge_base_with_head(pr_base)
-    log.info(f"PR lock scoping from merge-base {merge_base}")
-    changed = _list_changed_files(merge_base)
+    log.info(f"PR lock scoping from merge-base {pr_base}")
+    changed = _list_changed_files(pr_base)
     all_dirs = discover_all_image_project_dirs()
 
     if any(_is_global_lock_input(path) for path in changed):
@@ -726,7 +709,7 @@ def main(
         str | None,
         typer.Option(
             "--pr-base",
-            help="PR target branch tip (e.g. pull_request.base.sha); merge-base with HEAD is used for scoping",
+            help="Merge-base ref for PR scoping (three-dot diff pr_base...HEAD); CI passes compare API result",
         ),
     ] = None,
 ) -> None:

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -42,6 +42,8 @@ Usage:
   6. PR-scoped lock regen (CI only; skips dirs whose lock chain the PR did not touch)::
 
        PYLOCKS_CI_CHECK=1 python pylocks_generator.py auto --pr-base <merge-base-sha>
+       PYLOCKS_CI_CHECK=1 python pylocks_generator.py auto --pr-base <merge-base-sha> \\
+           --pr-changed-files-file /path/to/changed-files.txt
 
 Reproducible CI checks (PYLOCKS_CI_CHECK):
   When ``PYLOCKS_CI_CHECK=1`` (set only by ``check-generated-code`` in CI),
@@ -250,6 +252,17 @@ def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
     return gha_pr_changed_files.list_changed_files(from_ref, to_ref)
 
 
+def _load_pr_changed_files(path: Path) -> list[str]:
+    """Load PR changed paths from a file (one repo-relative path per line)."""
+    cached_builds = ROOT_DIR / "ci" / "cached-builds"
+    if str(cached_builds) not in sys.path:
+        sys.path.insert(0, str(cached_builds))
+    import gha_pr_changed_files
+
+    files = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    return gha_pr_changed_files.expand_changed_paths(files)
+
+
 def _path_under(path: Path, prefix: Path) -> bool:
     return path.is_relative_to(prefix)
 
@@ -288,14 +301,20 @@ def _is_lock_chain_file(relative_to_project: Path) -> bool:
     return bool(relative_to_project.parts) and relative_to_project.parts[0] == "uv.lock.d"
 
 
-def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
+def resolve_pr_scoped_target_dirs(
+    pr_base: str,
+    log: LogBuffer,
+    *,
+    changed_files: list[str] | None = None,
+) -> list[Path]:
     """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed.
 
     ``pr_base`` is the merge-base ref for a three-dot PR diff (``pr_base...HEAD``). CI resolves
-    it via the GitHub compare API; locally use ``git merge-base <base> HEAD``.
+    it via the GitHub compare API; locally use ``git merge-base <base> HEAD``. When
+    ``changed_files`` is set (CI passes compare API ``files[].filename``), git diff is skipped.
     """
     log.info(f"PR lock scoping from merge-base {pr_base}")
-    changed = _list_changed_files(pr_base, "HEAD")
+    changed = changed_files if changed_files is not None else _list_changed_files(pr_base, "HEAD")
     all_dirs = discover_all_image_project_dirs()
 
     if any(_is_global_lock_input(path) for path in changed):
@@ -708,6 +727,13 @@ def main(
             help="Merge-base ref for PR scoping (three-dot diff pr_base...HEAD); CI passes compare API result",
         ),
     ] = None,
+    pr_changed_files_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--pr-changed-files-file",
+            help="PR changed paths, one per line (CI: GitHub compare API files[].filename)",
+        ),
+    ] = None,
 ) -> None:
     """Generate pylock.toml lock files for Python project directories."""
     log = LogBuffer(buffered=False)
@@ -737,7 +763,8 @@ def main(
         if target_dir is not None:
             log.error("Cannot combine a specific target directory with --pr-base.")
             raise SystemExit(1)
-        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log)
+        changed_files = _load_pr_changed_files(pr_changed_files_file) if pr_changed_files_file else None
+        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log, changed_files=changed_files)
         if not target_dirs:
             log.ok("Skipped pylocks regeneration.")
             return

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -288,14 +288,19 @@ def _is_lock_chain_file(relative_to_project: Path) -> bool:
     return bool(relative_to_project.parts) and relative_to_project.parts[0] == "uv.lock.d"
 
 
-def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
+def resolve_pr_scoped_target_dirs(
+    pr_base: str,
+    log: LogBuffer,
+    *,
+    pr_to_ref: str = "HEAD",
+) -> list[Path]:
     """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed.
 
-    ``pr_base`` is the base ref for a three-dot PR diff (``pr_base...HEAD``). CI passes
-    ``origin/<base-branch>`` after fetching refs; locally use ``origin/main`` or a merge-base SHA.
+    ``pr_base`` and ``pr_to_ref`` form a three-dot PR diff (``pr_base...pr_to_ref``). CI passes
+    ``origin/<base-branch>`` and the fetched PR branch name; locally use ``origin/main`` and ``HEAD``.
     """
-    log.info(f"PR lock scoping from {pr_base}")
-    changed = _list_changed_files(pr_base, "HEAD")
+    log.info(f"PR lock scoping from {pr_base}...{pr_to_ref}")
+    changed = _list_changed_files(pr_base, pr_to_ref)
     all_dirs = discover_all_image_project_dirs()
 
     if any(_is_global_lock_input(path) for path in changed):
@@ -705,9 +710,16 @@ def main(
         str | None,
         typer.Option(
             "--pr-base",
-            help="Base ref for PR scoping (three-dot diff pr_base...HEAD); CI uses origin/<base-branch>",
+            help="Base ref for PR scoping (three-dot diff pr_base...pr_to_ref); CI uses origin/<base-branch>",
         ),
     ] = None,
+    pr_to_ref: Annotated[
+        str,
+        typer.Option(
+            "--pr-to-ref",
+            help="Head ref for PR scoping (three-dot diff pr_base...pr_to_ref); CI uses fetched PR branch",
+        ),
+    ] = "HEAD",
 ) -> None:
     """Generate pylock.toml lock files for Python project directories."""
     log = LogBuffer(buffered=False)
@@ -737,7 +749,7 @@ def main(
         if target_dir is not None:
             log.error("Cannot combine a specific target directory with --pr-base.")
             raise SystemExit(1)
-        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log)
+        target_dirs = resolve_pr_scoped_target_dirs(pr_base, log, pr_to_ref=pr_to_ref)
         if not target_dirs:
             log.ok("Skipped pylocks regeneration.")
             return

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -240,6 +240,22 @@ def find_target_dirs(target_dir: Path | None, log: LogBuffer) -> list[Path]:
     return discover_all_image_project_dirs()
 
 
+def _merge_base_with_head(base_ref: str) -> str:
+    """Merge-base of the PR base branch tip and HEAD (for three-dot PR diffs)."""
+    result = subprocess.run(
+        ["git", "merge-base", base_ref, "HEAD"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"git merge-base {base_ref} HEAD failed: {result.stderr.strip() or result.returncode}"
+        )
+    return result.stdout.strip()
+
+
 def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
     """PR file diff via ci/cached-builds helper (symlink-aware three-dot diff)."""
     cached_builds = ROOT_DIR / "ci" / "cached-builds"
@@ -293,8 +309,14 @@ def _is_lock_chain_file(relative_to_project: Path) -> bool:
 
 
 def resolve_pr_scoped_target_dirs(pr_base: str, log: LogBuffer) -> list[Path]:
-    """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed."""
-    changed = _list_changed_files(pr_base)
+    """Image project dirs whose lock chain changed in the PR, or all dirs if global inputs changed.
+
+    ``pr_base`` is the PR target branch tip (e.g. ``pull_request.base.sha``). The merge-base
+    with HEAD is computed before diffing so rebased or behind-main branches still work.
+    """
+    merge_base = _merge_base_with_head(pr_base)
+    log.info(f"PR lock scoping from merge-base {merge_base}")
+    changed = _list_changed_files(merge_base)
     all_dirs = discover_all_image_project_dirs()
 
     if any(_is_global_lock_input(path) for path in changed):
@@ -704,7 +726,7 @@ def main(
         str | None,
         typer.Option(
             "--pr-base",
-            help="Merge-base ref for PR-scoped lock regen (only dirs whose lock chain changed)",
+            help="PR target branch tip (e.g. pull_request.base.sha); merge-base with HEAD is used for scoping",
         ),
     ] = None,
 ) -> None:

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -251,11 +251,7 @@ def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
 
 
 def _path_under(path: Path, prefix: Path) -> bool:
-    try:
-        path.relative_to(prefix)
-        return True
-    except ValueError:
-        return False
+    return path.is_relative_to(prefix)
 
 
 def image_project_dir_for_repo_file(

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -307,34 +307,20 @@ def test_resolve_pr_scoped_touched_requirements(
     )
 
 
-def test_resolve_pr_scoped_diffs_from_merge_base_ref(
+def test_resolve_pr_scoped_diffs_from_base_ref(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    merge_base = "b61e56bea2594f7e31042d33d3a0981aceb80512"
+    base_ref = "origin/main"
     changed_files_mock = Mock(
         return_value=["jupyter/minimal/ubi9-python-3.12/pyproject.toml"],
     )
     monkeypatch.setattr(pg, "_list_changed_files", changed_files_mock)
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs(merge_base, pg.LogBuffer()) == [expected], (
-        "merge-base diff should scope to touched image dir"
+    assert pg.resolve_pr_scoped_target_dirs(base_ref, pg.LogBuffer()) == [expected], (
+        "three-dot diff from base ref should scope to touched image dir"
     )
-    changed_files_mock.assert_called_once_with(merge_base, "HEAD")
-
-
-def test_resolve_pr_scoped_uses_explicit_changed_files(
-    repo_root: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    changed_files_mock = Mock()
-    monkeypatch.setattr(pg, "_list_changed_files", changed_files_mock)
-    expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    changed = ["jupyter/minimal/ubi9-python-3.12/pyproject.toml"]
-    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer(), changed_files=changed) == [expected], (
-        "explicit changed_files should scope without git diff"
-    )
-    changed_files_mock.assert_not_called()
+    changed_files_mock.assert_called_once_with(base_ref, "HEAD")
 
 
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -323,6 +323,20 @@ def test_resolve_pr_scoped_diffs_from_merge_base_ref(
     changed_files_mock.assert_called_once_with(merge_base, "HEAD")
 
 
+def test_resolve_pr_scoped_uses_explicit_changed_files(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    changed_files_mock = Mock()
+    monkeypatch.setattr(pg, "_list_changed_files", changed_files_mock)
+    expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
+    changed = ["jupyter/minimal/ubi9-python-3.12/pyproject.toml"]
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer(), changed_files=changed) == [expected], (
+        "explicit changed_files should scope without git diff"
+    )
+    changed_files_mock.assert_not_called()
+
+
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pg, "_list_changed_files", lambda _base, _to="HEAD": ["README.md"])
     assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [], (

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -286,6 +286,7 @@ def test_resolve_pr_scoped_touched_requirements(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -295,7 +296,29 @@ def test_resolve_pr_scoped_touched_requirements(
     assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
 
 
+def test_resolve_pr_scoped_uses_merge_base(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    merge_base = "b61e56bea2594f7e31042d33d3a0981aceb80512"
+    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: merge_base)
+    monkeypatch.setattr(
+        pg,
+        "_list_changed_files",
+        lambda from_ref, to_ref="HEAD": (
+            ["jupyter/minimal/ubi9-python-3.12/pyproject.toml"]
+            if from_ref == merge_base
+            else []
+        ),
+    )
+    expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
+    assert pg.resolve_pr_scoped_target_dirs("700203d19866528215a41844b961a175eb08b498", pg.LogBuffer()) == [
+        expected
+    ]
+
+
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(pg, "_list_changed_files", lambda _base, _to="HEAD": ["README.md"])
     assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == []
 
@@ -304,6 +327,7 @@ def test_resolve_pr_scoped_touched_pyproject(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -317,6 +341,7 @@ def test_resolve_pr_scoped_touched_codeserver(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -329,6 +354,7 @@ def test_resolve_pr_scoped_touched_codeserver(
 def test_resolve_pr_scoped_global_input_expands_to_all(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -268,16 +268,16 @@ def test_generate_requirements_txt_falls_back_to_pylock_header_when_index_resolu
 
 def test_image_project_dir_for_repo_file_jupyter(repo_root: Path) -> None:
     project = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert (
-        pg.image_project_dir_for_repo_file("jupyter/minimal/ubi9-python-3.12/pyproject.toml") == project
-    ), "jupyter pyproject.toml should map to image project dir"
+    assert pg.image_project_dir_for_repo_file("jupyter/minimal/ubi9-python-3.12/pyproject.toml") == project, (
+        "jupyter pyproject.toml should map to image project dir"
+    )
 
 
 def test_image_project_dir_for_repo_file_codeserver(repo_root: Path) -> None:
     project = repo_root / "codeserver" / "ubi9-python-3.12"
-    assert (
-        pg.image_project_dir_for_repo_file("codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml") == project
-    ), "codeserver pylock path should map to image project dir"
+    assert pg.image_project_dir_for_repo_file("codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml") == project, (
+        "codeserver pylock path should map to image project dir"
+    )
 
 
 def test_is_lock_chain_file(subtests: pytest.Subtests) -> None:

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -286,7 +286,6 @@ def test_resolve_pr_scoped_touched_requirements(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -296,12 +295,11 @@ def test_resolve_pr_scoped_touched_requirements(
     assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
 
 
-def test_resolve_pr_scoped_uses_merge_base(
+def test_resolve_pr_scoped_diffs_from_merge_base_ref(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     merge_base = "b61e56bea2594f7e31042d33d3a0981aceb80512"
-    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: merge_base)
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -312,13 +310,10 @@ def test_resolve_pr_scoped_uses_merge_base(
         ),
     )
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs("700203d19866528215a41844b961a175eb08b498", pg.LogBuffer()) == [
-        expected
-    ]
+    assert pg.resolve_pr_scoped_target_dirs(merge_base, pg.LogBuffer()) == [expected]
 
 
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(pg, "_list_changed_files", lambda _base, _to="HEAD": ["README.md"])
     assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == []
 
@@ -327,7 +322,6 @@ def test_resolve_pr_scoped_touched_pyproject(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -341,7 +335,6 @@ def test_resolve_pr_scoped_touched_codeserver(
     repo_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
@@ -354,7 +347,6 @@ def test_resolve_pr_scoped_touched_codeserver(
 def test_resolve_pr_scoped_global_input_expands_to_all(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(pg, "_merge_base_with_head", lambda _base: "base")
     monkeypatch.setattr(
         pg,
         "_list_changed_files",

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -311,8 +311,10 @@ def test_resolve_pr_scoped_diffs_from_merge_base_ref(
     )
     monkeypatch.setattr(pg, "_list_changed_files", changed_files_mock)
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs(merge_base, pg.LogBuffer()) == [expected]
-    changed_files_mock.assert_called_once_with(merge_base)
+    assert pg.resolve_pr_scoped_target_dirs(merge_base, pg.LogBuffer()) == [expected], (
+        "merge-base diff should scope to touched image dir"
+    )
+    changed_files_mock.assert_called_once_with(merge_base, "HEAD")
 
 
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -257,23 +257,27 @@ def test_generate_requirements_txt_falls_back_to_pylock_header_when_index_resolu
 
     success = pg.generate_requirements_txt(project_dir, "cpu", log)
 
-    assert success is True
+    assert success is True, "generate_requirements_txt should succeed when index resolution fails"
     assert captured_cmd == [
         pg.sys.executable,
         str(pg.PYLOCK_TO_REQUIREMENTS),
         str(project_dir / "uv.lock.d" / "pylock.cpu.toml"),
         str(project_dir / "requirements.cpu.txt"),
-    ]
+    ], f"unexpected pylock-to-requirements command: {captured_cmd}"
 
 
 def test_image_project_dir_for_repo_file_jupyter(repo_root: Path) -> None:
     project = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.image_project_dir_for_repo_file("jupyter/minimal/ubi9-python-3.12/pyproject.toml") == project
+    assert (
+        pg.image_project_dir_for_repo_file("jupyter/minimal/ubi9-python-3.12/pyproject.toml") == project
+    ), "jupyter pyproject.toml should map to image project dir"
 
 
 def test_image_project_dir_for_repo_file_codeserver(repo_root: Path) -> None:
     project = repo_root / "codeserver" / "ubi9-python-3.12"
-    assert pg.image_project_dir_for_repo_file("codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml") == project
+    assert (
+        pg.image_project_dir_for_repo_file("codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml") == project
+    ), "codeserver pylock path should map to image project dir"
 
 
 def test_is_lock_chain_file(subtests: pytest.Subtests) -> None:
@@ -298,7 +302,9 @@ def test_resolve_pr_scoped_touched_requirements(
         lambda _base, _to="HEAD": ["jupyter/minimal/ubi9-python-3.12/requirements.cuda.txt"],
     )
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected], (
+        "requirements.txt change should scope to touched image dir"
+    )
 
 
 def test_resolve_pr_scoped_diffs_from_merge_base_ref(
@@ -319,7 +325,9 @@ def test_resolve_pr_scoped_diffs_from_merge_base_ref(
 
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pg, "_list_changed_files", lambda _base, _to="HEAD": ["README.md"])
-    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == []
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [], (
+        "unrelated file changes should not trigger lock regen"
+    )
 
 
 def test_resolve_pr_scoped_touched_pyproject(
@@ -332,7 +340,9 @@ def test_resolve_pr_scoped_touched_pyproject(
         lambda _base, _to="HEAD": ["jupyter/minimal/ubi9-python-3.12/pyproject.toml"],
     )
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected], (
+        "pyproject.toml change should scope to touched image dir"
+    )
 
 
 def test_resolve_pr_scoped_touched_codeserver(
@@ -345,7 +355,9 @@ def test_resolve_pr_scoped_touched_codeserver(
         lambda _base, _to="HEAD": ["codeserver/ubi9-python-3.12/pyproject.toml"],
     )
     expected = repo_root / "codeserver" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected], (
+        "codeserver pyproject.toml change should scope to touched image dir"
+    )
 
 
 def test_resolve_pr_scoped_global_input_expands_to_all(
@@ -357,5 +369,6 @@ def test_resolve_pr_scoped_global_input_expands_to_all(
         lambda _base, _to="HEAD": ["dependencies/cve-constraints.txt"],
     )
     scoped = pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer())
-    assert scoped == pg.discover_all_image_project_dirs()
-    assert len(scoped) > 1
+    all_dirs = pg.discover_all_image_project_dirs()
+    assert scoped == all_dirs, "global input change should expand to all image dirs"
+    assert len(scoped) > 1, "expected multiple image project dirs for global-input fallback"

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -312,15 +312,16 @@ def test_resolve_pr_scoped_diffs_from_base_ref(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     base_ref = "origin/main"
+    head_ref = "rhaieng-6397-scoped-pr-lock-regen"
     changed_files_mock = Mock(
         return_value=["jupyter/minimal/ubi9-python-3.12/pyproject.toml"],
     )
     monkeypatch.setattr(pg, "_list_changed_files", changed_files_mock)
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
-    assert pg.resolve_pr_scoped_target_dirs(base_ref, pg.LogBuffer()) == [expected], (
+    assert pg.resolve_pr_scoped_target_dirs(base_ref, pg.LogBuffer(), pr_to_ref=head_ref) == [expected], (
         "three-dot diff from base ref should scope to touched image dir"
     )
-    changed_files_mock.assert_called_once_with(base_ref, "HEAD")
+    changed_files_mock.assert_called_once_with(base_ref, head_ref)
 
 
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -263,3 +263,77 @@ def test_generate_requirements_txt_falls_back_to_pylock_header_when_index_resolu
         str(project_dir / "uv.lock.d" / "pylock.cpu.toml"),
         str(project_dir / "requirements.cpu.txt"),
     ]
+
+
+def test_image_project_dir_for_repo_file_jupyter(repo_root: Path) -> None:
+    project = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
+    assert pg.image_project_dir_for_repo_file("jupyter/minimal/ubi9-python-3.12/pyproject.toml") == project
+
+
+def test_image_project_dir_for_repo_file_codeserver(repo_root: Path) -> None:
+    project = repo_root / "codeserver" / "ubi9-python-3.12"
+    assert pg.image_project_dir_for_repo_file("codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml") == project
+
+
+def test_is_lock_chain_file() -> None:
+    assert pg._is_lock_chain_file(Path("pyproject.toml"))
+    assert pg._is_lock_chain_file(Path("uv.lock.d/pylock.cpu.toml"))
+    assert pg._is_lock_chain_file(Path("requirements.cpu.txt"))
+    assert not pg._is_lock_chain_file(Path("README.md"))
+
+
+def test_resolve_pr_scoped_touched_requirements(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pg,
+        "_list_changed_files",
+        lambda _base, _to="HEAD": ["jupyter/minimal/ubi9-python-3.12/requirements.cuda.txt"],
+    )
+    expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
+
+
+def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pg, "_list_changed_files", lambda _base, _to="HEAD": ["README.md"])
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == []
+
+
+def test_resolve_pr_scoped_touched_pyproject(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pg,
+        "_list_changed_files",
+        lambda _base, _to="HEAD": ["jupyter/minimal/ubi9-python-3.12/pyproject.toml"],
+    )
+    expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
+
+
+def test_resolve_pr_scoped_touched_codeserver(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pg,
+        "_list_changed_files",
+        lambda _base, _to="HEAD": ["codeserver/ubi9-python-3.12/pyproject.toml"],
+    )
+    expected = repo_root / "codeserver" / "ubi9-python-3.12"
+    assert pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer()) == [expected]
+
+
+def test_resolve_pr_scoped_global_input_expands_to_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pg,
+        "_list_changed_files",
+        lambda _base, _to="HEAD": ["dependencies/cve-constraints.txt"],
+    )
+    scoped = pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer())
+    assert scoped == pg.discover_all_image_project_dirs()
+    assert len(scoped) > 1

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -275,11 +276,16 @@ def test_image_project_dir_for_repo_file_codeserver(repo_root: Path) -> None:
     assert pg.image_project_dir_for_repo_file("codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml") == project
 
 
-def test_is_lock_chain_file() -> None:
-    assert pg._is_lock_chain_file(Path("pyproject.toml"))
-    assert pg._is_lock_chain_file(Path("uv.lock.d/pylock.cpu.toml"))
-    assert pg._is_lock_chain_file(Path("requirements.cpu.txt"))
-    assert not pg._is_lock_chain_file(Path("README.md"))
+def test_is_lock_chain_file(subtests: pytest.Subtests) -> None:
+    cases = [
+        (Path("pyproject.toml"), True),
+        (Path("uv.lock.d/pylock.cpu.toml"), True),
+        (Path("requirements.cpu.txt"), True),
+        (Path("README.md"), False),
+    ]
+    for path, expected in cases:
+        with subtests.test(path=str(path)):
+            assert pg._is_lock_chain_file(path) is expected, f"{path} lock-chain={expected}"
 
 
 def test_resolve_pr_scoped_touched_requirements(
@@ -300,17 +306,13 @@ def test_resolve_pr_scoped_diffs_from_merge_base_ref(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     merge_base = "b61e56bea2594f7e31042d33d3a0981aceb80512"
-    monkeypatch.setattr(
-        pg,
-        "_list_changed_files",
-        lambda from_ref, to_ref="HEAD": (
-            ["jupyter/minimal/ubi9-python-3.12/pyproject.toml"]
-            if from_ref == merge_base
-            else []
-        ),
+    changed_files_mock = Mock(
+        return_value=["jupyter/minimal/ubi9-python-3.12/pyproject.toml"],
     )
+    monkeypatch.setattr(pg, "_list_changed_files", changed_files_mock)
     expected = repo_root / "jupyter" / "minimal" / "ubi9-python-3.12"
     assert pg.resolve_pr_scoped_target_dirs(merge_base, pg.LogBuffer()) == [expected]
+    changed_files_mock.assert_called_once_with(merge_base)
 
 
 def test_resolve_pr_scoped_skips_unrelated(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-6397

## Description

Scopes `check-generated-code` lock regeneration on pull requests to image directories whose lock chain the PR actually touched (`pyproject.toml`, `pylock.toml`, `requirements.*.txt`, or `uv.lock.d/*`). Push builds to `main` / `stable` / `rhoai-*` keep full regen unchanged.

This avoids unrelated PR failures when external AIPCC/Pulp index churn updates locks after the last renewal ([RHAIENG-6397](https://redhat.atlassian.net/browse/RHAIENG-6397) / [RHAIENG-4443](https://redhat.atlassian.net/browse/RHAIENG-4443)).

**Demo setup:** branch is rebased onto `b61e56bea` (pre–today's lock renewal in #4146), so committed locks are older than `main`. The PR diff is CI-only; scoped regen should skip pylocks and `check-generated-code` should pass — the failure mode that blocked unrelated PRs before this change.

## How Has This Been Tested?

- `uv run pytest tests/unit/scripts/test_pylocks_generator.py` (30 passed)
- Local `ci/generate_code.sh --pr-base <merge-base>` skips pylocks when no lock-chain files in PR diff
- Local `ci/generate_code.sh` (no args) still regenerates all 16 image dirs

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — unit tests for pylocks scoping
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` — CI/scripts only

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

[RHAIENG-6397]: https://redhat.atlassian.net/browse/RHAIENG-6397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4443]: https://redhat.atlassian.net/browse/RHAIENG-4443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull request checks now regenerate dependency locks only for affected image projects, skipping unrelated-file changes to reduce churn.
  - Shared/global lock inputs still trigger full regeneration across all image projects.
  - Code-generation tooling now supports PR-scoped operation via optional `--pr-base` (and `--pr-to-ref`) with validation and help.

- **Bug Fixes**
  - Improved CI “generated code” behavior to run PR-scoped generation only on pull requests, and full regeneration on other events.

- **Documentation**
  - Updated CI parity docs to cover the `check-generated-code` prerequisite and enforcing a clean git state.

- **Tests**
  - Expanded unit tests for project mapping, lock-chain classification, and PR-scoped target resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->