### PR TITLE
chore-ci: add RHDS-style /build-* comment triggers for ODH PR pipelines

### DIFF
--- a/.tekton/README-odh.md
+++ b/.tekton/README-odh.md
@@ -25,7 +25,7 @@ The `-ci` suffix distinguishes stable components. Both sets of files live on `ma
 
 The `prefetch-input/odh/` directory at the repo root contains shared RPM and generic artifact inputs used by hermetic builds across all images. This directory is **intentionally not watched** in any pipeline's `pathChanged()` CEL expression.
 
-Watching it would trigger rebuilds of every single image whenever any shared prefetch input changes. Instead, changes to shared prefetch inputs should be rebuilt via `/kfbuild all` or `trigger-pac-build`. See [PR #3232 (RHAIENG-4234)](https://github.com/opendatahub-io/notebooks/pull/3232) which centralized prefetch inputs and explicitly removed them from triggers.
+Watching it would trigger rebuilds of every single image whenever any shared prefetch input changes. Instead, changes to shared prefetch inputs should be rebuilt via `/kfbuild-all`, `/build-konflux`, or `trigger-pac-build`. See [PR #3232 (RHAIENG-4234)](https://github.com/opendatahub-io/notebooks/pull/3232) which centralized prefetch inputs and explicitly removed them from triggers.
 
 ## Base images
 

--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-base\-image\-cpu\-py312\-c9s|base\-images/cpu/c9s\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-base\-cpu)
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "base-images/utils/**".pathChanged() || "base-images/cpu/c9s-python-3.12/**".pathChanged() || "base-images/build-args/cpu.conf".pathChanged() || ".tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml".pathChanged() ) && body.repository.full_name == "opendatahub-io/notebooks"
   labels:
     appstudio.openshift.io/application: opendatahub-release

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-base\-image\-cuda\-py312\-c9s|base\-images/cuda/12\.9/c9s\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-base\-cuda\-12\-9)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main"  && ( "base-images/utils/**".pathChanged() || "base-images/cuda/12.9/c9s-python-3.12/**".pathChanged() || "base-images/build-args/cuda12.9.conf".pathChanged() || ".tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-base\-image\-cuda\-py312\-c9s|base\-images/cuda/13\.0/c9s\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-base\-cuda\-13\-0)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main"  && ( "base-images/utils/**".pathChanged() || "base-images/cuda/13.0/c9s-python-3.12/**".pathChanged() || "base-images/build-args/cuda13.0.conf".pathChanged() || ".tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-base\-image\-rocm\-py312\-c9s|base\-images/rocm/7\.14/c9s\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-base\-rocm)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main"  && ( "base-images/utils/**".pathChanged() || "base-images/rocm/7.14/c9s-python-3.12/**".pathChanged() || "base-images/build-args/rocm7.14.conf".pathChanged() || ".tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-datascience\-cpu\-py312\-ubi9|runtimes/datascience/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-datascience)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( "runtimes/datascience/ubi9-python-3.12/**".pathChanged() || "runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf".pathChanged() || ".tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-minimal\-cpu\-py312\-ubi9|runtimes/minimal/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-minimal\-cpu)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( "runtimes/minimal/ubi9-python-3.12/**".pathChanged() || "runtimes/minimal/build-args/cpu.conf".pathChanged() || ".tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-pytorch\-cuda\-py312\-ubi9|runtimes/pytorch/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-pytorch\-cuda)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml".pathChanged() || "runtimes/pytorch/ubi9-python-3.12/**".pathChanged() || "runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-pytorch\-llmcompressor\-cuda\-py312\-ubi9|runtimes/pytorch\+llmcompressor/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-pytorch\-llmcompressor)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml".pathChanged() || "runtimes/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged() || "runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-pytorch\-rocm\-py312\-ubi9|runtimes/rocm\-pytorch/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-pytorch\-rocm)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && (".tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml".pathChanged() || "runtimes/rocm-pytorch/ubi9-python-3.12/**".pathChanged() || "runtimes/rocm-pytorch/ubi9-python-3.12/build-args/rocm.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-tensorflow\-cuda\-py312\-ubi9|runtimes/tensorflow/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-tensorflow\-cuda)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && (".tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml".pathChanged() || "runtimes/tensorflow/ubi9-python-3.12/**".pathChanged() || "runtimes/tensorflow/ubi9-python-3.12/build-args/cuda.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-pipeline\-runtime\-tensorflow\-rocm\-py312\-ubi9|runtimes/rocm\-tensorflow/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-runtime\-tensorflow\-rocm)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml".pathChanged() || "runtimes/rocm-tensorflow/ubi9-python-3.12/**".pathChanged() || "runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-codeserver\-datascience\-cpu\-py312\-ubi9|codeserver/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-codeserver)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" &&
       !("manifests/base/params-latest.env".pathChanged()) &&

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-datascience\-cpu\-py312\-ubi9|jupyter/datascience/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-datascience)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-minimal\-cpu\-py312\-ubi9|jupyter/minimal/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-minimal\-cpu)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" &&
       !("manifests/base/params-latest.env".pathChanged()) &&

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-minimal\-cuda\-py312\-ubi9|jupyter/minimal/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-minimal\-cuda)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" &&
       !("manifests/base/params-latest.env".pathChanged()) &&

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-minimal\-rocm\-py312\-ubi9|jupyter/minimal/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-minimal\-rocm)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" &&
       !("manifests/base/params-latest.env".pathChanged()) &&

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-pytorch\-cuda\-py312\-ubi9|jupyter/pytorch/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-pytorch\-cuda)
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request"
       && target_branch == "main"

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-pytorch\-llmcompressor\-cuda\-py312\-ubi9|jupyter/pytorch\+llmcompressor/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-pytorch\-llmcompressor)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml".pathChanged() || "jupyter/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged() || "jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-pytorch\-rocm\-py312\-ubi9|jupyter/rocm/pytorch/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-pytorch\-rocm)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml".pathChanged() || "jupyter/rocm/pytorch/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf".pathChanged() || "prefetch-input/mongocli/**".pathChanged() || "prefetch-input/odh/rpms.lock.yaml".pathChanged() || "prefetch-input/odh/artifacts.lock.yaml".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-tensorflow\-cuda\-py312\-ubi9|jupyter/tensorflow/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-tensorflow\-cuda)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml".pathChanged() || "jupyter/tensorflow/ubi9-python-3.12/**".pathChanged() || "jupyter/tensorflow/ubi9-python-3.12/build-args/cuda.conf".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-tensorflow\-rocm\-py312\-ubi9|jupyter/rocm/tensorflow/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-tensorflow\-rocm)
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && !("manifests/base/params-latest.env".pathChanged()) && ( ".tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml".pathChanged() || "jupyter/rocm/tensorflow/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() || "jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf".pathChanged() )
       && body.repository.full_name == "opendatahub-io/notebooks"

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-comment: ^/kfbuild\s+(all|odh\-workbench\-jupyter\-trustyai\-cpu\-py312\-ubi9|jupyter/trustyai/ubi9\-python\-3\.12)
+    pipelinesascode.tekton.dev/on-comment: ^/(kfbuild\-all|build\-konflux|build\-trustyai)
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request" && target_branch == "main"
       && !("manifests/base/params-latest.env".pathChanged())

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -55,9 +55,8 @@ for the full list.
 
 | Command | Effect |
 |---------|--------|
-| `/kfbuild all` | Triggers all PR build pipelines |
-| `/kfbuild <component>` | Triggers a single component build |
-| `/kfbuild <source-path>` | Triggers by source directory |
+| `/kfbuild-all` or `/build-konflux` | Triggers all PR build pipelines |
+| `/build-<image-type>` | Triggers a single component (e.g. `/build-minimal-cpu`, `/build-runtime-datascience`) |
 | `/group-test` | Triggers the integration test pipeline |
 
 **RHDS (`red-hat-data-services/notebooks`):**
@@ -81,7 +80,7 @@ GHA workflow, use the GitHub UI "Re-run" button on the Actions or Checks tab.
 PR opened/updated
   ├── GitHub Actions: runs automatically (code-quality, security, etc.)
   ├── Konflux/PaC: runs if pathChanged() matches .tekton/ CEL expressions
-  │                 or triggered manually via /kfbuild, /test, /retest
+  │                 or triggered manually via /kfbuild-all, /build-*, /test, /retest
   └── Prow/Tide: watches for label state
                   └── When lgtm + approved + all checks green → auto-merge
 ```

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -287,9 +287,16 @@ Our push pipelines use `on-cel-expression` combining event + branch + `pathChang
 
 **ODH (`opendatahub-io/notebooks`):**
 
-- `/kfbuild all` -- triggers all PR build pipelines
-- `/kfbuild <component-name>` -- triggers a single component, e.g. `/kfbuild odh-base-image-cpu-py312-ubi9`
-- `/kfbuild <source-path>` -- triggers by source directory, e.g. `/kfbuild base-images/cpu/ubi9-python-3.12`
+- `/kfbuild-all` or `/build-konflux` -- triggers all PR build pipelines
+- `/build-<image-type>` -- triggers a single component, e.g.:
+  - `/build-runtime-minimal-cpu`, `/build-runtime-datascience`
+  - `/build-runtime-pytorch-cuda`, `/build-runtime-pytorch-rocm`, `/build-runtime-pytorch-llmcompressor`
+  - `/build-runtime-tensorflow-cuda`, `/build-runtime-tensorflow-rocm`
+  - `/build-datascience`, `/build-codeserver`, `/build-trustyai`
+  - `/build-minimal-cpu`, `/build-minimal-cuda`, `/build-minimal-rocm`
+  - `/build-pytorch-cuda`, `/build-pytorch-rocm`, `/build-pytorch-llmcompressor`
+  - `/build-tensorflow-cuda`, `/build-tensorflow-rocm`
+  - `/build-base-cpu`, `/build-base-cuda-12-9`, `/build-base-cuda-13-0`, `/build-base-rocm`
 - `/group-test` -- triggers the integration test pipeline that tests images from the `stable` branch (see [Integration Testing guide](konflux-integration.md))
 
 **RHDS (`red-hat-data-services/notebooks`):**
@@ -298,11 +305,12 @@ PipelineRuns live in `red-hat-data-services/notebooks@main:.tekton/`.
 
 - `/build-konflux` -- triggers all RHDS PR build pipelines
 - `/build-<image-type>` -- triggers a specific image, e.g.:
-  - `/build-runtime-minimal-cpu`, `/build-runtime-datascience-cpu`
-  - `/build-runtime-pytorch-cuda`, `/build-runtime-pytorch-rocm`, `/build-runtime-pytorch-llmcompressor-cuda`
+  - `/build-runtime-minimal-cpu`, `/build-runtime-datascience`
+  - `/build-runtime-pytorch-cuda`, `/build-runtime-pytorch-rocm`, `/build-runtime-pytorch-llmcompressor`
   - `/build-runtime-tensorflow-cuda`, `/build-runtime-tensorflow-rocm`
-  - `/build-jupyter-datascience`, `/build-codeserver`
-  - `/build-workbench-jupyter-minimal-cpu`, `/build-workbench-jupyter-minimal-cuda`, `/build-workbench-jupyter-minimal-rocm`
+  - `/build-datascience`, `/build-codeserver`
+  - `/build-minimal-cpu`, `/build-minimal-cuda`, `/build-minimal-rocm`
+  - `/build-pytorch-cuda`, `/build-pytorch-rocm`, `/build-pytorch-llmcompressor`
   - `/build-tensorflow-cuda`, `/build-tensorflow-rocm`
 - `kfbuild-*` labels -- PR labels also trigger builds (e.g. `kfbuild-all`, `kfbuild-runtime`, `kfbuild-workbench`, `kfbuild-cpu`, `kfbuild-cuda`, `kfbuild-rocm`, `kfbuild-pytorch`, `kfbuild-tensorflow`, etc.)
 
@@ -360,9 +368,9 @@ successfully triggered a push pipeline. Also confirmed working in
 [ACS](https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1771841918073429) and
 [AAP Hub](https://redhat-internal.slack.com/archives/C07BMJL2X42/p1771333521169669).
 
-**Warning:** Custom `on-comment` triggers (like `/kfbuild`) also work on commit comments,
+**Warning:** Custom `on-comment` triggers (like `/kfbuild-all` or `/build-konflux`) also work on commit comments,
 but they match **all** pipelines with a matching regex -- including PR pipelines. Commenting
-`/kfbuild all` on a commit triggers all PR build pipelines, not push pipelines. Use the
+`/kfbuild-all` on a commit triggers all PR build pipelines, not push pipelines. Use the
 built-in `/test <name>` for commit comments instead.
 
 See also: [Running Build Pipelines (Konflux docs)](https://konflux-ci.dev/docs/building/running/),
@@ -400,7 +408,7 @@ Push pipelines declare a `build.appstudio.openshift.io/build-nudge-files` annota
 
 ### `prefetch-input/` path watching
 
-Most pipelines intentionally do not watch `prefetch-input/` in their CEL expressions — changing prefetched inputs will not retrigger those builds. This is deliberate: `prefetch-input/odh/` is shared across all images, and watching it would trigger 30+ simultaneous rebuilds on any change. Changes to shared prefetch inputs should be rebuilt via `/kfbuild all` or `trigger-pac-build`. See [PR #3232](https://github.com/opendatahub-io/notebooks/pull/3232) (RHAIENG-4234) which centralized prefetch inputs and removed them from triggers. A few workbench pipelines (pytorch-cuda, pytorch-rocm, trustyai) still watch image-specific paths like `prefetch-input/mongocli/**`.
+Most pipelines intentionally do not watch `prefetch-input/` in their CEL expressions — changing prefetched inputs will not retrigger those builds. This is deliberate: `prefetch-input/odh/` is shared across all images, and watching it would trigger 30+ simultaneous rebuilds on any change. Changes to shared prefetch inputs should be rebuilt via `/kfbuild-all`, `/build-konflux`, or `trigger-pac-build`. See [PR #3232](https://github.com/opendatahub-io/notebooks/pull/3232) (RHAIENG-4234) which centralized prefetch inputs and removed them from triggers. A few workbench pipelines (pytorch-cuda, pytorch-rocm, trustyai) still watch image-specific paths like `prefetch-input/mongocli/**`.
 
 ### Tenant RBAC for build operations
 


### PR DESCRIPTION
add RHDS-style /build-* comment triggers for ODH PR pipelines

## Description

Simplify each pull-request PipelineRun on-comment to short aliases (`/kfbuild-all|/build-konflux|/build-<image>`) so individual Konflux components can be retriggered with the same slash commands as downstream, and update the Konflux/CI docs to match.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated pull-request build triggers to support streamlined commands such as `/kfbuild-all`, `/build-konflux`, and image-specific `/build-*` commands.
  * Standardized build comment handling across base images, runtimes, and workbench pipelines.

* **Documentation**
  * Updated CI and Konflux guidance with the new build and retrigger commands.
  * Clarified manual pipeline triggers and shared-input rebuild instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->