### PR TITLE
ISSUE#4128: refactor(cve): dedupe extract_cve_id between create_cve_trackers and cve_due_dates

### DIFF
--- a/scripts/cve/__init__.py
+++ b/scripts/cve/__init__.py
@@ -1,7 +1,14 @@
 """Shared utilities for CVE scripts."""
 
 import os
+import re
 import ssl
+
+
+def extract_cve_id(text: str) -> str | None:
+    """Extract CVE ID from text."""
+    match = re.search(r"CVE-\d{4}-\d+", text)
+    return match.group() if match else None
 
 
 def create_ssl_context() -> ssl.SSLContext:

--- a/scripts/cve/create_cve_trackers.py
+++ b/scripts/cve/create_cve_trackers.py
@@ -40,6 +40,7 @@ import urllib.parse
 from dataclasses import dataclass, field
 from typing import Any
 
+from scripts.cve import extract_cve_id
 from scripts.cve.jira_auth import JiraAuthError
 from scripts.cve.jira_client import JIRA_DEFAULT_URL, JiraClient
 
@@ -100,12 +101,6 @@ class CVEInfo:
     @property
     def issue_count(self) -> int:
         return len(self.issues)
-
-
-def extract_cve_id(text: str) -> str | None:
-    """Extract CVE ID from text."""
-    match = re.search(r"CVE-\d{4}-\d+", text)
-    return match.group() if match else None
 
 
 def extract_version(summary: str) -> str | None:

--- a/scripts/cve/cve_due_dates.py
+++ b/scripts/cve/cve_due_dates.py
@@ -29,11 +29,11 @@ Requires:
 """
 
 import argparse
-import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, date
 
+from scripts.cve import extract_cve_id
 from scripts.cve.jira_auth import JiraAuthError
 from scripts.cve.jira_client import JiraClient
 
@@ -67,12 +67,6 @@ class TrackerInfo:
         """True if tracker has no due date but linked issues do."""
         return self.due_date is None and self.earliest_child_due_date is not None
 
-
-
-def extract_cve_id(text: str) -> str | None:
-    """Extract CVE ID from text."""
-    match = re.search(r'CVE-\d{4}-\d+', text)
-    return match.group() if match else None
 
 
 def parse_date(date_str: str | None) -> date | None:

--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -36,17 +36,6 @@ def adf_to_text(doc: dict) -> str:
     return "\n".join(parts)
 
 
-def test_extract_cve_id_from_label_and_summary(subtests: Subtests) -> None:
-    cases = [
-        ("CVE-2026-8643", "CVE-2026-8643"),
-        ("EMBARGOED CVE-2026-8643 foo", "CVE-2026-8643"),
-        ("no cve here", None),
-    ]
-    for raw, expected in cases:
-        with subtests.test(msg=f"extract_cve_id({raw!r})"):
-            assert cct.extract_cve_id(raw) == expected
-
-
 def test_extract_version(subtests: Subtests) -> None:
     cases = [
         ("EMBARGOED CVE-2026-8643 rhoai/odh-workbench: flaw [rhoai-2.25]", "rhoai-2.25"),

--- a/tests/unit/scripts/cve/test_cve_due_dates.py
+++ b/tests/unit/scripts/cve/test_cve_due_dates.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
+from scripts.cve import extract_cve_id
 from scripts.cve.cve_due_dates import (
     TrackerInfo,
-    extract_cve_id,
     get_linked_issue_keys,
     list_missing_due_dates,
     list_overdue_trackers,


### PR DESCRIPTION
## Summary

`scripts/cve/create_cve_trackers.py` and `scripts/cve/cve_due_dates.py` each defined an identical `extract_cve_id(text: str) -> str | None` function using the same regex (`CVE-\d{4}-\d+`). Fixing a regex bug would have required two edits, and a missed one would silently diverge.

- Moved the single canonical `extract_cve_id` into `scripts/cve/__init__.py`, next to the existing `create_ssl_context()` shared utility.
- Both `create_cve_trackers.py` and `cve_due_dates.py` now import it (`from scripts.cve import extract_cve_id`); removed the now-unused `import re` from `cve_due_dates.py` (no other use in that file).
- Consolidated the overlapping `extract_cve_id` test cases into `test_cve_due_dates.py` (already held the superset of cases), repointed at the canonical import, and removed the now-redundant `test_extract_cve_id_from_label_and_summary` from `test_create_cve_trackers.py`.

Fixes #4128

## Test plan

- [x] `uv run pytest tests/unit/scripts/cve/ -q` — 117 passed
- [x] `uv run ruff check` / `ruff format --check` on changed test files — clean
- [x] `uv run pyright` on all changed files — 0 errors
- [x] `uv run prek --all-files` — clean except pre-existing, unrelated failures in `ci/agentic-reviewer/` (missing deps) and one unrelated file; `scripts/cve/*.py` isn't in ruff's pre-commit scope (see #4270)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared utility for extracting CVE identifiers from text.
  * Returns the first matching CVE identifier or no result when none is found.

* **Refactor**
  * Standardized CVE extraction across tracker and due-date tools.

* **Tests**
  * Updated test imports to use the shared CVE extraction utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->