### PR TITLE
fix(ci): centralize coverage configuration in GHA workflow

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -108,6 +108,11 @@ jobs:
         run: make test
         if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
         env:
+          PYTEST_ADDOPTS: >-
+            --cov=.
+            --cov-branch
+            --cov-report=term-missing
+            --cov-report=xml:coverage.xml
           # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
           # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).
           NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,6 @@
 addopts =
     --strict-markers --capture=no --tb=short
     --doctest-modules
-    --cov --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml
     --junitxml=junit.xml -o junit_family=legacy
 
 # Directories to collect tests from (speeds up collection significantly).


### PR DESCRIPTION
This PR moves the pytest coverage configuration from `pytest.ini` to the GitHub Actions workflow environment variable `PYTEST_ADDOPTS`. This improves local developer environments by not forcing coverage collection when running tests locally, while maintaining full coverage reporting in the CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced automated test reporting with branch coverage, missing-line details, and XML coverage output.
  * Updated test configuration to apply coverage settings through the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->