### PR TITLE
chore: warn instead of fail secret-backed CI jobs on fork PRs

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -107,15 +107,31 @@ jobs:
         env:
           platform: ${{ inputs.platform }}
 
+      # Fork PRs do not receive repository secrets. When subscription was requested
+      # but GIT_CRYPT_KEY is missing, warn and continue without subscription so the
+      # reusable workflow does not fail hard at unlock.
+      - name: Resolve subscription availability
+        id: sub
+        if: ${{ inputs.subscription }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          if [[ -z "${GIT_CRYPT_KEY}" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Skipping RHEL subscription setup::GIT_CRYPT_KEY is unavailable (common for fork PRs). Continuing without subscription. See CONTRIBUTING.md#contributing-from-branches-vs-forks."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # do this early because it's fast and why not
       - name: Install git-crypt
-        if: ${{ inputs.subscription }}
+        if: steps.sub.outputs.enabled == 'true'
         uses: ./.github/actions/apt-install
         with:
           packages: git-crypt
 
       - name: Unlock encrypted secrets with git-crypt
-        if: ${{ inputs.subscription }}
+        if: steps.sub.outputs.enabled == 'true'
         run: |
           echo "${GIT_CRYPT_KEY}" | base64 --decode > ./git-crypt-key
           git-crypt unlock ./git-crypt-key
@@ -127,7 +143,7 @@ jobs:
       # This runs slower than storing the entitlement certificates with git-crypt,
       #  but on the other hand, it's then not necessary to regularly update them in the repo.
       - name: Add subscriptions from GitHub secret
-        if: ${{ inputs.subscription }}
+        if: steps.sub.outputs.enabled == 'true'
         run: |
           # https://access.redhat.com/solutions/5870841
           # https://github.com/containers/common/issues/1735
@@ -386,7 +402,8 @@ jobs:
             # AIPCC builds use RHEL-based base images, so prefetch from the rhds
             # variant to avoid RPM conflicts (e.g. openssl-fips-provider vs
             # openssl-fips-provider-so).
-            if [ "${{ inputs.subscription }}" = "true" ]; then
+            # Prefer the resolved subscription flag (false when fork PRs lack secrets).
+            if [ "${{ steps.sub.outputs.enabled }}" = "true" ]; then
               if [ ! -d "$PREFETCH_ROOT/rhds" ]; then
                 echo "Subscription build requires $PREFETCH_ROOT/rhds" >&2
                 exit 1

--- a/.github/workflows/software-versions.yaml
+++ b/.github/workflows/software-versions.yaml
@@ -41,7 +41,22 @@ jobs:
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
 
+      # Fork PRs do not receive repository secrets (GIT_CRYPT_KEY). Skip with a
+      # warning so the job stays green; same-repo PRs and pushes still validate.
+      - name: Check registry secrets availability
+        id: secrets
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          if [[ -z "${GIT_CRYPT_KEY}" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Skipping imagestream software-version validation::GIT_CRYPT_KEY is unavailable (common for fork PRs). Push the branch to the main repo for full CI. See CONTRIBUTING.md#contributing-from-branches-vs-forks."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Unlock encrypted secrets with git-crypt
+        if: steps.secrets.outputs.available == 'true'
         run: |
           echo "${GIT_CRYPT_KEY}" | base64 --decode > ./git-crypt-key
           trap 'rm -f ./git-crypt-key' EXIT
@@ -50,6 +65,7 @@ jobs:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: Configure registry auth from pull-secret
+        if: steps.secrets.outputs.available == 'true'
         run: |
           mkdir -p "$HOME/.config/containers"
           cp ci/secrets/pull-secret.json "$HOME/.config/containers/auth.json"
@@ -57,7 +73,7 @@ jobs:
           cp ci/secrets/pull-secret.json "$HOME/.docker/config.json"
 
       - name: Configure Quay.io API auth for RHOAI namespace
-        if: env.RHOAI_QUAY_BOT_USERNAME != ''
+        if: steps.secrets.outputs.available == 'true' && env.RHOAI_QUAY_BOT_USERNAME != ''
         run: |
           QUAY_AUTH=$(echo -n "${RHOAI_QUAY_BOT_USERNAME}:${RHOAI_QUAY_BOT_PASSWORD}" | base64 -w 0)
           echo "::add-mask::$QUAY_AUTH"
@@ -68,5 +84,6 @@ jobs:
           RHOAI_QUAY_BOT_PASSWORD: ${{ secrets.RHOAI_QUAY_BOT_PASSWORD }}
 
       - name: Validate manifest annotations against Quay.io Clair scan
+        if: steps.secrets.outputs.available == 'true'
         run: |
           uv run pytest tests/containers/manifest_validation_test.py::test_old_tag_annotations_match_quay -v

--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -37,7 +37,9 @@ jobs:
       github: ${{ toJson(github) }}
       platform: linux/amd64
       # ODH midstream vs RHDS downstream: avoid exercising stale odh lockfiles on RHDS.
-      product: ${{ github.repository == 'red-hat-data-services/notebooks' && 'rhoai' || 'odh' }}
+      # Fork PRs do not receive RHDS secrets (GIT_CRYPT_KEY / subscription), so fall
+      # back to the ODH path — same policy as build-notebooks-pr.yaml fork skips.
+      product: ${{ github.repository == 'red-hat-data-services/notebooks' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'rhoai' || 'odh' }}
       # jupyter-minimal PDF deps need RHEL AppStream on RHDS (RHAIENG-2345 / #2310).
-      subscription: ${{ github.repository == 'red-hat-data-services/notebooks' }}
+      subscription: ${{ github.repository == 'red-hat-data-services/notebooks' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     secrets: inherit


### PR DESCRIPTION
## Summary
* **software-versions**: skip imagestream Clair validation with a warning when `GIT_CRYPT_KEY` is unavailable (typical for fork PRs).
* **build-notebooks-TEMPLATE / test-build-notebooks-template**: do not enable RHDS subscription on fork PRs; if subscription was requested but secrets are missing, warn and continue without unlock instead of failing hard.

Fork `pull_request` workflows do not receive repository secrets. These jobs were failing at git-crypt unlock and reding CI for developers working from forks, contrary to CONTRIBUTING guidance that non-secret checks should still pass.

Once merged, this should sync ODH → RHDS via the usual nightly sync.

## Test plan
- [ ] Fork PR touching imagestream / `software-versions.yaml` paths — validation job passes with a warning
- [ ] Fork PR touching template / Podman CI paths on RHDS — template self-test does not fail at git-crypt unlock (runs ODH path without subscription)
- [ ] Same-repo PR or push with secrets set — software-versions still validates; template still uses subscription on RHDS