### PR TITLE
RHAIENG-3124: follow-up(ci): open PR instead of pushing commit-latest.env to main

### DIFF
--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -6,18 +6,24 @@ name: Update commit-latest.env on params-latest.env change
   schedule:
     - cron: '0 11 * * *'  # Daily at 11:00 UTC
 
+env:
+  BASE_BRANCH: main
+  UPDATE_BRANCH: ci/update-commit-latest-env
+
 jobs:
   sync-commit-latest:
     runs-on: ubuntu-26.04
     concurrency:
-      group: update-commit-latest-env-${{ github.ref }}
+      group: update-commit-latest-env
       cancel-in-progress: false
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ env.BASE_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
 
@@ -41,8 +47,12 @@ jobs:
       - name: Update commit-latest.env manifests
         run: uv run scripts/update-commit-latest-env.py --variant both
 
-      - name: Commit and push changes
+      - name: Commit, push branch, and open or refresh pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
@@ -51,8 +61,30 @@ jobs:
             manifests/rhoai/base/commit-latest.env
 
           if git diff --cached --quiet; then
-            echo "No effective changes in commit-latest.env files, skipping commit."
-          else
-            git commit -m "ci: update commit SHAs in commit-latest.env"
-            git push
+            echo "No effective changes in commit-latest.env files, skipping PR update."
+            exit 0
           fi
+
+          git checkout -B "${UPDATE_BRANCH}"
+          git commit -m "ci: update commit SHAs in commit-latest.env"
+          git push --force-with-lease -u origin "${UPDATE_BRANCH}"
+
+          existing_pr="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${UPDATE_BRANCH}" \
+            --base "${BASE_BRANCH}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "${existing_pr}" ]]; then
+            echo "Updated branch for existing PR #${existing_pr}."
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "ci: update commit SHAs in commit-latest.env" \
+            --head "${UPDATE_BRANCH}" \
+            --base "${BASE_BRANCH}" \
+            --body "Automated refresh of ODH and RHOAI commit-latest.env from Quay image vcs-ref labels. Created by .github/workflows/update-commit-latest-env.yaml."


### PR DESCRIPTION
Repository rules require changes through pull requests. Push updates to ci/update-commit-latest-env and create or refresh an open PR to main.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated environment updates by skipping pull request creation when no changes are detected.
  * Prevented duplicate pull requests when an update is already in progress.
  * Added safer branch updates and failure handling for automated refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->