### PR TITLE
fix(scripts): derive RHOAI image refs from ODH params when placeholders are dummy

### DIFF
--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -87,13 +87,40 @@ def load_workbench_images(params_path: pathlib.Path) -> list[tuple[str, str]]:
     return result
 
 
-def rhoai_image_base(odh_url: str) -> str:
-    """Derive the quay.io/rhoai image base (no tag) from a quay.io/opendatahub URL.
+def _is_placeholder_image_url(image_url: str) -> bool:
+    return not image_url or image_url.strip().lower() == "dummy"
+
+
+def _is_rstudio_entry(variable: str, image_url: str) -> bool:
+    token = f"{variable} {image_url}".lower()
+    return "rstudio" in token
+
+
+def _odh_image_base_from_variable(variable: str) -> str:
+    image_name = variable.removesuffix("-n")
+    return f"quay.io/opendatahub/{image_name}"
+
+
+def rhoai_image_base(variable: str, odh_url: str) -> str:
+    """Derive the quay.io/rhoai image base (no tag) from workbench metadata.
 
     quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:<tag>
     → quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9
+
+    If the source URL is missing or a placeholder (e.g. ``dummy``), derive the
+    ODH image base from the variable name to keep RHOAI updates working.
     """
-    base = odh_url.rsplit(":", 1)[0]
+    if _is_placeholder_image_url(odh_url) or not odh_url.startswith("quay.io/opendatahub/"):
+        base = _odh_image_base_from_variable(variable)
+        log.warning(
+            "RHOAI: using ODH-derived image base fallback",
+            variable=variable,
+            source_image=odh_url,
+            derived_base=base,
+        )
+    else:
+        base = odh_url.rsplit(":", 1)[0]
+
     base = base.replace("quay.io/opendatahub/", "quay.io/rhoai/", 1)
     base = base.replace("-ubi9", "-rhel9")
     return base
@@ -452,7 +479,11 @@ async def collect_rhoai_entries(
     semaphore: asyncio.Semaphore,
 ) -> list[tuple[str, str]] | None:
     async def process_one(variable: str, odh_url: str) -> tuple[str, str] | None:
-        image_url = f"{rhoai_image_base(odh_url)}:{rhoai_tag}"
+        if _is_rstudio_entry(variable, odh_url):
+            log.info("RHOAI: skipping RStudio workbench entry", variable=variable)
+            return "", ""
+
+        image_url = f"{rhoai_image_base(variable, odh_url)}:{rhoai_tag}"
         _, cfg = await skopeo_inspect_config(image_url, semaphore)
         if cfg is None:
             log.error("RHOAI: inspect failed", image=image_url)
@@ -468,7 +499,11 @@ async def collect_rhoai_entries(
     ])
     if any(result is None for result in results):
         return None
-    return list(results)
+    entries = [entry for entry in results if entry and entry[0]]
+    if not entries:
+        log.error("RHOAI: no workbench entries produced after filtering")
+        return None
+    return entries
 
 
 async def main() -> None:


### PR DESCRIPTION
…rs are dummy

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing, placeholder, or nonstandard image URLs when generating RHOAI image references.
  * RStudio workbench entries are now excluded from RHOAI image processing.
  * Prevented incomplete commit updates when no valid image entries are available.
  * Improved compatibility with UBI9 and RHEL9 image naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->