### PR TITLE
ci(test-containers): add a job to run the openshift-marked container tests

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -176,3 +176,57 @@ jobs:
         uses: ./.github/actions/capture-kernel-logs
         with:
           log-prefix: ${{ matrix.name }}
+
+  openshift-container-tests:
+    name: "openshift: ${{ matrix.name }}"
+    needs: find-images
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
+      - name: Install deps
+        run: uv sync --locked
+
+      # Rootful podman sharing image storage with cri-o, same as build-notebooks-TEMPLATE.yaml,
+      # so the pod created by the openshift-marked tests can find the image without re-pulling.
+      - name: Install and configure Podman
+        uses: './.github/actions/install-podman-action'
+        with:
+          platform: linux/amd64
+
+      - name: Provision K8s cluster
+        uses: ./.github/actions/provision-k8s
+
+      - name: Login to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and run OpenShift container tests
+        env:
+          TEST_IMAGE: ${{ matrix.image }}
+          DOCKER_HOST: "unix:///var/run/podman/podman.sock"
+          TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
+        run: |
+          set -Eeuxo pipefail
+          podman pull "${TEST_IMAGE}"
+          uv run pytest --capture=fd tests/containers \
+            -m 'openshift and not cuda and not rocm' \
+            --image="${TEST_IMAGE}" \
+            --junitxml=junit-openshift.xml \
+            -v
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit-openshift.xml

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -186,6 +186,8 @@ jobs:
       matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -210,6 +210,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # install-podman-action's storage.conf enables zstd:chunked partial pulls, which
+      # only matters for `podman build`'s own registry pulls elsewhere. Here we `podman
+      # pull` an already-published ghcr.io image, and ghcr.io's blob endpoint returns
+      # "501 Unsupported client range" for partial/ranged fetches, failing the pull
+      # outright instead of falling back to a full one. Disable it for this job only.
+      - name: Disable zstd:chunked partial image pulls
+        run: sudo sed -i 's/enable_partial_images = "true"/enable_partial_images = "false"/' /etc/containers/storage.conf
+
       - name: Pull and run OpenShift container tests
         env:
           TEST_IMAGE: ${{ matrix.image }}


### PR DESCRIPTION
## Summary

`.github/workflows/test-containers.yaml`'s self-test job explicitly excludes everything marked `openshift` — i.e. `test_image_run_on_openshift`, which exercises `kubernetes_utils.ImageDeployment` (Deployment + port-forward + HTTP readiness poll). That code path only otherwise runs inside the full, expensive image-build workflow, so regressions there go unnoticed for weeks (see red-hat-data-services/notebooks#2684, red-hat-data-services/notebooks#2685 for a concrete two-in-a-row regression that this exact gap let through downstream).

Two commits, cherry-picked (`-x`) from the concrete `rhoai-2.25` implementation at red-hat-data-services/notebooks#2685, with action pins/setup steps adapted to `main`'s current conventions (`./.github/actions/setup-uv`, `actions/checkout@…v7.0.0`, `docker/login-action@…v4.4.0`):

1. **`ci(test-containers): add a job to run the openshift-marked container tests`** — adds `openshift-container-tests`, reusing `find-images`'s matrix and mirroring the provisioning steps `build-notebooks-TEMPLATE.yaml` already uses for the same purpose: rootful podman (`install-podman-action`, sharing image storage with cri-o) + a kubeadm cluster (`provision-k8s`), then `pytest -m 'openshift and not cuda and not rocm'` against the pulled image.
2. **`fix(ci): disable zstd:chunked partial pulls in openshift-container-tests`** — fixes a failure the new job hit immediately in the reference PR's own CI: `podman pull` of an image with `zstd:chunked` layers failed with `501 Unsupported client range` against `ghcr.io`'s blob endpoint, because `install-podman-action`'s `storage.conf` enables partial/ranged fetches. Disabled for this job only.

Not ported: the reference PR's third commit (RStudio `/` vs `/api` readiness-probe fix) — `main` dropped RStudio entirely, so the existing `/api`-only probe in `kubernetes_utils.py` is already correct here; that fix is `rhoai-2.25`-specific.

Fixes #4257.

## Test plan

- [x] `yamllint --strict` and `pinact run --check` clean on the edited workflow file.
- [ ] CI: `openshift-container-tests` job runs and passes across the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated container testing on Kubernetes and OpenShift environments.
  * Added test result reporting through uploaded JUnit reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->