### PR TITLE
NO-JIRA: ci: add dependency review action for public repos

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -35,13 +35,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Dependency Review
+      - name: Dependency Review (pull_request)
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           # Block high/critical advisories introduced by the PR; ignore lower noise.
           fail-on-severity: high
           # No SPDX allowlist yet; vulnerability checks only.
           license-check: false
-          # Needed for workflow_dispatch; ignored for pull_request events.
-          base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || github.sha }}
-          head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.sha }}
+
+      - name: Dependency Review (dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          fail-on-severity: high
+          license-check: false
+          base-ref: ${{ inputs.base-ref }}
+          head-ref: ${{ inputs.head-ref || github.sha }}

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,33 @@
+# yamllint disable rule:line-length
+---
+name: Dependency Review
+
+# Free on public repositories. Private repos need GitHub Code Security.
+# https://github.com/security/plans
+"on":
+  pull_request:
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    # Private RHDS needs paid Code Security; keep free on public repos/forks.
+    if: github.repository != 'red-hat-data-services/notebooks'
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          # Block high/critical advisories introduced by the PR; ignore lower noise.
+          fail-on-severity: high
+          # No SPDX allowlist yet; vulnerability checks only.
+          license-check: false

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,13 +6,22 @@ name: Dependency Review
 # https://github.com/security/plans
 "on":
   pull_request:
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: Base git ref for comparison (required for manual runs)
+        required: false
+        default: main
+        type: string
+      head-ref:
+        description: Head git ref for comparison (defaults to the ref that triggered the run)
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: dependency-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   dependency-review:
@@ -20,6 +29,8 @@ jobs:
     # Private RHDS needs paid Code Security; keep free on public repos/forks.
     if: github.repository != 'red-hat-data-services/notebooks'
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -31,3 +42,6 @@ jobs:
           fail-on-severity: high
           # No SPDX allowlist yet; vulnerability checks only.
           license-check: false
+          # Needed for workflow_dispatch; ignored for pull_request events.
+          base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || github.sha }}
+          head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Dependency Review (pull_request)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Description

Adds a GitHub Dependency Review workflow that scans pull requests for high/critical advisories introduced by dependency changes.

- Uses `actions/dependency-review-action` (pinned SHA, v5.0.0)
- Runs on `pull_request` and `workflow_dispatch`
- Separate steps per event so the PR path stays simple; dispatch passes `base-ref` / `head-ref`
- Skips `red-hat-data-services/notebooks` (private; needs paid Code Security)
- Job-scoped `contents: read` permissions
- License checks disabled until we define an SPDX policy

This is free on public repositories per [GitHub Security plans](https://github.com/security/plans).

## How Has This Been Tested?

- Workflow YAML reviewed against existing Actions conventions (`ubuntu-26.04`, SHA pins, RHDS skip pattern)
- Validate on this PR once checks run, and via Actions → Dependency Review → Run workflow after merge

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency scanning for pull requests.
  * Added a manual option to run dependency reviews on demand.
  * Dependency review now fails only for high-severity advisories, with license checks skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->