### PR TITLE
fix(ci): resolve test-containers cross-org GHCR auth failure

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -55,14 +55,8 @@ jobs:
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          repository = os.environ.get("GITHUB_REPOSITORY", "")
-          if repository == "red-hat-data-services/notebooks":
-              # RHDS push tags are currently {target}-_{sha} (empty ref prefix; see build-notebooks-TEMPLATE).
-              ref_prefix = ""
-              tag_suffix = ""
-          else:
-              ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
-              tag_suffix = "_odh_linux_amd64"
+          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
+          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -56,7 +56,10 @@ jobs:
 
           registry = os.environ["IMAGE_REGISTRY"]
           ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
-          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
+          if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks":
+              tag_suffix = "_odh_linux_amd64"
+          else:
+              tag_suffix = "_rhoai_linux_amd64"
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -55,8 +55,14 @@ jobs:
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
-          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
+          repository = os.environ.get("GITHUB_REPOSITORY", "")
+          if repository == "red-hat-data-services/notebooks":
+              # RHDS push tags are currently {target}-_{sha} (empty ref prefix; see build-notebooks-TEMPLATE).
+              ref_prefix = ""
+              tag_suffix = ""
+          else:
+              ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
+              tag_suffix = "_odh_linux_amd64"
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -4,7 +4,7 @@ name: Test Infrastructure Self-Test
 "on":
   workflow_dispatch:
   pull_request:
-    paths:
+    paths: &test-containers-paths
       - 'tests/containers/**'
       - 'tests/conftest.py'
       - 'pytest.ini'
@@ -12,12 +12,7 @@ name: Test Infrastructure Self-Test
       - 'ci/find_images_for_test_matrix.py'
   push:
     branches: [main, stable, 'rhoai-*']
-    paths:
-      - 'tests/containers/**'
-      - 'tests/conftest.py'
-      - 'pytest.ini'
-      - '.github/workflows/test-containers.yaml'
-      - 'ci/find_images_for_test_matrix.py'
+    paths: *test-containers-paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -9,6 +9,7 @@ name: Test Infrastructure Self-Test
       - 'tests/conftest.py'
       - 'pytest.ini'
       - '.github/workflows/test-containers.yaml'
+      - 'ci/find_images_for_test_matrix.py'
   push:
     branches: [main, stable, 'rhoai-*']
     paths:
@@ -16,6 +17,7 @@ name: Test Infrastructure Self-Test
       - 'tests/conftest.py'
       - 'pytest.ini'
       - '.github/workflows/test-containers.yaml'
+      - 'ci/find_images_for_test_matrix.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,7 +29,7 @@ permissions:
 
 env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
-  IMAGE_REGISTRY: "ghcr.io/opendatahub-io/notebooks/workbench-images"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
 
 jobs:
   find-images:
@@ -48,16 +50,18 @@ jobs:
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
         shell: python
         # language=python
         run: |
-          import json, os, subprocess, sys
+          import json, os, re, subprocess, sys
           sys.path.insert(0, "ci")
 
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          suffix = "_odh_linux_amd64"
+          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
+          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",
@@ -73,11 +77,11 @@ jobs:
               print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
               sys.exit(1)
 
-          sha = find_suitable_sha(suffix, required, result.stdout)
+          sha = find_suitable_sha(ref_prefix, tag_suffix, required, result.stdout)
           matrix = {"include": [
-              {"name": img, "image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
+              {"name": img, "image": f"{registry}:{img}-{ref_prefix}_{sha}{tag_suffix}"} for img in required
           ]}
-          print(f"Using SHA {sha}")
+          print(f"Using ref {ref_prefix!r}, SHA {sha}")
           print(json.dumps(matrix, indent=2))
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -55,7 +55,6 @@ jobs:
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
           if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks":
               tag_suffix = "_odh_linux_amd64"
           else:
@@ -66,6 +65,14 @@ jobs:
               "jupyter-datascience-ubi9-python-3.12",
               "runtime-datascience-ubi9-python-3.12",
           ]
+          # 40 is a placeholder cap, not derived from anything. The exactly-correct
+          # value would mirror build-notebooks-TEMPLATE.yaml's max_ref_len formula
+          # (128 - len(target) - 7-char short sha - len(suffix) - 3 separators),
+          # minimized over `required` since that formula is computed per target
+          # there. In practice it doesn't matter: real branch names (main, stable,
+          # rhoai-X.Y[-eaN]) are far shorter than either cap, so no truncation ever
+          # actually happens on either side.
+          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
 
           result = subprocess.run(
               ["skopeo", "list-tags", "--creds", f"token:{os.environ['GH_TOKEN']}", f"docker://{registry}"],

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -3,7 +3,12 @@ import sys
 
 
 def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], skopeo_output: str) -> str:
-    """Skopeo lists tags oldest to newest."""
+    """Skopeo lists tags oldest to newest.
+
+    Image tags are formed as ``{target}-{ref_prefix}_{sha}{tag_suffix}``.
+    On RHDS rhoai-2.25 push builds the ref prefix is currently empty, yielding
+    tags like ``jupyter-minimal-ubi9-python-3.12-_<sha>``.
+    """
     tags = list(json.loads(skopeo_output)["Tags"])
 
     sha_list: list[list[str]] = []
@@ -45,6 +50,22 @@ def test_find_suitable_sha__rhoai_branch_without_suffix():
     )
 
 
+def test_find_suitable_sha__rhds_empty_ref_prefix():
+    sha = "568c8cfa48c44e90b30ce8e37c671d15b03950de"
+    skopeo_output = json.dumps(
+        {
+            "Tags": [
+                f"jupyter-minimal-ubi9-python-3.12-_{sha}",
+                f"jupyter-datascience-ubi9-python-3.12-_{sha}",
+            ]
+        }
+    )
+    assert (
+        find_suitable_sha("", "", ["jupyter-minimal-ubi9-python-3.12", "jupyter-datascience-ubi9-python-3.12"], skopeo_output)
+        == sha
+    )
+
+
 def test_find_suitable_sha__multiple():
     skopeo_output = json.dumps(
         {
@@ -62,5 +83,6 @@ def test_find_suitable_sha__multiple():
 if __name__ == "__main__":
     test_find_suitable_sha__single()
     test_find_suitable_sha__rhoai_branch_without_suffix()
+    test_find_suitable_sha__rhds_empty_ref_prefix()
     test_find_suitable_sha__multiple()
     print("OK")

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -2,15 +2,17 @@ import json
 import sys
 
 
-def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> str:
+def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], skopeo_output: str) -> str:
     """Skopeo lists tags oldest to newest."""
     tags = list(json.loads(skopeo_output)["Tags"])
 
     sha_list: list[list[str]] = []
     for img in required:
-        prefix = f"{img}-main_"
+        prefix = f"{img}-{ref_prefix}_"
         shas = [
-            t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)
+            t.removeprefix(prefix).removesuffix(tag_suffix)
+            for t in tags
+            if t.startswith(prefix) and t.endswith(tag_suffix) and len(t) > len(prefix) + len(tag_suffix)
         ]
         print(f"  {img}: {len(shas)} builds")
         sha_list.append(shas)
@@ -27,15 +29,23 @@ def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> s
 
 
 def test_find_suitable_sha__single():
-    suffix = "_suffix"
-    required = ["codeserver-ubi9-python-3.12"]
-    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_suffix"]})
-    assert find_suitable_sha(suffix, required, skopeo_output) == "abdcef"
+    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_odh_linux_amd64"]})
+    assert (
+        find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
+    )
+
+
+def test_find_suitable_sha__rhoai_branch_without_suffix():
+    skopeo_output = json.dumps(
+        {"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc123def456"]}
+    )
+    assert (
+        find_suitable_sha("rhoai-2.25", "", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
+        == "abc123def456"
+    )
 
 
 def test_find_suitable_sha__multiple():
-    suffix = "_suffix"
-    required = ["img-a", "img-b"]
     skopeo_output = json.dumps(
         {
             "Tags": [
@@ -46,10 +56,11 @@ def test_find_suitable_sha__multiple():
             ]
         }
     )
-    assert find_suitable_sha(suffix, required, skopeo_output) == "new222"
+    assert find_suitable_sha("main", "_suffix", ["img-a", "img-b"], skopeo_output) == "new222"
 
 
 if __name__ == "__main__":
     test_find_suitable_sha__single()
+    test_find_suitable_sha__rhoai_branch_without_suffix()
     test_find_suitable_sha__multiple()
     print("OK")

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -6,8 +6,6 @@ def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], sko
     """Skopeo lists tags oldest to newest.
 
     Image tags are formed as ``{target}-{ref_prefix}_{sha}{tag_suffix}``.
-    On RHDS rhoai-2.25 push builds the ref prefix is currently empty, yielding
-    tags like ``jupyter-minimal-ubi9-python-3.12-_<sha>``.
     """
     tags = list(json.loads(skopeo_output)["Tags"])
 
@@ -50,22 +48,6 @@ def test_find_suitable_sha__rhoai_branch_without_suffix():
     )
 
 
-def test_find_suitable_sha__rhds_empty_ref_prefix():
-    sha = "568c8cfa48c44e90b30ce8e37c671d15b03950de"
-    skopeo_output = json.dumps(
-        {
-            "Tags": [
-                f"jupyter-minimal-ubi9-python-3.12-_{sha}",
-                f"jupyter-datascience-ubi9-python-3.12-_{sha}",
-            ]
-        }
-    )
-    assert (
-        find_suitable_sha("", "", ["jupyter-minimal-ubi9-python-3.12", "jupyter-datascience-ubi9-python-3.12"], skopeo_output)
-        == sha
-    )
-
-
 def test_find_suitable_sha__multiple():
     skopeo_output = json.dumps(
         {
@@ -83,6 +65,5 @@ def test_find_suitable_sha__multiple():
 if __name__ == "__main__":
     test_find_suitable_sha__single()
     test_find_suitable_sha__rhoai_branch_without_suffix()
-    test_find_suitable_sha__rhds_empty_ref_prefix()
     test_find_suitable_sha__multiple()
     print("OK")

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -33,18 +33,14 @@ def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], sko
 
 def test_find_suitable_sha__single():
     skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_odh_linux_amd64"]})
-    assert (
-        find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
-    )
+    assert find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
 
 
-def test_find_suitable_sha__rhoai_branch_without_suffix():
-    skopeo_output = json.dumps(
-        {"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc123def456"]}
-    )
+def test_find_suitable_sha__rhoai_branch_with_platform_suffix():
+    skopeo_output = json.dumps({"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc1234_rhoai_linux_amd64"]})
     assert (
-        find_suitable_sha("rhoai-2.25", "", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
-        == "abc123def456"
+        find_suitable_sha("rhoai-2.25", "_rhoai_linux_amd64", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
+        == "abc1234"
     )
 
 
@@ -64,6 +60,6 @@ def test_find_suitable_sha__multiple():
 
 if __name__ == "__main__":
     test_find_suitable_sha__single()
-    test_find_suitable_sha__rhoai_branch_without_suffix()
+    test_find_suitable_sha__rhoai_branch_with_platform_suffix()
     test_find_suitable_sha__multiple()
     print("OK")


### PR DESCRIPTION
## Summary

`test-containers.yaml` hardcodes `IMAGE_REGISTRY: ghcr.io/opendatahub-io/notebooks/workbench-images` and authenticates `skopeo list-tags` with `github.token`. On `opendatahub-io/notebooks` this works because the token's installation matches the registry's org. When the same workflow runs downstream on `red-hat-data-services/notebooks` (e.g. any push/PR touching this file, or a `main`→`rhoai-*` sync merge), `github.token` belongs to a different org's installation and GHCR rejects it outright:

```
skopeo list-tags failed: ... denied: permission_denied: The requested installation does not exist.
```

This has already been fixed downstream on `rhoai-2.25` ([RHAIENG-6066](https://redhat.atlassian.net/browse/RHAIENG-6066) / PR red-hat-data-services/notebooks#2450), by resolving the registry, ref prefix, and tag suffix from `github.repository`/branch name instead of hardcoding the ODH org. This PR cherry-picks (`-x`) that fix onto `main` so `rhoai-3.5` and other downstream branches synced from `main` stop inheriting the hardcoded ODH-only registry.

Skipped from the original `build-notebooks-TEMPLATE.yaml` hunk (part of red-hat-data-services/notebooks#2450): `main` already computes the `{product}_{platform}` tag suffix natively — that commit was itself porting this logic *from* `main` down to `rhoai-2.25`, so there was nothing to port back.

## Test plan

- [x] `uv run pytest ci/find_images_for_test_matrix.py -v` passes (updated signature/tests)
- [x] `uv run pytest ci/` passes (32 tests)
- [x] YAML parses (`yaml.safe_load`), anchors resolve correctly
- [ ] CI: "Test Infrastructure Self-Test" workflow runs and finds images successfully on this PR (self-triggering, touches `.github/workflows/test-containers.yaml`)

[RHAIENG-6066]: https://redhat.atlassian.net/browse/RHAIENG-6066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Improved automated test image selection across branches and repository variants.
  * Updated image tags to reflect the relevant branch, commit, and architecture.
  * Expanded workflow triggers to detect changes affecting test image selection.
  * Added coverage for additional branch and platform scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->