### PR TITLE
ISSUE#4100: chore(prefetch-input/mongocli): bump submodule to mongocli/v2.0.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = codeserver/ubi9-python-3.12/prefetch-input/code-server
 	url = https://github.com/coder/code-server.git
 	shallow = true
-# mongocli: keep at tag mongocli/v2.0.4 (pinned by parent commit; update via: cd path && git fetch && git checkout mongocli/v2.0.4)
+# mongocli: keep at tag mongocli/v2.0.7 (pinned by parent commit; update via: cd path && git fetch && git checkout mongocli/v2.0.7)
 [submodule "prefetch-input/mongocli"]
 	path = prefetch-input/mongocli
 	url = https://github.com/mongodb/mongodb-cli


### PR DESCRIPTION
Related to #4100

## Description

Bump the `prefetch-input/mongocli` git submodule (tracks `mongodb/mongodb-cli`) from `mongocli/v2.0.4` (May 2025, last bumped in [RHAIENG-540](https://redhat.atlassian.net/browse/RHAIENG-540) / #1970) to the latest official tag, `mongocli/v2.0.7` (Jan 2026).

`govulncheck ./cmd/mongocli/...` against the pinned commit found 2 **reachable** vulnerabilities (unlike a typical dependency scan, these are confirmed to be on an actual call path exercised by the CLI):

- `GO-2025-3787` — mapstructure may leak sensitive info in logs on malformed data, reachable via `viper.init`. **Fixed by this bump** (mapstructure 2.2.1 → 2.4.0).
- `GO-2026-5970` — infinite loop on invalid input in `golang.org/x/text`, reachable via mongocli's own KMIP client init and SCRAM-credential config path. **Not fixed by this bump** — upstream's v2.0.7 tag only reaches x/text 0.32.0, still below the 0.39.0 fix. Accepted as a known gap: DoS-class (hang, not memory corruption/RCE), reachable only through this admin CLI tool's own code paths (not attacker-facing), and upstream's `main` branch already carries the fix (x/text 0.40.0) pending their next tagged release — tracking upstream for that rather than carrying a local patch on top of the tag.

No Dockerfile changes needed — the `mongocli-builder` stage (shared across 7 workbench images via `dockerfile_fragments.py`, #2798) just `COPY prefetch-input/mongocli /tmp/mongocli-src` and builds whatever commit is checked out.

## How Has This Been Tested?

- Confirmed via `git show`/`git ls-tree` against the target tag (without checking out) that the module path, `go 1.25.1` minimum, and `cmd/mongocli/` build entrypoint are unchanged from v2.0.4.
- Built the actual `CGO_ENABLED=1 GOOS=linux go build -a -tags strictfipsruntime -o /tmp/mongocli ./cmd/mongocli/` recipe (matching the Dockerfile exactly) inside a real `registry.access.redhat.com/ubi9/go-toolset:1.26.5-1785443561` container via podman on a remote Linux build machine (this needs a real Linux CGO toolchain; can't cross-compile from macOS). Build succeeded; ran `/tmp/mongocli --help` inside the container to confirm the binary works.
- Re-ran `govulncheck -show verbose ./cmd/mongocli/...` on that same Linux machine post-bump: confirmed `GO-2025-3787` (mapstructure) is now resolved, and `GO-2026-5970` (x/text) is the only remaining reachable finding, matching expectations above.
- `git submodule status` confirms the gitlink now points at `mongocli/v2.0.7`.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHAIENG-540]: https://redhat.atlassian.net/browse/RHAIENG-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled MongoDB command-line tooling to a newer release.
  - Includes the latest maintenance updates and improvements available in that version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->