### PR TITLE
GHA: Renew lock files

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -74,13 +74,13 @@ arches:
     name: cmake-filesystem
     evr: 3.31.8-3.el9
     sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 1445639
-    checksum: sha256:60751fa608555192d7f128aac92f86c17f2009a22519d3a157e42943d6b6de17
+    size: 1444467
+    checksum: sha256:99329e643cb30e51fdb045b81c5ac128cd8a9ab75a01b7915ca617fc8373ffe0
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/containers-common-5.8-1.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 170106
@@ -4912,13 +4912,13 @@ arches:
     name: cmake-filesystem
     evr: 3.31.8-3.el9
     sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 1599892
-    checksum: sha256:8a2d33a1a379495c7851a95637be0105b1d5834c98a161ab1a282efb2da5ebdd
+    size: 1600057
+    checksum: sha256:b5bcdecc5ac2d6d65dfa71ccdc4e2a65b59a8212d5fd10ced6e40a334a3396fd
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/containers-common-5.8-1.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 170148
@@ -9771,13 +9771,13 @@ arches:
     name: cmake-filesystem
     evr: 3.31.8-3.el9
     sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
-    size: 1223387
-    checksum: sha256:50e1ba3df2fa427b10facf98050188ab003b2b74417cc4c66aaa7da13fb380bc
+    size: 1223661
+    checksum: sha256:e0f66a88d4d8e30040a01c22bc6d1539a37c9c9d0204b02172e5ed9dc9b67489
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/containers-common-5.8-1.el9.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 170120
@@ -14602,13 +14602,13 @@ arches:
     name: cmake-filesystem
     evr: 3.31.8-3.el9
     sourcerpm: cmake-3.31.8-3.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 1531286
-    checksum: sha256:5bc820b926bc36c3e2b5aff01201f2836b5b1b5800a7882e92be75f56d3bd9db
+    size: 1531403
+    checksum: sha256:e52e794e480ce92ffa7c4f677c71efc9a229c4c4aaa139b915f9ee1fbd18f4f6
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/containers-common-5.8-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 170139

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -4365,13 +4365,13 @@ arches:
     name: httpd-tools
     evr: 2.4.62-4.el9_6.5
     sourcerpm: httpd-2.4.62-4.el9_6.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3812853
-    checksum: sha256:cd80036a417662f4939ae5169d6470e67aeeadd6ac6a0de8996d17706d90f21d
+    size: 3815345
+    checksum: sha256:48095ac15e91e603b9bd82a24397016427e9836d8e4be63f109e94e7f65c15ec
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/k/krb5-devel-1.21.1-8.el9_6.2.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 145361
@@ -4885,14 +4885,14 @@ arches:
     sourcerpm: vim-8.2.2637-22.el9_6.3.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/repodata/ba49dd21ea55e59722cc07b70343cf862177af17a7cd62c69d2a1ebfedc17f2c-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/repodata/f9a2575dc15df4e872e7ccb180dd6070962a22b3c74c1370dd19b8aba1bbcd93-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34364
-    checksum: sha256:ba49dd21ea55e59722cc07b70343cf862177af17a7cd62c69d2a1ebfedc17f2c
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/817a61123fb8157fedd09fdd0596c3ddc8758004ae1d434e3b43e99b7bef1868-modules.yaml.gz
+    checksum: sha256:f9a2575dc15df4e872e7ccb180dd6070962a22b3c74c1370dd19b8aba1bbcd93
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/e76450914cc87d6a62108baebe2442b42c5f0d175891bf66a4fdd675c271a5e3-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 43340
-    checksum: sha256:817a61123fb8157fedd09fdd0596c3ddc8758004ae1d434e3b43e99b7bef1868
+    checksum: sha256:e76450914cc87d6a62108baebe2442b42c5f0d175891bf66a4fdd675c271a5e3
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.3/os/Packages/n/ninja-build-1.11.1-9.el9ai.ppc64le.rpm
@@ -9291,13 +9291,13 @@ arches:
     name: httpd-tools
     evr: 2.4.62-4.el9_6.5
     sourcerpm: httpd-2.4.62-4.el9_6.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3834501
-    checksum: sha256:b38a405f5804d0e1aa7324b85c665987b71dc2534704ea7ce960dbe5910a0f2f
+    size: 3837097
+    checksum: sha256:2dc692e0af28d8c6bd300ac99a4693a8125dc3009db46735bbecd3bbbca96d4c
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/k/krb5-devel-1.21.1-8.el9_6.2.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 145358
@@ -9811,14 +9811,14 @@ arches:
     sourcerpm: vim-8.2.2637-22.el9_6.3.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/repodata/e001d9a095c742b04e431d725fca55dfcab7dc9cc9334c4fd48cf5daba8e95a0-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/repodata/58c82e7ecc8665401fb0ce58bbe0bae0ccf84e1d3d60489859861188490deb59-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32808
-    checksum: sha256:e001d9a095c742b04e431d725fca55dfcab7dc9cc9334c4fd48cf5daba8e95a0
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/repodata/680abee39fbce7f0e83f3fdb25a49c3bfe797ba3b1eca31202e37cdeca4f6cb9-modules.yaml.gz
+    checksum: sha256:58c82e7ecc8665401fb0ce58bbe0bae0ccf84e1d3d60489859861188490deb59
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/repodata/19a133e39429e6449b4f8d24e04b02e2d6c591bd37cdb44ee9f82da069c7a9cd-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 41135
-    checksum: sha256:680abee39fbce7f0e83f3fdb25a49c3bfe797ba3b1eca31202e37cdeca4f6cb9
+    checksum: sha256:19a133e39429e6449b4f8d24e04b02e2d6c591bd37cdb44ee9f82da069c7a9cd
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.3/os/Packages/n/ninja-build-1.11.1-9.el9ai.s390x.rpm
@@ -14189,13 +14189,13 @@ arches:
     name: httpd-tools
     evr: 2.4.62-4.el9_6.5
     sourcerpm: httpd-2.4.62-4.el9_6.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3842457
-    checksum: sha256:de268edb8669c3bd7b04101cff1fa0d30d9de086ab7e7e4fe3af0b16afaaa8bf
+    size: 3845001
+    checksum: sha256:8ca5eb3424bcc2d3653861a71dd7af8e3fb1f7472f4fe20c868e836fa5a99d14
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/k/krb5-devel-1.21.1-8.el9_6.2.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 145325
@@ -14709,14 +14709,14 @@ arches:
     sourcerpm: vim-8.2.2637-22.el9_6.3.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/repodata/a621d58aac5fbc3798a781bb73a741728406231fd87f981841347a512a9d00f0-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/repodata/41b8bf58defca8d42d0c657b178e24c0e9f5110b250853ea060a56663e6d4659-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 33005
-    checksum: sha256:a621d58aac5fbc3798a781bb73a741728406231fd87f981841347a512a9d00f0
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/repodata/5ce77f122b642a1c0dc6fbff78e294bc5598e934dd939ec13f53f9252b831dd1-modules.yaml.gz
+    checksum: sha256:41b8bf58defca8d42d0c657b178e24c0e9f5110b250853ea060a56663e6d4659
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/repodata/ed444690cf41ae5c7d15809c0b412474cdd4753f11df52a48dae37c8fa4cdfea-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 42141
-    checksum: sha256:5ce77f122b642a1c0dc6fbff78e294bc5598e934dd939ec13f53f9252b831dd1
+    checksum: sha256:ed444690cf41ae5c7d15809c0b412474cdd4753f11df52a48dae37c8fa4cdfea
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.3/os/Packages/n/ninja-build-1.11.1-9.el9ai.x86_64.rpm
@@ -19122,13 +19122,13 @@ arches:
     name: httpd-tools
     evr: 2.4.62-4.el9_6.5
     sourcerpm: httpd-2.4.62-4.el9_6.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3851773
-    checksum: sha256:208a87f523a34654b04f54b28784123b60f6f2bddac3954e5126364a5df76323
+    size: 3854369
+    checksum: sha256:8d52c97057460c36c7bb4a3bbd0535c45ee6facf5a9502b36486322134aaea40
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/k/krb5-devel-1.21.1-8.el9_6.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 145331
@@ -19642,11 +19642,11 @@ arches:
     sourcerpm: vim-8.2.2637-22.el9_6.3.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/repodata/8d341eb4be4df0769e1e91ab14787837a05a977c4d4d695a9f583db156598921-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/repodata/276e25ee5701b5872629aa69c6f02ae41fb47cee8991417e15205a5914edaf0b-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34742
-    checksum: sha256:8d341eb4be4df0769e1e91ab14787837a05a977c4d4d695a9f583db156598921
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/d26f9e24c772b58b82e6b77e3fb088f07a5ab6956158ae8238d3129069d37d2c-modules.yaml.gz
+    checksum: sha256:276e25ee5701b5872629aa69c6f02ae41fb47cee8991417e15205a5914edaf0b
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/51fdb35e9f5d0a89f636dfbcaa7762b1b4033513cc9d3a6ee97f7c2d81eb4608-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 41573
-    checksum: sha256:d26f9e24c772b58b82e6b77e3fb088f07a5ab6956158ae8238d3129069d37d2c
+    checksum: sha256:51fdb35e9f5d0a89f636dfbcaa7762b1b4033513cc9d3a6ee97f7c2d81eb4608

--- a/prefetch-input/odh/rpms.lock.yaml
+++ b/prefetch-input/odh/rpms.lock.yaml
@@ -137,13 +137,13 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 1445639
-    checksum: sha256:60751fa608555192d7f128aac92f86c17f2009a22519d3a157e42943d6b6de17
+    size: 1444467
+    checksum: sha256:99329e643cb30e51fdb045b81c5ac128cd8a9ab75a01b7915ca617fc8373ffe0
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 57636
@@ -6196,13 +6196,13 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 1599892
-    checksum: sha256:8a2d33a1a379495c7851a95637be0105b1d5834c98a161ab1a282efb2da5ebdd
+    size: 1600057
+    checksum: sha256:b5bcdecc5ac2d6d65dfa71ccdc4e2a65b59a8212d5fd10ced6e40a334a3396fd
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 62898
@@ -12255,13 +12255,13 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
-    size: 1223387
-    checksum: sha256:50e1ba3df2fa427b10facf98050188ab003b2b74417cc4c66aaa7da13fb380bc
+    size: 1223661
+    checksum: sha256:e0f66a88d4d8e30040a01c22bc6d1539a37c9c9d0204b02172e5ed9dc9b67489
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 58254
@@ -18300,13 +18300,13 @@ arches:
     name: colord-libs
     evr: 1.4.5-6.el9_6
     sourcerpm: colord-1.4.5-6.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.3.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_8.4.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 1531286
-    checksum: sha256:5bc820b926bc36c3e2b5aff01201f2836b5b1b5800a7882e92be75f56d3bd9db
+    size: 1531403
+    checksum: sha256:e52e794e480ce92ffa7c4f677c71efc9a229c4c4aaa139b915f9ee1fbd18f4f6
     name: compat-openssl11
-    evr: 1:1.1.1k-5.el9_8.3
-    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.3.src.rpm
+    evr: 1:1.1.1k-5.el9_8.4
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_8.4.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/composefs-libs-1.0.8-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 58172

--- a/prefetch-input/rhds/rpms.lock.yaml
+++ b/prefetch-input/rhds/rpms.lock.yaml
@@ -5485,13 +5485,13 @@ arches:
     name: java-17-openjdk-headless
     evr: 1:17.0.20.0.8-1.1.el9
     sourcerpm: java-17-openjdk-17.0.20.0.8-1.1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3812853
-    checksum: sha256:cd80036a417662f4939ae5169d6470e67aeeadd6ac6a0de8996d17706d90f21d
+    size: 3815345
+    checksum: sha256:48095ac15e91e603b9bd82a24397016427e9836d8e4be63f109e94e7f65c15ec
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libexif-0.6.22-6.el9_6.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 436481
@@ -11495,13 +11495,13 @@ arches:
     name: java-17-openjdk-headless
     evr: 1:17.0.20.0.8-1.1.el9
     sourcerpm: java-17-openjdk-17.0.20.0.8-1.1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3834501
-    checksum: sha256:b38a405f5804d0e1aa7324b85c665987b71dc2534704ea7ce960dbe5910a0f2f
+    size: 3837097
+    checksum: sha256:2dc692e0af28d8c6bd300ac99a4693a8125dc3009db46735bbecd3bbbca96d4c
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/Packages/l/libexif-0.6.22-6.el9_6.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 441898
@@ -17491,13 +17491,13 @@ arches:
     name: java-17-openjdk-headless
     evr: 1:17.0.20.0.8-1.1.el9
     sourcerpm: java-17-openjdk-17.0.20.0.8-1.1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3842457
-    checksum: sha256:de268edb8669c3bd7b04101cff1fa0d30d9de086ab7e7e4fe3af0b16afaaa8bf
+    size: 3845001
+    checksum: sha256:8ca5eb3424bcc2d3653861a71dd7af8e3fb1f7472f4fe20c868e836fa5a99d14
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/Packages/l/libexif-0.6.22-6.el9_6.1.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 433909
@@ -23487,13 +23487,13 @@ arches:
     name: java-17-openjdk-headless
     evr: 1:17.0.20.0.8-1.1.el9
     sourcerpm: java-17-openjdk-17.0.20.0.8-1.1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.128.1.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.129.1.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3851773
-    checksum: sha256:208a87f523a34654b04f54b28784123b60f6f2bddac3954e5126364a5df76323
+    size: 3854369
+    checksum: sha256:8d52c97057460c36c7bb4a3bbd0535c45ee6facf5a9502b36486322134aaea40
     name: kernel-headers
-    evr: 5.14.0-570.128.1.el9_6
-    sourcerpm: kernel-5.14.0-570.128.1.el9_6.src.rpm
+    evr: 5.14.0-570.129.1.el9_6
+    sourcerpm: kernel-5.14.0-570.129.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libexif-0.6.22-6.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 444817


### PR DESCRIPTION
Automated lock file renewal in a single PR with separate commits:

1. Pylock lock files
2. Manifest annotations and generated Dockerfiles
3. ODH `rpms.lock.yaml` regeneration
4. RHDS `rpms.lock.yaml` regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenSSL compatibility packages to the latest EL9.8.4 builds across supported CPU architectures.
  * Updated kernel headers to version 5.14.0-570.129.1 across supported CPU architectures.
  * Refreshed package metadata references and integrity checksums for the updated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->