### PR TITLE
fix(manifests): normalize imagestream rollout comments and default-image annotation

### DIFF
--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -699,14 +699,20 @@ def normalize_rollout_state(tag: dict[str, Any], index: int) -> None:
     annotations[_OUTDATED_KEY] = SingleQuotedScalarString("true")
 
 
-def normalize_default_image_annotation(tags: Any, path: Path) -> None:
+def normalize_default_image_annotation(tags: Any, path: Path) -> bool:
+    changed = False
     is_minimal_default_imagestream = path.name == "jupyter-minimal-notebook-imagestream.yaml"
     for index, tag in enumerate(tags):
         annotations = tag.setdefault("annotations", {})
         if is_minimal_default_imagestream and index == 0:
-            annotations[_DEFAULT_IMAGE_KEY] = DoubleQuotedScalarString("true")
+            if annotations.get(_DEFAULT_IMAGE_KEY) != "true":
+                annotations[_DEFAULT_IMAGE_KEY] = DoubleQuotedScalarString("true")
+                changed = True
             continue
-        annotations.pop(_DEFAULT_IMAGE_KEY, None)
+        if _DEFAULT_IMAGE_KEY in annotations:
+            annotations.pop(_DEFAULT_IMAGE_KEY, None)
+            changed = True
+    return changed
 
 
 def rollout_tag_sequence(tags: Any, target_tag_name: str, *, keep_history: bool) -> bool:
@@ -760,8 +766,7 @@ def rollout_imagestream_file(path: Path, target_tag_name: str, *, keep_history: 
         raise ValueError(f"ImageStream has no spec.tags: {path}")
 
     changed = rollout_tag_sequence(tags, target_tag_name, keep_history=keep_history)
-    if changed:
-        normalize_default_image_annotation(tags, path)
+    changed |= normalize_default_image_annotation(tags, path)
     if changed and not dry_run:
         output = io.StringIO()
         if len(docs) > 1:

--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -40,6 +40,7 @@ ROOT_DIR = SCRIPT_DIR.parents[1]
 _RECOMMENDED_KEY = "opendatahub.io/workbench-image-recommended"
 _OUTDATED_KEY = "opendatahub.io/image-tag-outdated"
 _COMMIT_KEY = "opendatahub.io/notebook-build-commit"
+_DEFAULT_IMAGE_KEY = "opendatahub.io/default-image"
 _PLACEHOLDER_RE = re.compile(r"^(?P<prefix>.+?)(?P<suffix>-(?:n|\d+(?:-\d+)*))_PLACEHOLDER$")
 _VERSIONED_KEY_RE = re.compile(r"^(?P<base>.+?)(?P<suffix>-(?:n|\d+(?:-\d+)*))$")
 _ODH_RELEASE_FAMILY_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)$")
@@ -698,6 +699,16 @@ def normalize_rollout_state(tag: dict[str, Any], index: int) -> None:
     annotations[_OUTDATED_KEY] = SingleQuotedScalarString("true")
 
 
+def normalize_default_image_annotation(tags: Any, path: Path) -> None:
+    is_minimal_default_imagestream = path.name == "jupyter-minimal-notebook-imagestream.yaml"
+    for index, tag in enumerate(tags):
+        annotations = tag.setdefault("annotations", {})
+        if is_minimal_default_imagestream and index == 0:
+            annotations[_DEFAULT_IMAGE_KEY] = DoubleQuotedScalarString("true")
+            continue
+        annotations.pop(_DEFAULT_IMAGE_KEY, None)
+
+
 def rollout_tag_sequence(tags: Any, target_tag_name: str, *, keep_history: bool) -> bool:
     if not tags:
         return False
@@ -749,6 +760,8 @@ def rollout_imagestream_file(path: Path, target_tag_name: str, *, keep_history: 
         raise ValueError(f"ImageStream has no spec.tags: {path}")
 
     changed = rollout_tag_sequence(tags, target_tag_name, keep_history=keep_history)
+    if changed:
+        normalize_default_image_annotation(tags, path)
     if changed and not dry_run:
         output = io.StringIO()
         if len(docs) > 1:

--- a/manifests/tools/rollout_tag_on_imagestreams.py
+++ b/manifests/tools/rollout_tag_on_imagestreams.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import copy
 import importlib
+import io
 import re
 import sys
 import urllib.error
@@ -46,6 +47,7 @@ _ODH_GA_BUILD_TAG_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)-v\d+\.(?P<bu
 _RHOAI_WORKBENCH_BASE_KEY_RE = re.compile(
     r"^odh-workbench-(?P<middle>.+)-py(?P<pyver>\d+)-(?P<platform>ubi9|c9s)$"
 )
+_ROLLOUT_TRAILING_COMMENT_RE = re.compile(r"^\s*# N - 1 Version of the image\s*$")
 _RHOAI_BUILD_CONFIG_REPO = "red-hat-data-services/RHOAI-Build-Config"
 _RHOAI_BUILD_CONFIG_CSV_PATH = "bundle/manifests/rhods-operator.clusterserviceversion.yaml"
 _SKOPEO_INSPECT = importlib.import_module("manifests.tools.skopeo_inspect")
@@ -720,6 +722,21 @@ def rollout_tag_sequence(tags: Any, target_tag_name: str, *, keep_history: bool)
     return True
 
 
+def cleanup_trailing_rollout_comment(yaml_text: str) -> str:
+    lines = yaml_text.splitlines(keepends=True)
+    if not lines:
+        return yaml_text
+
+    # ruamel can keep the removed third-tag marker as a dangling EOF comment.
+    # Remove only trailing comment-only lines that match this rollout marker.
+    index = len(lines) - 1
+    while index >= 0 and lines[index].strip() == "":
+        index -= 1
+    if index >= 0 and _ROLLOUT_TRAILING_COMMENT_RE.fullmatch(lines[index].rstrip("\n")):
+        del lines[index]
+    return "".join(lines)
+
+
 def rollout_imagestream_file(path: Path, target_tag_name: str, *, keep_history: bool, dry_run: bool, yml: YAML) -> bool:
     with path.open("r", encoding="utf-8") as handle:
         docs = list(yml.load_all(handle))
@@ -733,11 +750,12 @@ def rollout_imagestream_file(path: Path, target_tag_name: str, *, keep_history: 
 
     changed = rollout_tag_sequence(tags, target_tag_name, keep_history=keep_history)
     if changed and not dry_run:
-        with path.open("w", encoding="utf-8") as handle:
-            if len(docs) > 1:
-                yml.dump_all(docs, handle)
-            else:
-                yml.dump(document, handle)
+        output = io.StringIO()
+        if len(docs) > 1:
+            yml.dump_all(docs, output)
+        else:
+            yml.dump(document, output)
+        path.write_text(cleanup_trailing_rollout_comment(output.getvalue()), encoding="utf-8")
     return changed
 
 


### PR DESCRIPTION
follow up for: https://redhat.atlassian.net/browse/RHAIENG-6164

This PR fixes two rollout side effects in `manifests/tools/rollout_tag_on_imagestreams.py`:
1. Prevents a dangling EOF comment (`# N - 1 Version of the image`) from being retained after tag rollover, which can break strict YAML linting. https://github.com/opendatahub-io/notebooks/actions/runs/30483091901/job/90681901151
2. Normalizes `opendatahub.io/default-image` so it is kept only on:
   - `jupyter-minimal-notebook-imagestream.yaml`
   - the latest `N` tag only https://github.com/opendatahub-io/notebooks/pull/4200#discussion_r3677407208 
  
As part of this, the annotation is removed from `N-1` and from non-minimal imagestreams.
## Why
Rollout output should remain lint-clean and preserve intended annotation semantics:
- no stale trailing comments after trimming tags
- `default-image` should only mark the current minimal default image
## How Has This Been Tested?
- Regression check for trailing comment cleanup logic:
  - verifies orphan EOF marker is removed
  - verifies valid in-sequence marker remains
- Rollout behavior check:
  - minimal imagestream keeps `default-image` only on tag `N`
  - non-minimal imagestreams do not keep `default-image`
- `yamllint --strict` validation run with CI-equivalent scope/exclusions
## Impact
- No change to release/tag selection logic.
- Changes only affect generated YAML formatting/annotations post-rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured `opendatahub.io/default-image` annotations are consistently normalized after rollout tag sequencing, even when tag sequencing itself doesn’t result in changes.
  - Prevented unwanted rollout marker comments from being left at the end of generated YAML files.
  - Preserved cleaner, more consistent manifest output during image tag updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->