### PR TITLE
(no-jira):(chore/manifests)fix vcs-type extraction on the rollout_tag script

### DIFF
--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -440,6 +440,13 @@ def load_rhoai_workbench_related_images(
     return cache[release_tag]
 
 
+def _quay_rhoai_ref_from_registry_ref(image_ref: str) -> str | None:
+    prefix = "registry.redhat.io/rhoai/"
+    if not image_ref.startswith(prefix):
+        return None
+    return f"quay.io/rhoai/{image_ref.removeprefix(prefix)}"
+
+
 def _resolve_rhoai_released_image(
     path: Path,
     related_images_cache: dict[str, dict[str, str]],
@@ -477,8 +484,18 @@ def _resolve_rhoai_released_image(
             f"No {related_image_name} entry in RHOAI-Build-Config for release {release_tag!r}"
         )
 
-    config_payload = _SKOPEO_INSPECT.inspect_config(digest_ref)
-    commit_sha = extract_short_vcs_ref(config_payload, digest_ref)
+    commit_ref = digest_ref
+    try:
+        config_payload = _SKOPEO_INSPECT.inspect_config(commit_ref)
+    except ValueError as exc:
+        if "manifest unknown" not in str(exc):
+            raise
+        quay_ref = _quay_rhoai_ref_from_registry_ref(digest_ref)
+        if quay_ref is None:
+            raise
+        commit_ref = quay_ref
+        config_payload = _SKOPEO_INSPECT.inspect_image(commit_ref).payload
+    commit_sha = extract_short_vcs_ref(config_payload, commit_ref)
     released_suffix = match.group("suffix")
     return ReleasedImage(
         base_key=base_key,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix vcs-type extraction on the rollout_tag script
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`uv run manifests/tools/rollout_tag_on_imagestreams.py`

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image resolution for RHOAI releases when registry manifests are unavailable.
  * Added fallback handling to retrieve commit information from the corresponding Quay image reference.
  * More reliably identifies the short commit reference associated with a released image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->