### PR TITLE
ci(addons): use a YAML anchor to dedupe pull_request/push path filters

### DIFF
--- a/.github/workflows/test-addons.yaml
+++ b/.github/workflows/test-addons.yaml
@@ -3,16 +3,13 @@ name: Test Jupyter Addons
 "on":
   workflow_dispatch:
   pull_request:
-    paths:
+    paths: &test-addons-paths
       - '.github/workflows/test-addons.yaml'
       - 'jupyter/utils/addons/**'
       - 'scripts/get-pnpm-version.sh'
   push:
     branches: [main, stable, 'rhoai-*']
-    paths:
-      - '.github/workflows/test-addons.yaml'
-      - 'jupyter/utils/addons/**'
-      - 'scripts/get-pnpm-version.sh'
+    paths: *test-addons-paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

`test-addons.yaml`'s `pull_request.paths` and `push.paths` lists were byte-for-byte duplicated. Follow-up to #4260: use the same YAML anchor/alias pattern `test-containers.yaml` already uses (`&test-containers-paths`/`*test-containers-paths`) so the two lists can't silently drift apart when a path is added to one but not the other.

No behavior change — verified the anchor resolves identically on both keys.

## Test plan

- [x] `yamllint --strict` clean.
- [x] Parsed with PyYAML: both `pull_request.paths` and `push.paths` resolve to the identical 3-item list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified addon-related workflow path filtering by removing duplicated configuration.
  * Ensured consistent path filters for pull request and push checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->