### PR TITLE
NO-JIRA: chore(deps): preserve BASE_IMAGE tags while pinning digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,12 +123,12 @@
         "/(jupyter|codeserver|runtimes)/.+/build-args/konflux\\..+\\.conf$/",
       ],
       "matchStrings": [
-        "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>\\S+)",
+        "BASE_IMAGE=(?<depName>[^:@\\s]+(?:/[^:@\\s]+)+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?",
       ],
       // Renovate's auto-replace locates the full match (replaceString) first, then
       // substitutes with this template.  Without it the default template may not
       // reconstruct the BASE_IMAGE=… line correctly.
-      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}",
+      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}",
       "datasourceTemplate": "docker",
       // Stable tags become [major, minor, patch, timestamp].
       // EA tags keep [major, minor, patch] and encode ea_version + timestamp in

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -195,6 +195,7 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["/^quay\\.io\\/aipcc\\//"],
       "groupName": "konflux BASE_IMAGE {{{depNameSanitized}}}",
+      "pinDigests": true,
       "recreateWhen": "always",
       "semanticCommits": "enabled",
     },
@@ -276,6 +277,7 @@
       // https://docs.renovatebot.com/configuration-options/#matchpackagenames
       "matchPackageNames": ["/^registry\\.redhat\\.io\\/rhai\\//"],
       "groupName": "Red Hat registry base images",
+      "pinDigests": true,
       "semanticCommits": "enabled",
     },
     {

--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-ubi9

--- a/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-codeserver-datascience-cpu-py312-rhel9

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-ubi9

--- a/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-datascience-cpu-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-ubi9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:3d17071c62fb5f19e5920a08a30fc1bf02ddbece167e82e0119bb39190f19cbe
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0@sha256:e42e80df19b0aa042d572a47ee9409310bfe113f00936755a3a14c3fe2b8bfae
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-ubi9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cpu-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1784654597@sha256:29a52d2e17b34f3b050d3d09e206662382d1656414aa933151a08f1fbb8f4d22
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-cuda-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6:3.5.0-1784224657@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-rhel9

--- a/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:eb18f8faa2b19ac641e53427555de608b6368b486312e02b581399d79a27cc04
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.14@sha256:194443760b6e02f3ab3bcb94fad54d9b197668432ede187f9b25cf51af1e97d8
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-minimal-rocm-py312-ubi9

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:3d17071c62fb5f19e5920a08a30fc1bf02ddbece167e82e0119bb39190f19cbe
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0@sha256:e42e80df19b0aa042d572a47ee9409310bfe113f00936755a3a14c3fe2b8bfae
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1784654597@sha256:29a52d2e17b34f3b050d3d09e206662382d1656414aa933151a08f1fbb8f4d22
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:3d17071c62fb5f19e5920a08a30fc1bf02ddbece167e82e0119bb39190f19cbe
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0@sha256:e42e80df19b0aa042d572a47ee9409310bfe113f00936755a3a14c3fe2b8bfae
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-ubi9

--- a/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1784654597@sha256:29a52d2e17b34f3b050d3d09e206662382d1656414aa933151a08f1fbb8f4d22
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-cuda-py312-rhel9

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6:3.5.0-1784224657@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-rhel9

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:eb18f8faa2b19ac641e53427555de608b6368b486312e02b581399d79a27cc04
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.14@sha256:194443760b6e02f3ab3bcb94fad54d9b197668432ede187f9b25cf51af1e97d8
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-pytorch-rocm-py312-ubi9

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6:3.5.0-1784224657@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-rhel9

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:eb18f8faa2b19ac641e53427555de608b6368b486312e02b581399d79a27cc04
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.14@sha256:194443760b6e02f3ab3bcb94fad54d9b197668432ede187f9b25cf51af1e97d8
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-rocm-py312-ubi9

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:b3b2d35032404b96a271f37986e00ccef282fa5edc4a2c2ba67b2736aeaad621
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9@sha256:b9aef6823ad6e58ce7468150dd10ab3df450d8d11c49d9dca822376e7217942a
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-ubi9

--- a/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6@sha256:079ae5aaf9f9d9f98b61aaf59e27cf692a1f061b8d7f069cd4e5e480743e18b7
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1784224754@sha256:079ae5aaf9f9d9f98b61aaf59e27cf692a1f061b8d7f069cd4e5e480743e18b7
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-tensorflow-cuda-py312-rhel9

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-ubi9

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-workbench-jupyter-trustyai-cpu-py312-rhel9

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-ubi9

--- a/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-datascience-cpu-py312-rhel9

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest@sha256:51696c5f359338bfff3706ea84fd87f354fc4363cff1ba6253a25e4783d2b3c6
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-ubi9

--- a/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/konflux.cpu.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cpu@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585
 PYLOCK_FLAVOR=cpu
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-minimal-cpu-py312-rhel9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:3d17071c62fb5f19e5920a08a30fc1bf02ddbece167e82e0119bb39190f19cbe
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0@sha256:e42e80df19b0aa042d572a47ee9409310bfe113f00936755a3a14c3fe2b8bfae
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1784654597@sha256:29a52d2e17b34f3b050d3d09e206662382d1656414aa933151a08f1fbb8f4d22
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:3d17071c62fb5f19e5920a08a30fc1bf02ddbece167e82e0119bb39190f19cbe
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v13.0@sha256:e42e80df19b0aa042d572a47ee9409310bfe113f00936755a3a14c3fe2b8bfae
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-ubi9

--- a/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.5.0-1784654597@sha256:29a52d2e17b34f3b050d3d09e206662382d1656414aa933151a08f1fbb8f4d22
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-cuda-py312-rhel9

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6:3.5.0-1784224657@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-rhel9

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:eb18f8faa2b19ac641e53427555de608b6368b486312e02b581399d79a27cc04
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.14@sha256:194443760b6e02f3ab3bcb94fad54d9b197668432ede187f9b25cf51af1e97d8
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-pytorch-rocm-py312-ubi9

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/konflux.rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
+BASE_IMAGE=quay.io/aipcc/base-images/rocm-7.14-el9.6:3.5.0-1784224657@sha256:a2d3d94279eb9627fb9b22fb028ccd3ff59ac55827f763788e03107a705d8397
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-rhel9

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s@sha256:eb18f8faa2b19ac641e53427555de608b6368b486312e02b581399d79a27cc04
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-rocm-py312-c9s:v7.14@sha256:194443760b6e02f3ab3bcb94fad54d9b197668432ede187f9b25cf51af1e97d8
 PYLOCK_FLAVOR=rocm
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-rocm-py312-ubi9

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s@sha256:b3b2d35032404b96a271f37986e00ccef282fa5edc4a2c2ba67b2736aeaad621
+BASE_IMAGE=quay.io/opendatahub/odh-base-image-cuda-py312-c9s:v12.9@sha256:b9aef6823ad6e58ce7468150dd10ab3df450d8d11c49d9dca822376e7217942a
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=opendatahub
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-ubi9

--- a/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/tensorflow/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # To update `BASE_IMAGE` edit `versions_config.yml` and run `gmake sync-build-args-from-versions`
 # For more information, see `docs/base_image_versions_update_configuration.md`.
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6@sha256:079ae5aaf9f9d9f98b61aaf59e27cf692a1f061b8d7f069cd4e5e480743e18b7
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1784224754@sha256:079ae5aaf9f9d9f98b61aaf59e27cf692a1f061b8d7f069cd4e5e480743e18b7
 PYLOCK_FLAVOR=cuda
 LABEL_REGISTRY_PREFIX=rhoai
 LABEL_COMPONENT=odh-pipeline-runtime-tensorflow-cuda-py312-rhel9

--- a/scripts/index_url_resolver.py
+++ b/scripts/index_url_resolver.py
@@ -40,9 +40,10 @@ class ResolvedIndexConfig:
 _RHOAI_INDEX_PATH_RE = re.compile(
     r"/rhoai/(?P<release>[^/]+)/(?P<accelerator>[^/]+)-ubi9(?:-test)?/simple/?$",
 )
-# Accepts tag (:3.5.0-…) or digest (@sha256:…) refs; image name stops at : or @.
+# Accepts tag (:3.5.0-…), digest (@sha256:…), or tag+digest (:3.5.0-…@sha256:…).
+# Image name stops at : or @.
 _BASE_IMAGE_RE = re.compile(
-    r"^quay\.io/aipcc/base-images/(?P<image>[^:@]+)(?::(?P<tag>[^@]+)|@sha256:[0-9a-f]+)$",
+    r"^quay\.io/aipcc/base-images/(?P<image>[^:@]+)(?::(?P<tag>[^@]+)(?:@sha256:[0-9a-f]+)?|@sha256:[0-9a-f]+)$",
 )
 _RELEASE_OVERRIDE_RE = re.compile(r"^(?P<minor>\d+\.\d+)(?:-EA(?P<ea>\d+))?$")
 _ACCELERATOR_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -7,8 +7,8 @@ files, rewrites managed ``BASE_IMAGE`` and ``RELEASE`` assignments plus the
 root ``Makefile`` release defaults, resolves newer RHDS ``channel: fast``
 releases to the highest already-published phase per target repository, uses
 ``skopeo`` to select the latest build in the chosen release-and-phase family,
-and pins each resolved ``BASE_IMAGE`` to an immutable ``repository@sha256:…``
-reference.
+and pins each resolved ``BASE_IMAGE`` to an immutable
+``repository:tag@sha256:…`` reference.
 """
 
 from __future__ import annotations
@@ -795,7 +795,7 @@ def resolve_image_digest(
         return image if "@" in image else f"{repository}@{ref}"
 
     if digest_cache is not None and image in digest_cache:
-        pinned = f"{repository}@{digest_cache[image]}"
+        pinned = f"{repository}:{ref}@{digest_cache[image]}"
         if source_tag_by_digest is not None:
             source_tag_by_digest[pinned] = ref
         return pinned
@@ -810,7 +810,7 @@ def resolve_image_digest(
 
     if digest_cache is not None:
         digest_cache[image] = digest
-    pinned = f"{repository}@{digest}"
+    pinned = f"{repository}:{ref}@{digest}"
     if source_tag_by_digest is not None:
         source_tag_by_digest[pinned] = ref
     return pinned

--- a/tests/unit/scripts/test_index_url_resolver.py
+++ b/tests/unit/scripts/test_index_url_resolver.py
@@ -51,6 +51,7 @@ DIGEST_PINNED_CPU = (
 DIGEST_PINNED_CUDA = (
     "quay.io/aipcc/base-images/cuda-13.0-el9.6@sha256:1620d9ade9a2a196b9d9bcca7842918dbf911273957abdd064a25e5f9d3f027c"
 )
+TAG_AND_DIGEST_PINNED_CPU = "quay.io/aipcc/base-images/cpu:3.5.0-1784227534@sha256:2f93df7e0b1b823bb63311f38b91cb8e0dc305d588813815dd4f77061fd15585"
 
 
 def assert_skopeo_inspect_cmd(cmd: list[str], base_image: str) -> None:
@@ -335,6 +336,7 @@ def test_resolve_falls_back_to_tag_when_label_missing(
     ("conf_name", "base_image", "flavor", "accelerator"),
     [
         ("konflux.cpu.conf", DIGEST_PINNED_CPU, "cpu", "cpu"),
+        ("konflux.cpu.conf", TAG_AND_DIGEST_PINNED_CPU, "cpu", "cpu"),
         ("konflux.cuda.conf", DIGEST_PINNED_CUDA, "cuda", "cuda13.0"),
     ],
 )

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -42,8 +42,7 @@ RHDS_ROCM_EA2_IMAGE = "quay.io/aipcc/base-images/rocm-7.1-el9.6:3.5.0-ea.2-17779
 def pin_image_for_test(tagged_image: str) -> str:
     if "@" in tagged_image:
         return tagged_image
-    repository, _tag = tagged_image.rsplit(":", 1)
-    return f"{repository}@{TEST_IMAGE_DIGEST}"
+    return f"{tagged_image}@{TEST_IMAGE_DIGEST}"
 
 
 def pinned_base_image(tagged_image: str) -> str:
@@ -698,7 +697,7 @@ def test_resolve_image_digest_uses_skopeo_inspect(monkeypatch: pytest.MonkeyPatc
     pinned = updater.resolve_image_digest("quay.io/aipcc/base-images/cpu:3.5.0-1782914735")
 
     assert inspect_calls == ["quay.io/aipcc/base-images/cpu:3.5.0-1782914735"]
-    assert pinned == f"quay.io/aipcc/base-images/cpu@{digest}"
+    assert pinned == f"quay.io/aipcc/base-images/cpu:3.5.0-1782914735@{digest}"
     assert pinned != pin_image_for_test("quay.io/aipcc/base-images/cpu:3.5.0-1782914735")
 
 
@@ -720,7 +719,7 @@ def test_resolve_image_digest_records_source_tag_for_digest_reference(
         source_tag_by_digest=source_tag_by_digest,
     )
 
-    assert pinned == f"quay.io/aipcc/base-images/cpu@{digest}"
+    assert pinned == f"quay.io/aipcc/base-images/cpu:3.5.0-ea.2-1777919771@{digest}"
     assert source_tag_by_digest[pinned] == "3.5.0-ea.2-1777919771"
 
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keep BASE_IMAGE values in repo:tag@sha256 format so Renovate can continue EA-to-stable tag progression while retaining immutable digest pinning. Inspired from this [konflux updates](https://github.com/opendatahub-io/notebooks/pull/3879) that keep tag along with digets

❗ NOTEs:
-  It updates the AIPCC based images as we had some updates.
- It replaces this one https://github.com/opendatahub-io/notebooks/pull/3995 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Build Updates**
  * Refreshed CPU, CUDA, and ROCm base image references across supported environments to updated tag/digest combinations for improved immutability and traceability.

* **Maintenance**
  * Enhanced automated base-image updates to correctly preserve existing tags when applying sha256 digest pins.
  * Expanded parsing to recognize tag+digest `BASE_IMAGE` formats.

* **Tests**
  * Updated unit tests to cover tag-preserving digest pin behavior during base-image resolution and update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->