### PR TITLE
RHAIENG-5022: chore(deps): follow-up docs and pylocks test hardening

### DIFF
--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -6,7 +6,7 @@ dependency rules:
 | Layer | File | uv flag | Purpose |
 |-------|------|---------|---------|
 | 1 | `constraints.txt` | `--constraints` | Global version **floors** (`package>=X`) |
-| 2 | `overrides.txt` | `--override` | Global **forced pins/ranges** when a floor is insufficient |
+| 2 | `overrides.txt` | `--override` | Global **forced pins/ranges** when a floor is insufficient; **replaces** package-declared requirements (runtime risk — see below) |
 | 3 | `pyproject.toml` `[tool.uv.override-dependencies]` | (from pyproject) | **Image-specific** overrides |
 
 Both global files are always passed to `uv pip compile`, even when empty.
@@ -44,6 +44,12 @@ guarantee. On `rhoai-x.y`, constraints also record CVE remediation for the relea
 
 Forced pins or ranges that `constraints.txt` cannot express, or that lose in resolver
 conflicts. Keep this file smaller than `constraints.txt`.
+
+**Runtime risk:** `uv --override` replaces package-declared requirements rather than
+adding a bound. A successful lock resolution therefore does **not** guarantee the
+forced version works at runtime with every image's dependency tree. Before adding a
+global entry, require compatibility evidence (tests, upstream guidance, or a
+deliberate all-image audit) — this file applies to **every** image.
 
 **Review obligation:** every time you touch this file, carefully review all entries
 for obsolete, broken, or dangerous pins. Fix or remove anything no longer justified

--- a/docs/cves/python.md
+++ b/docs/cves/python.md
@@ -55,7 +55,7 @@ Do not maintain a historical ledger of superseded CVE fixes.
 ### How it works
 
 1. **Constraints file format** (requirements.txt style):
-   ```
+   ```text
    # RHAIENG-XXXX: CVE-YYYY-ZZZZ description
    package>=fixed_version
    ```
@@ -70,7 +70,7 @@ Do not maintain a historical ledger of superseded CVE fixes.
 ### Adding a new CVE constraint
 
 1. Add the constraint to `dependencies/constraints.txt` in the CVE section:
-   ```
+   ```text
    # RHAIENG-XXXX: CVE-YYYY-ZZZZZ package_name vulnerability description
    # Upstream: https://github.com/...
    package_name>=fixed_version

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -395,10 +396,16 @@ def test_run_lock_always_passes_constraints_and_overrides(
     )
 
     assert success is True
+    expected_constraints = os.path.relpath(pg.CONSTRAINTS_FILE, project_dir)
+    expected_overrides = os.path.relpath(pg.OVERRIDES_FILE, project_dir)
     constraints_idx = captured_cmd.index("--constraints")
     overrides_idx = captured_cmd.index("--override")
-    assert captured_cmd[constraints_idx + 1].endswith("dependencies/constraints.txt")
-    assert captured_cmd[overrides_idx + 1].endswith("dependencies/overrides.txt")
+    assert captured_cmd[constraints_idx + 1] == expected_constraints, (
+        f"expected constraints path {expected_constraints!r}, got {captured_cmd[constraints_idx + 1]!r}"
+    )
+    assert captured_cmd[overrides_idx + 1] == expected_overrides, (
+        f"expected overrides path {expected_overrides!r}, got {captured_cmd[overrides_idx + 1]!r}"
+    )
 
 
 def test_resolve_pr_scoped_global_input_expands_to_all(

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -408,15 +408,20 @@ def test_run_lock_always_passes_constraints_and_overrides(
     )
 
 
+@pytest.mark.parametrize(
+    "global_input",
+    ["dependencies/constraints.txt", "dependencies/overrides.txt"],
+)
 def test_resolve_pr_scoped_global_input_expands_to_all(
+    global_input: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         pg,
         "_list_changed_files",
-        lambda _base, _to="HEAD": ["dependencies/constraints.txt"],
+        lambda _base, _to="HEAD": [global_input],
     )
     scoped = pg.resolve_pr_scoped_target_dirs("base", pg.LogBuffer())
     all_dirs = pg.discover_all_image_project_dirs()
-    assert scoped == all_dirs, "global input change should expand to all image dirs"
+    assert scoped == all_dirs, f"{global_input} change should expand to all image dirs"
     assert len(scoped) > 1, "expected multiple image project dirs for global-input fallback"


### PR DESCRIPTION
## Summary
Follow-up to #4154 (merged). Applies review fixups that were prepared locally but not included in the plumbing PR:

- Document `uv --override` runtime risk in `dependencies/README.md`
- Add `text` language tags to fenced code blocks in `docs/cves/python.md` (markdownlint MD040)
- Harden `test_pylocks_generator` unit tests: exact relative paths for `--constraints`/`--override`, parameterized PR-scoping for both global lock inputs

## Test plan
- [x] `uv run pytest tests/unit/scripts/test_pylocks_generator.py`
- [x] `uvx prek run --all-files --hook-stage manual`
- [ ] CI prek / unit tests

## Follow-up
- **PR 3 (planned):** dedupe per-image overrides (`urllib3`, `pillow`, `protobuf`) into global files
- [RHAIENG-5847](https://redhat.atlassian.net/browse/RHAIENG-5847) / [RHAIENG-6408](https://redhat.atlassian.net/browse/RHAIENG-6408) build on the merged plumbing

Related: [RHAIENG-5022](https://redhat.atlassian.net/browse/RHAIENG-5022)

Made with [Cursor](https://cursor.com)

[RHAIENG-5022]: https://redhat.atlassian.net/browse/RHAIENG-5022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RHAIENG-5847]: https://redhat.atlassian.net/browse/RHAIENG-5847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6408]: https://redhat.atlassian.net/browse/RHAIENG-6408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how global dependency overrides are applied and highlighted potential runtime compatibility risks.
  * Added guidance to require compatibility evidence before introducing global overrides.
  * Improved code block formatting in Python CVE documentation.

* **Tests**
  * Strengthened validation of dependency constraint and override paths.
  * Expanded coverage to verify both global constraints and overrides in pull-request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->