### PR TITLE
NO-JIRA: chore(ci): add versions_config JSON Schema generator

### DIFF
--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -41,6 +41,7 @@ uv --version || pip install 'uv>=0.10,<0.12'
 
 uv run scripts/dockerfile_fragments.py
 uv run manifests/tools/generate_kustomization.py
+uv run python -m ci.versions_config_schema
 
 if [[ -n "${PR_BASE}" ]]; then
   PYLOCKS_CI_CHECK=1 uv run scripts/pylocks_generator.py auto --pr-base "${PR_BASE}" --pr-to-ref "${PR_TO_REF}"

--- a/ci/versions_config.schema.json
+++ b/ci/versions_config.schema.json
@@ -1,0 +1,375 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "versions_config.schema.json",
+  "$defs": {
+    "Artifacts": {
+      "additionalProperties": false,
+      "description": "Artifact groups managed by the versions sync flow.",
+      "properties": {
+        "base_image": {
+          "$ref": "#/$defs/BaseImageArtifacts"
+        }
+      },
+      "required": [
+        "base_image"
+      ],
+      "title": "Artifacts",
+      "type": "object"
+    },
+    "BaseImageArtifacts": {
+      "additionalProperties": false,
+      "description": "Managed base-image policy tree.",
+      "properties": {
+        "cpu": {
+          "$ref": "#/$defs/CpuArtifact",
+          "description": "Shared CPU policy for all managed CPU workbenches."
+        },
+        "cuda": {
+          "additionalProperties": {
+            "$ref": "#/$defs/GpuFlavor"
+          },
+          "description": "CUDA flavor map keyed by image/flavor ID (open keys; sync enforces the managed inventory).",
+          "minProperties": 1,
+          "propertyNames": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "CUDA flavors",
+          "type": "object"
+        },
+        "rocm": {
+          "additionalProperties": {
+            "$ref": "#/$defs/GpuFlavor"
+          },
+          "description": "ROCm flavor map keyed by image/flavor ID (open keys; sync enforces the managed inventory).",
+          "minProperties": 1,
+          "propertyNames": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "ROCm flavors",
+          "type": "object"
+        }
+      },
+      "required": [
+        "cpu",
+        "cuda",
+        "rocm"
+      ],
+      "title": "BaseImageArtifacts",
+      "type": "object"
+    },
+    "CpuArtifact": {
+      "additionalProperties": false,
+      "description": "Shared CPU base-image policy (not per image-name).",
+      "properties": {
+        "rhds": {
+          "discriminator": {
+            "mapping": {
+              "fast": "#/$defs/RhdsFastCpuPolicy",
+              "stable": "#/$defs/RhdsStableCpuPolicy"
+            },
+            "propertyName": "channel"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/RhdsFastCpuPolicy"
+            },
+            {
+              "$ref": "#/$defs/RhdsStableCpuPolicy"
+            }
+          ],
+          "title": "RHDS CPU policy"
+        },
+        "odh": {
+          "$ref": "#/$defs/OdhCpuPolicy"
+        }
+      },
+      "required": [
+        "rhds",
+        "odh"
+      ],
+      "title": "CpuArtifact",
+      "type": "object"
+    },
+    "GpuFlavor": {
+      "additionalProperties": false,
+      "description": "Shared GPU flavor policy block.",
+      "properties": {
+        "acc_version": {
+          "description": "Accelerator stream (major.minor) shared by RHDS and ODH for this flavor, or \"<full_version>\". Nested acc_version under rhds/odh is not allowed.",
+          "examples": [
+            "13.0",
+            "7.14"
+          ],
+          "pattern": "^(\\d+\\.\\d+|<full_version>)$",
+          "title": "Accelerator version",
+          "type": "string"
+        },
+        "rhds": {
+          "discriminator": {
+            "mapping": {
+              "fast": "#/$defs/RhdsFastGpuPolicy",
+              "stable": "#/$defs/RhdsStableGpuPolicy"
+            },
+            "propertyName": "channel"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/RhdsFastGpuPolicy"
+            },
+            {
+              "$ref": "#/$defs/RhdsStableGpuPolicy"
+            }
+          ],
+          "title": "RHDS GPU policy"
+        },
+        "odh": {
+          "$ref": "#/$defs/OdhGpuPolicy"
+        }
+      },
+      "required": [
+        "acc_version",
+        "rhds",
+        "odh"
+      ],
+      "title": "GpuFlavor",
+      "type": "object"
+    },
+    "OdhCpuPolicy": {
+      "additionalProperties": false,
+      "description": "ODH CPU base-image policy.",
+      "properties": {
+        "origin": {
+          "description": "ODH image origin: \"in-house\" or \"midstream\".",
+          "enum": [
+            "in-house",
+            "midstream"
+          ],
+          "title": "Origin",
+          "type": "string"
+        },
+        "version": {
+          "const": "latest",
+          "description": "CPU ODH targets must stay on the rolling latest tag.",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "origin",
+        "version"
+      ],
+      "title": "OdhCpuPolicy",
+      "type": "object"
+    },
+    "OdhGpuPolicy": {
+      "additionalProperties": false,
+      "description": "ODH GPU base-image policy. Stream comes from flavor-level acc_version.",
+      "properties": {
+        "origin": {
+          "description": "ODH image origin: \"in-house\" or \"midstream\".",
+          "enum": [
+            "in-house",
+            "midstream"
+          ],
+          "title": "Origin",
+          "type": "string"
+        }
+      },
+      "required": [
+        "origin"
+      ],
+      "title": "OdhGpuPolicy",
+      "type": "object"
+    },
+    "Release": {
+      "additionalProperties": false,
+      "description": "Release metadata shared across RHDS and ODH base-image resolution.",
+      "properties": {
+        "full_version": {
+          "description": "Product release in semantic version form; drives RHDS selection and Makefile RELEASE.",
+          "examples": [
+            "3.5.0"
+          ],
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "title": "Full version",
+          "type": "string"
+        },
+        "rhds_os_base": {
+          "description": "RHDS CUDA/ROCm repository OS suffix, for example \"el9.6\".",
+          "examples": [
+            "el9.6"
+          ],
+          "pattern": "^el\\d+\\.\\d+$",
+          "title": "RHDS OS base",
+          "type": "string"
+        },
+        "python_version": {
+          "description": "Python interpreter major.minor version used for ODH CPU repository naming.",
+          "examples": [
+            "3.12"
+          ],
+          "pattern": "^\\d+\\.\\d+$",
+          "title": "Python version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "full_version",
+        "rhds_os_base",
+        "python_version"
+      ],
+      "title": "Release",
+      "type": "object"
+    },
+    "RhdsFastCpuPolicy": {
+      "additionalProperties": false,
+      "description": "RHDS CPU policy for the progressing (fast) channel.",
+      "properties": {
+        "channel": {
+          "const": "fast",
+          "description": "Must be \"fast\" for this policy shape.",
+          "title": "Channel",
+          "type": "string"
+        },
+        "version": {
+          "description": "RHDS fast CPU release version, or \"<full_version>\" to follow release.full_version.",
+          "examples": [
+            "<full_version>",
+            "3.5.0"
+          ],
+          "pattern": "^(\\d+\\.\\d+\\.\\d+|<full_version>)$",
+          "title": "RHDS CPU version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel",
+        "version"
+      ],
+      "title": "RhdsFastCpuPolicy",
+      "type": "object"
+    },
+    "RhdsFastGpuPolicy": {
+      "additionalProperties": false,
+      "description": "RHDS GPU policy for the progressing (fast) channel. Stream comes from flavor-level acc_version.",
+      "properties": {
+        "channel": {
+          "const": "fast",
+          "description": "Must be \"fast\" for this policy shape.",
+          "title": "Channel",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel"
+      ],
+      "title": "RhdsFastGpuPolicy",
+      "type": "object"
+    },
+    "RhdsStableCpuPolicy": {
+      "additionalProperties": false,
+      "description": "RHDS CPU policy for the stable channel (version is derived from release.full_version).",
+      "properties": {
+        "channel": {
+          "const": "stable",
+          "description": "Must be \"stable\" for this policy shape.",
+          "title": "Channel",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel"
+      ],
+      "title": "RhdsStableCpuPolicy",
+      "type": "object"
+    },
+    "RhdsStableGpuPolicy": {
+      "additionalProperties": false,
+      "description": "RHDS GPU policy for the stable channel. Stream matching uses flavor-level acc_version.",
+      "properties": {
+        "channel": {
+          "const": "stable",
+          "description": "Must be \"stable\" for this policy shape.",
+          "title": "Channel",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel"
+      ],
+      "title": "RhdsStableGpuPolicy",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Top-level ``versions_config.yml`` document (``schema_version: 1``).",
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "description": "Config schema revision; only version 1 is supported today.",
+      "title": "Schema version",
+      "type": "integer"
+    },
+    "release": {
+      "$ref": "#/$defs/Release"
+    },
+    "artifacts": {
+      "$ref": "#/$defs/Artifacts"
+    }
+  },
+  "required": [
+    "schema_version",
+    "release",
+    "artifacts"
+  ],
+  "title": "VersionsConfig",
+  "type": "object",
+  "examples": [
+    {
+      "schema_version": 1,
+      "release": {
+        "full_version": "3.5.0",
+        "rhds_os_base": "el9.6",
+        "python_version": "3.12"
+      },
+      "artifacts": {
+        "base_image": {
+          "cpu": {
+            "rhds": {
+              "channel": "fast",
+              "version": "<full_version>"
+            },
+            "odh": {
+              "origin": "in-house",
+              "version": "latest"
+            }
+          },
+          "cuda": {
+            "minimal": {
+              "acc_version": "13.0",
+              "rhds": {
+                "channel": "fast"
+              },
+              "odh": {
+                "origin": "in-house"
+              }
+            }
+          },
+          "rocm": {
+            "minimal": {
+              "acc_version": "7.14",
+              "rhds": {
+                "channel": "fast"
+              },
+              "odh": {
+                "origin": "in-house"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/ci/versions_config_schema.py
+++ b/ci/versions_config_schema.py
@@ -1,0 +1,271 @@
+"""Generate JSON Schema for ``versions_config.yml`` (IDE validation).
+
+Pydantic models here exist only to emit ``versions_config.schema.json`` for
+``yaml-language-server``. Sync/rollout do not import this module; they keep
+their own hand-rolled validation until a later migration.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, TypeAdapter
+from pydantic.json_schema import GenerateJsonSchema
+
+SEMVER_PATTERN = r"^\d+\.\d+\.\d+$"
+PYTHON_VERSION_PATTERN = r"^\d+\.\d+$"
+STREAM_VERSION_PATTERN = r"^\d+\.\d+$"
+RHDS_OS_BASE_PATTERN = r"^el\d+\.\d+$"
+FULL_VERSION_PLACEHOLDER = "<full_version>"
+RHDS_FAST_CPU_VERSION_PATTERN = rf"^({SEMVER_PATTERN[1:-1]}|{re.escape(FULL_VERSION_PLACEHOLDER)})$"
+ACC_VERSION_PATTERN = rf"^({STREAM_VERSION_PATTERN[1:-1]}|{re.escape(FULL_VERSION_PLACEHOLDER)})$"
+
+STRICT_CONFIG = ConfigDict(
+    extra="forbid",
+    str_strip_whitespace=True,
+    frozen=True,
+)
+
+SCHEMA_ID = "versions_config.schema.json"
+
+SemVer = Annotated[str, StringConstraints(pattern=SEMVER_PATTERN)]
+PythonVersion = Annotated[
+    str,
+    StringConstraints(pattern=PYTHON_VERSION_PATTERN),
+    Field(
+        title="Python version",
+        description="Python interpreter major.minor version used for ODH CPU repository naming.",
+        examples=["3.12"],
+    ),
+]
+RhdsOsBase = Annotated[
+    str,
+    StringConstraints(pattern=RHDS_OS_BASE_PATTERN),
+    Field(
+        title="RHDS OS base",
+        description='RHDS CUDA/ROCm repository OS suffix, for example "el9.6".',
+        examples=["el9.6"],
+    ),
+]
+RhdsFastCpuVersion = Annotated[
+    str,
+    StringConstraints(pattern=RHDS_FAST_CPU_VERSION_PATTERN),
+    Field(
+        title="RHDS CPU version",
+        description=f'RHDS fast CPU release version, or "{FULL_VERSION_PLACEHOLDER}" to follow release.full_version.',
+        examples=[FULL_VERSION_PLACEHOLDER, "3.5.0"],
+    ),
+]
+AccVersion = Annotated[
+    str,
+    StringConstraints(pattern=ACC_VERSION_PATTERN),
+    Field(
+        title="Accelerator version",
+        description=(
+            "Accelerator stream (major.minor) shared by RHDS and ODH for this flavor, "
+            f'or "{FULL_VERSION_PLACEHOLDER}". Nested acc_version under rhds/odh is not allowed.'
+        ),
+        examples=["13.0", "7.14"],
+    ),
+]
+OdhOrigin = Literal["in-house", "midstream"]
+SchemaVersion = Literal[1]
+
+
+class StrictModel(BaseModel):
+    """Strict structural shapes for operator-edited YAML (feeds JSON Schema)."""
+
+    model_config = STRICT_CONFIG
+
+
+class Release(StrictModel):
+    """Release metadata shared across RHDS and ODH base-image resolution."""
+
+    full_version: SemVer = Field(
+        title="Full version",
+        description="Product release in semantic version form; drives RHDS selection and Makefile RELEASE.",
+        examples=["3.5.0"],
+    )
+    rhds_os_base: RhdsOsBase
+    python_version: PythonVersion
+
+
+class RhdsFastCpuPolicy(StrictModel):
+    """RHDS CPU policy for the progressing (fast) channel."""
+
+    channel: Literal["fast"] = Field(title="Channel", description='Must be "fast" for this policy shape.')
+    version: RhdsFastCpuVersion
+
+
+class RhdsStableCpuPolicy(StrictModel):
+    """RHDS CPU policy for the stable channel (version is derived from release.full_version)."""
+
+    channel: Literal["stable"] = Field(title="Channel", description='Must be "stable" for this policy shape.')
+
+
+RhdsCpuPolicy = Annotated[
+    RhdsFastCpuPolicy | RhdsStableCpuPolicy,
+    Field(discriminator="channel", title="RHDS CPU policy"),
+]
+
+
+class OdhCpuPolicy(StrictModel):
+    """ODH CPU base-image policy."""
+
+    origin: OdhOrigin = Field(
+        title="Origin",
+        description='ODH image origin: "in-house" or "midstream".',
+    )
+    version: Literal["latest"] = Field(
+        title="Version",
+        description="CPU ODH targets must stay on the rolling latest tag.",
+    )
+
+
+class CpuArtifact(StrictModel):
+    """Shared CPU base-image policy (not per image-name)."""
+
+    rhds: RhdsCpuPolicy
+    odh: OdhCpuPolicy
+
+
+class RhdsFastGpuPolicy(StrictModel):
+    """RHDS GPU policy for the progressing (fast) channel. Stream comes from flavor-level acc_version."""
+
+    channel: Literal["fast"] = Field(title="Channel", description='Must be "fast" for this policy shape.')
+
+
+class RhdsStableGpuPolicy(StrictModel):
+    """RHDS GPU policy for the stable channel. Stream matching uses flavor-level acc_version."""
+
+    channel: Literal["stable"] = Field(title="Channel", description='Must be "stable" for this policy shape.')
+
+
+RhdsGpuPolicy = Annotated[
+    RhdsFastGpuPolicy | RhdsStableGpuPolicy,
+    Field(discriminator="channel", title="RHDS GPU policy"),
+]
+
+
+class OdhGpuPolicy(StrictModel):
+    """ODH GPU base-image policy. Stream comes from flavor-level acc_version."""
+
+    origin: OdhOrigin = Field(
+        title="Origin",
+        description='ODH image origin: "in-house" or "midstream".',
+    )
+
+
+class GpuFlavor(StrictModel):
+    """Shared GPU flavor policy block."""
+
+    acc_version: AccVersion
+    rhds: RhdsGpuPolicy
+    odh: OdhGpuPolicy
+
+
+CudaFlavors: TypeAlias = dict[str, GpuFlavor]
+"""CUDA flavor policies. Keys are image/flavor IDs (e.g. minimal, pytorch-llmcompressor)."""
+
+RocmFlavors: TypeAlias = dict[str, GpuFlavor]
+"""ROCm flavor policies. Keys are image/flavor IDs."""
+
+
+class BaseImageArtifacts(StrictModel):
+    """Managed base-image policy tree."""
+
+    cpu: CpuArtifact = Field(description="Shared CPU policy for all managed CPU workbenches.")
+    cuda: CudaFlavors = Field(
+        title="CUDA flavors",
+        description="CUDA flavor map keyed by image/flavor ID (open keys; sync enforces the managed inventory).",
+        json_schema_extra={
+            "propertyNames": {"type": "string", "minLength": 1},
+            "minProperties": 1,
+        },
+    )
+    rocm: RocmFlavors = Field(
+        title="ROCm flavors",
+        description="ROCm flavor map keyed by image/flavor ID (open keys; sync enforces the managed inventory).",
+        json_schema_extra={
+            "propertyNames": {"type": "string", "minLength": 1},
+            "minProperties": 1,
+        },
+    )
+
+
+class Artifacts(StrictModel):
+    """Artifact groups managed by the versions sync flow."""
+
+    base_image: BaseImageArtifacts
+
+
+class VersionsConfig(StrictModel):
+    """Top-level ``versions_config.yml`` document (``schema_version: 1``)."""
+
+    schema_version: SchemaVersion = Field(
+        title="Schema version",
+        description="Config schema revision; only version 1 is supported today.",
+    )
+    release: Release
+    artifacts: Artifacts
+
+
+_VERSIONS_CONFIG_ADAPTER = TypeAdapter(VersionsConfig)
+
+
+def build_json_schema() -> dict[str, object]:
+    """Build the JSON Schema document for ``versions_config.yml``."""
+    schema = _VERSIONS_CONFIG_ADAPTER.json_schema(schema_generator=GenerateJsonSchema)
+    return {
+        "$schema": GenerateJsonSchema.schema_dialect,
+        "$id": SCHEMA_ID,
+        **schema,
+        "examples": [
+            {
+                "schema_version": 1,
+                "release": {
+                    "full_version": "3.5.0",
+                    "rhds_os_base": "el9.6",
+                    "python_version": "3.12",
+                },
+                "artifacts": {
+                    "base_image": {
+                        "cpu": {
+                            "rhds": {"channel": "fast", "version": "<full_version>"},
+                            "odh": {"origin": "in-house", "version": "latest"},
+                        },
+                        "cuda": {
+                            "minimal": {
+                                "acc_version": "13.0",
+                                "rhds": {"channel": "fast"},
+                                "odh": {"origin": "in-house"},
+                            }
+                        },
+                        "rocm": {
+                            "minimal": {
+                                "acc_version": "7.14",
+                                "rhds": {"channel": "fast"},
+                                "odh": {"origin": "in-house"},
+                            }
+                        },
+                    }
+                },
+            }
+        ],
+    }
+
+
+def main() -> None:
+    """Generate the JSON schema for versions_config.yml."""
+    out = Path(__file__).parent / "versions_config.schema.json"
+    with out.open("w", encoding="utf-8") as handle:
+        json.dump(build_json_schema(), handle, indent=2)
+        handle.write("\n")
+    print(f"Schema generated: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/base_image_versions_update_configuration.md
+++ b/docs/base_image_versions_update_configuration.md
@@ -11,6 +11,13 @@ and updates the root `Makefile` release defaults. The implementation lives in
 `scripts/update_build_args_from_versions.py`, and the standard entry point is
 `make sync-build-args-from-versions`.
 
+Editor validation uses the checked-in JSON Schema
+([`ci/versions_config.schema.json`](../ci/versions_config.schema.json)), generated
+from Pydantic models in [`ci/versions_config_schema.py`](../ci/versions_config_schema.py).
+The sync script still applies its own structural checks at runtime. Regenerate
+the schema after model changes with `uv run python -m ci.versions_config_schema`
+(`# yaml-language-server: $schema=…` in `versions_config.yml` points at it).
+
 ## What This Flow Manages
 
 The sync flow manages:

--- a/docs/base_image_versions_update_configuration.md
+++ b/docs/base_image_versions_update_configuration.md
@@ -15,8 +15,9 @@ Editor validation uses the checked-in JSON Schema
 ([`ci/versions_config.schema.json`](../ci/versions_config.schema.json)), generated
 from Pydantic models in [`ci/versions_config_schema.py`](../ci/versions_config_schema.py).
 The sync script still applies its own structural checks at runtime. Regenerate
-the schema after model changes with `uv run python -m ci.versions_config_schema`
-(`# yaml-language-server: $schema=…` in `versions_config.yml` points at it).
+the schema with `bash ci/generate_code.sh` (or
+`uv run python -m ci.versions_config_schema`);
+`# yaml-language-server: $schema=…` in `versions_config.yml` points at it.
 
 ## What This Flow Manages
 

--- a/tests/test_versions_config_schema.py
+++ b/tests/test_versions_config_schema.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from ci.versions_config_schema import (
+    ACC_VERSION_PATTERN,
+    PYTHON_VERSION_PATTERN,
+    RHDS_FAST_CPU_VERSION_PATTERN,
+    RHDS_OS_BASE_PATTERN,
+    SEMVER_PATTERN,
+    VersionsConfig,
+    build_json_schema,
+)
+from tests import PROJECT_ROOT
+
+_GPU_FLAVOR = {
+    "acc_version": "13.0",
+    "rhds": {"channel": "fast"},
+    "odh": {"origin": "in-house"},
+}
+
+
+def _minimal_valid_config() -> dict:
+    return {
+        "schema_version": 1,
+        "release": {
+            "full_version": "3.5.0",
+            "rhds_os_base": "el9.6",
+            "python_version": "3.12",
+        },
+        "artifacts": {
+            "base_image": {
+                "cpu": {
+                    "rhds": {"channel": "fast", "version": "3.5.0"},
+                    "odh": {"origin": "in-house", "version": "latest"},
+                },
+                "cuda": {
+                    "minimal": copy.deepcopy(_GPU_FLAVOR),
+                },
+                "rocm": {
+                    "minimal": {
+                        "acc_version": "7.14",
+                        "rhds": {"channel": "fast"},
+                        "odh": {"origin": "in-house"},
+                    },
+                },
+            }
+        },
+    }
+
+
+def test_repo_versions_config_validates() -> None:
+    data = yaml.safe_load((PROJECT_ROOT / "versions_config.yml").read_text(encoding="utf-8"))
+    config = VersionsConfig.model_validate(data)
+    assert config.schema_version == 1
+    assert config.release.full_version == "3.5.0"
+    assert config.artifacts.base_image.cuda["minimal"].acc_version == "13.0"
+    assert "pytorch-llmcompressor" in config.artifacts.base_image.cuda
+
+
+def test_rejects_unexpected_top_level_key() -> None:
+    data = _minimal_valid_config()
+    data["unexpected"] = True
+    with pytest.raises(ValidationError):
+        VersionsConfig.model_validate(data)
+
+
+def test_rejects_unknown_cpu_distribution_key() -> None:
+    data = _minimal_valid_config()
+    data["artifacts"]["base_image"]["cpu"]["extra"] = {"channel": "fast", "version": "3.5.0"}
+    with pytest.raises(ValidationError):
+        VersionsConfig.model_validate(data)
+
+
+def test_rejects_cpu_odh_non_latest_version() -> None:
+    data = _minimal_valid_config()
+    data["artifacts"]["base_image"]["cpu"]["odh"]["version"] = "3.5.0"
+    with pytest.raises(ValidationError):
+        VersionsConfig.model_validate(data)
+
+
+def test_accepts_experimental_cuda_flavor_key() -> None:
+    data = _minimal_valid_config()
+    data["artifacts"]["base_image"]["cuda"]["my-experimental-flavor"] = copy.deepcopy(_GPU_FLAVOR)
+    data["artifacts"]["base_image"]["cuda"]["pytorch+llmcompressor"] = copy.deepcopy(_GPU_FLAVOR)
+    config = VersionsConfig.model_validate(data)
+    assert "my-experimental-flavor" in config.artifacts.base_image.cuda
+    assert "pytorch+llmcompressor" in config.artifacts.base_image.cuda
+
+
+def test_rejects_rhds_os_base_without_el_prefix() -> None:
+    data = _minimal_valid_config()
+    data["release"]["rhds_os_base"] = "9.6"
+    with pytest.raises(ValidationError) as exc_info:
+        VersionsConfig.model_validate(data)
+    assert any(err["type"] == "string_pattern_mismatch" for err in exc_info.value.errors())
+
+
+def test_rejects_nested_gpu_acc_version() -> None:
+    data = _minimal_valid_config()
+    data["artifacts"]["base_image"]["cuda"]["minimal"]["odh"]["acc_version"] = "13.0"
+    with pytest.raises(ValidationError) as exc_info:
+        VersionsConfig.model_validate(data)
+    assert any(err["type"] == "extra_forbidden" for err in exc_info.value.errors())
+
+
+def test_json_schema_includes_string_patterns() -> None:
+    schema = build_json_schema()
+    release = schema["$defs"]["Release"]["properties"]
+    assert release["full_version"]["pattern"] == SEMVER_PATTERN
+    assert release["rhds_os_base"]["pattern"] == RHDS_OS_BASE_PATTERN
+    assert release["python_version"]["pattern"] == PYTHON_VERSION_PATTERN
+    assert schema["$defs"]["GpuFlavor"]["properties"]["acc_version"]["pattern"] == ACC_VERSION_PATTERN
+    assert schema["$defs"]["RhdsFastCpuPolicy"]["properties"]["version"]["pattern"] == RHDS_FAST_CPU_VERSION_PATTERN
+
+
+def test_committed_json_schema_matches_generator() -> None:
+    committed = json.loads((PROJECT_ROOT / "ci" / "versions_config.schema.json").read_text(encoding="utf-8"))
+    assert committed == build_json_schema()
+    assert committed["$id"] == "versions_config.schema.json"
+    assert committed["examples"]

--- a/versions_config.yml
+++ b/versions_config.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./ci/versions_config.schema.json
 ---
 schema_version: 1
 
@@ -41,7 +42,6 @@ artifacts:
           channel: fast
         odh:
           origin: in-house
-
     rocm:
       minimal:
         acc_version: "7.14"


### PR DESCRIPTION
## Description

First piecemeal step toward Pydantic for `versions_config.yml`: introduce models **only** to generate IDE JSON Schema. Sync/rollout runtime validation is unchanged.

- Add [`ci/versions_config_schema.py`](ci/versions_config_schema.py) with schema-visible constraints (`extra=forbid`, `Literal`s, discriminators, `pattern`s, field docs)
- Commit generated [`ci/versions_config.schema.json`](ci/versions_config.schema.json)
- Point `versions_config.yml` at the schema via `# yaml-language-server: $schema=…`
- Regenerate via `ci/generate_code.sh` (keeps `check-generated-code` honest)
- Unit tests for structural shape + committed schema sync

Later PRs can wire load sites onto the same models.

## How Has This Been Tested?

- `uv run pytest tests/test_versions_config_schema.py -q`
- `uv run python -m ci.versions_config_schema` (schema regenerates cleanly)
- Confirmed sync/rollout do not import `ci.versions_config_schema`

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — ran targeted schema unit tests (no Dockerfile/deps change)
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Test plan

- [ ] CI `check-generated-code` passes (schema stays in sync via `generate_code.sh`)
- [ ] Open `versions_config.yml` in an editor with YAML schema support and confirm autocomplete/validation against the new schema
- [ ] Confirm `make sync-build-args-from-versions --dry-run` behavior is unchanged vs `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured validation for base image version configuration files.
  * Editors can now provide schema-based autocomplete and validation for `versions_config.yml`.
  * Added checks for version formats, required fields, supported policies, and unexpected configuration entries.

* **Documentation**
  * Updated configuration guidance with schema validation and regeneration instructions.

* **Tests**
  * Added comprehensive validation tests and checks to keep the generated schema synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->