### PR TITLE
NO-JIRA: Fix GHA release kickoff flow end-to-end

### DIFF
--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -75,6 +75,72 @@ jobs:
         with:
           packages: skopeo git-crypt
 
+      - name: Prepare Podman temp directory
+        run: mkdir -p "$TMPDIR"
+
+      # Registry auth must be configured before Install Podman. install-podman-action runs
+      # `sudo podman system reset`, which can leave root-owned files under ~/.config/containers.
+      - name: Unlock encrypted secrets with git-crypt
+        run: |
+          KEY_PATH="$(mktemp "${RUNNER_TEMP}/git-crypt-key.XXXXXX")"
+          printf '%s' "${GIT_CRYPT_KEY}" | base64 --decode > "${KEY_PATH}"
+          trap 'rm -f "${KEY_PATH}"' EXIT
+          git-crypt unlock "${KEY_PATH}"
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: Configure registry auth from pull-secret
+        run: |
+          mkdir -p "$HOME/.config/containers"
+          cp ci/secrets/pull-secret.json "$HOME/.config/containers/auth.json"
+
+      - name: Add scoped Quay credentials (if secrets are present)
+        env:
+          AIPCC_USER: ${{ secrets.AIPCC_QUAY_BOT_USERNAME }}
+          AIPCC_PASS: ${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}
+          RHOAI_USER: ${{ secrets.RHOAI_QUAY_BOT_USERNAME }}
+          RHOAI_PASS: ${{ secrets.RHOAI_QUAY_BOT_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import base64
+          import json
+          import os
+          from pathlib import Path
+
+          auth_path = Path.home() / ".config/containers/auth.json"
+          auth_doc = json.loads(auth_path.read_text(encoding="utf-8"))
+          auths = auth_doc.setdefault("auths", {})
+
+          def set_scoped_auth(scope: str, username: str, password: str) -> bool:
+              if not username or not password:
+                  return False
+              token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+              auths[scope] = {"auth": token}
+              return True
+
+          has_aipcc = set_scoped_auth(
+              "quay.io/aipcc",
+              os.environ.get("AIPCC_USER", "").strip(),
+              os.environ.get("AIPCC_PASS", "").strip(),
+          )
+          has_rhoai = set_scoped_auth(
+              "quay.io/rhoai",
+              os.environ.get("RHOAI_USER", "").strip(),
+              os.environ.get("RHOAI_PASS", "").strip(),
+          )
+
+          auth_path.write_text(json.dumps(auth_doc, indent=2) + "\n", encoding="utf-8")
+
+          if not has_aipcc:
+              print("AIPCC_QUAY_BOT_USERNAME/AIPCC_QUAY_BOT_PASSWORD missing, skipped quay.io/aipcc scoped auth")
+          if not has_rhoai:
+              print("RHOAI_QUAY_BOT_USERNAME/RHOAI_QUAY_BOT_PASSWORD missing, skipped quay.io/rhoai scoped auth")
+          PY
+
       - name: Apply versions_config release overrides (optional)
         env:
           RELEASE_FULL_VERSION: ${{ github.event.inputs.release_full_version }}
@@ -167,36 +233,6 @@ jobs:
             git diff -- versions_config.yml
           fi
 
-      - name: Login to quay.io/aipcc (if the secret is present)
-        shell: bash
-        env:
-          AIPCC_USER: ${{ secrets.AIPCC_QUAY_BOT_USERNAME }}
-          AIPCC_PASS: ${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}
-        run: |
-          if [[ -z "${AIPCC_USER}" ]]; then
-            echo "AIPCC_QUAY_BOT_USERNAME is not set, skipping quay.io/aipcc login"
-            exit 0
-          fi
-          printf '%s' "${AIPCC_PASS}" | skopeo login --username "${AIPCC_USER}" --password-stdin quay.io
-
-      - name: Prepare Podman temp directory
-        run: mkdir -p "$TMPDIR"
-
-      # Registry auth must be configured before Install Podman. install-podman-action runs
-      # `sudo podman system reset`, which can leave root-owned files under ~/.config/containers.
-      - name: Unlock encrypted secrets with git-crypt
-        run: |
-          echo "${GIT_CRYPT_KEY}" | base64 --decode > ./git-crypt-key
-          trap 'rm -f ./git-crypt-key' EXIT
-          git-crypt unlock ./git-crypt-key
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
-
-      - name: Configure registry auth from pull-secret
-        run: |
-          mkdir -p "$HOME/.config/containers"
-          cp ci/secrets/pull-secret.json "$HOME/.config/containers/auth.json"
-
       - name: Install Podman
         uses: ./.github/actions/install-podman-action
         with:
@@ -251,7 +287,7 @@ jobs:
             2>/dev/null || true
 
           gh pr create \
-            --title "GHA: Kick off new release ${RELEASE_FULL_VERSION}" \
+            --title "[Major Release: ${RELEASE_FULL_VERSION}]: Automated PR for new major release updates" \
             --head "${KICKOFF_BRANCH}" \
             --body "$(cat <<EOF
           Automated release kickoff run for release **${RELEASE_FULL_VERSION}** using:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -593,7 +593,24 @@ def test_rhds_pipelines_use_rhds_args(subtests: pytest_subtests.plugin.SubTests)
             )
 
 
-CANONICAL_TAG_ORDER = ["3.5", "3.4", "2025.2", "2025.1", "2024.2", "2024.1", "2023.2", "2023.1", "1.2"]
+_BASE_CANONICAL_TAG_ORDER = ["3.5", "3.4", "2025.2", "2025.1", "2024.2", "2024.1", "2023.2", "2023.1", "1.2"]
+
+
+def _canonical_tag_order_from_versions_config() -> list[str]:
+    versions_config = yaml.safe_load((PROJECT_ROOT / "versions_config.yml").read_text())
+    release = versions_config.get("release", {})
+    full_version = release.get("full_version")
+    if not isinstance(full_version, str):
+        raise ValueError("versions_config.yml release.full_version must be a string")
+
+    release_major_minor = _major_minor_from_version(full_version)
+    if release_major_minor is None:
+        raise ValueError(f"versions_config.yml release.full_version is invalid: {full_version!r}")
+
+    return [release_major_minor, *[tag for tag in _BASE_CANONICAL_TAG_ORDER if tag != release_major_minor]]
+
+
+CANONICAL_TAG_ORDER = _canonical_tag_order_from_versions_config()
 
 _PLACEHOLDER_RE = re.compile(
     r"""


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release kickoff pull requests now use a clearer major-release title format based on the selected version.
  * Release automation more reliably prepares registry authentication and release credentials.

* **Tests**
  * Version tag ordering now adapts automatically to the configured release version, improving validation across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->