### PR TITLE
docs: sync Konflux PR trigger commands after #4157

### DIFF
--- a/.tekton/README-odh.md
+++ b/.tekton/README-odh.md
@@ -29,10 +29,12 @@ Watching it would trigger rebuilds of every single image whenever any shared pre
 
 ## PR comment triggers
 
-PR build pipelines are triggered by `pathChanged()` CEL expressions on push, or manually
-via PR comments (`/build-konflux`, `/kfbuild-all`, `/build-<type>`). See
-[docs/konflux.md](../docs/konflux.md#pr-comment-triggers-repo-specific) for the full
-command list and `/retest` behavior.
+PR build pipelines auto-trigger when `pathChanged()` CEL expressions match on
+push. Manual triggers use either built-in PaC commands (`/test`, `/retest` — CEL
+still evaluated) or custom `on-comment` regexes (`/build-konflux`, `/kfbuild-all`,
+`/build-<type>` — CEL bypassed). See
+[docs/konflux.md](../docs/konflux.md#how-pr-comment-commands-match-pipelines) for
+the full command list, behavior table, and known PaC limitations.
 
 ## Base images
 

--- a/.tekton/README-odh.md
+++ b/.tekton/README-odh.md
@@ -27,6 +27,13 @@ The `prefetch-input/odh/` directory at the repo root contains shared RPM and gen
 
 Watching it would trigger rebuilds of every single image whenever any shared prefetch input changes. Instead, changes to shared prefetch inputs should be rebuilt via `/kfbuild-all`, `/build-konflux`, or `trigger-pac-build`. See [PR #3232 (RHAIENG-4234)](https://github.com/opendatahub-io/notebooks/pull/3232) which centralized prefetch inputs and explicitly removed them from triggers.
 
+## PR comment triggers
+
+PR build pipelines are triggered by `pathChanged()` CEL expressions on push, or manually
+via PR comments (`/build-konflux`, `/kfbuild-all`, `/build-<type>`). See
+[docs/konflux.md](../docs/konflux.md#pr-comment-triggers-repo-specific) for the full
+command list and `/retest` behavior.
+
 ## Base images
 
 Base image pipelines (cuda, rocm) have version-specific filenames but version-agnostic component names. Multiple files share one component, so `trigger-pac-build` can't disambiguate them. These are triggered by `pathChanged()` on real pushes.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,7 +23,8 @@ independently based on their own job/pipeline registries.
 
 | Command | Prow response | PaC/Konflux response |
 |---------|--------------|---------------------|
-| `/retest` (bare) | Retriggers all failed Prow presubmit jobs | Retriggers all failed PaC pipelines. Ignores successful and in-progress ones. |
+| `/retest` (bare) | Retriggers all failed Prow presubmit jobs | Often re-runs all Konflux pipelines that already ran on the commit (including passed ones); see [konflux.md](konflux.md#pr-builds) and [tektoncd/pipelines-as-code#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580) |
+| `/test` (bare) | Retriggers all failed Prow presubmit jobs | Re-runs all annotation-matched PR pipelines (no success filter) |
 | `/retest <name>` | Retriggers the named Prow job if it failed | Triggers the named PaC pipeline regardless of previous outcome — even if it never ran on this PR |
 | `/test <name>` | Same as `/retest <name>` for Prow | Same as `/retest <name>` for PaC |
 | `/ok-to-test` | Trusts a fork PR for Prow CI | Trusts a fork PR for PaC pipelines |
@@ -51,20 +52,11 @@ for OWNERS approvers. See the [review mapping table](tide.md#github-review-appro
 These commands are handled exclusively by PaC. See [docs/konflux.md](konflux.md#triggering-builds)
 for the full list.
 
-**ODH (`opendatahub-io/notebooks`):**
-
 | Command | Effect |
 |---------|--------|
 | `/kfbuild-all` or `/build-konflux` | Triggers all PR build pipelines |
-| `/build-<image-type>` | Triggers a single component (e.g. `/build-minimal-cpu`, `/build-runtime-datascience`) |
-| `/group-test` | Triggers the integration test pipeline |
-
-**RHDS (`red-hat-data-services/notebooks`):**
-
-| Command | Effect |
-|---------|--------|
-| `/build-konflux` | Triggers all RHDS PR build pipelines |
-| `/build-<image-type>` | Triggers a specific image build |
+| `/build-<type>` | Triggers a specific image build (e.g. `/build-base-cpu`, `/build-runtime-pytorch-cuda`) |
+| `/group-test` | Triggers the integration test pipeline (ODH only) |
 
 RHDS also supports label-based triggers (`kfbuild-all`, `kfbuild-cuda`, etc.).
 
@@ -80,7 +72,7 @@ GHA workflow, use the GitHub UI "Re-run" button on the Actions or Checks tab.
 PR opened/updated
   ├── GitHub Actions: runs automatically (code-quality, security, etc.)
   ├── Konflux/PaC: runs if pathChanged() matches .tekton/ CEL expressions
-  │                 or triggered manually via /kfbuild-all, /build-*, /test, /retest
+  │                 or triggered manually via /build-konflux, /test, /retest
   └── Prow/Tide: watches for label state
                   └── When lgtm + approved + all checks green → auto-merge
 ```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,8 +23,8 @@ independently based on their own job/pipeline registries.
 
 | Command | Prow response | PaC/Konflux response |
 |---------|--------------|---------------------|
-| `/retest` (bare) | Retriggers all failed Prow presubmit jobs | Often re-runs all Konflux pipelines that already ran on the commit (including passed ones); see [konflux.md](konflux.md#pr-builds) and [tektoncd/pipelines-as-code#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580) |
-| `/test` (bare) | Retriggers all failed Prow presubmit jobs | Re-runs all annotation-matched PR pipelines (no success filter) |
+| `/retest` (bare) | Retriggers all failed Prow presubmit jobs | Re-runs CEL-matched Konflux pipelines; *intended* failed-only but often reruns all matched (including passed) — [#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580); see [konflux.md](konflux.md#how-pr-comment-commands-match-pipelines) |
+| `/test` (bare) | Retriggers all failed Prow presubmit jobs | Re-runs pipelines whose CEL `pathChanged()` matches the PR (subset, not all 22); see [konflux.md](konflux.md#how-pr-comment-commands-match-pipelines) |
 | `/retest <name>` | Retriggers the named Prow job if it failed | Triggers the named PaC pipeline regardless of previous outcome — even if it never ran on this PR |
 | `/test <name>` | Same as `/retest <name>` for Prow | Same as `/retest <name>` for PaC |
 | `/ok-to-test` | Trusts a fork PR for Prow CI | Trusts a fork PR for PaC pipelines |
@@ -58,6 +58,8 @@ for the full list.
 | `/build-<type>` | Triggers a specific image build (e.g. `/build-base-cpu`, `/build-runtime-pytorch-cuda`) |
 | `/group-test` | Triggers the integration test pipeline (ODH only) |
 
+`/build-*` and `/kfbuild-all` bypass CEL via `on-comment`; bare `/test` and `/retest` do not — see [konflux.md](konflux.md#how-pr-comment-commands-match-pipelines).
+
 RHDS also supports label-based triggers (`kfbuild-all`, `kfbuild-cuda`, etc.).
 
 ### GitHub Actions
@@ -72,7 +74,7 @@ GHA workflow, use the GitHub UI "Re-run" button on the Actions or Checks tab.
 PR opened/updated
   ├── GitHub Actions: runs automatically (code-quality, security, etc.)
   ├── Konflux/PaC: runs if pathChanged() matches .tekton/ CEL expressions
-  │                 or triggered manually via /build-konflux, /test, /retest
+  │                 or triggered manually via /kfbuild-all, /build-*, /test, /retest
   └── Prow/Tide: watches for label state
                   └── When lgtm + approved + all checks green → auto-merge
 ```

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -248,19 +248,28 @@ All PipelineRuns in `.tekton/` override compute resources for several tasks that
 
 ### PR builds
 
-Comment `/retest` on the pull request to retrigger **failed** PR pipelines.
-Successfully completed pipelines are not re-run. However, if the PipelineRun
-has `cancel-in-progress: "true"` (our pipelines do), `/retest` also **cancels
-all in-progress runs** before starting new ones -- PaC treats the `/retest`
-comment as a new event and applies the cancel-in-progress logic
+Comment `/retest` on the pull request to retrigger Konflux PR pipelines. PaC
+*intends* bare `/retest` to retry only failed pipelines, but in our Konflux
+setup that filtering is **unreliable**: bare `/retest` often re-runs **all**
+pipelines that already ran on the commit, including ones that already passed.
+This is especially likely after PipelineRun pruning (`max-keep-runs: 3` on our
+pipelines) — see [tektoncd/pipelines-as-code#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580).
+Verified on [PR #4161](https://github.com/opendatahub-io/notebooks/pull/4161)
+(5 passed + 2 failed → all 7 restarted after bare `/retest`).
+
+If the PipelineRun has `cancel-in-progress: "true"` (our pipelines do), `/retest`
+also **cancels all in-progress runs** before starting new ones -- PaC treats the
+`/retest` comment as a new event and applies the cancel-in-progress logic
 ([PaC cancel_pipelineruns.go](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/pipelineascode/cancel_pipelineruns.go),
 [PR #1833](https://github.com/openshift-pipelines/pipelines-as-code/pull/1833)).
-This means a `/retest` posted while builds are still running will cancel them
-and restart everything that hasn't succeeded yet.
 
-To retrigger a **single** pipeline (without cancelling others), use
-`/retest <pipelinerun-name>`. To trigger a pipeline regardless of its previous
-outcome -- including pipelines that never ran -- use `/test <pipelinerun-name>`.
+Bare `/test` re-runs all annotation-matched PR pipelines with **no** success
+filtering (use when you explicitly want a full rerun). To retrigger a **single**
+pipeline, use `/retest <pipelinerun-name>` or `/test <pipelinerun-name>`
+(always targets that pipeline, regardless of previous outcome). To explicitly
+trigger all PR build pipelines, use `/build-konflux` or `/kfbuild-all` (see
+[PR comment triggers](#pr-comment-triggers-repo-specific) below).
+
 See [PaC GitOps Commands](https://pipelinesascode.com/docs/guides/gitops-commands/).
 
 **Note:** When PaC retriggers a pipeline, it **replaces** the GitHub check run
@@ -285,34 +294,29 @@ Beyond `/retest`, PipelineRun YAMLs declare [Pipelines-as-Code trigger annotatio
 
 Our push pipelines use `on-cel-expression` combining event + branch + `pathChanged()`. The PR pipelines use `on-comment`, `on-label`, `on-event`, and `on-target-branch`. For `.tekton/` file and component naming conventions (`metadata.name` contract, `-ci` suffix, service account patterns), see [`.tekton/README-odh.md`](../.tekton/README-odh.md).
 
-**ODH (`opendatahub-io/notebooks`):**
+**ODH and RHDS** use the same `on-comment` trigger pattern (since
+[PR #4157](https://github.com/opendatahub-io/notebooks/pull/4157)). Each
+`*-pull-request.yaml` declares a regex like
+`^/(kfbuild\-all|build\-konflux|build\-base\-cpu)`.
 
-- `/kfbuild-all` or `/build-konflux` -- triggers all PR build pipelines
-- `/build-<image-type>` -- triggers a single component, e.g.:
-  - `/build-runtime-minimal-cpu`, `/build-runtime-datascience`
-  - `/build-runtime-pytorch-cuda`, `/build-runtime-pytorch-rocm`, `/build-runtime-pytorch-llmcompressor`
-  - `/build-runtime-tensorflow-cuda`, `/build-runtime-tensorflow-rocm`
-  - `/build-datascience`, `/build-codeserver`, `/build-trustyai`
-  - `/build-minimal-cpu`, `/build-minimal-cuda`, `/build-minimal-rocm`
-  - `/build-pytorch-cuda`, `/build-pytorch-rocm`, `/build-pytorch-llmcompressor`
-  - `/build-tensorflow-cuda`, `/build-tensorflow-rocm`
+- `/kfbuild-all` or `/build-konflux` -- triggers all PR build pipelines (22 on ODH)
+- `/build-<type>` -- triggers a specific image, e.g.:
   - `/build-base-cpu`, `/build-base-cuda-12-9`, `/build-base-cuda-13-0`, `/build-base-rocm`
-- `/group-test` -- triggers the integration test pipeline that tests images from the `stable` branch (see [Integration Testing guide](konflux-integration.md))
-
-**RHDS (`red-hat-data-services/notebooks`):**
-
-PipelineRuns live in `red-hat-data-services/notebooks@main:.tekton/`.
-
-- `/build-konflux` -- triggers all RHDS PR build pipelines
-- `/build-<image-type>` -- triggers a specific image, e.g.:
   - `/build-runtime-minimal-cpu`, `/build-runtime-datascience`
   - `/build-runtime-pytorch-cuda`, `/build-runtime-pytorch-rocm`, `/build-runtime-pytorch-llmcompressor`
   - `/build-runtime-tensorflow-cuda`, `/build-runtime-tensorflow-rocm`
-  - `/build-datascience`, `/build-codeserver`
   - `/build-minimal-cpu`, `/build-minimal-cuda`, `/build-minimal-rocm`
+  - `/build-datascience`, `/build-codeserver`
   - `/build-pytorch-cuda`, `/build-pytorch-rocm`, `/build-pytorch-llmcompressor`
   - `/build-tensorflow-cuda`, `/build-tensorflow-rocm`
-- `kfbuild-*` labels -- PR labels also trigger builds (e.g. `kfbuild-all`, `kfbuild-runtime`, `kfbuild-workbench`, `kfbuild-cpu`, `kfbuild-cuda`, `kfbuild-rocm`, `kfbuild-pytorch`, `kfbuild-tensorflow`, etc.)
+  - `/build-trustyai`
+- `/group-test` -- triggers the integration test pipeline (ODH only; tests images from the `stable` branch — see [Integration Testing guide](konflux-integration.md))
+- `kfbuild-*` labels -- PR labels also trigger builds on RHDS (e.g. `kfbuild-all`, `kfbuild-runtime`, `kfbuild-workbench`, `kfbuild-cpu`, `kfbuild-cuda`, `kfbuild-rocm`, `kfbuild-pytorch`, `kfbuild-tensorflow`, etc.)
+
+**Reference-only PRs** (e.g. MintMaker "Update Konflux references" that only
+touch `.tekton/multiarch-*`) do not match per-pipeline `pathChanged()` CEL
+expressions and will not auto-trigger component builds. Post `/build-konflux` or
+`/test <pipelinerun-name>` manually on such PRs.
 
 ### Push builds (post-merge)
 
@@ -350,8 +354,9 @@ this is the PipelineRun name, not the component name or filename).
 2. Scroll to the Comments section at the bottom of the commit page
 3. To trigger a specific push pipeline:
    `/test <pipelinerun-name>` (always works, even if the pipeline never ran)
-4. To retrigger failed push pipelines:
-   `/retest` (retriggers failed runs; also cancels in-progress runs if `cancel-in-progress` is enabled)
+4. To retrigger push pipelines:
+   `/retest` (same caveats as PR builds — often reruns all previously-run pipelines;
+   see [PR builds](#pr-builds) above)
 5. For non-default branches:
    `/test <pipelinerun-name> branch:<branch-name>` (pipeline name first, then `branch:`)
 

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -288,11 +288,11 @@ Beyond `/retest`, PipelineRun YAMLs declare [Pipelines-as-Code trigger annotatio
 - `pipelinesascode.tekton.dev/on-target-branch` -- target branch filter
 - `pipelinesascode.tekton.dev/on-comment` -- regex matched against PR comments (e.g. `"^/build-konflux"`)
 - `pipelinesascode.tekton.dev/on-label` -- PR labels that trigger the pipeline when added
-- `pipelinesascode.tekton.dev/on-cel-expression` -- CEL expression; takes priority over all the above when present
+- `pipelinesascode.tekton.dev/on-cel-expression` -- CEL expression; when PaC evaluates it, takes priority over `on-event`, `on-target-branch`, `on-label`, and legacy path annotations. **Not evaluated** when a PR comment matches `on-comment` — custom `/build-*` commands skip CEL ([PaC `annotation_matcher.go` L275–307](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/matcher/annotation_matcher.go#L275-L307)). Built-in bare `/test` and `/retest` do not use `on-comment`; PaC falls through to CEL for those (see [How PR comment commands match pipelines](#how-pr-comment-commands-match-pipelines))
 - `pipelinesascode.tekton.dev/on-path-change` -- only trigger when files matching a glob changed
 - `pipelinesascode.tekton.dev/on-path-change-ignore` -- don't trigger when only these paths changed
 
-Our push pipelines use `on-cel-expression` combining event + branch + `pathChanged()`. The PR pipelines use `on-comment`, `on-label`, `on-event`, and `on-target-branch`. For `.tekton/` file and component naming conventions (`metadata.name` contract, `-ci` suffix, service account patterns), see [`.tekton/README-odh.md`](../.tekton/README-odh.md).
+Our push pipelines use `on-cel-expression` combining event + branch + `pathChanged()`. PR pipelines declare both `on-cel-expression` (auto-trigger on push, and bare `/test`/`/retest`) and `on-comment` (manual `/build-konflux`, `/kfbuild-all`, `/build-*`). For `.tekton/` file and component naming conventions (`metadata.name` contract, `-ci` suffix, service account patterns), see [`.tekton/README-odh.md`](../.tekton/README-odh.md).
 
 **ODH and RHDS** use the same `on-comment` trigger pattern (since
 [PR #4157](https://github.com/opendatahub-io/notebooks/pull/4157)). Each

--- a/docs/konflux.md
+++ b/docs/konflux.md
@@ -248,29 +248,29 @@ All PipelineRuns in `.tekton/` override compute resources for several tasks that
 
 ### PR builds
 
-Comment `/retest` on the pull request to retrigger Konflux PR pipelines. PaC
-*intends* bare `/retest` to retry only failed pipelines, but in our Konflux
-setup that filtering is **unreliable**: bare `/retest` often re-runs **all**
-pipelines that already ran on the commit, including ones that already passed.
-This is especially likely after PipelineRun pruning (`max-keep-runs: 3` on our
-pipelines) — see [tektoncd/pipelines-as-code#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580).
-Verified on [PR #4161](https://github.com/opendatahub-io/notebooks/pull/4161)
-(5 passed + 2 failed → all 7 restarted after bare `/retest`).
+Bare `/retest` and bare `/test` are [PaC GitOps commands](https://pipelinesascode.com/docs/guides/gitops-commands/) that still evaluate each pipeline's `on-cel-expression` (including `pathChanged()`). They only affect pipelines whose CEL matches the PR's changed files — typically the same subset that auto-triggered on push. They do **not** start all 22 pipelines. Use `/build-konflux` or `/kfbuild-all` to bypass CEL and trigger everything (see [How PR comment commands match pipelines](#how-pr-comment-commands-match-pipelines) below).
 
-If the PipelineRun has `cancel-in-progress: "true"` (our pipelines do), `/retest`
-also **cancels all in-progress runs** before starting new ones -- PaC treats the
-`/retest` comment as a new event and applies the cancel-in-progress logic
-([PaC cancel_pipelineruns.go](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/pipelineascode/cancel_pipelineruns.go),
-[PR #1833](https://github.com/openshift-pipelines/pipelines-as-code/pull/1833)).
+PaC *intends* bare `/retest` to retry only **failed** pipelines within that CEL-matched subset, but in our Konflux setup that success filtering is **unreliable**: bare `/retest` often re-runs **all** CEL-matched pipelines on the commit, including ones that already passed. This is especially likely after PipelineRun pruning (`max-keep-runs: 3` on our pipelines) — see [tektoncd/pipelines-as-code#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580) ([`filterSuccessfulTemplates`](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/matcher/annotation_matcher.go#L451); GitHub [`GetCommitStatuses`](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/provider/github/github.go#L383-L385) returns `nil`, so Konflux Checks API results are not used as fallback). Verified on [PR #4161](https://github.com/opendatahub-io/notebooks/pull/4161) (5 passed + 2 failed → all 7 CEL-matched pipelines restarted after bare `/retest`).
 
-Bare `/test` re-runs all annotation-matched PR pipelines with **no** success
-filtering (use when you explicitly want a full rerun). To retrigger a **single**
-pipeline, use `/retest <pipelinerun-name>` or `/test <pipelinerun-name>`
-(always targets that pipeline, regardless of previous outcome). To explicitly
-trigger all PR build pipelines, use `/build-konflux` or `/kfbuild-all` (see
-[PR comment triggers](#pr-comment-triggers-repo-specific) below).
+Bare `/test` uses the same CEL scope as bare `/retest` but has **no** success filter. Verified on [PR #4164](https://github.com/opendatahub-io/notebooks/pull/4164) (reference-only → **0** new runs) and [PR #4160](https://github.com/opendatahub-io/notebooks/pull/4160) (CUDA paths → **7** runs, not 22).
 
-See [PaC GitOps Commands](https://pipelinesascode.com/docs/guides/gitops-commands/).
+If the PipelineRun has `cancel-in-progress: "true"` (our pipelines do), bare `/retest` and bare `/test` also **cancel all in-progress runs** before starting new ones — PaC treats the comment as a new event and applies cancel-in-progress logic ([PaC `cancel_pipelineruns.go`](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/pipelineascode/cancel_pipelineruns.go), [PR #1833](https://github.com/openshift-pipelines/pipelines-as-code/pull/1833)).
+
+To retrigger a **single** pipeline (bypassing CEL), use `/retest <pipelinerun-name>` or `/test <pipelinerun-name>` ([PaC push-commands docs](https://pipelinesascode.com/docs/guides/gitops-commands/push-commands/) — restarts the named PipelineRun regardless of event-matching annotations).
+
+#### How PR comment commands match pipelines
+
+PaC evaluates PipelineRun templates differently depending on the comment:
+
+| Command | Matching | Scope on ODH | Success filter |
+|---------|----------|--------------|----------------|
+| `/build-konflux` / `/kfbuild-all` | `on-comment` regex; **CEL skipped** ([source](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/matcher/annotation_matcher.go#L275-L307)) | All **22** PR pipelines | None |
+| `/build-<type>` | `on-comment` regex; **CEL skipped** | One pipeline | None |
+| bare `/test` | Built-in GitOps; **CEL evaluated** | Pipelines whose `pathChanged()` is true for this PR | None |
+| bare `/retest` | Same CEL scope as bare `/test` | Same subset | *Intended* failed-only; **unreliable** on GitHub — [#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580) |
+| `/test <name>` / `/retest <name>` | By `metadata.name` | One pipeline (even if CEL false / never ran) | None for `/test`; `/retest` always reruns named pipeline |
+
+Custom `on-comment` triggers (`/build-konflux`, `/kfbuild-all`, `/build-*`) match the regex in each `*-pull-request.yaml` and skip CEL entirely. Built-in `/test` and `/retest` do not use `on-comment`; PaC falls through to `on-cel-expression` evaluation ([CEL precedence](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/matcher/annotation_matcher.go#L176-L202)). Repo `on-comment` regexes were unified in [PR #4157](https://github.com/opendatahub-io/notebooks/pull/4157).
 
 **Note:** When PaC retriggers a pipeline, it **replaces** the GitHub check run
 (same external ID) rather than creating a new one. The GitHub Checks API only
@@ -315,7 +315,8 @@ Our push pipelines use `on-cel-expression` combining event + branch + `pathChang
 
 **Reference-only PRs** (e.g. MintMaker "Update Konflux references" that only
 touch `.tekton/multiarch-*`) do not match per-pipeline `pathChanged()` CEL
-expressions and will not auto-trigger component builds. Post `/build-konflux` or
+expressions and will not auto-trigger component builds. Bare `/test` and bare
+`/retest` also match nothing on such PRs. Post `/build-konflux` or
 `/test <pipelinerun-name>` manually on such PRs.
 
 ### Push builds (post-merge)


### PR DESCRIPTION
## Summary
- Update Konflux PR trigger docs for post-#4157 `on-comment` commands (`/kfbuild-all`, `/build-konflux`, `/build-<type>`)
- Unify ODH/RHDS command documentation and add reference-only PR manual-trigger note
- Document **how PR comment commands match pipelines** ([`docs/konflux.md#how-pr-comment-commands-match-pipelines`](docs/konflux.md#how-pr-comment-commands-match-pipelines)):
  - `/build-konflux` / `/kfbuild-all` / `/build-*` use `on-comment` and **bypass CEL** → all 22 PR pipelines
  - bare `/test` and `/retest` still evaluate `on-cel-expression` / `pathChanged()` → only the CEL-matched subset (not all 22)
  - `/test <pipelinerun-name>` / `/retest <pipelinerun-name>` target one pipeline by name, bypassing CEL
- Correct `/retest` behavior: *intended* failed-only within the CEL-matched subset, but often reruns all matched pipelines (including passed) on GitHub — [tektoncd/pipelines-as-code#2580](https://github.com/tektoncd/pipelines-as-code/issues/2580); verified on [PR #4161](https://github.com/opendatahub-io/notebooks/pull/4161)
- Document bare `/test` CEL scope with empirical verification: [PR #4164](https://github.com/opendatahub-io/notebooks/pull/4164) (reference-only → 0 runs), [PR #4160](https://github.com/opendatahub-io/notebooks/pull/4160) (CUDA paths → 7 runs, not 22)
- Link PaC sources (`annotation_matcher.go`, `filterSuccessfulTemplates`, `GetCommitStatuses`) and expand `.tekton/README-odh.md` pointer

## Test plan
- [x] `rg '/kfbuild all|/kfbuild <|/rebuild'` across `docs/` and `.tekton/README-odh.md` — zero hits
- [x] `rg 'all annotation-matched'` in `docs/` — zero hits
- [x] Command list matches live `on-comment` regexes on `main`
- [x] Bare `/test` and `/build-konflux` behavior verified on live PRs (#4160, #4164)
- [ ] Docs-only change; no build/test required

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added/expanded guidance on PR comment triggers and build activation rules, including `pathChanged()`-based auto-triggers on push.
  - Clarified how built-in commands behave: bare `/test`/`/retest` evaluate each pipeline’s CEL (and `/retest` often restarts already-passed runs), with optional in-progress cancellation; targeted `/test <pipelinerun-name>` and `/retest <pipelinerun-name>` rerun specific pipelines.
  - Consolidated and standardized Konflux command tables (`/kfbuild-all`, `/build-konflux`, `/build-<type>`, `/group-test`) and documented when CEL is bypassed.
  - Noted that reference-only PRs won’t match per-pipeline `pathChanged()` and require manual triggering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->