### PR TITLE
RHAIENG-6403: ci: grant packages read to Antigravity dispatch review job

### DIFF
--- a/.github/workflows/antigravity-ci-gated-review.yml
+++ b/.github/workflows/antigravity-ci-gated-review.yml
@@ -105,6 +105,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}
           PULL_REQUEST_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REVIEW_AUTHOR_LOGIN: ${{ steps.mint_identity_token.outputs.app-slug != '' && format('{0}[bot]', steps.mint_identity_token.outputs.app-slug) || 'github-actions[bot]' }}
           REVIEW_BODY_PATH: 'review-summary-body.md'
           WORKFLOW_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: 'uv run --package odh-ci-agent odh-ci-upsert-review-comment'

--- a/.github/workflows/antigravity-ci-gated-review.yml
+++ b/.github/workflows/antigravity-ci-gated-review.yml
@@ -100,6 +100,7 @@ jobs:
         if: |-
           github.event.workflow_run.pull_requests[0] != null
         env:
+          GITHUB_APP_SLUG: ${{ steps.mint_identity_token.outputs.app-slug }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}

--- a/.github/workflows/antigravity-ci-gated-review.yml
+++ b/.github/workflows/antigravity-ci-gated-review.yml
@@ -18,7 +18,8 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository
-    runs-on: 'ubuntu-latest'
+    # ubuntu-latest is ubuntu-24.04; stock podman/crun flakes in prepare-review-context (opendatahub-io/notebooks#4211).
+    runs-on: 'ubuntu-26.04'
     timeout-minutes: 12
     permissions:
       actions: 'read'
@@ -58,6 +59,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Install Podman'
+        uses: './.github/actions/install-podman-action'
+        with:
+          platform: 'linux/amd64'
 
       - name: 'Prepare review context'
         if: |-

--- a/.github/workflows/antigravity-ci-summary.yml
+++ b/.github/workflows/antigravity-ci-summary.yml
@@ -39,7 +39,7 @@ jobs:
           github.event.workflow_run.head_repository.full_name == github.repository
         )
       )
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-26.04'
     timeout-minutes: 12
     permissions:
       actions: 'read'

--- a/.github/workflows/antigravity-dispatch.yml
+++ b/.github/workflows/antigravity-dispatch.yml
@@ -111,6 +111,7 @@ jobs:
     permissions:
       contents: 'read'
       issues: 'write'
+      packages: 'read'
       pull-requests: 'write'
     with:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'

--- a/.github/workflows/antigravity-dispatch.yml
+++ b/.github/workflows/antigravity-dispatch.yml
@@ -56,7 +56,7 @@ jobs:
         ) &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-26.04'
     permissions:
       contents: 'read'
     outputs:

--- a/.github/workflows/antigravity-pr-review.yml
+++ b/.github/workflows/antigravity-pr-review.yml
@@ -34,7 +34,8 @@ concurrency:
 
 jobs:
   review:
-    runs-on: 'ubuntu-latest'
+    # ubuntu-latest is ubuntu-24.04; stock podman/crun flakes in prepare-review-context (opendatahub-io/notebooks#4211).
+    runs-on: 'ubuntu-26.04'
     timeout-minutes: 10
     permissions:
       contents: 'read'
@@ -72,6 +73,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Install Podman'
+        uses: './.github/actions/install-podman-action'
+        with:
+          platform: 'linux/amd64'
 
       - name: 'Validate pull request number'
         id: 'validate_pr'

--- a/.github/workflows/antigravity-pr-review.yml
+++ b/.github/workflows/antigravity-pr-review.yml
@@ -140,6 +140,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}
           PULL_REQUEST_NUMBER: ${{ steps.validate_pr.outputs.pull_request_number }}
+          REVIEW_AUTHOR_LOGIN: ${{ steps.mint_identity_token.outputs.app-slug != '' && format('{0}[bot]', steps.mint_identity_token.outputs.app-slug) || 'github-actions[bot]' }}
           REVIEW_BODY_PATH: 'review-summary-body.md'
           WORKFLOW_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: 'uv run --package odh-ci-agent odh-ci-upsert-review-comment'

--- a/.github/workflows/antigravity-pr-review.yml
+++ b/.github/workflows/antigravity-pr-review.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: 'Upsert review summary comment'
         env:
+          GITHUB_APP_SLUG: ${{ steps.mint_identity_token.outputs.app-slug }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}

--- a/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
+++ b/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
@@ -49,6 +49,20 @@ def read_github_token() -> str:
     return os.environ.get("GITHUB_TOKEN", "").strip()
 
 
+def _is_user_endpoint_forbidden(exc: GitHubCommandError) -> bool:
+    return "Resource not accessible by integration" in exc.stdout or "Resource not accessible by integration" in exc.stderr
+
+
+def _login_from_user_api() -> str:
+    user = gh_api_json("user")
+    if not isinstance(user, dict):
+        raise SystemExit("Expected GitHub user response to include login")
+    login = user.get("login")
+    if not isinstance(login, str) or not login:
+        raise SystemExit("Expected GitHub user response to include login")
+    return login
+
+
 @functools.lru_cache(maxsize=1)
 def authenticated_user_login() -> str:
     """Return the login for the token in GITHUB_TOKEN (workflow or GitHub App bot)."""
@@ -61,13 +75,12 @@ def authenticated_user_login() -> str:
     if app_slug:
         return f"{app_slug}[bot]"
 
-    user = gh_api_json("user")
-    if not isinstance(user, dict):
-        raise SystemExit("Expected GitHub user response to include login")
-    login = user.get("login")
-    if not isinstance(login, str) or not login:
-        raise SystemExit("Expected GitHub user response to include login")
-    return login
+    try:
+        return _login_from_user_api()
+    except GitHubCommandError as exc:
+        if _is_user_endpoint_forbidden(exc):
+            return "github-actions[bot]"
+        raise
 
 
 def _query_path(path: str, query: Mapping[str, object] | None = None) -> str:

--- a/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
+++ b/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
@@ -53,6 +53,14 @@ def read_github_token() -> str:
 def authenticated_user_login() -> str:
     """Return the login for the token in GITHUB_TOKEN (workflow or GitHub App bot)."""
 
+    explicit_login = os.environ.get("REVIEW_AUTHOR_LOGIN", "").strip()
+    if explicit_login:
+        return explicit_login
+
+    app_slug = os.environ.get("GITHUB_APP_SLUG", "").strip()
+    if app_slug:
+        return f"{app_slug}[bot]"
+
     user = gh_api_json("user")
     if not isinstance(user, dict):
         raise SystemExit("Expected GitHub user response to include login")

--- a/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
+++ b/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
@@ -50,7 +50,9 @@ def read_github_token() -> str:
 
 
 def _is_user_endpoint_forbidden(exc: GitHubCommandError) -> bool:
-    return "Resource not accessible by integration" in exc.stdout or "Resource not accessible by integration" in exc.stderr
+    return (
+        "Resource not accessible by integration" in exc.stdout or "Resource not accessible by integration" in exc.stderr
+    )
 
 
 def _login_from_user_api() -> str:

--- a/ci/agentic-reviewer/tests/unit/test_github_api.py
+++ b/ci/agentic-reviewer/tests/unit/test_github_api.py
@@ -97,6 +97,25 @@ def test_authenticated_user_login_falls_back_when_user_endpoint_forbidden(monkey
         github_api.authenticated_user_login.cache_clear()
 
 
+def test_authenticated_user_login_reraises_non_forbidden_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    github_api.authenticated_user_login.cache_clear()
+    monkeypatch.delenv("REVIEW_AUTHOR_LOGIN", raising=False)
+    monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+    server_error = github_api.GitHubCommandError(
+        ("gh", "api", "user"),
+        1,
+        '{"message":"Internal Server Error","status":"500"}',
+        "gh: Internal Server Error (HTTP 500)\n",
+    )
+    try:
+        with patch("odh_ci_agent.github_api.gh_api_json", side_effect=server_error):
+            with pytest.raises(github_api.GitHubCommandError) as exc_info:
+                github_api.authenticated_user_login()
+            assert exc_info.value is server_error
+    finally:
+        github_api.authenticated_user_login.cache_clear()
+
+
 def test_authenticated_user_login_prefers_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
     github_api.authenticated_user_login.cache_clear()
     monkeypatch.setenv("REVIEW_AUTHOR_LOGIN", "custom-bot[bot]")

--- a/ci/agentic-reviewer/tests/unit/test_github_api.py
+++ b/ci/agentic-reviewer/tests/unit/test_github_api.py
@@ -51,8 +51,10 @@ def test_parse_positive_issue_number_rejects_invalid_values(raw: str) -> None:
         github_api.parse_positive_issue_number(raw, label="pull request number")
 
 
-def test_authenticated_user_login_returns_login() -> None:
+def test_authenticated_user_login_returns_login(monkeypatch: pytest.MonkeyPatch) -> None:
     github_api.authenticated_user_login.cache_clear()
+    monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+    monkeypatch.delenv("REVIEW_AUTHOR_LOGIN", raising=False)
     try:
         with patch(
             "odh_ci_agent.github_api.gh_api_json",
@@ -65,11 +67,40 @@ def test_authenticated_user_login_returns_login() -> None:
         github_api.authenticated_user_login.cache_clear()
 
 
+def test_authenticated_user_login_uses_github_app_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    github_api.authenticated_user_login.cache_clear()
+    monkeypatch.setenv("GITHUB_APP_SLUG", "odh-antigravity")
+    try:
+        with patch("odh_ci_agent.github_api.gh_api_json") as mock_gh_api_json:
+            assert github_api.authenticated_user_login() == "odh-antigravity[bot]"
+            mock_gh_api_json.assert_not_called()
+    finally:
+        github_api.authenticated_user_login.cache_clear()
+        monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+
+
+def test_authenticated_user_login_prefers_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    github_api.authenticated_user_login.cache_clear()
+    monkeypatch.setenv("REVIEW_AUTHOR_LOGIN", "custom-bot[bot]")
+    monkeypatch.setenv("GITHUB_APP_SLUG", "ignored-app")
+    try:
+        with patch("odh_ci_agent.github_api.gh_api_json") as mock_gh_api_json:
+            assert github_api.authenticated_user_login() == "custom-bot[bot]"
+            mock_gh_api_json.assert_not_called()
+    finally:
+        github_api.authenticated_user_login.cache_clear()
+        monkeypatch.delenv("REVIEW_AUTHOR_LOGIN", raising=False)
+        monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+
+
 @pytest.mark.parametrize("user_response", [{"login": 12345}, {"login": ""}, {"login": None}, {}])
 def test_authenticated_user_login_rejects_malformed_login(
+    monkeypatch: pytest.MonkeyPatch,
     user_response: object,
 ) -> None:
     github_api.authenticated_user_login.cache_clear()
+    monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+    monkeypatch.delenv("REVIEW_AUTHOR_LOGIN", raising=False)
     with patch("odh_ci_agent.github_api.gh_api_json", return_value=user_response):
         with pytest.raises(SystemExit, match="Expected GitHub user response to include login"):
             github_api.authenticated_user_login()

--- a/ci/agentic-reviewer/tests/unit/test_github_api.py
+++ b/ci/agentic-reviewer/tests/unit/test_github_api.py
@@ -69,6 +69,7 @@ def test_authenticated_user_login_returns_login(monkeypatch: pytest.MonkeyPatch)
 
 def test_authenticated_user_login_uses_github_app_slug(monkeypatch: pytest.MonkeyPatch) -> None:
     github_api.authenticated_user_login.cache_clear()
+    monkeypatch.delenv("REVIEW_AUTHOR_LOGIN", raising=False)
     monkeypatch.setenv("GITHUB_APP_SLUG", "odh-antigravity")
     try:
         with patch("odh_ci_agent.github_api.gh_api_json") as mock_gh_api_json:
@@ -77,6 +78,23 @@ def test_authenticated_user_login_uses_github_app_slug(monkeypatch: pytest.Monke
     finally:
         github_api.authenticated_user_login.cache_clear()
         monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+
+
+def test_authenticated_user_login_falls_back_when_user_endpoint_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    github_api.authenticated_user_login.cache_clear()
+    monkeypatch.delenv("REVIEW_AUTHOR_LOGIN", raising=False)
+    monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
+    forbidden = github_api.GitHubCommandError(
+        ("gh", "api", "user"),
+        1,
+        '{"message":"Resource not accessible by integration","status":"403"}',
+        "gh: Resource not accessible by integration (HTTP 403)\n",
+    )
+    try:
+        with patch("odh_ci_agent.github_api.gh_api_json", side_effect=forbidden):
+            assert github_api.authenticated_user_login() == "github-actions[bot]"
+    finally:
+        github_api.authenticated_user_login.cache_clear()
 
 
 def test_authenticated_user_login_prefers_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fixes Antigravity PR review dispatches that fail at workflow validation with **startup failure** before any job runs.

`antigravity-dispatch.yml` calls `antigravity-pr-review.yml` as a reusable workflow. The review workflow declares `packages: read` (needed to pull the private `buildinputs` image from GHCR during `odh-ci-prepare-review-context`), but dispatch only granted `contents`, `issues`, and `pull-requests`. GitHub rejects the nested call:

> The nested job `review` is requesting `packages: read`, but is only allowed `packages: none`.

This one-line change passes `packages: read` through the `workflow_call` boundary.

Related: [RHAIENG-6403](https://redhat.atlassian.net/browse/RHAIENG-6403)

## Problem

After GHCR login was added to `antigravity-pr-review.yml` (so `bin/buildinputs` can pull `ghcr.io/<repo>/buildinputs` while resolving affected image targets), every dispatch-triggered review started failing at parse time.

Observed on RHDS after syncing upstream (example runs):

- https://github.com/red-hat-data-services/notebooks/actions/runs/30530768858
- https://github.com/red-hat-data-services/notebooks/actions/runs/30530784102
- https://github.com/red-hat-data-services/notebooks/actions/runs/30530899916
- https://github.com/red-hat-data-services/notebooks/actions/runs/30530934912

Triggers included `/agy review` issue comments and PR open/edit events — all died in the dispatch → review handoff.

`antigravity-ci-gated-review.yml` was unaffected because it is a top-level workflow with its own `packages: read`. Only the **dispatch → pr-review** path was missing the permission.

## Why `packages: read` is required

`Prepare review context` runs `odh-ci-prepare-review-context`, which calls `gha_pr_changed_files.filter_out_unchanged()` → `bin/buildinputs` per Dockerfile. That tooling may pull container images from GHCR (including the repo's `buildinputs` image). On RHDS that image is private; the workflow logs in with `GITHUB_TOKEN` via `docker/login-action`, which requires `packages: read` on the job token.

Reusable workflows cannot escalate permissions beyond what the caller grants, so dispatch must explicitly include `packages: read` on the job that `uses:` `antigravity-pr-review.yml`.

## Change

Add `packages: read` to the `review` job permissions in `.github/workflows/antigravity-dispatch.yml`.

## Test plan

- [ ] Merge and sync to RHDS (or cherry-pick)
- [ ] Comment `/agy review` on a PR — Antigravity Dispatch should start and the nested review workflow should pass workflow validation
- [ ] Confirm `Prepare review context` completes (GHCR login + buildinputs pull)

Made with [Cursor](https://cursor.com)

[RHAIENG-6403]: https://redhat.atlassian.net/browse/RHAIENG-6403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated review and CI workflows to run on Ubuntu 26.04.
  * Added an explicit Podman installation step in review workflows to improve stability.
  * Enhanced review comment attribution by supplying GitHub App identity details (for consistent author naming).
* **Bug Fixes**
  * Fixed login/author resolution to honor `REVIEW_AUTHOR_LOGIN` first, derive from `GITHUB_APP_SLUG` when set, and safely fall back to `github-actions[bot]` when user lookups are blocked.
* **Tests**
  * Updated and expanded unit tests to be deterministic and to verify override precedence and forbidden-endpoint fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->