### PR TITLE
RHAIENG-6400: Enable Copilot with GitHub Device Code Flow defaults

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/README.md
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.122.1/README.md
@@ -29,5 +29,6 @@ High/critical runtime CVEs cleared via npm overrides (refresh locks after changi
   AIPCC/RHOAI `ripgrep` Python wheel and overwrite those binaries via
   `../replace-aipcc-ripgrep.sh` after `npm ci` / `build:vscode` / `release` (FIPS).
 - Built-in Copilot requires `compile-copilot-extension-full-build` during `build:vscode`
-- Keep `"chat.disableAIFeatures": true` in `run-code-server.sh` until Legal (RHAI-113)
+- RHAIENG-6400 spike: `run-code-server.sh` sets `chat.disableAIFeatures: false` and
+  `github-authentication.preferDeviceCodeFlow: true`. Customer GA still gated by Legal (RHAI-113).
 - Upstream dropped `release:standalone`; use `KEEP_MODULES=1 npm run release` → `./release`

--- a/codeserver/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver/ubi9-python-3.12/run-code-server.sh
@@ -59,9 +59,12 @@ universal_json_settings='// vscode settings are written in json-with-comments
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
 
-  // Disable GitHub Copilot in code-server
-  // official doc https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code
-  "chat.disableAIFeatures": true,
+  // RHAIENG-6400 / RHAISTRAT-2209: enable Copilot Chat surfaces for Device Code auth validation.
+  // Customer GA still gated by Legal RHAI-113; preferDeviceCodeFlow so UrlHandler/OAuth
+  // redirects are not tried first behind Kubeflow OAuth / kube-rbac-proxy.
+  // https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code
+  "chat.disableAIFeatures": false,
+  "github-authentication.preferDeviceCodeFlow": true,
 
   // RHOAIENG-14518: Disable the "Do you trust the authors [...]" startup prompt
   "security.workspace.trust.enabled": false,

--- a/tests/browser/tests/codeserver.spec.ts
+++ b/tests/browser/tests/codeserver.spec.ts
@@ -75,8 +75,12 @@ test.describe('code-server', { tag: '@codeserver' }, () => {
     await codeServer.isEditorVisible()
     page.on("console", (msg) => log.info(msg.text()))
 
-    await codeServer.isEditorVisible()
-    await utils.waitForStableDOM(page, "div.monaco-workbench", 1000, 10000)
+    // With chat.disableAIFeatures:false, Agent Status / Chat keep mutating
+    // div.monaco-workbench, so whole-workbench waitForStableDOM never settles.
+    // Assert the welcome surface itself instead (title is heading + paragraph).
+    await expect(page.getByRole('tab', { name: /Welcome/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'code-server', level: 1 })).toBeVisible()
+    await expect(page.getByText('Editing evolved')).toBeVisible()
     await utils.waitForNextRender(page)
 
     await utils.takeScreenshot(page, testInfo, "welcome.png")


### PR DESCRIPTION
## Summary
- Enable Copilot Chat surfaces (`chat.disableAIFeatures: false`) and prefer GitHub Device Code Flow (`github-authentication.preferDeviceCodeFlow: true`) in code-server default user settings.
- Targets workbench auth behind Kubeflow OAuth / kube-rbac-proxy where OAuth redirect / UrlHandler is unreliable ([RHAIENG-6400](https://redhat.atlassian.net/browse/RHAIENG-6400), parent [RHAISTRAT-2209](https://redhat.atlassian.net/browse/RHAISTRAT-2209)).
- Customer GA still gated by Legal ([RHAI-113](https://redhat.atlassian.net/browse/RHAI-113)).

**Depends on:** #4251 (code-server v4.122.1 upgrade). Merge that first (or rebase this after it lands); the [RHAIENG-6400](https://redhat.atlassian.net/browse/RHAIENG-6400) delta is the `run-code-server.sh` defaults (+ overlay README note).

## Test plan
- [x] Local arm64 image (4.122.1) with mounted `run-code-server.sh`
- [x] Settings written: AI enabled + preferDeviceCodeFlow
- [x] Built-in `github-authentication` + `copilot` present
- [x] Container egress to `https://github.com/login/device/code` returns device/user codes
- [x] Manual browser Device Code sign-in to Copilot succeeded locally
- [x] Unit tests — 356 passed
- [ ] Validate behind kube-rbac-proxy / Kubeflow OAuth on a cluster (remaining AC)


Made with [Cursor](https://cursor.com)

[RHAIENG-6400]: https://redhat.atlassian.net/browse/RHAIENG-6400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAISTRAT-2209]: https://redhat.atlassian.net/browse/RHAISTRAT-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAI-113]: https://redhat.atlassian.net/browse/RHAI-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6400]: https://redhat.atlassian.net/browse/RHAIENG-6400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI-assisted coding features are now enabled by default in code-server.
  - GitHub Device Code authentication is now preferred for signing in to AI services.

- **Documentation**
  - Updated setup guidance to reflect the enabled AI features and device-code authentication flow.

- **Bug Fixes**
  - Improved welcome-screen validation for more reliable startup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->