### PR TITLE
RHAIENG-6664: fix excessively verbose pytest/CI output

### DIFF
--- a/.cursor/rules/test-conventions.mdc
+++ b/.cursor/rules/test-conventions.mdc
@@ -21,8 +21,7 @@ alwaysApply: false
 
 | Tool | Purpose |
 |------|---------|
-| pytest | Test runner for all Python tests |
-| pytest-subtests | Granular sub-assertions within a single test |
+| pytest | Test runner for all Python tests (subtests support is built in since pytest 9.0) |
 | pytest-cov | Coverage (XML + terminal) |
 | allure-pytest | Issue tracking + step decoration |
 | testcontainers | Container lifecycle for integration tests |
@@ -48,12 +47,11 @@ Use **module-level functions**. Group related assertions with `subtests`:
 from __future__ import annotations
 
 import pytest
-import pytest_subtests
 
 from tests import PROJECT_ROOT
 
 
-def test_something_across_manifests(subtests: pytest_subtests.SubTests):
+def test_something_across_manifests(subtests: pytest.Subtests):
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):
         with subtests.test(msg=str(file.relative_to(PROJECT_ROOT))):
             # assertion per file
@@ -78,7 +76,7 @@ class TestMyFeature:
     def test_something(
         self,
         workbench_image: conftest.Image,
-        subtests: pytest_subtests.SubTests,
+        subtests: pytest.Subtests,
     ):
         with WorkbenchContainer(workbench_image) as container:
             container.start()
@@ -245,7 +243,7 @@ from __future__ import annotations  # Always first
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import pytest_subtests
+    import pytest
     from pathlib import Path
 ```
 

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -492,7 +492,7 @@ jobs:
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
+          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}" -o junit_family=legacy
 
       - name: Upload Testcontainers pytest JUnit XML
         if: ${{ always() && steps.pytest-testcontainers.conclusion != 'skipped' }}
@@ -566,7 +566,7 @@ jobs:
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}"
+          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}" -o junit_family=legacy
 
       - name: Upload OpenShift pytest JUnit XML
         if: ${{ always() && steps.pytest-openshift.conclusion != 'skipped' }}

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -105,6 +105,7 @@ jobs:
         run: uv sync --locked
 
       - name: Static tests (pytest + Dockerfile alignment)
+        id: static-tests
         run: make test
         if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
         env:
@@ -113,9 +114,19 @@ jobs:
             --cov-branch
             --cov-report=term-missing
             --cov-report=xml:coverage.xml
+            -o log_file=logs/pytest-logs.txt -o log_file_level=DEBUG
           # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
           # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).
           NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+      - name: Upload pytest debug log
+        if: ${{ always() && steps.static-tests.conclusion != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          path: logs/pytest-logs.txt
+          archive: false
+          retention-days: 14
+          if-no-files-found: warn
 
       - name: Upload Python coverage to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -114,6 +114,7 @@ jobs:
             --cov-branch
             --cov-report=term-missing
             --cov-report=xml:coverage.xml
+            --junitxml=junit.xml -o junit_family=legacy
             -o log_file=logs/pytest-logs.txt -o log_file_level=DEBUG
           # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
           # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -136,6 +136,7 @@ jobs:
           uv run pytest tests/containers \
             -m 'not openshift and not cuda and not rocm and not manifest_validation' \
             --image="${TEST_IMAGE}" \
+            --junitxml=junit.xml -o junit_family=legacy \
             -v
 
       - name: Upload test results

--- a/ntb/strings.py
+++ b/ntb/strings.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from os import PathLike
 
-    import pytest_subtests
+    import pytest
     from pyfakefs.fake_filesystem import FakeFilesystem
 
 
@@ -76,7 +76,7 @@ def process_template_with_indents(template: templatelib.Template) -> str:
 
 
 class TestProcessTemplateWithIndents:
-    def test_process_template_with_indents(self, subtests: pytest_subtests.plugin.SubTests) -> None:
+    def test_process_template_with_indents(self, subtests: pytest.Subtests) -> None:
         a = "a\na"
         b = "b\n b"
         test_cases = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     #
     "pytest",
     "pytest-cov",
+    "pytest-instafail",
     "allure-pytest",
     #
     "pyfakefs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dev = [
     "pytest",
     "pytest-cov",
     "allure-pytest",
-    "pytest-subtests",
     #
     "pyfakefs",
     # Python 3.14 changed the internal typing._eval_type() function signature - it now includes a new prefer_fwd_module parameter

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,13 +39,17 @@ required_plugins =
 junit_logging = all
 junit_log_passing_tests = False
 
-log_cli = True
+# log_cli forces pytest's global verbosity to at least 1 (see _pytest/logging.py), which
+# turns the compact dot-per-test summary into one report line per test/subtest -- very
+# noisy given the thousands of subtests in test_image_pyprojects. So it (and log_file,
+# which otherwise writes a debug-level log file on every run) are off by default.
+# For interactive debugging, opt in on the command line instead of editing this file:
+#   uv run pytest -o log_cli=true -o log_file=logs/pytest-logs.txt -o log_file_level=DEBUG ...
+log_cli = False
 log_cli_date_format = %Y-%m-%d %H:%M:%S
 log_cli_format = %(asctime)s %(levelname)s %(message)s
 log_cli_level = INFO
-
-log_file = logs/pytest-logs.txt
-log_file_level = DEBUG
+verbosity_subtests = 0
 
 # https://docs.pytest.org/en/stable/example/markers.html#registering-markers
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,9 +6,11 @@
 addopts =
     --strict-markers --capture=no --tb=short
     --doctest-modules
-    --junitxml=junit.xml -o junit_family=legacy
     # print each failure's traceback the moment it happens, instead of only at the end
     --instafail
+    # JUnit XML output (--junitxml, -o junit_family=legacy) is a CI concern for
+    # Codecov/Allure ingestion, not a local-dev default -- it's added on the
+    # command line by the GitHub Actions jobs that consume the resulting file.
 
 # Directories to collect tests from (speeds up collection significantly).
 #

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,8 @@ addopts =
     --strict-markers --capture=no --tb=short
     --doctest-modules
     --junitxml=junit.xml -o junit_family=legacy
+    # print each failure's traceback the moment it happens, instead of only at the end
+    --instafail
 
 # Directories to collect tests from (speeds up collection significantly).
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 import pytest
 
 # Enable pytest assertion introspection for the ntb helper module.
@@ -11,8 +9,6 @@ import pytest
 # https://github.com/pytest-dev/pytest/issues/1871
 # https://github.com/pytest-dev/pytest/issues/3454
 pytest.register_assert_rewrite("ntb.asserts")
-
-logging.basicConfig(level=logging.DEBUG)
 
 # Exclude tests/containers from default collection (see pytest.ini near testpaths).
 # Rationale: heavy third-party imports at collection time; run that subtree explicitly

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -25,8 +25,6 @@ LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import pytest_subtests
-
 
 class TestBaseImage:
     """Tests that are applicable for all images we have in this repository."""
@@ -35,7 +33,7 @@ class TestBaseImage:
         with docker_utils.running_container(image) as container:
             test_fn(container)
 
-    def test_elf_files_can_link_runtime_libs(self, subtests: pytest_subtests.SubTests, image):
+    def test_elf_files_can_link_runtime_libs(self, subtests: pytest.Subtests, image):
         def test_fn(container: testcontainers.core.container.DockerContainer):
             def check_elf_file():
                 """This python function will be executed on the image itself.
@@ -176,7 +174,7 @@ class TestBaseImage:
         self._run_test(image=image, test_fn=test_fn)
 
     # @pytest.mark.environmentss("docker")
-    def test_oc_command_runs_fake_fips(self, image: str, subtests: pytest_subtests.SubTests):
+    def test_oc_command_runs_fake_fips(self, image: str, subtests: pytest.Subtests):
         """Establishes a best-effort fake FIPS environment and attempts to execute `oc` binary in it.
 
         Related issue: RHOAIENG-4350 In workbench the oc CLI tool cannot be used on FIPS enabled cluster.
@@ -248,7 +246,7 @@ class TestBaseImage:
                 with docker_utils.BestEffortCleanup():
                     docker_utils.NotebookContainer(container).stop(timeout=0)
 
-    def test_file_permissions(self, image: str, subtests: pytest_subtests.SubTests):
+    def test_file_permissions(self, image: str, subtests: pytest.Subtests):
         """Checks the permissions and ownership for some selected files/directories."""
 
         app_root_path = "/opt/app-root"
@@ -272,7 +270,7 @@ class TestBaseImage:
         self._run_test(image=image, test_fn=test_fn)
 
     @allure.issue("RHAIENG-2189")
-    def test_python_package_index(self, image: str, subtests: pytest_subtests.SubTests):
+    def test_python_package_index(self, image: str, subtests: pytest.Subtests):
         """Verify all images have AIPCC index config.
 
         All images (both ODH and RHOAI) use AIPCC wheels and must point pip/uv

--- a/tests/containers/manifest_validation_test.py
+++ b/tests/containers/manifest_validation_test.py
@@ -50,7 +50,6 @@ from manifests.tools.package_names import all_workbench_pip_names, manifest_name
 from tests import PROJECT_ROOT
 
 if TYPE_CHECKING:
-    import pytest_subtests
     import testcontainers.core.container
 
 _LOG = logging.getLogger(__name__)
@@ -476,7 +475,7 @@ def _resolve_software_version(sw_item: dict[str, str], actual_packages: dict[str
 
 
 def _compare_manifest_vs_actual(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     is_name: str,
     tag_name: str,
     expected_deps: list[dict[str, str]],
@@ -606,7 +605,7 @@ _BASE_DIRS = [PROJECT_ROOT / "manifests" / "odh" / "base", PROJECT_ROOT / "manif
 @pytest.mark.manifest_validation
 @pytest.mark.parametrize("base_dir", _BASE_DIRS, ids=["odh", "rhoai"])
 def test_old_tag_annotations_match_sbom(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     base_dir: pathlib.Path,
 ):
     """Fast: validate N-1 tag annotations against SBOM artifacts (cosign + skopeo, no image pull).
@@ -650,7 +649,7 @@ def test_old_tag_annotations_match_sbom(
 @pytest.mark.manifest_validation
 @pytest.mark.parametrize("base_dir", _BASE_DIRS, ids=["odh", "rhoai"])
 def test_old_tag_annotations_match_image_content(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     base_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
@@ -808,7 +807,7 @@ def _packages_from_quay(image_ref: str, quay_auth: str) -> dict[str, str]:
 @pytest.mark.manifest_validation
 @pytest.mark.parametrize("base_dir", _BASE_DIRS, ids=["odh", "rhoai"])
 def test_old_tag_annotations_match_quay(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     base_dir: pathlib.Path,
 ):
     """Validate N-1 tag annotations against Quay.io Clair security scan data."""

--- a/tests/containers/params_env_validation_test.py
+++ b/tests/containers/params_env_validation_test.py
@@ -28,8 +28,6 @@ from tests import PROJECT_ROOT
 if TYPE_CHECKING:
     import pathlib
 
-    import pytest_subtests
-
 _LOG = logging.getLogger(__name__)
 
 _BASE_DIRS = [PROJECT_ROOT / "manifests" / "odh" / "base", PROJECT_ROOT / "manifests" / "rhoai" / "base"]
@@ -212,7 +210,7 @@ def _find_commit_value(variable: str, commit_entries: dict[str, str]) -> str | N
 @pytest.mark.manifest_validation
 @pytest.mark.parametrize("base_dir", _BASE_DIRS, ids=["odh", "rhoai"])
 def test_params_env_variable_uniqueness(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     base_dir: pathlib.Path,
 ):
     """All variable names in params.env + params-latest.env are unique."""
@@ -252,7 +250,7 @@ def test_params_env_variable_uniqueness(
 @pytest.mark.manifest_validation
 @pytest.mark.parametrize("base_dir", _BASE_DIRS, ids=["odh", "rhoai"])
 def test_params_env_record_count(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     base_dir: pathlib.Path,
 ):
     """Expected number of entries in env files."""
@@ -274,7 +272,7 @@ def test_params_env_record_count(
 @pytest.mark.manifest_validation
 @pytest.mark.parametrize("base_dir", _BASE_DIRS, ids=["odh", "rhoai"])
 def test_params_env_image_metadata(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     base_dir: pathlib.Path,
 ):
     """Each image in params.env has correct labels, commit ID, repo name, and size."""

--- a/tests/containers/workbenches/gpu_library_loading_test.py
+++ b/tests/containers/workbenches/gpu_library_loading_test.py
@@ -52,9 +52,6 @@ class RocmLibCheckResult(pydantic.BaseModel):
     rocm_lib: str
 
 
-if TYPE_CHECKING:
-    import pytest_subtests
-
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
@@ -101,7 +98,7 @@ class TestGPULibraryLoading:
             pytest.fail(f"Test function did not return a result. Exit code: {ecode}, Output: {output_str}")
 
     @pytest.mark.parametrize("loading_mode", ["LAZY", "EAGER"])
-    def test_pytorch_cuda_library_loading(self, cuda_image: str, subtests: pytest_subtests.SubTests, loading_mode: str):
+    def test_pytorch_cuda_library_loading(self, cuda_image: str, subtests: pytest.Subtests, loading_mode: str):
         """Test that PyTorch CUDA libraries can be loaded."""
         image_metadata = conftest.get_image_metadata(cuda_image)
         if "-pytorch-" not in image_metadata.labels.get("name", ""):
@@ -231,7 +228,7 @@ class TestGPULibraryLoading:
             if any(x in lib for x in ["cuda", "cublas", "cudnn", "nccl", "nvrtc", "torch"]):
                 LOGGER.info(f"  GPU-related lib: {lib}")
 
-    def test_pytorch_rocm_library_loading(self, rocm_image: str, subtests: pytest_subtests.SubTests):
+    def test_pytorch_rocm_library_loading(self, rocm_image: str, subtests: pytest.Subtests):
         """Test that PyTorch ROCm libraries can be loaded."""
         image_metadata = conftest.get_image_metadata(rocm_image)
         if "-pytorch-" not in image_metadata.labels.get("name", ""):
@@ -339,7 +336,7 @@ class TestGPULibraryLoading:
             if any(x in lib for x in ["hip", "rocm", "roc", "mio", "amd", "torch"]):
                 LOGGER.info(f"  ROCm-related lib: {lib}")
 
-    def test_tensorflow_cuda_library_loading(self, cuda_image: str, subtests: pytest_subtests.SubTests):
+    def test_tensorflow_cuda_library_loading(self, cuda_image: str, subtests: pytest.Subtests):
         """Test that TensorFlow CUDA libraries can be loaded."""
         image_metadata = conftest.get_image_metadata(cuda_image)
         if "-tensorflow-" not in image_metadata.labels.get("name", ""):
@@ -418,7 +415,7 @@ class TestGPULibraryLoading:
 
         LOGGER.info(f"TensorFlow devices: {result.get('devices')}")
 
-    def test_tensorflow_rocm_library_loading(self, rocm_image: str, subtests: pytest_subtests.SubTests):
+    def test_tensorflow_rocm_library_loading(self, rocm_image: str, subtests: pytest.Subtests):
         """Test that TensorFlow ROCm libraries can be loaded."""
         image_metadata = conftest.get_image_metadata(rocm_image)
         if "-tensorflow-" not in image_metadata.labels.get("name", ""):
@@ -491,7 +488,7 @@ class TestGPULibraryLoading:
 
         LOGGER.info(f"TensorFlow devices: {result.get('devices')}")
 
-    def test_rocm_critical_library_loading(self, rocm_image: str, subtests: pytest_subtests.SubTests):
+    def test_rocm_critical_library_loading(self, rocm_image: str, subtests: pytest.Subtests):
         """Verify critical ROCm compute libraries can be loaded via ctypes.
 
         Uses ctypes.cdll.LoadLibrary to attempt loading each critical ROCm library.
@@ -598,7 +595,7 @@ class TestGPULibraryLoading:
 class TestLibrarySymlinks:
     """Tests that verify library symlinks are correctly set up."""
 
-    def test_rocm_devendor_symlinks(self, rocm_image: str, subtests: pytest_subtests.SubTests):
+    def test_rocm_devendor_symlinks(self, rocm_image: str, subtests: pytest.Subtests):
         """Verify that PyTorch's de-vendored ROCm libraries are correctly symlinked."""
         image_metadata = conftest.get_image_metadata(rocm_image)
         if "-pytorch-" not in image_metadata.labels.get("name", ""):

--- a/tests/containers/workbenches/jupyterlab/libraries_test.py
+++ b/tests/containers/workbenches/jupyterlab/libraries_test.py
@@ -7,7 +7,7 @@ from tests.containers import docker_utils
 from tests.containers.workbenches.workbench_image_test import WorkbenchContainer, grab_and_check_logs
 
 if TYPE_CHECKING:
-    import pytest_subtests
+    import pytest
 
     from tests.containers.conftest import Image
 
@@ -16,9 +16,7 @@ class TestWorkbenchImage:
     """Tests for workbench images in this repository.
     A workbench image is an image running a web IDE that listens on port 8888."""
 
-    def test_image_entrypoint_starts(
-        self, subtests: pytest_subtests.SubTests, jupyterlab_datascience_image: Image
-    ) -> None:
+    def test_image_entrypoint_starts(self, subtests: pytest.Subtests, jupyterlab_datascience_image: Image) -> None:
         with WorkbenchContainer(image=jupyterlab_datascience_image.name, user=1000, group_add=[0]) as container:
             try:
                 container.start()

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -24,8 +24,6 @@ from tests.containers import docker_utils, kubernetes_utils, podman_machine_util
 if TYPE_CHECKING:
     from types import TracebackType
 
-    import pytest_subtests
-
     from tests.containers.conftest import Image
 
 
@@ -44,7 +42,7 @@ class TestWorkbenchImage:
             {"net.ipv6.conf.all.disable_ipv6": "1"},
         ],
     )
-    def test_image_entrypoint_starts(self, subtests: pytest_subtests.SubTests, workbench_image: str, sysctls) -> None:
+    def test_image_entrypoint_starts(self, subtests: pytest.Subtests, workbench_image: str, sysctls) -> None:
         with WorkbenchContainer(image=workbench_image, user=1000, group_add=[0], sysctls=sysctls) as container:
             try:
                 container.start()
@@ -55,7 +53,7 @@ class TestWorkbenchImage:
                 # try to grab logs regardless of whether container started or not
                 grab_and_check_logs(subtests, container)
 
-    def test_ipv6_only(self, subtests: pytest_subtests.SubTests, workbench_image: str, test_frame):
+    def test_ipv6_only(self, subtests: pytest.Subtests, workbench_image: str, test_frame):
         """Test that workbench image is accessible via IPv6.
         Workarounds for macOS will be needed, so that's why it's a separate test."""
 
@@ -117,7 +115,7 @@ class TestWorkbenchImage:
                 grab_and_check_logs(subtests, container)
 
     @pytest.mark.codeserver
-    def test_codeserver_starts_airgapped(self, subtests: pytest_subtests.SubTests, codeserver_image: Image) -> None:
+    def test_codeserver_starts_airgapped(self, subtests: pytest.Subtests, codeserver_image: Image) -> None:
         """Smoke test: code-server must start and serve its UI without network access."""
         with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
             container.with_kwargs(network_mode="none")
@@ -138,7 +136,7 @@ class TestWorkbenchImage:
 
     @pytest.mark.codeserver
     @allure.issue("RHAIENG-5652")
-    def test_nginx_absolute_redirect_off(self, subtests: pytest_subtests.SubTests, codeserver_image: Image) -> None:
+    def test_nginx_absolute_redirect_off(self, subtests: pytest.Subtests, codeserver_image: Image) -> None:
         """CWE-601: absolute_redirect off must be present in the live nginx config."""
         with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
             container.start(wait_for_readiness=True)
@@ -151,7 +149,7 @@ class TestWorkbenchImage:
 
     @pytest.mark.codeserver
     @allure.issue("RHAIENG-5652")
-    def test_nginx_no_open_redirect(self, subtests: pytest_subtests.SubTests, codeserver_image: Image) -> None:
+    def test_nginx_no_open_redirect(self, subtests: pytest.Subtests, codeserver_image: Image) -> None:
         """CWE-601 regression: return 302 rules must emit relative Location headers (FIND-011).
 
         A forged Host header must not appear in the Location response header.
@@ -303,7 +301,7 @@ def _wait_for_http_inside_container(container: WorkbenchContainer, port: int = 8
 
 
 def grab_and_check_logs(
-    subtests: pytest_subtests.SubTests,
+    subtests: pytest.Subtests,
     container: WorkbenchContainer,
     extra_allowed: list[str] | None = None,
 ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
     from typing import Any
 
-    import pytest_subtests
-
 MAKE = shutil.which("gmake") or shutil.which("make") or "make"
 
 _LOG = logging.getLogger(__name__)
@@ -182,7 +180,7 @@ def test_dockerfiles_unintended_subscription_manager_pattern():
 
 
 @pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])
-def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_directory: pathlib.Path):
+def test_image_pyprojects(subtests: pytest.Subtests, manifests_directory: pathlib.Path):
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):
         logging.info(file)
         with subtests.test(msg="checking pyproject.toml", pipfile=file):
@@ -382,9 +380,7 @@ def test_image_pyprojects(subtests: pytest_subtests.plugin.SubTests, manifests_d
 
 
 @pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])
-def test_image_manifests_version_alignment(
-    subtests: pytest_subtests.plugin.SubTests, manifests_directory: pathlib.Path
-):
+def test_image_manifests_version_alignment(subtests: pytest.Subtests, manifests_directory: pathlib.Path):
     """Check recommended-tag package versions across imagestreams, allowing lockfile-backed rolling drifts."""
     collected_manifests = []
     pylock_major_minor_versions = _collect_pylock_major_minor_versions()
@@ -470,7 +466,7 @@ def test_image_manifests_version_alignment(
             pytest.fail(f"{name} has multiple versions: {pprint.pformat(mapping)}")
 
 
-def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.SubTests):
+def test_image_pyprojects_version_alignment(subtests: pytest.Subtests):
     requirements = defaultdict(list)
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):
         logging.info(file)
@@ -517,7 +513,7 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
             )
 
 
-def test_files_that_should_be_same_are_same(subtests: pytest_subtests.plugin.SubTests):
+def test_files_that_should_be_same_are_same(subtests: pytest.Subtests):
     file_groups = {
         "ROCm de-vendor script": [
             PROJECT_ROOT / "jupyter/rocm/pytorch/ubi9-python-3.12/de-vendor-torch.py",
@@ -535,7 +531,7 @@ def test_files_that_should_be_same_are_same(subtests: pytest_subtests.plugin.Sub
 
 
 @allure.issue("RHOAIENG-42632")
-def test_rhds_pipelines_use_rhds_args(subtests: pytest_subtests.plugin.SubTests):
+def test_rhds_pipelines_use_rhds_args(subtests: pytest.Subtests):
     r"""RHDS pipelines (output-image under quay.io/rhoai/) must pair Dockerfile.konflux.*
     with konflux.* build-args conf files.
 
@@ -631,7 +627,7 @@ _PLACEHOLDER_RE = re.compile(
 @pytest.mark.parametrize(
     "base_dir", [PROJECT_ROOT / "manifests" / "odh" / "base", PROJECT_ROOT / "manifests" / "rhoai" / "base"]
 )
-def test_imagestream_kustomization_consistency(subtests: pytest_subtests.plugin.SubTests, base_dir):
+def test_imagestream_kustomization_consistency(subtests: pytest.Subtests, base_dir):
     """Validate that imagestream YAML files, kustomization.yaml replacements, and .env files are consistent."""
     kustomization = yaml.safe_load((base_dir / "kustomization.yaml").read_text())
     replacements = kustomization.get("replacements", [])
@@ -910,7 +906,7 @@ def test_get_accelerator_version_for_directory_returns_none_for_gpu_stable_tag(t
 def _check_all_accelerator_variants(
     directory: pathlib.Path,
     manifests_directory: pathlib.Path,
-    subtests: pytest_subtests.plugin.SubTests,
+    subtests: pytest.Subtests,
 ) -> None:
     """Check accelerator versions for all build-args variants (cuda, rocm) in a directory.
 
@@ -962,7 +958,7 @@ _KNOWN_EVR_MISMATCHES: frozenset[str] = frozenset()
 
 
 @pytest.mark.parametrize("lockfile", _collect_rpms_lock_files(), ids=lambda p: str(p.relative_to(PROJECT_ROOT)))
-def test_rpms_lock_nvr_consistency_across_arches(subtests: pytest_subtests.plugin.SubTests, lockfile: pathlib.Path):
+def test_rpms_lock_nvr_consistency_across_arches(subtests: pytest.Subtests, lockfile: pathlib.Path):
     """Assert that every RPM name pinned in RHDS rpms.lock.yaml has the same EVR across all architectures.
 
     This only validates lockfile-installed RPMs. Packages inherited from the base

--- a/uv.lock
+++ b/uv.lock
@@ -1288,7 +1288,6 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-subtests" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -1320,7 +1319,6 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-subtests" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich", specifier = ">=15.0.0" },
@@ -1903,19 +1901,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "pytest-subtests"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/d9/20097971a8d315e011e055d512fa120fd6be3bdb8f4b3aa3e3c6bf77bebc/pytest_subtests-0.15.0.tar.gz", hash = "sha256:cb495bde05551b784b8f0b8adfaa27edb4131469a27c339b80fd8d6ba33f887c", size = 18525, upload-time = "2025-10-20T16:26:18.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/64/bba465299b37448b4c1b84c7a04178399ac22d47b3dc5db1874fe55a2bd3/pytest_subtests-0.15.0-py3-none-any.whl", hash = "sha256:da2d0ce348e1f8d831d5a40d81e3aeac439fec50bd5251cbb7791402696a9493", size = 9185, upload-time = "2025-10-20T16:26:17.239Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1288,6 +1288,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-instafail" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -1319,6 +1320,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-instafail" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich", specifier = ">=15.0.0" },
@@ -1901,6 +1903,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-instafail"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/bd/e0ba6c3cd20b9aa445f0af229f3a9582cce589f083537978a23e6f14e310/pytest-instafail-0.5.0.tar.gz", hash = "sha256:33a606f7e0c8e646dc3bfee0d5e3a4b7b78ef7c36168cfa1f3d93af7ca706c9e", size = 5849, upload-time = "2023-03-31T17:17:32.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c0/c32dc39fc172e684fdb3d30169843efb65c067be1e12689af4345731126e/pytest_instafail-0.5.0-py3-none-any.whl", hash = "sha256:6855414487e9e4bb76a118ce952c3c27d3866af15487506c4ded92eb72387819", size = 4176, upload-time = "2023-03-31T17:17:30.065Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Fixes [RHAIENG-6664](https://redhat.atlassian.net/browse/RHAIENG-6664): `gmake test` / the `pytest-tests` CI job produced ~40,800 lines of output for a ~38s run.

Root cause: `pytest.ini` set `log_cli = True`, which per pytest's own logging code silently forces global verbosity to at least 1 regardless of any `-v` flag — this turns the compact dot-per-test summary into one report line per test *and per subtest*. With thousands of subtests in `tests/test_main.py::test_image_pyprojects` (checking every image's `pyproject.toml`/`pylock.toml` consistency via `pytest-subtests`), that's ~38,700 lines of `SUBPASSED`/`SUBSKIPPED`/`SUBXFAIL` output alone. A stray `logging.basicConfig(level=logging.DEBUG)` in `tests/conftest.py` added further `INFO:root:`-style noise that bypassed pytest's own log capture entirely.

Along the way, also found that the `pytest-subtests` dependency itself was dead weight: pytest 9's builtin subtests plugin registers under the same `"subtests"` name and shadows the third-party package, so it was never actually loaded (confirmed via `pytest -VV`) despite `TYPE_CHECKING`-only type hints referencing it throughout the codebase.

Changes:
- Drop the unused `pytest-subtests` dependency; switch `subtests: pytest_subtests(.plugin)?.SubTests` type hints to the real runtime type, `pytest.Subtests` (built into pytest 9+).
- `pytest.ini`: `log_cli = False` by default, explicit `verbosity_subtests = 0` (suppresses SUBPASSED/SUBSKIPPED/SUBXFAIL; SUBFAILED still always shows in full). Local-dev defaults no longer generate a DEBUG log file or `junit.xml` — those are CI-only concerns now, added via `PYTEST_ADDOPTS`/CLI args only in the GitHub Actions jobs that consume them (`code-quality.yaml`, `test-containers.yaml`, `build-notebooks-TEMPLATE.yaml`).
- Remove the stray `logging.basicConfig(level=logging.DEBUG)` from `tests/conftest.py` that was bypassing pytest's log capture.
- `code-quality.yaml`'s `pytest-tests` job now uploads the DEBUG-level pytest log (`logs/pytest-logs.txt`) as an uncompressed workflow artifact, for anyone who needs to debug a CI run without reproducing locally.
- Add `pytest-instafail` so test/subtest failures print their traceback immediately when they happen, instead of only at the end of the run.

## How Has This Been Tested?

Ran the full suite (`gmake test`) in a clean git worktree to avoid local working-tree clutter: `411 passed in 22.67s`, ~800 total lines of output (mostly Dockerfile-alignment checks, not pytest) vs. the ~40,800-line baseline. Also ran `uv run prek run --all-files` (ruff/pyright clean on every touched file) and spot-checked that `-o log_cli=true -o log_file=... -o log_file_level=DEBUG` still works as an opt-in for interactive debugging, and that `pytest-instafail` prints immediately for both plain and subtest failures with no duplicate end-of-run output.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


[RHAIENG-6664]: https://redhat.atlassian.net/browse/RHAIENG-6664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Migrated test subtest handling to pytest’s built-in support.
  * Enabled immediate failure reporting and improved test logging options.
  * Added JUnit XML results and debug-log artifacts to automated test workflows.
  * Standardized legacy JUnit report formatting for container test suites.
* **Chores**
  * Removed the external subtest testing dependency and added enhanced failure reporting support.
  * Simplified default pytest logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->