### PR TITLE
#4239: fix(ci): validate versions_config_schema example against the model

### DIFF
--- a/ci/versions_config_schema.py
+++ b/ci/versions_config_schema.py
@@ -220,42 +220,42 @@ _VERSIONS_CONFIG_ADAPTER = TypeAdapter(VersionsConfig)
 def build_json_schema() -> dict[str, Any]:
     """Build the JSON Schema document for ``versions_config.yml``."""
     schema = _VERSIONS_CONFIG_ADAPTER.json_schema(schema_generator=GenerateJsonSchema)
+    example = {
+        "schema_version": 1,
+        "release": {
+            "full_version": "3.5.0",
+            "rhds_os_base": "el9.6",
+            "python_version": "3.12",
+        },
+        "artifacts": {
+            "base_image": {
+                "cpu": {
+                    "rhds": {"channel": "fast", "version": "<full_version>"},
+                    "odh": {"origin": "in-house", "version": "latest"},
+                },
+                "cuda": {
+                    "minimal": {
+                        "acc_version": "13.0",
+                        "rhds": {"channel": "fast"},
+                        "odh": {"origin": "in-house"},
+                    }
+                },
+                "rocm": {
+                    "minimal": {
+                        "acc_version": "7.14",
+                        "rhds": {"channel": "fast"},
+                        "odh": {"origin": "in-house"},
+                    }
+                },
+            }
+        },
+    }
+    _VERSIONS_CONFIG_ADAPTER.validate_python(example)  # fail fast if example drifts from the model
     return {
         "$schema": GenerateJsonSchema.schema_dialect,
         "$id": SCHEMA_ID,
         **schema,
-        "examples": [
-            {
-                "schema_version": 1,
-                "release": {
-                    "full_version": "3.5.0",
-                    "rhds_os_base": "el9.6",
-                    "python_version": "3.12",
-                },
-                "artifacts": {
-                    "base_image": {
-                        "cpu": {
-                            "rhds": {"channel": "fast", "version": "<full_version>"},
-                            "odh": {"origin": "in-house", "version": "latest"},
-                        },
-                        "cuda": {
-                            "minimal": {
-                                "acc_version": "13.0",
-                                "rhds": {"channel": "fast"},
-                                "odh": {"origin": "in-house"},
-                            }
-                        },
-                        "rocm": {
-                            "minimal": {
-                                "acc_version": "7.14",
-                                "rhds": {"channel": "fast"},
-                                "odh": {"origin": "in-house"},
-                            }
-                        },
-                    }
-                },
-            }
-        ],
+        "examples": [example],
     }
 
 


### PR DESCRIPTION
## Description

Fixes #4239.

`build_json_schema()` (in `ci/versions_config_schema.py`) embeds a hand-written `examples` entry alongside the JSON Schema generated from the `VersionsConfig` Pydantic model. That example was never validated against the model itself, and `test_committed_json_schema_matches_generator` only asserted the examples list was non-empty — it never checked contents. A future change to `VersionsConfig` (e.g. tightening `RHDS_OS_BASE_PATTERN`, adding a required key under `artifacts.base_image`) could silently invalidate the example with nothing in CI catching it.

This adds `_VERSIONS_CONFIG_ADAPTER.validate_python(example)` inside `build_json_schema()` before it's returned, so drift raises a `ValidationError` at generation/test time instead of shipping silently. No behavior/output change: the generated schema is byte-identical to before, since the example is currently valid.

## How Has This Been Tested?

- `uv run pytest tests/test_versions_config_schema.py -v` — all 9 tests pass.
- Verified the check actually catches drift: temporarily changed `"rhds_os_base": "el9.6"` to `"9.6"` in the example and re-ran `test_committed_json_schema_matches_generator`; it failed with a clear `pydantic_core.ValidationError: string_pattern_mismatch` raised from `build_json_schema()`. Reverted afterward.
- `uv run python -m ci.versions_config_schema` (schema regeneration) confirms `ci/versions_config.schema.json` is unchanged.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of the version configuration schema example to ensure generated schema output remains accurate and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->