### PR TITLE
ci(podman): tune ephemeral GHA runners for faster image builds

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -28,6 +28,11 @@ because Docker on GHA runners sets `FORWARD DROP`, which breaks rootful netavark
 ([podman #24486](https://github.com/containers/podman/issues/24486),
 [runner-images #13422](https://github.com/actions/runner-images/issues/13422)).
 
+On ephemeral runners the install action also applies best-effort host I/O greed
+(`swapoff`, `vm.swappiness=0`, `nobarrier`/`nodiscard`/`commit` remounts, WBT off) and
+`ci/cached-builds/storage.conf` sets overlay `mountopt=nodev,metacopy=off,redirect_dir=off`
+so Podman can use native overlay diff for faster layer commits.
+
 `test-install-podman` validates container IP and DNS reachability (TCP `nc`, HTTP `wget`, `dig` UDP/TCP) after configure.
 
 ## buildinputs image

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -35,7 +35,7 @@ runs:
 
         # Ephemeral runners: favor build throughput over durability guarantees.
         sudo swapoff -a 2>/dev/null || true
-        sudo sysctl -w vm.swappiness=0
+        sudo sysctl -w vm.swappiness=0 || true
 
         remount_greed() {
           local target="$1"
@@ -48,6 +48,7 @@ runs:
 
         graphroot=/mnt/containers/storage
         sudo mkdir -p "${graphroot}"
+        # Single-disk runners resolve graphroot to /; remounting both is idempotent.
         remount_greed "$(findmnt -n -o TARGET --target "${graphroot}")"
         remount_greed "$(findmnt -n -o TARGET --target /)"
 

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -28,6 +28,34 @@ runs:
           sudo apparmor_parser -r /etc/apparmor.d/usr.bin.pasta
         fi
 
+    - name: Tune ephemeral host I/O and memory for CI builds
+      shell: bash
+      run: |
+        set -Eeuxo pipefail
+
+        # Ephemeral runners: favor build throughput over durability guarantees.
+        sudo swapoff -a 2>/dev/null || true
+        sudo sysctl -w vm.swappiness=0
+
+        remount_greed() {
+          local target="$1"
+          if mountpoint -q "${target}"; then
+            if ! sudo mount -o remount,nobarrier,nodiscard,commit=600 "${target}"; then
+              echo "warning: remount greed options failed for ${target}" >&2
+            fi
+          fi
+        }
+
+        graphroot=/mnt/containers/storage
+        sudo mkdir -p "${graphroot}"
+        remount_greed "$(findmnt -n -o TARGET --target "${graphroot}")"
+        remount_greed "$(findmnt -n -o TARGET --target /)"
+
+        for wbt in /sys/block/*/queue/wbt_lat_usec; do
+          [[ -f "${wbt}" ]] || continue
+          echo 0 | sudo tee "${wbt}" >/dev/null || true
+        done
+
     - name: Configure Podman
       shell: bash
       run: |

--- a/.github/workflows/test-install-podman.yaml
+++ b/.github/workflows/test-install-podman.yaml
@@ -30,6 +30,33 @@ jobs:
         with:
           platform: linux/amd64
 
+      - name: Verify Podman overlay mountopt and native diff
+        run: |
+          set -Eeuxo pipefail
+
+          grep -q 'metacopy=off' /etc/containers/storage.conf
+          grep -q 'redirect_dir=off' /etc/containers/storage.conf
+
+          if podman --log-level=debug info 2>&1 | grep -qiE 'useNativeDiff=true|native diff'; then
+            echo "Podman native overlay diff is active"
+          else
+            echo "podman --log-level=debug info did not report native diff; probing build output" >&2
+            probe_dir="$(mktemp -d)"
+            trap 'rm -rf "${probe_dir}"' EXIT
+            printf '%s\n' 'FROM docker.io/alpine' 'RUN echo native-diff-probe' > "${probe_dir}/Containerfile"
+            build_log="$(mktemp)"
+            if ! podman --log-level=debug build -t native-diff-probe "${probe_dir}" >"${build_log}" 2>&1; then
+              cat "${build_log}"
+              exit 1
+            fi
+            if grep -qi 'Not using native diff for overlay' "${build_log}"; then
+              cat "${build_log}"
+              echo "Podman is not using native overlay diff" >&2
+              exit 1
+            fi
+            echo "Podman native overlay diff probe passed"
+          fi
+
       - name: Test Podman installation
         run: |
           set -Eeuxo pipefail

--- a/.github/workflows/test-install-podman.yaml
+++ b/.github/workflows/test-install-podman.yaml
@@ -37,24 +37,11 @@ jobs:
           grep -q 'metacopy=off' /etc/containers/storage.conf
           grep -q 'redirect_dir=off' /etc/containers/storage.conf
 
-          if podman --log-level=debug info 2>&1 | grep -qi 'useNativeDiff=true'; then
+          if podman info 2>&1 | grep -qiE '"?Native Overlay Diff"?:\s*"?true"?'; then
             echo "Podman native overlay diff is active"
           else
-            echo "podman --log-level=debug info did not report native diff; probing build output" >&2
-            probe_dir="$(mktemp -d)"
-            trap 'rm -rf "${probe_dir}"' EXIT
-            printf '%s\n' 'FROM docker.io/alpine' 'RUN echo native-diff-probe' > "${probe_dir}/Containerfile"
-            build_log="$(mktemp)"
-            if ! podman --log-level=debug build -t native-diff-probe "${probe_dir}" >"${build_log}" 2>&1; then
-              cat "${build_log}"
-              exit 1
-            fi
-            if grep -qi 'Not using native diff for overlay' "${build_log}"; then
-              cat "${build_log}"
-              echo "Podman is not using native overlay diff" >&2
-              exit 1
-            fi
-            echo "Podman native overlay diff probe passed"
+            echo "Podman is not using native overlay diff" >&2
+            exit 1
           fi
 
       - name: Test Podman installation

--- a/.github/workflows/test-install-podman.yaml
+++ b/.github/workflows/test-install-podman.yaml
@@ -37,7 +37,7 @@ jobs:
           grep -q 'metacopy=off' /etc/containers/storage.conf
           grep -q 'redirect_dir=off' /etc/containers/storage.conf
 
-          if podman --log-level=debug info 2>&1 | grep -qiE 'useNativeDiff=true|native diff'; then
+          if podman --log-level=debug info 2>&1 | grep -qi 'useNativeDiff=true'; then
             echo "Podman native overlay diff is active"
           else
             echo "podman --log-level=debug info did not report native diff; probing build output" >&2

--- a/ci/cached-builds/storage.conf
+++ b/ci/cached-builds/storage.conf
@@ -20,3 +20,6 @@ transient_store = true
 pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
 
 [storage.options.overlay]
+# Native overlay diff for buildah/podman layer commits (avoid naive tree walk).
+# Prefer mountopt over modprobe reload — applies on next overlay mount.
+mountopt = "nodev,metacopy=off,redirect_dir=off"


### PR DESCRIPTION
Fixes #4216 

## Summary
- Set overlay `mountopt=nodev,metacopy=off,redirect_dir=off` in `ci/cached-builds/storage.conf` so Podman uses native overlay diff for faster layer commits.
- Add best-effort ephemeral host I/O/memory greed (`swapoff`, `vm.swappiness=0`, `nobarrier`/`nodiscard`/`commit` remounts, WBT off) to `install-podman-action`.
- Extend `test-install-podman` to assert mountopt and native diff; document tunings in `ACTIONS.md`.

## Test plan
* https://github.com/opendatahub-io/notebooks/actions/runs/30746975779
- [x] `Test Install Podman` workflow runs on this PR (path filters cover changed files)
- [ ] Optional follow-up: compare one cold Build Notebooks run before/after for wall-clock delta

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Improved Podman configuration for faster and more reliable ephemeral CI builds.
* Optimized container storage placement, filesystem behavior, memory usage, and I/O performance.
* Added validation to confirm required overlay storage settings and native overlay support.

## Documentation

* Documented the additional Podman performance and storage configuration for CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->