### PR TITLE
docs: prohibit git add -A/./--all in AGENTS.md, require explicit staging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,12 @@ make refresh-lock-files
   pipeline regen, imagestream manifest updates), a scoped pathspec is fine — but only right
   after checking `git status`/`git diff --stat` for that scope so you know exactly what it
   matches, using a tight pattern anchored to a shared prefix and suffix (e.g.
-  `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`). Re-run
-  `git status` before committing to confirm nothing else rode along. If the changed set is
-  short enough to read at a glance, just spell out the filenames — a glob earns its keep only
-  when the set is too large to enumerate by hand.
+  `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`). Before
+  committing, re-run `git status` and skim `git diff --cached` for the staged paths —
+  `git status` only shows which paths are staged, not which hunks, so a file you explicitly
+  staged can still carry an unrelated edit. If the changed set is short enough to read at a
+  glance, just spell out the filenames — a glob earns its keep only when the set is too large
+  to enumerate by hand.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,15 @@ make refresh-lock-files
 - Prefer existing docs over guesswork. Read the linked doc before inventing process or policy.
 - Verify bulk edits after scripting them. This repo has generated files and repeated patterns.
 - Update nearby documentation when behavior changes, especially build, dependency, and CI workflows.
+- Stage explicitly: `git add <file1> <file2> ...`. For genuine bulk-regen output where
+  hand-listing every path is impractical (lockfiles from `make refresh-lock-files`, `.tekton/`
+  pipeline regen, imagestream manifest updates), a scoped pathspec is fine — but only right
+  after checking `git status`/`git diff --stat` for that scope so you know exactly what it
+  matches, using a tight pattern anchored to a shared prefix and suffix (e.g.
+  `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`). Re-run
+  `git status` before committing to confirm nothing else rode along. If the changed set is
+  short enough to read at a glance, just spell out the filenames — a glob earns its keep only
+  when the set is too large to enumerate by hand.
 
 ## Boundaries
 
@@ -96,6 +105,9 @@ make refresh-lock-files
   directly (PipelineRuns are synced from `konflux-central`). Bump container OS bases
   to RHEL/UBI/CentOS 10 or accept MintMaker PRs that do — the project stays on EL9;
   see [base-images/README.md](base-images/README.md#os-version-policy-el9-only).
+  Stage with `git add -A`, `git add .`, or `git add --all` — these sweep in whatever
+  else is sitting in the tree (scratch files, unrelated in-progress edits, generated
+  artifacts) with no chance to notice until it's already committed.
 
 ## Communication
 


### PR DESCRIPTION
## Description

Closes #3557.

Adds a git-staging rule to `AGENTS.md`:

- **Boundaries → Never:** don't stage with `git add -A`, `git add .`, or `git add --all` — these sweep in whatever else happens to be sitting in the tree (scratch files, unrelated in-progress edits, generated artifacts) with no chance to notice until it's already committed.
- **Agent conduct:** stage explicitly by filename. A scoped pathspec/glob is allowed for genuine bulk-regen output (lockfiles, `.tekton/`, imagestream manifests) where hand-listing every path is impractical — but only right after inspecting the change set (`git status`/`git diff --stat`) for that scope, using a tight pattern anchored to a shared prefix/suffix, and re-checking `git status` before committing.

No other `AGENTS.md`/`CLAUDE.md`/`.cursor/rules/*.mdc` file duplicates this content, and per `docs/ai-coding-assistant-project-config.md`'s own recommendation (canonical file + pointers, not duplication), this rule lives once in the root `AGENTS.md` rather than being copied into the subsystem-scoped `AGENTS.md` files.

## How Has This Been Tested?

Docs-only change. Verified the diff only touches the two intended bullets (`git diff AGENTS.md`), and confirmed the "stage explicitly" guidance in practice: `git add AGENTS.md` (a single literal file) left the ~20 untracked scratch files/dirs currently sitting in this checkout root untouched — the exact failure mode the new rule documents.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — N/A, docs-only change with no code/build impact
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for safely staging changes.
  * Encourages reviewing status and staged contents before committing.
  * Advises against broad staging commands that may include unintended files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->