### PR TITLE
RHAIENG-6664 followups: quiet tests/containers logging + colorize CI pytest output

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -492,7 +492,7 @@ jobs:
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}" -o junit_family=legacy
+          uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm and not manifest_validation' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}" -o junit_family=legacy --log-level=DEBUG
 
       - name: Upload Testcontainers pytest JUnit XML
         if: ${{ always() && steps.pytest-testcontainers.conclusion != 'skipped' }}
@@ -566,7 +566,7 @@ jobs:
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
-          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}" -o junit_family=legacy
+          uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${OUTPUT_IMAGE}" --junitxml="${JUNIT_XML}" -o junit_family=legacy --log-level=DEBUG
 
       - name: Upload OpenShift pytest JUnit XML
         if: ${{ always() && steps.pytest-openshift.conclusion != 'skipped' }}

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -489,6 +489,9 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           OUTPUT_IMAGE: "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
           JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_testcontainers-junit.xml"
+          # pytest's --color=auto sees a non-tty stdout in CI and disables color;
+          # FORCE_COLOR forces it back on for the (colorable) GitHub Actions log viewer.
+          FORCE_COLOR: "1"
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"
@@ -563,6 +566,9 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           OUTPUT_IMAGE: "${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
           JUNIT_XML: "${{ runner.temp }}/pytest-reports/${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_openshift-junit.xml"
+          # pytest's --color=auto sees a non-tty stdout in CI and disables color;
+          # FORCE_COLOR forces it back on for the (colorable) GitHub Actions log viewer.
+          FORCE_COLOR: "1"
         run: |
           set -Eeuxo pipefail
           mkdir -p "$(dirname "${JUNIT_XML}")"

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -116,6 +116,9 @@ jobs:
             --cov-report=xml:coverage.xml
             --junitxml=junit.xml -o junit_family=legacy
             -o log_file=logs/pytest-logs.txt -o log_file_level=DEBUG
+          # pytest's --color=auto sees a non-tty stdout in CI and disables color;
+          # FORCE_COLOR forces it back on for the (colorable) GitHub Actions log viewer.
+          FORCE_COLOR: "1"
           # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
           # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).
           NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -146,6 +146,7 @@ jobs:
             -m 'not openshift and not cuda and not rocm and not manifest_validation' \
             --image="${TEST_IMAGE}" \
             --junitxml=junit.xml -o junit_family=legacy \
+            --log-level=DEBUG \
             -v
 
       - name: Upload test results

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -142,6 +142,7 @@ jobs:
       - name: Pull and run tests
         env:
           TEST_IMAGE: ${{ matrix.image }}
+          LOG_PREFIX: ${{ matrix.name }}
         run: |
           set -Eeuxo pipefail
           podman pull "${TEST_IMAGE}"
@@ -150,7 +151,18 @@ jobs:
             --image="${TEST_IMAGE}" \
             --junitxml=junit.xml -o junit_family=legacy \
             --log-level=DEBUG \
+            -o "log_file=logs/pytest-logs-${LOG_PREFIX}.txt" -o log_file_level=DEBUG \
             -v
+
+      - name: Upload pytest debug log
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pytest-logs-${{ matrix.name }}
+          path: logs/pytest-logs-${{ matrix.name }}.txt
+          archive: false
+          retention-days: 14
+          if-no-files-found: warn
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -25,6 +25,9 @@ permissions:
 env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
+  # pytest's --color=auto sees a non-tty stdout in CI and disables color;
+  # FORCE_COLOR forces it back on for the (colorable) GitHub Actions log viewer.
+  FORCE_COLOR: "1"
 
 jobs:
   find-images:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,18 @@ Use formatting: bold, italics and code blocks.
 - Python 3.14: `except ExcA, ExcB:` (no parentheses) is valid when there is no
   `as` clause (PEP 758). Ruff format enforces this style. Parentheses are still
   required when binding: `except (ExcA, ExcB) as e:`.
+- CI pytest runs force `FORCE_COLOR=1`, so their console output contains ANSI
+  color codes. Don't grep/process that text directly. Prefer the
+  `pytest-logs.txt` artifact instead (uploaded by the `pytest-tests` job's
+  "Upload pytest debug log" step) — it's written by pytest's `log_file`
+  handler, a plain `logging.FileHandler` independent of the colorized
+  terminal writer, so pytest itself never colors it. It can still contain
+  color if a logged message embeds its own escape codes (e.g.
+  `scripts/update_build_args_from_versions.py`'s `ANSI_RED`-style warnings),
+  so don't assume it's *guaranteed* ANSI-free — check with `grep -c $'\x1b'`
+  if it matters. If you do need to strip ANSI codes from console/log text,
+  reuse the pattern already in `code-quality.yaml`'s `prek` step:
+  `sed -E 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGK]//g'`.
 
 ## Commit and PR title style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,11 +131,12 @@ Use formatting: bold, italics and code blocks.
   required when binding: `except (ExcA, ExcB) as e:`.
 - CI pytest runs force `FORCE_COLOR=1`, so their console output contains ANSI
   color codes. Don't grep/process that text directly. Prefer the
-  `pytest-logs.txt` artifact instead (uploaded by the `pytest-tests` job's
-  "Upload pytest debug log" step) — it's written by pytest's `log_file`
-  handler, a plain `logging.FileHandler` independent of the colorized
-  terminal writer, so pytest itself never colors it. It can still contain
-  color if a logged message embeds its own escape codes (e.g.
+  `pytest-logs*.txt` artifact instead (uploaded by each job's own
+  "Upload pytest debug log" step, e.g. `pytest-tests` in `code-quality.yaml`
+  and `container-tests` in `test-containers.yaml`) — it's written by pytest's
+  `log_file` handler, a plain `logging.FileHandler` independent of the
+  colorized terminal writer, so pytest itself never colors it. It can still
+  contain color if a logged message embeds its own escape codes (e.g.
   `scripts/update_build_args_from_versions.py`'s `ANSI_RED`-style warnings),
   so don't assume it's *guaranteed* ANSI-free — check with `grep -c $'\x1b'`
   if it matters. If you do need to strip ANSI codes from console/log text,

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -19,7 +19,6 @@ import ntb
 from tests import index_config_utils
 from tests.containers import docker_utils
 
-logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -39,7 +39,6 @@ class TestFrameConstants:
     READINESS_TIMEOUT = TIMEOUT_5MIN
 
 
-logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/containers/podman_machine_utils.py
+++ b/tests/containers/podman_machine_utils.py
@@ -12,9 +12,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-logging.basicConfig(level=logging.DEBUG)
-
-
 def open_ssh_tunnel(
     machine_predicate: Callable[[tests.containers.pydantic_schemas.PodmanMachine], bool],
     local_port: int,

--- a/tests/containers/workbenches/gpu_library_loading_test.py
+++ b/tests/containers/workbenches/gpu_library_loading_test.py
@@ -52,7 +52,6 @@ class RocmLibCheckResult(pydantic.BaseModel):
     rocm_lib: str
 
 
-logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Description

Two small followups to [RHAIENG-6664](https://redhat.atlassian.net/browse/RHAIENG-6664) / #4242, both discovered while watching CI for that PR.

### 1. `tests/containers` unconditionally installed a DEBUG log handler

`tests/containers` runs printed unconditional `DEBUG:urllib3.connectionpool:...` / `DEBUG:root:...` noise for every test, e.g. https://github.com/opendatahub-io/notebooks/actions/runs/30639752486/job/91186453257?pr=4242 — same root cause as the `pytest-tests` job fixed in #4242, just in a different spot.

`tests/containers/kubernetes_utils.py`, `base_image_test.py`, `workbenches/gpu_library_loading_test.py`, and `podman_machine_utils.py` each called `logging.basicConfig(level=logging.DEBUG)` at import time. This installs a root-logger `StreamHandler` unconditionally the moment any of these modules is imported (which happens for every `tests/containers` run, since `conftest.py` imports `kubernetes_utils` at collection time) — bypassing pytest's own log capture entirely, so it prints DEBUG noise from every library (`urllib3`, `testcontainers`, etc.) for every test, whether it passes or fails.

That DEBUG output can be genuinely useful when a container/pod test fails (pod readiness, port-forward setup, HTTP calls to the container runtime), so the fix isn't to just delete it — it's to let pytest's own logging capture handle it instead: drop `basicConfig()`, and pass `--log-level=DEBUG` at the three `tests/containers` invocations (`test-containers.yaml`, and both pytest calls in `build-notebooks-TEMPLATE.yaml`). This sets pytest's log-capture threshold without forcing verbose mode (unlike `log_cli`, which was the cause of #4242) — DEBUG records are only shown in the "Captured log call" section for tests that actually fail.

### 2. pytest CI output had no color

pytest's `--color` option defaults to `"auto"`, which decides whether to emit ANSI color based on `sys.stdout.isatty()`. A GitHub Actions step's stdout is not a TTY, so `auto` silently disables color, even though the Actions log viewer does render ANSI (the `prek` step in `code-quality.yaml` already relies on this, passing `--color always` explicitly). Fixed by setting `FORCE_COLOR: "1"` — a convention pytest already honors directly, no `--color` flag needed — on the three CI steps that invoke pytest.

Also added a note to `AGENTS.md`'s Operational notes: since CI pytest output can now contain ANSI codes, prefer the `pytest-logs.txt` debug artifact (written via pytest's `log_file` handler, independent of the colorized terminal writer, so always ANSI-free) for any programmatic log processing, with a fallback `sed` pattern for stripping ANSI codes if you must process console text directly.

## How Has This Been Tested?

- Verified the log-level mechanism with a throwaway two-test module (one passing, one failing, each logging at DEBUG): without `--log-level`, neither test's DEBUG log shows; with `--log-level=DEBUG`, the passing test still shows nothing, and the failing test's DEBUG log appears under "Captured log call".
- Verified the color mechanism the same way: without `FORCE_COLOR`, piped/non-TTY pytest output has zero ANSI escape sequences; with `FORCE_COLOR=1`, it has several — and confirmed `log_file` output has zero ANSI sequences either way (0 vs 9-11 escape sequences observed).
- Ran `uv run prek run` (ruff/pyright) and `yamllint --strict` on all touched files — clean.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHAIENG-6664]: https://redhat.atlassian.net/browse/RHAIENG-6664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved container test diagnostics with DEBUG-level logging and preserved colored output in CI logs.
  * Added matrix-specific downloadable pytest log artifacts, retained for 14 days, to simplify troubleshooting.
  * Applied consistent colored output settings across automated test and quality-check workflows.

* **Chores**
  * Removed test-level global logging configuration to avoid unintended logging side effects.

* **Documentation**
  * Added guidance for reviewing and cleaning ANSI-colored pytest logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->