### PR TITLE
red-hat-data-services/notebooks#2304: chore(ci): replace archived and third-party PR/token actions

### DIFF
--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -16,7 +16,9 @@ jobs:
           app-id: ${{ secrets.DEVOPS_APP_ID }}
           private-key: ${{ secrets.DEVOPS_APP_PRIVATE_KEY }}
           owner: opendatahub-io
+          repositories: notebooks
           permission-organization-projects: write
+          permission-issues: read
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/opendatahub-io/projects/40

--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -11,10 +11,12 @@ jobs:
     steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789  # v4.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app_id: ${{ secrets.DEVOPS_APP_ID }}
-          private_key: ${{ secrets.DEVOPS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.DEVOPS_APP_ID }}
+          private-key: ${{ secrets.DEVOPS_APP_PRIVATE_KEY }}
+          owner: opendatahub-io
+          permission-organization-projects: write
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/opendatahub-io/projects/40

--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -18,7 +18,7 @@ jobs:
           owner: opendatahub-io
           repositories: notebooks
           permission-organization-projects: write
-          permission-issues: read
+          permission-issues: read  # add-to-project reads the triggering issue; no PR permission needed since this workflow only fires on issues: opened
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/opendatahub-io/projects/40

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -142,11 +142,13 @@ jobs:
             :exclamation: **IMPORTANT NOTE**: Remember to delete the `${{ env.SEC_SCAN_BRANCH }}` branch after merging the changes
         run: |
           gh label create "automated pr" \
+            --repo "$GITHUB_REPOSITORY" \
             --description "Pull requests created by automation" \
             --color "ededed" \
             2>/dev/null || true
 
           gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
             --head "${{ env.SEC_SCAN_BRANCH }}" \
             --base "${{ env.BRANCH_NAME }}" \
             --title "$PR_TITLE" \

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -126,24 +126,29 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
-      - name: pull-request
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5  # v2.12.1
-        with:
-          source_branch: ${{ env.SEC_SCAN_BRANCH }}
-          destination_branch: ${{ env.BRANCH_NAME}}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_label: "automated pr"
-          pr_title: "[Security Scanner Action] Weekly update of security vulnerabilities reported by Quay"
-          pr_body: |
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: "[Security Scanner Action] Weekly update of security vulnerabilities reported by Quay"
+          PR_BODY: |
             :rocket: This is an automated Pull Request.
 
             This PR updates:
 
             * `ci/security-scan/security_scan_results.md` file with the latest security vulnerabilities reported by Quay.
             * `ci/security-scan/weekly_commit_ids` with the latest updated SHA digests of the notebooks (N & N-1)
-            Created by `/.github/workflows/sec-scan.yaml`
+            Created by `/.github/workflows/sec-scan.yml`
 
-            :exclamation: **IMPORTANT NOTE**: Remember to delete the ` ${{ env.SEC_SCAN_BRANCH }}` branch after merging the changes
+            :exclamation: **IMPORTANT NOTE**: Remember to delete the `${{ env.SEC_SCAN_BRANCH }}` branch after merging the changes
+        run: |
+          gh label create "automated pr" \
+            --description "Pull requests created by automation" \
+            --color "ededed" \
+            2>/dev/null || true
+
+          gh pr create \
+            --head "${{ env.SEC_SCAN_BRANCH }}" \
+            --base "${{ env.BRANCH_NAME }}" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --label "automated pr"


### PR DESCRIPTION
## Summary

- **`sec-scan.yml`**: replace archived [`repo-sync/pull-request`](https://github.com/repo-sync/pull-request) with `gh pr create` (same pattern as `update-buildconfigs.yaml`, `update-tags.yaml`, etc.); drop unnecessary checkout in the PR job
- **`auto-add-issue-to-project.yml`**: replace `getsentry/action-github-app-token` with official [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (same pin as Antigravity workflows), scoped to `opendatahub-io` with `organization-projects: write`

Addresses red-hat-data-services/notebooks#2304 for the `sec-scan.yml` `open-pull-request` job on `main` (`notebook-digest-updater.yaml` is `rhoai-2.25`-only and out of scope here; that issue's acceptance criteria won't be fully closed until it's backported there too). Cross-repo references don't auto-close on merge, so that issue should be closed/updated manually once this lands.

## Test plan

- [ ] `auto-add-issue-to-project` still adds new issues to org projects 40 and 45
- [ ] `sec-scan` `open-pull-request` job opens a PR with label `automated pr` when the workflow runs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated project automation authentication and permissions for more reliable issue and project management workflows.
  - Improved security-scan automation by automatically creating the required pull request label and streamlining pull request creation.
  - Preserved existing behavior when the label is already available, while suppressing non-blocking label-creation errors.
  - Improved automation handling of pull request metadata to make generated pull requests more consistent and dependable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
