### PR TITLE
ISSUE#4129: test(cve): dedupe FakeClient scaffolding in create_cve_trackers tests

### DIFF
--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -201,16 +201,22 @@ Fix should be applied to: [https://github.com/red-hat-data-services/notebooks](h
 """)
 
 
-def test_create_tracker_issue_api_payload(monkeypatch: MonkeyPatch) -> None:
+def _capturing_client(return_key: str = "RHAIENG-9999") -> tuple[JiraClient, dict[str, Any]]:
     captured: dict[str, Any] = {}
 
     class FakeClient:
         def create_issue(self, **kwargs: Any) -> dict:
             captured.update(kwargs)
-            return {"key": "RHAIENG-9999"}
+            return {"key": return_key}
 
         def get_current_user(self) -> dict:
             return {"accountId": "runner-id-123"}
+
+    return cast("JiraClient", FakeClient()), captured
+
+
+def test_create_tracker_issue_api_payload(monkeypatch: MonkeyPatch) -> None:
+    client, captured = _capturing_client(return_key="RHAIENG-9999")
 
     monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
     monkeypatch.delenv("JIRA_RUNNER_ACCOUNT_ID", raising=False)
@@ -224,7 +230,7 @@ def test_create_tracker_issue_api_payload(monkeypatch: MonkeyPatch) -> None:
         contributor_account_ids={"child-contrib-id"},
     )
 
-    result = cct.create_tracker_issue(cast("JiraClient", FakeClient()), info)
+    result = cct.create_tracker_issue(client, info)
     assert result == "RHAIENG-9999"
 
     assert adf_to_text(captured.pop("description")) == snapshot("""\
@@ -253,15 +259,7 @@ Fix should be applied to: [https://github.com/red-hat-data-services/notebooks](h
 
 
 def test_create_tracker_issue_no_version_omits_target_version(monkeypatch: MonkeyPatch) -> None:
-    captured: dict[str, Any] = {}
-
-    class FakeClient:
-        def create_issue(self, **kwargs: Any) -> dict:
-            captured.update(kwargs)
-            return {"key": "RHAIENG-8888"}
-
-        def get_current_user(self) -> dict:
-            return {"accountId": "runner-id-123"}
+    client, captured = _capturing_client(return_key="RHAIENG-8888")
 
     monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
     monkeypatch.delenv("JIRA_RUNNER_ACCOUNT_ID", raising=False)
@@ -272,5 +270,5 @@ def test_create_tracker_issue_no_version_omits_target_version(monkeypatch: Monke
         description="Some flaw",
     )
 
-    cct.create_tracker_issue(cast("JiraClient", FakeClient()), info)
+    cct.create_tracker_issue(client, info)
     assert cct.RHAIENG_TARGET_VERSION_FIELD not in captured.get("extra_fields", {})


### PR DESCRIPTION
## Summary

Fixes #4129

`test_create_tracker_issue_api_payload` and `test_create_tracker_issue_no_version_omits_target_version` in `tests/unit/scripts/cve/test_create_cve_trackers.py` each defined a near-identical inline `FakeClient` (same `create_issue` capture pattern, same `get_current_user` stub — only the returned key string differed).

Extracted a shared `_capturing_client(return_key=...)` factory returning a `(client, captured)` tuple, mirroring the existing `_capturing_client()` pattern in `test_jira_client_create_issue.py`.

## Test plan

- [x] `uv run pytest tests/unit/scripts/cve/test_create_cve_trackers.py -q` — 17 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run pyright tests/unit/scripts/cve/test_create_cve_trackers.py` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated test setup for CVE tracker creation.
  * Improved coverage support for captured issue payloads and configurable issue responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->