### PR TITLE
ci: make commit-latest refresh branch-aware for downstream on-demand runs

### DIFF
--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -7,14 +7,16 @@ name: Update commit-latest.env on params-latest.env change
     - cron: '0 11 * * *'  # Daily at 11:00 UTC
 
 env:
-  BASE_BRANCH: main
-  UPDATE_BRANCH: ci/update-commit-latest-env
+  BASE_BRANCH: ${{ github.ref_name }}
 
 jobs:
   sync-commit-latest:
+    if: |
+      !(github.repository == 'red-hat-data-services/notebooks' && github.ref_name == 'main') &&
+      (github.event_name != 'schedule' || github.ref_name == 'main')
     runs-on: ubuntu-26.04
     concurrency:
-      group: update-commit-latest-env
+      group: update-commit-latest-env-${{ github.ref_name }}
       cancel-in-progress: false
     permissions:
       contents: write
@@ -26,6 +28,28 @@ jobs:
           ref: ${{ env.BASE_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
+
+      - name: Select update mode for branch
+        id: mode
+        run: |
+          set -euo pipefail
+          update_branch="ci/update-commit-latest-env-${BASE_BRANCH//\//-}"
+
+          if [[ "${BASE_BRANCH}" == "main" ]]; then
+            echo "variant=both" >> "${GITHUB_OUTPUT}"
+            echo "rhoai_tag=" >> "${GITHUB_OUTPUT}"
+            echo "target_scope=ODH+RHOAI" >> "${GITHUB_OUTPUT}"
+          elif [[ "${BASE_BRANCH}" =~ ^rhoai-[0-9]+\.[0-9]+$ ]]; then
+            echo "variant=rhoai" >> "${GITHUB_OUTPUT}"
+            echo "rhoai_tag=${BASE_BRANCH}" >> "${GITHUB_OUTPUT}"
+            echo "target_scope=RHOAI only" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Unsupported branch for this workflow: ${BASE_BRANCH}"
+            echo "Allowed branches: main or rhoai-X.Y"
+            exit 1
+          fi
+
+          echo "update_branch=${update_branch}" >> "${GITHUB_OUTPUT}"
 
       - name: Install skopeo
         uses: ./.github/actions/apt-install
@@ -45,7 +69,15 @@ jobs:
           RHOAI_QUAY_BOT_PASSWORD: ${{ secrets.RHOAI_QUAY_BOT_PASSWORD }}
 
       - name: Update commit-latest.env manifests
-        run: uv run scripts/update-commit-latest-env.py --variant both
+        run: |
+          set -euo pipefail
+          cmd=(uv run scripts/update-commit-latest-env.py --variant "${{ steps.mode.outputs.variant }}")
+          if [[ -n "${{ steps.mode.outputs.rhoai_tag }}" ]]; then
+            cmd+=(--rhoai-version-tag "${{ steps.mode.outputs.rhoai_tag }}")
+          fi
+
+          echo "Running update scope: ${{ steps.mode.outputs.target_scope }}"
+          "${cmd[@]}"
 
       - name: Commit, push branch, and open or refresh pull request
         env:
@@ -53,25 +85,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-          git add \
-            manifests/odh/base/commit-latest.env \
-            manifests/rhoai/base/commit-latest.env
+          git add manifests/rhoai/base/commit-latest.env
+          if [[ "${{ steps.mode.outputs.variant }}" == "both" ]]; then
+            git add manifests/odh/base/commit-latest.env
+          fi
 
           if git diff --cached --quiet; then
             echo "No effective changes in commit-latest.env files, skipping PR update."
             exit 0
           fi
 
-          git checkout -B "${UPDATE_BRANCH}"
+          git checkout -B "${{ steps.mode.outputs.update_branch }}"
           git commit -m "ci: update commit SHAs in commit-latest.env"
-          git push --force-with-lease -u origin "${UPDATE_BRANCH}"
+          git push --force-with-lease -u origin "${{ steps.mode.outputs.update_branch }}"
 
           existing_pr="$(gh pr list \
             --repo "${GITHUB_REPOSITORY}" \
-            --head "${UPDATE_BRANCH}" \
+            --head "${{ steps.mode.outputs.update_branch }}" \
             --base "${BASE_BRANCH}" \
             --state open \
             --json number \
@@ -85,6 +118,6 @@ jobs:
           gh pr create \
             --repo "${GITHUB_REPOSITORY}" \
             --title "ci: update commit SHAs in commit-latest.env" \
-            --head "${UPDATE_BRANCH}" \
+            --head "${{ steps.mode.outputs.update_branch }}" \
             --base "${BASE_BRANCH}" \
-            --body "Automated refresh of ODH and RHOAI commit-latest.env from Quay image vcs-ref labels. Created by .github/workflows/update-commit-latest-env.yaml."
+            --body "Automated refresh of ${{ steps.mode.outputs.target_scope }} commit-latest.env from Quay image vcs-ref labels. Created by .github/workflows/update-commit-latest-env.yaml."

--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -13,9 +13,12 @@ ODH variant:
   Writes ``manifests/odh/base/commit-latest.env``.
 
 RHOAI variant:
-  Probes quay.io/rhoai to find the most recently created ``rhoai-X.Y`` tag
-  Uses that tag across all RHOAI images, extracting vcs-ref from each. Writes
+  Uses a ``rhoai-X.Y`` tag across all RHOAI images, extracting vcs-ref from each. Writes
   ``manifests/rhoai/base/commit-latest.env``.
+  Tag selection priority:
+    1) ``--rhoai-version-tag``
+    2) ``GITHUB_REF_NAME`` when it matches ``rhoai-X.Y`` (for branch-driven GHA runs)
+    3) auto-detected most recently created ``rhoai-X.Y`` tag on quay.io/rhoai
   Quay.io images are 1:1 mapped with the RedHat catalogue images, so vcs-ref remains the same.
 
 Pipeline runtime images are intentionally skipped (only odh-workbench-* processed).
@@ -428,6 +431,7 @@ async def resolve_rhoai_version_tag(
     if args.rhoai_version_tag:
         normalized = normalize_rhoai_version_tag(args.rhoai_version_tag)
         if normalized:
+            log.info("using RHOAI tag from --rhoai-version-tag", tag=normalized)
             return normalized
         log.error("invalid RHOAI version tag", tag=args.rhoai_version_tag)
         return None
@@ -435,6 +439,7 @@ async def resolve_rhoai_version_tag(
     branch = os.environ.get("GITHUB_REF_NAME", "")
     normalized = normalize_rhoai_version_tag(branch)
     if normalized:
+        log.info("using RHOAI tag from branch name", branch=branch, tag=normalized)
         return normalized
 
     log.info("auto-detecting latest RHOAI tag from quay.io/rhoai...")
@@ -483,8 +488,8 @@ async def main() -> None:
         default=None,
         help=(
             "Pin a specific RHOAI tag (e.g. 'rhoai-3.5'). "
-            "When omitted the script auto-detects the most recently created rhoai-X.Y tag. "
-            "GITHUB_REF_NAME is also checked as a fallback before auto-detection."
+            "When omitted the script uses GITHUB_REF_NAME when it matches rhoai-X.Y; "
+            "otherwise it auto-detects the most recently created rhoai-X.Y tag."
         ),
     )
     args = parser.parse_args()


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This updates the `update-commit-latest-env` automation to support downstream older branches (`rhoai-x.y`

- Make workflow branch-aware by using `github.ref_name` as the base branch.
- For `rhoai-x.y` branches, run **RHOAI-only** updates and pin tag lookup to the same branch tag (e.g. `rhoai-2.25`).
- Keep `main` behavior as ODH+RHOAI updates.
- Ensure scheduled runs execute only on `main`; older downstream branches are **workflow_dispatch only** (on-demand).
- Use branch-specific update branches/concurrency groups to avoid cross-branch collisions.
## Why
Downstream maintenance branches need manual refreshes that stay aligned with their release stream.  
Previously, the workflow was effectively main-centric and could pick the latest RHOAI tag rather than the calling branch’s tag.
## Behavior details
- If run on `main`:
  - schedule + manual dispatch allowed
  - updates both ODH and RHOAI commit-latest manifests
- If run on `rhoai-X.Y`:
  - manual dispatch only (schedule skipped)
  - updates only `manifests/rhoai/base/commit-latest.env`
  - uses `rhoai-X.Y` as the tag source of truth
## Script updates
`scripts/update-commit-latest-env.py` now documents and logs RHOAI tag resolution priority:
1. `--rhoai-version-tag`
2. `GITHUB_REF_NAME` when matching `rhoai-X.Y`
3. auto-detect newest `rhoai-X.Y` tag (fallback)
## Validation
- Verified Python syntax for updated script (`compileall`).
- Checked lint diagnostics for edited files (no issues).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated environment updates now derive behavior from the active branch, with branch-scoped concurrency to prevent cross-branch interference.
  * Scheduled updates remain limited to the main branch; other supported events can run on release branches.
  * The workflow computes an update mode per branch (ODH+RHOAI vs RHOAI-only) and uses a branch-specific update branch for commits and PRs.
  * Manifest updates apply the RHOAI version tag only when applicable.
  * RHOAI tag selection now prioritizes an explicit version tag, then matching branch names, otherwise the latest available tag, with improved logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->