### PR TITLE
fix(ci): add ghcr login for Antigravity prepare-review-context

### DIFF
--- a/.github/workflows/antigravity-ci-gated-review.yml
+++ b/.github/workflows/antigravity-ci-gated-review.yml
@@ -24,6 +24,7 @@ jobs:
       actions: 'read'
       contents: 'read'
       issues: 'write'
+      packages: 'read'
       pull-requests: 'write'
     steps:
       - name: 'Mint identity token'
@@ -49,6 +50,14 @@ jobs:
 
       - name: 'Install from uv.lock (project + dev deps)'
         run: 'uv sync --locked --package odh-ci-agent'
+
+      # odh-ci-prepare-review-context pulls the buildinputs image to resolve affected image targets.
+      - name: 'Login to GitHub Container Registry'
+        uses: 'docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0'  # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Prepare review context'
         if: |-

--- a/.github/workflows/antigravity-pr-review.yml
+++ b/.github/workflows/antigravity-pr-review.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: 'read'
       issues: 'write'
+      packages: 'read'
       pull-requests: 'write'
     steps:
       - name: 'Mint identity token'
@@ -63,6 +64,14 @@ jobs:
 
       - name: 'Install from uv.lock (project + dev deps)'
         run: 'uv sync --locked --package odh-ci-agent'
+
+      # odh-ci-prepare-review-context pulls the buildinputs image to resolve affected image targets.
+      - name: 'Login to GitHub Container Registry'
+        uses: 'docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0'  # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Validate pull request number'
         id: 'validate_pr'


### PR DESCRIPTION
## Summary

- Add `packages: read` and an unconditional GHCR login step to Antigravity PR review workflows before `odh-ci-prepare-review-context`.
- Fixes `prepare-review-context` failing on RHDS when podman cannot pull `ghcr.io/<repo>/buildinputs:main` (unauthorized).

## Description

`odh-ci-prepare-review-context` computes `affected_image_targets` via the `buildinputs` container image. In CI that runs through podman and requires registry auth. RHDS Antigravity review runs were failing at the prepare step with:

```
unable to retrieve auth token: invalid username/password: unauthorized
```

This mirrors the existing `docker/login-action` pattern from `build-notebooks-pr.yaml`, but without the `opendatahub-io/notebooks` skip guard so the same workflow works after sync to RHDS.

## How Has This Been Tested?

- Rebased onto current `main`; change is workflow-only (no Python/Dockerfile edits).
- Root cause confirmed from failed RHDS run: https://github.com/red-hat-data-services/notebooks/actions/runs/30213104940/job/89822571922

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — workflow-only change; no code paths affected
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Test plan

- [ ] Merge to `main` and let sync propagate to RHDS
- [ ] Re-trigger Antigravity review on an RHDS PR (e.g. `/agy review`) and confirm `Prepare review context` succeeds
- [ ] Confirm `review / review` job completes (not only `dispatch`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflows to authenticate with GitHub Container Registry.
  * Enabled read access to required package resources so review checks can retrieve container images successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->