### PR TITLE
[RHAIENG-6068] Add orchestration recipe for major release `make kickoff-release`

### DIFF
--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -1,0 +1,124 @@
+---
+name: Release Kickoff Action
+
+permissions: {}
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to update"
+        required: false
+        default: "main"
+
+jobs:
+  kickoff-release:
+    runs-on: ubuntu-26.04
+    concurrency:
+      group: kickoff-release-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: read
+    env:
+      BRANCH: ${{ github.event.inputs.branch || 'main' }}
+      TMPDIR: /var/tmp
+      CI: "true"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ env.BRANCH }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Create kickoff branch
+        run: |
+          BRANCH_NAME="release-kickoff-$(date +%Y%m%d-%H%M)"
+          git checkout -b "$BRANCH_NAME"
+          echo "KICKOFF_BRANCH=$BRANCH_NAME" >> "${GITHUB_ENV}"
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
+      - name: Install skopeo
+        uses: ./.github/actions/apt-install
+        with:
+          packages: skopeo
+
+      - name: Login to quay.io/aipcc (if the secret is present)
+        shell: bash
+        env:
+          AIPCC_USER: ${{ secrets.AIPCC_QUAY_BOT_USERNAME }}
+          AIPCC_PASS: ${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}
+        run: |
+          if [[ -z "${AIPCC_USER}" ]]; then
+            echo "AIPCC_QUAY_BOT_USERNAME is not set, skipping quay.io/aipcc login"
+            exit 0
+          fi
+          printf '%s' "${AIPCC_PASS}" | skopeo login --username "${AIPCC_USER}" --password-stdin quay.io
+
+      - name: Install Podman
+        uses: ./.github/actions/install-podman-action
+        with:
+          platform: linux/amd64
+
+      - name: Mask subscription credentials
+        env:
+          SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
+          SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
+        run: |
+          if [[ -z "$SUBSCRIPTION_ACTIVATION_KEY" || -z "$SUBSCRIPTION_ORG" ]]; then
+            echo "SUBSCRIPTION_ACTIVATION_KEY and SUBSCRIPTION_ORG repository secrets are required." >&2
+            exit 1
+          fi
+          echo "::add-mask::${SUBSCRIPTION_ACTIVATION_KEY}"
+          echo "::add-mask::${SUBSCRIPTION_ORG}"
+
+      - name: Run release kickoff recipe
+        env:
+          SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
+          SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
+        run: |
+          set -euo pipefail
+          make kickoff-release
+
+      - name: Create Pull Request with updates
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git add -u
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Kick off release updates"
+          git push -u "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "${KICKOFF_BRANCH}"
+
+          gh label create "automated-release-kickoff" \
+            --description "Auto-created PR by release kickoff workflow" \
+            --color "0E8A16" \
+            2>/dev/null || true
+
+          gh pr create \
+            --title "GHA: Kick off release updates" \
+            --head "${KICKOFF_BRANCH}" \
+            --body "$(cat <<'EOF'
+          Automated release kickoff run using:
+
+          - `make kickoff-release`
+          - lockfile and build-arg refresh
+          - imagestream tag rollout updates
+          EOF
+          )" \
+            --label "automated-release-kickoff" \
+            --base "${BRANCH}"

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -93,9 +93,6 @@ jobs:
           import yaml
 
 
-          cfg_path = Path("versions_config.yml")
-          doc = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
-
           direct_overrides = {
               "release.full_version": os.environ.get("RELEASE_FULL_VERSION", "").strip(),
               "release.rhds_os_base": os.environ.get("RELEASE_RHDS_OS_BASE", "").strip(),
@@ -121,6 +118,11 @@ jobs:
 
           effective = {k: v for k, v in direct_overrides.items() if v}
           effective.update(dynamic_overrides)
+          if not effective:
+              raise SystemExit(0)
+
+          cfg_path = Path("versions_config.yml")
+          doc = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
 
           def _parse_value(raw: str):
               lowered = raw.lower()
@@ -158,11 +160,11 @@ jobs:
           )
           PY
 
-          if [[ -n "${RELEASE_FULL_VERSION}${RELEASE_RHDS_OS_BASE}${RELEASE_PYTHON_VERSION}${VERSIONS_OVERRIDES}" ]]; then
+          if git diff --quiet -- versions_config.yml; then
+            echo "No versions_config.yml release overrides provided."
+          else
             echo "Applied versions_config.yml release overrides:"
             git diff -- versions_config.yml
-          else
-            echo "No versions_config.yml release overrides provided."
           fi
 
       - name: Login to quay.io/aipcc (if the secret is present)
@@ -224,10 +226,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           RELEASE_FULL_VERSION_INPUT: ${{ github.event.inputs.release_full_version }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          git add -u
+          git add -A .
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0
@@ -240,7 +243,7 @@ jobs:
           fi
 
           git commit -m "Kick off release updates for ${RELEASE_FULL_VERSION}"
-          git push -u "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "${KICKOFF_BRANCH}"
+          git push -u "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "${KICKOFF_BRANCH}"
 
           gh label create "automated-release-kickoff" \
             --description "Auto-created PR by release kickoff workflow" \

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -1,13 +1,6 @@
 ---
 # Manual release kickoff: apply optional versions_config overrides, run make kickoff-release,
 # validate with make test, and open a PR with the resulting changes.
-# Required repo secrets on opendatahub-io/notebooks:
-#   - GIT_CRYPT_KEY
-#   - SUBSCRIPTION_ACTIVATION_KEY
-#   - SUBSCRIPTION_ORG
-#   - GH_ACCESS_TOKEN
-# Recommended:
-#   - AIPCC_QUAY_BOT_USERNAME / AIPCC_QUAY_BOT_PASSWORD (RHDS base-image resolution)
 name: Release Kickoff Action
 
 permissions: {}

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -1,4 +1,13 @@
 ---
+# Manual release kickoff: apply optional versions_config overrides, run make kickoff-release,
+# validate with make test, and open a PR with the resulting changes.
+# Required repo secrets on opendatahub-io/notebooks:
+#   - GIT_CRYPT_KEY
+#   - SUBSCRIPTION_ACTIVATION_KEY
+#   - SUBSCRIPTION_ORG
+#   - GH_ACCESS_TOKEN
+# Recommended:
+#   - AIPCC_QUAY_BOT_USERNAME / AIPCC_QUAY_BOT_PASSWORD (RHDS base-image resolution)
 name: Release Kickoff Action
 
 permissions: {}
@@ -68,10 +77,10 @@ jobs:
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
 
-      - name: Install skopeo
+      - name: Install skopeo and git-crypt
         uses: ./.github/actions/apt-install
         with:
-          packages: skopeo
+          packages: skopeo git-crypt
 
       - name: Apply versions_config release overrides (optional)
         env:
@@ -175,6 +184,24 @@ jobs:
           fi
           printf '%s' "${AIPCC_PASS}" | skopeo login --username "${AIPCC_USER}" --password-stdin quay.io
 
+      - name: Prepare Podman temp directory
+        run: mkdir -p "$TMPDIR"
+
+      # Registry auth must be configured before Install Podman. install-podman-action runs
+      # `sudo podman system reset`, which can leave root-owned files under ~/.config/containers.
+      - name: Unlock encrypted secrets with git-crypt
+        run: |
+          echo "${GIT_CRYPT_KEY}" | base64 --decode > ./git-crypt-key
+          trap 'rm -f ./git-crypt-key' EXIT
+          git-crypt unlock ./git-crypt-key
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: Configure registry auth from pull-secret
+        run: |
+          mkdir -p "$HOME/.config/containers"
+          cp ci/secrets/pull-secret.json "$HOME/.config/containers/auth.json"
+
       - name: Install Podman
         uses: ./.github/actions/install-podman-action
         with:
@@ -203,6 +230,7 @@ jobs:
       - name: Create Pull Request with updates
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          RELEASE_FULL_VERSION_INPUT: ${{ github.event.inputs.release_full_version }}
         run: |
           set -euo pipefail
 
@@ -212,7 +240,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Kick off release updates"
+          if [[ -n "${RELEASE_FULL_VERSION_INPUT}" ]]; then
+            RELEASE_FULL_VERSION="${RELEASE_FULL_VERSION_INPUT}"
+          else
+            RELEASE_FULL_VERSION="$(./uv run python -c "import yaml; print(yaml.safe_load(open('versions_config.yml', encoding='utf-8'))['release']['full_version'])")"
+          fi
+
+          git commit -m "Kick off release updates for ${RELEASE_FULL_VERSION}"
           git push -u "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "${KICKOFF_BRANCH}"
 
           gh label create "automated-release-kickoff" \
@@ -221,14 +255,14 @@ jobs:
             2>/dev/null || true
 
           gh pr create \
-            --title "GHA: Kick off release updates" \
+            --title "GHA: Kick off new release ${RELEASE_FULL_VERSION}" \
             --head "${KICKOFF_BRANCH}" \
-            --body "$(cat <<'EOF'
-          Automated release kickoff run using:
+            --body "$(cat <<EOF
+          Automated release kickoff run for release **${RELEASE_FULL_VERSION}** using:
 
-          - `make kickoff-release`
-          - lockfile and build-arg refresh
-          - imagestream tag rollout updates
+          - optional \`versions_config.yml\` overrides from workflow inputs
+          - \`make kickoff-release\` (build-args sync, lock refresh, ODH/RHDS RPM locks, rollout)
+          - \`make test\` validation gate inside kickoff-release
           EOF
           )" \
             --label "automated-release-kickoff" \

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -10,6 +10,27 @@ on:  # yamllint disable-line rule:truthy
         description: "Branch to update"
         required: false
         default: "main"
+      release_full_version:
+        description: "Optional override for versions_config.yml release.full_version (e.g. 3.6.0)"
+        required: false
+        default: ""
+      release_rhds_os_base:
+        description: "Optional override for versions_config.yml release.rhds_os_base (e.g. el9.6)"
+        required: false
+        default: ""
+      release_python_version:
+        description: "Optional override for versions_config.yml release.python_version (e.g. 3.12)"
+        required: false
+        default: ""
+      versions_overrides:
+        description: |
+          Optional overrides for any versions_config.yml fields as dot.path=value pairs, one per line.
+          Example:
+          artifacts.base_image.cuda.tensorflow.acc_version=13.0
+          artifacts.base_image.cpu.rhds.channel=fast
+          artifacts.base_image.rocm.pytorch.rhds.channel=stable
+        required: false
+        default: ""
 
 jobs:
   kickoff-release:
@@ -51,6 +72,96 @@ jobs:
         uses: ./.github/actions/apt-install
         with:
           packages: skopeo
+
+      - name: Apply versions_config release overrides (optional)
+        env:
+          RELEASE_FULL_VERSION: ${{ github.event.inputs.release_full_version }}
+          RELEASE_RHDS_OS_BASE: ${{ github.event.inputs.release_rhds_os_base }}
+          RELEASE_PYTHON_VERSION: ${{ github.event.inputs.release_python_version }}
+          VERSIONS_OVERRIDES: ${{ github.event.inputs.versions_overrides }}
+        run: |
+          set -euo pipefail
+
+          ./uv run python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          from pathlib import Path
+
+          import yaml
+
+
+          cfg_path = Path("versions_config.yml")
+          doc = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+
+          direct_overrides = {
+              "release.full_version": os.environ.get("RELEASE_FULL_VERSION", "").strip(),
+              "release.rhds_os_base": os.environ.get("RELEASE_RHDS_OS_BASE", "").strip(),
+              "release.python_version": os.environ.get("RELEASE_PYTHON_VERSION", "").strip(),
+          }
+
+          raw_pairs = os.environ.get("VERSIONS_OVERRIDES", "")
+          dynamic_overrides: dict[str, str] = {}
+          for raw_line in raw_pairs.splitlines():
+              line = raw_line.strip()
+              if not line or line.startswith("#"):
+                  continue
+              if "=" not in line:
+                  raise ValueError(
+                      "Invalid versions_overrides line "
+                      f"{line!r}. Expected dot.path=value."
+                  )
+              key, value = line.split("=", 1)
+              key = key.strip()
+              if not key:
+                  raise ValueError(f"Invalid versions_overrides line {line!r}: empty key.")
+              dynamic_overrides[key] = value.strip()
+
+          effective = {k: v for k, v in direct_overrides.items() if v}
+          effective.update(dynamic_overrides)
+
+          def _parse_value(raw: str):
+              lowered = raw.lower()
+              if lowered == "true":
+                  return True
+              if lowered == "false":
+                  return False
+              try:
+                  if raw.isdigit() or (raw.startswith("-") and raw[1:].isdigit()):
+                      return int(raw)
+              except ValueError:
+                  pass
+              return raw
+
+          for dotted_key, raw_value in effective.items():
+              node = doc
+              parts = dotted_key.split(".")
+              for part in parts[:-1]:
+                  if part not in node or not isinstance(node[part], dict):
+                      raise KeyError(
+                          f"Path '{dotted_key}' is invalid at '{part}'. "
+                          "Only existing keys are allowed."
+                      )
+                  node = node[part]
+              leaf = parts[-1]
+              if leaf not in node:
+                  raise KeyError(
+                      f"Path '{dotted_key}' does not exist in versions_config.yml."
+                  )
+              node[leaf] = _parse_value(raw_value)
+
+          cfg_path.write_text(
+              yaml.safe_dump(doc, sort_keys=False, default_flow_style=False),
+              encoding="utf-8",
+          )
+          PY
+
+          if [[ -n "${RELEASE_FULL_VERSION}${RELEASE_RHDS_OS_BASE}${RELEASE_PYTHON_VERSION}${VERSIONS_OVERRIDES}" ]]; then
+            echo "Applied versions_config.yml release overrides:"
+            git diff -- versions_config.yml
+          else
+            echo "No versions_config.yml release overrides provided."
+          fi
 
       - name: Login to quay.io/aipcc (if the secret is present)
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,7 @@ sync-build-args-from-versions:
 #   5=create RHDS rpm lockfile (root prefetch input)
 #   6=create RHDS rpm lockfile (codeserver prefetch input)
 #   7=rollout tags on imagestreams
+#   8=validate manifests (make test)
 # Notes:
 #   - KICKOFF_START_STEP=auto (default) resumes from .kickoff-release.state when present
 #   - After a successful full run, the state file is removed
@@ -493,8 +494,8 @@ kickoff-release:
 			start_step="1"; \
 		fi; \
 	fi; \
-	if [[ ! "$$start_step" =~ ^[1-7]$$ ]]; then \
-		echo "ERROR: KICKOFF_START_STEP must be auto or an integer from 1 to 7 (got: $(KICKOFF_START_STEP))."; \
+	if [[ ! "$$start_step" =~ ^[1-8]$$ ]]; then \
+		echo "ERROR: KICKOFF_START_STEP must be auto or an integer from 1 to 8 (got: $(KICKOFF_START_STEP))."; \
 		echo "If resuming automatically, delete an invalid state file and retry:"; \
 		echo "  rm -f $$(printf '%q' "$$state_file")"; \
 		exit 1; \
@@ -511,7 +512,7 @@ kickoff-release:
 	echo "▶️  Running from KICKOFF_START_STEP=$$start_step"
 	@record_step_completion() { \
 		local step="$$1"; \
-		if (( step < 7 )); then \
+		if (( step < 8 )); then \
 			echo "$$((step + 1))" > "$$state_file"; \
 		else \
 			rm -f "$$state_file"; \
@@ -522,11 +523,11 @@ kickoff-release:
 		local desc="$$2"; \
 		shift 2; \
 		if (( start_step <= step )); then \
-			echo "➡️  [$$step/7] $$desc"; \
+			echo "➡️  [$$step/8] $$desc"; \
 			"$$@"; \
 			record_step_completion "$$step"; \
 		else \
-			echo "⏭️  [$$step/7] Skipping $$desc"; \
+			echo "⏭️  [$$step/8] Skipping $$desc"; \
 		fi; \
 	}; \
 	last_rpm_flavor=""; \
@@ -541,11 +542,11 @@ kickoff-release:
 				$(MAKE) clean-rpm-lockfile-cache; \
 				last_rpm_flavor="$$flavor"; \
 			fi; \
-			echo "➡️  [$$step/7] $$desc"; \
+			echo "➡️  [$$step/8] $$desc"; \
 			"$$@"; \
 			record_step_completion "$$step"; \
 		else \
-			echo "⏭️  [$$step/7] Skipping $$desc"; \
+			echo "⏭️  [$$step/8] Skipping $$desc"; \
 		fi; \
 	}; \
 	run_step 1 "sync-build-args-from-versions" $(MAKE) sync-build-args-from-versions; \
@@ -554,7 +555,8 @@ kickoff-release:
 	run_rpm_step odh 4 "create ODH rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml; \
 	run_rpm_step rhds 5 "create RHDS rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input prefetch-input/rhds/rpms.in.yaml; \
 	run_rpm_step rhds 6 "create RHDS rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml; \
-	run_step 7 "rollout tags on imagestreams" uv run manifests/tools/rollout_tag_on_imagestreams.py
+	run_step 7 "rollout tags on imagestreams" uv run manifests/tools/rollout_tag_on_imagestreams.py; \
+	run_step 8 "validate manifests (make test)" $(MAKE) test
 
 # ======================================================================================
 #   gmake update-imagestream-annotations

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ endef
 #######################################        Build helpers                 #######################################
 
 # https://stackoverflow.com/questions/78899903/how-to-create-a-make-target-which-is-an-implicit-dependency-for-all-other-target
-skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files sync-build-args-from-versions sync-commit-env-files update-imagestream-annotations refresh-imagestream-metadata scan-image-vulnerabilities print-release
+skip-init-for := all-images deploy% undeploy% test% validate% refresh-lock-files sync-build-args-from-versions sync-commit-env-files update-imagestream-annotations refresh-imagestream-metadata scan-image-vulnerabilities print-release kickoff-release clean-rpm-lockfile-cache
 # CI uses the pre-built container image via buildinputs_runner.py instead
 ifneq ($(CI),true)
 ifneq (,$(filter-out $(skip-init-for),$(MAKECMDGOALS) $(.DEFAULT_GOAL)))
@@ -551,8 +551,8 @@ kickoff-release:
 	}; \
 	run_step 1 "sync-build-args-from-versions" $(MAKE) sync-build-args-from-versions; \
 	run_step 2 "refresh-lock-files" env FORCE_LOCKFILES_UPGRADE=1 $(MAKE) refresh-lock-files; \
-	run_rpm_step odh 3 "create ODH rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input prefetch-input/odh/rpms.in.yaml; \
-	run_rpm_step odh 4 "create ODH rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml; \
+	run_rpm_step odh 3 "create ODH rpm lockfile (root prefetch input)" env -u SUBSCRIPTION_ACTIVATION_KEY -u SUBSCRIPTION_ORG ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input prefetch-input/odh/rpms.in.yaml; \
+	run_rpm_step odh 4 "create ODH rpm lockfile (codeserver prefetch input)" env -u SUBSCRIPTION_ACTIVATION_KEY -u SUBSCRIPTION_ORG ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml; \
 	run_rpm_step rhds 5 "create RHDS rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input prefetch-input/rhds/rpms.in.yaml; \
 	run_rpm_step rhds 6 "create RHDS rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml; \
 	run_step 7 "rollout tags on imagestreams" uv run manifests/tools/rollout_tag_on_imagestreams.py; \

--- a/Makefile
+++ b/Makefile
@@ -553,8 +553,8 @@ kickoff-release:
 	run_step 2 "refresh-lock-files" env FORCE_LOCKFILES_UPGRADE=1 $(MAKE) refresh-lock-files; \
 	run_rpm_step odh 3 "create ODH rpm lockfile (root prefetch input)" env -u SUBSCRIPTION_ACTIVATION_KEY -u SUBSCRIPTION_ORG ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input prefetch-input/odh/rpms.in.yaml; \
 	run_rpm_step odh 4 "create ODH rpm lockfile (codeserver prefetch input)" env -u SUBSCRIPTION_ACTIVATION_KEY -u SUBSCRIPTION_ORG ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml; \
-	run_rpm_step rhds 5 "create RHDS rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input prefetch-input/rhds/rpms.in.yaml; \
-	run_rpm_step rhds 6 "create RHDS rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml; \
+	run_rpm_step rhds 5 "create RHDS rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input prefetch-input/rhds/rpms.in.yaml; \
+	run_rpm_step rhds 6 "create RHDS rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml; \
 	run_step 7 "rollout tags on imagestreams" uv run manifests/tools/rollout_tag_on_imagestreams.py; \
 	run_step 8 "validate manifests (make test)" $(MAKE) test
 

--- a/Makefile
+++ b/Makefile
@@ -453,6 +453,110 @@ sync-build-args-from-versions:
 	@cd "$(ROOT_DIR)" && ./uv run scripts/update_build_args_from_versions.py $(value SYNC_BUILD_ARGS_ARGS)
 
 # ======================================================================================
+# Kick off release updates in one command
+# Usage:
+#   gmake kickoff-release SUBSCRIPTION_ACTIVATION_KEY=<key> SUBSCRIPTION_ORG=<org>
+#   gmake kickoff-release KICKOFF_START_STEP=5 SUBSCRIPTION_ACTIVATION_KEY=<key> SUBSCRIPTION_ORG=<org>
+#   gmake kickoff-release KICKOFF_START_STEP=auto SUBSCRIPTION_ACTIVATION_KEY=<key> SUBSCRIPTION_ORG=<org>
+# Step index:
+#   1=sync-build-args-from-versions
+#   2=refresh-lock-files (with FORCE_LOCKFILES_UPGRADE=1)
+#   3=create ODH rpm lockfile (root prefetch input)
+#   4=create ODH rpm lockfile (codeserver prefetch input)
+#   5=create RHDS rpm lockfile (root prefetch input)
+#   6=create RHDS rpm lockfile (codeserver prefetch input)
+#   7=rollout tags on imagestreams
+# Notes:
+#   - KICKOFF_START_STEP=auto (default) resumes from .kickoff-release.state when present
+#   - After a successful full run, the state file is removed
+# ======================================================================================
+KICKOFF_START_STEP ?= auto
+KICKOFF_STATE_FILE ?= $(ROOT_DIR).kickoff-release.state
+.PHONY: clean-rpm-lockfile-cache
+clean-rpm-lockfile-cache:
+	@echo "🧹 Removing cached RPM lockfile generator image (if present)"
+	@podman image rm -f localhost/notebook-rpm-lockfile:latest >/dev/null 2>&1 || true
+
+.PHONY: kickoff-release
+kickoff-release:
+	@echo "==================================================================="
+	@echo "🚀 Starting release kickoff sequence"
+	@echo "==================================================================="
+	@# Disable xtrace for this recipe to avoid leaking subscription values in logs.
+	@set +x
+	@start_step="$(KICKOFF_START_STEP)"; \
+	state_file="$(KICKOFF_STATE_FILE)"; \
+	if [[ "$$start_step" == "auto" ]]; then \
+		if [[ -f "$$state_file" ]]; then \
+			start_step="$$(tr -d '[:space:]' < "$$state_file")"; \
+		else \
+			start_step="1"; \
+		fi; \
+	fi; \
+	if [[ ! "$$start_step" =~ ^[1-7]$$ ]]; then \
+		echo "ERROR: KICKOFF_START_STEP must be auto or an integer from 1 to 7 (got: $(KICKOFF_START_STEP))."; \
+		echo "If resuming automatically, delete an invalid state file and retry:"; \
+		echo "  rm -f $$(printf '%q' "$$state_file")"; \
+		exit 1; \
+	fi; \
+	if (( start_step <= 6 )) && [[ -z "$${SUBSCRIPTION_ACTIVATION_KEY:-}" || -z "$${SUBSCRIPTION_ORG:-}" ]]; then \
+		echo "ERROR: SUBSCRIPTION_ACTIVATION_KEY and SUBSCRIPTION_ORG must be set before running kickoff-release."; \
+		echo "Example:"; \
+		echo "  SUBSCRIPTION_ACTIVATION_KEY=<key> SUBSCRIPTION_ORG=<org> gmake kickoff-release"; \
+		exit 1; \
+	fi; \
+	if (( start_step <= 6 )); then \
+		echo "✅ Required subscription environment variables are set."; \
+	fi; \
+	echo "▶️  Running from KICKOFF_START_STEP=$$start_step"
+	@record_step_completion() { \
+		local step="$$1"; \
+		if (( step < 7 )); then \
+			echo "$$((step + 1))" > "$$state_file"; \
+		else \
+			rm -f "$$state_file"; \
+		fi; \
+	}; \
+	run_step() { \
+		local step="$$1"; \
+		local desc="$$2"; \
+		shift 2; \
+		if (( start_step <= step )); then \
+			echo "➡️  [$$step/7] $$desc"; \
+			"$$@"; \
+			record_step_completion "$$step"; \
+		else \
+			echo "⏭️  [$$step/7] Skipping $$desc"; \
+		fi; \
+	}; \
+	last_rpm_flavor=""; \
+	run_rpm_step() { \
+		local flavor="$$1"; \
+		local step="$$2"; \
+		local desc="$$3"; \
+		shift 3; \
+		if (( start_step <= step )); then \
+			if [[ "$$last_rpm_flavor" != "$$flavor" ]]; then \
+				echo "🧹 Clearing RPM lockfile generator cache for '$$flavor' inputs"; \
+				$(MAKE) clean-rpm-lockfile-cache; \
+				last_rpm_flavor="$$flavor"; \
+			fi; \
+			echo "➡️  [$$step/7] $$desc"; \
+			"$$@"; \
+			record_step_completion "$$step"; \
+		else \
+			echo "⏭️  [$$step/7] Skipping $$desc"; \
+		fi; \
+	}; \
+	run_step 1 "sync-build-args-from-versions" $(MAKE) sync-build-args-from-versions; \
+	run_step 2 "refresh-lock-files" env FORCE_LOCKFILES_UPGRADE=1 $(MAKE) refresh-lock-files; \
+	run_rpm_step odh 3 "create ODH rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input prefetch-input/odh/rpms.in.yaml; \
+	run_rpm_step odh 4 "create ODH rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --rpm-input codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml; \
+	run_rpm_step rhds 5 "create RHDS rpm lockfile (root prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input prefetch-input/rhds/rpms.in.yaml; \
+	run_rpm_step rhds 6 "create RHDS rpm lockfile (codeserver prefetch input)" ./scripts/lockfile-generators/create-rpm-lockfile.sh --activation-key "$${SUBSCRIPTION_ACTIVATION_KEY}" --org "$${SUBSCRIPTION_ORG}" --rpm-input codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml; \
+	run_step 7 "rollout tags on imagestreams" uv run manifests/tools/rollout_tag_on_imagestreams.py
+
+# ======================================================================================
 #   gmake update-imagestream-annotations
 #   gmake update-imagestream-annotations IMAGESTREAM_VARIANT=rhoai DRY_RUN=1
 # Prerequisites:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,71 @@ make sync-build-args-from-versions SYNC_BUILD_ARGS_ARGS=--check
 If the version update also requires lockfile refreshes, run
 `make refresh-lock-files` after the sync.
 
+### Kick off a new release (maintainers)
+
+Use this flow when starting a **new release stream** (for example, `3.5` → `3.6`).
+For mid-release image bumps only, use `make sync-build-args-from-versions` instead
+(see above).
+
+1. Update [`versions_config.yml`](versions_config.yml) (`release.full_version` and any
+   preferred base-image settings).
+2. Run the orchestrated kickoff recipe locally **or** via GitHub Actions.
+
+The kickoff recipe runs these steps in order:
+
+1. `make sync-build-args-from-versions`
+2. `make refresh-lock-files` (with `FORCE_LOCKFILES_UPGRADE=1`)
+3. Generate ODH RPM lockfile (root prefetch input)
+4. Generate ODH RPM lockfile (codeserver prefetch input)
+5. Generate RHDS RPM lockfile (root prefetch input)
+6. Generate RHDS RPM lockfile (codeserver prefetch input)
+7. Roll out imagestream tags (`manifests/tools/rollout_tag_on_imagestreams.py`)
+8. Validate with `make test`
+
+#### Local kickoff
+
+Export RHDS subscription credentials once per shell session, then run kickoff:
+
+```shell
+export SUBSCRIPTION_ACTIVATION_KEY='...'
+export SUBSCRIPTION_ORG='...'
+gmake kickoff-release
+```
+
+If a step fails, rerun the same command to auto-resume from
+`.kickoff-release.state`, or force a step:
+
+```shell
+gmake kickoff-release KICKOFF_START_STEP=5
+```
+
+To clear cached RPM lockfile generator images between ODH/RHDS phases manually:
+
+```shell
+gmake clean-rpm-lockfile-cache
+```
+
+#### GitHub Actions kickoff
+
+On `opendatahub-io/notebooks`, run **Actions → Release Kickoff Action → Run workflow**.
+
+Optional workflow inputs:
+
+- `release_full_version`, `release_rhds_os_base`, `release_python_version`
+- `versions_overrides` (`dot.path=value`, one per line), for example:
+
+```text
+artifacts.base_image.cuda.tensorflow.acc_version=13.0
+artifacts.base_image.cpu.rhds.channel=fast
+artifacts.base_image.rocm.pytorch.rhds.channel=stable
+```
+
+The workflow applies overrides, runs `make kickoff-release`, and opens a PR titled
+`GHA: Kick off new release <full_version>`.
+
+Required repository secrets: `GIT_CRYPT_KEY`, `SUBSCRIPTION_ACTIVATION_KEY`,
+`SUBSCRIPTION_ORG`, `GH_ACCESS_TOKEN`.
+
 ### Deploy & Test
 
 #### Prepare Python + uv + pytest env

--- a/versions_config.yml
+++ b/versions_config.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=./ci/versions_config.schema.json
+# =============================================================================
+# IMPORTANT: PRIMARY RELEASE COMMANDS
+# - New release stream (for example, 3.5 -> 3.6):
+#     1) Update full_version in this file and preferred image versions.
+#     2) Run: make kickoff-release
+# - Mid-release image version updates:
+#     1) Update preferred image versions in this file.
+#     2) Run: make sync-build-args-from-versions
+#     3) Run: make refresh-lock-files to refresh the lock files.
+# =============================================================================
 ---
 schema_version: 1
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
related to: https://redhat.atlassian.net/browse/RHAIENG-6068 

## Description
<!--- Describe your changes in detail -->
This PR adds a single orchestrated release kickoff path for maintainers, available both locally (`make kickoff-release`) and via GitHub Actions (Release Kickoff Action).

It consolidates the manual multi-step release process into one resumable flow with validation, and documents the two primary release commands directly in versions_config.yml.

Documentation instructions for the maintainer included on this PR: https://github.com/atheo89/notebooks/blob/release-orchistration-recipe/README.md#kick-off-a-new-release-maintainers 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To kick off a new major release for example, 3.5 -> 3.6, 
- Update `version_config.yml` file with preferred image versions and the `release.full_version` field.
- Then run: `make kickoff-release`

note the GHA is not tested, i plan to have follow ups in case of fixes

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions **“Release Kickoff”** workflow to start a release on demand, supporting version overrides and creating an automatically opened PR.
  * Added `kickoff-release` for an 8-step kickoff flow (lockfile refresh/generation, imagestream rollout, and validation).
  * Added `clean-rpm-lockfile-cache` to clear the cached RPM lockfile generator data.
* **Bug Fixes**
  * Improved kickoff safety with stricter override validation, resumable progress tracking, and safer handling of sensitive logging.
* **Documentation**
  * Documented the kickoff process in the README and added a banner to `versions_config.yml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->