### PR TITLE
NO-JIRA: ci(prek): include `scripts/` in Ruff hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,10 +35,10 @@ repos:
       - id: ruff-check
         types_or: [python, pyi, jupyter]
         args: [--fix]
-        files: '^((ci|tests|ntb|base-images)/.*\.(py|pyi)|jupyter/.*\.ipynb)$'
+        files: '^((ci|tests|ntb|base-images|scripts)/.*\.(py|pyi)|jupyter/.*\.ipynb)$'
       - id: ruff-format
         types_or: [python, pyi]
-        files: '^(ci|tests|ntb|base-images)/.*\.(py|pyi)$'
+        files: '^(ci|tests|ntb|base-images|scripts)/.*\.(py|pyi)$'
   # https://github.com/gitleaks/gitleaks
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,15 @@ reportAttributeAccessIssue = "none"
 
 # https://docs.astral.sh/ruff/configuration
 [tool.ruff]
-include = ["pyproject.toml", "ci/**/*.py", "ntb/**/*.py", "tests/**/*.py", "base-images/**/*.py", "jupyter/**/*.ipynb"]
+include = [
+    "pyproject.toml",
+    "ci/**/*.py",
+    "ntb/**/*.py",
+    "scripts/**/*.py",
+    "tests/**/*.py",
+    "base-images/**/*.py",
+    "jupyter/**/*.ipynb",
+]
 exclude = [ ]
 target-version = "py314"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,7 @@ pep8-naming.classmethod-decorators = ["pydantic.validator"]
 # S604: call-with-shell-equals-true
 "tests/**/*.py" = ["S101", "S602", "S603", "S604"]
 "ci/**/*.py" = ["S101", "S602", "S603", "S604"]
-"scripts/**/*.py" = ["S602", "S603", "S604"]
+  "scripts/**/*.py" = ["S101", "S602", "S603", "S604"]
 # Test assertion helpers use assert by design
 "ntb/**/*.py" = ["S101"]
 # Copr client wraps CLI commands via subprocess with controlled arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,7 @@ pep8-naming.classmethod-decorators = ["pydantic.validator"]
 # S604: call-with-shell-equals-true
 "tests/**/*.py" = ["S101", "S602", "S603", "S604"]
 "ci/**/*.py" = ["S101", "S602", "S603", "S604"]
-  "scripts/**/*.py" = ["S101", "S602", "S603", "S604"]
+"scripts/**/*.py" = ["S101", "S602", "S603", "S604"]
 # Test assertion helpers use assert by design
 "ntb/**/*.py" = ["S101"]
 # Copr client wraps CLI commands via subprocess with controlled arguments

--- a/scripts/ci/renovate_run.py
+++ b/scripts/ci/renovate_run.py
@@ -34,7 +34,9 @@ from pathlib import Path
 SCRIPTS_CI = Path(__file__).resolve().parent
 ROOT = SCRIPTS_CI.parent.parent
 REMOTE_DEFAULT_REPO = "opendatahub-io/notebooks"
-DEFAULT_RENOVATE_IMAGE = "ghcr.io/renovatebot/renovate:43@sha256:575256ce227ca81cd2a316d33f35108fe5c978d479c29232ec74cf9c0904a351"
+DEFAULT_RENOVATE_IMAGE = (
+    "ghcr.io/renovatebot/renovate:43@sha256:575256ce227ca81cd2a316d33f35108fe5c978d479c29232ec74cf9c0904a351"
+)
 DEFAULT_GIT_AUTHOR = "ide-developer <rhoai-ide-konflux@redhat.com>"
 LOCAL_MODES = ("local", "local-lookup")
 REMOTE_MODES = ("remote", "lookup")

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -183,8 +183,7 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
         (
             rule
             for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("description", "").startswith(CENTOS_STREAM_RULE_DESCRIPTION)
+            if isinstance(rule, dict) and rule.get("description", "").startswith(CENTOS_STREAM_RULE_DESCRIPTION)
         ),
         None,
     )

--- a/scripts/cve/__init__.py
+++ b/scripts/cve/__init__.py
@@ -1,43 +1,5 @@
 """Shared utilities for CVE scripts."""
 
-import os
-import re
-import ssl
+from scripts.cve.common import create_ssl_context, extract_cve_id
 
-
-def extract_cve_id(text: str) -> str | None:
-    """Extract CVE ID from text."""
-    match = re.search(r"CVE-\d{4}-\d+", text)
-    return match.group() if match else None
-
-
-def create_ssl_context() -> ssl.SSLContext:
-    """Create an SSL context that works on macOS with system certificates.
-
-    Tries certifi first, then falls back to extracting certificates from the
-    macOS system keychain.  The context is only needed when ``requests`` is not
-    installed and we fall back to ``urllib``.
-    """
-    ctx = ssl.create_default_context()
-    try:
-        import certifi
-        ctx.load_verify_locations(certifi.where())
-    except ImportError:
-        import subprocess
-        import tempfile
-        try:
-            result = subprocess.run(
-                ["security", "find-certificate", "-a", "-p",
-                 "/System/Library/Keychains/SystemRootCertificates.keychain"],
-                capture_output=True, text=True, timeout=10
-            )
-            if result.returncode == 0 and result.stdout:
-                with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as f:
-                    f.write(result.stdout)
-                try:
-                    ctx.load_verify_locations(f.name)
-                finally:
-                    os.unlink(f.name)
-        except (subprocess.SubprocessError, FileNotFoundError, OSError):
-            pass  # Fall back to default behavior
-    return ctx
+__all__ = ["create_ssl_context", "extract_cve_id"]

--- a/scripts/cve/common.py
+++ b/scripts/cve/common.py
@@ -1,0 +1,55 @@
+"""Shared helpers for CVE scripts."""
+
+import os
+import re
+import ssl
+import subprocess
+import tempfile
+
+try:
+    import certifi
+except ImportError:
+    certifi = None
+
+
+def extract_cve_id(text: str) -> str | None:
+    """Extract CVE ID from text."""
+    match = re.search(r"CVE-\d{4}-\d+", text)
+    return match.group() if match else None
+
+
+def create_ssl_context() -> ssl.SSLContext:
+    """Create an SSL context that works on macOS with system certificates.
+
+    Tries certifi first, then falls back to extracting certificates from the
+    macOS system keychain.  The context is only needed when ``requests`` is not
+    installed and we fall back to ``urllib``.
+    """
+    ctx = ssl.create_default_context()
+    if certifi is not None:
+        ctx.load_verify_locations(certifi.where())
+    else:
+        try:
+            result = subprocess.run(
+                [
+                    "security",
+                    "find-certificate",
+                    "-a",
+                    "-p",
+                    "/System/Library/Keychains/SystemRootCertificates.keychain",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout:
+                with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as f:
+                    f.write(result.stdout)
+                try:
+                    ctx.load_verify_locations(f.name)
+                finally:
+                    os.unlink(f.name)
+        except subprocess.SubprocessError, FileNotFoundError, OSError:
+            pass  # Fall back to default behavior
+    return ctx

--- a/scripts/cve/create_cve_trackers.py
+++ b/scripts/cve/create_cve_trackers.py
@@ -59,8 +59,7 @@ EMBARGOED_SECURITY_LEVEL = "Embargoed Security Issue"
 DEFAULT_SECURITY_LEVEL = "Red Hat Employee"
 
 SEARCH_FIELDS = (
-    f"key,summary,status,labels,security,issuelinks,"
-    f"{RHAIENG_TEAM_CUSTOM_FIELD},{RHAIENG_CONTRIBUTORS_FIELD}"
+    f"key,summary,status,labels,security,issuelinks,{RHAIENG_TEAM_CUSTOM_FIELD},{RHAIENG_CONTRIBUTORS_FIELD}"
 )
 
 
@@ -82,6 +81,7 @@ def build_tracker_team_extra_fields() -> dict[str, str]:
 @dataclass
 class CVEInfo:
     """Information about a CVE for a specific version."""
+
     cve_id: str
     version: str = ""
     description: str = ""
@@ -181,8 +181,7 @@ def build_tracker_summary(cve_info: CVEInfo) -> str:
     if len(summary) > 250:
         max_desc_len = 250 - len(prefix) - len(cve_info.cve_id) - len(cve_info.version_suffix) - 5
         summary = (
-            f"{prefix}{cve_info.cve_id} {cve_info.description[:max_desc_len]}... "
-            f"{cve_info.version_suffix}"
+            f"{prefix}{cve_info.cve_id} {cve_info.description[:max_desc_len]}... {cve_info.version_suffix}"
         ).strip()
 
     return summary
@@ -230,48 +229,57 @@ def build_description(cve_info: CVEInfo, base_url: str = JIRA_DEFAULT_URL, track
     child_keys = sorted(issue["key"] for issue in cve_info.issues)
     count = len(child_keys)
 
-    content: list[dict] = [_adf_paragraph(
-        _adf_text(
-            f"Tracker for {cve_info.cve_id} - {cve_info.description} "
-            f"affecting Notebooks Images components."
+    content: list[dict] = [
+        _adf_paragraph(
+            _adf_text(f"Tracker for {cve_info.cve_id} - {cve_info.description} affecting Notebooks Images components.")
         )
-    )]
+    ]
 
     branch_suffix = f" (branch: {cve_info.version})" if cve_info.version else " (on the respective release branch)"
-    content.append(_adf_paragraph(
-        _adf_text("Fix should be applied to: "),
-        _adf_link(
-            "https://github.com/red-hat-data-services/notebooks",
-            "https://github.com/red-hat-data-services/notebooks",
-        ),
-        _adf_text(branch_suffix),
-    ))
+    content.append(
+        _adf_paragraph(
+            _adf_text("Fix should be applied to: "),
+            _adf_link(
+                "https://github.com/red-hat-data-services/notebooks",
+                "https://github.com/red-hat-data-services/notebooks",
+            ),
+            _adf_text(branch_suffix),
+        )
+    )
 
     if child_keys:
-        content.append(_adf_paragraph(
-            _adf_text(f"Blocked Issues ({count}): ", marks=[{"type": "strong"}]),
-            _adf_text(", ".join(child_keys)),
-        ))
+        content.append(
+            _adf_paragraph(
+                _adf_text(f"Blocked Issues ({count}): ", marks=[{"type": "strong"}]),
+                _adf_text(", ".join(child_keys)),
+            )
+        )
 
         keys_csv = ", ".join(child_keys)
         static_jql = f"key in ({keys_csv}) ORDER BY key ASC"
         static_url = f"{base_url}/issues/?jql={urllib.parse.quote(static_jql)}"
 
-        content.append(_adf_paragraph(
-            _adf_text("JQL Query to View All Blocked Issues: ", marks=[{"type": "strong"}]),
-        ))
-        content.append(_adf_paragraph(
-            _adf_link(f"View all {count} blocked issues", static_url),
-        ))
+        content.append(
+            _adf_paragraph(
+                _adf_text("JQL Query to View All Blocked Issues: ", marks=[{"type": "strong"}]),
+            )
+        )
+        content.append(
+            _adf_paragraph(
+                _adf_link(f"View all {count} blocked issues", static_url),
+            )
+        )
 
     if tracker_key and child_keys:
         dynamic_jql = f'issue in linkedIssues({tracker_key}, "blocks") ORDER BY key ASC'
         dynamic_url = f"{base_url}/issues/?jql={urllib.parse.quote(dynamic_jql)}"
 
         content.append(_adf_code_block(dynamic_jql))
-        content.append(_adf_paragraph(
-            _adf_link("View blocked issues (dynamic)", dynamic_url),
-        ))
+        content.append(
+            _adf_paragraph(
+                _adf_link("View blocked issues (dynamic)", dynamic_url),
+            )
+        )
 
     return {"version": 1, "type": "doc", "content": content}
 
@@ -279,6 +287,7 @@ def build_description(cve_info: CVEInfo, base_url: str = JIRA_DEFAULT_URL, track
 @dataclass
 class OrphanCVEsResult:
     """Result of finding orphan CVEs in RHOAIENG."""
+
     orphans: dict[tuple[str, str], CVEInfo]
     issues: list[dict]
 
@@ -306,8 +315,8 @@ def find_orphan_cves(client: JiraClient, max_results: int = 1000) -> OrphanCVEsR
 
     # Get all RHOAIENG CVE issues
     jql = (
-        'project = RHOAIENG AND issuetype in (Bug, Vulnerability, Weakness) '
-        'AND resolution = Unresolved AND labels = SecurityTracking '
+        "project = RHOAIENG AND issuetype in (Bug, Vulnerability, Weakness) "
+        "AND resolution = Unresolved AND labels = SecurityTracking "
         'AND component = "Notebooks Images" ORDER BY created DESC'
     )
     issues = client.search_issues(jql, fields=SEARCH_FIELDS, max_results=max_results)
@@ -361,11 +370,13 @@ def find_orphan_cves(client: JiraClient, max_results: int = 1000) -> OrphanCVEsR
 
         info.contributor_account_ids |= extract_contributor_account_ids(fields)
 
-        info.issues.append({
-            "key": key,
-            "summary": summary,
-            "has_parent": has_rhaieng_blocker,
-        })
+        info.issues.append(
+            {
+                "key": key,
+                "summary": summary,
+                "has_parent": has_rhaieng_blocker,
+            }
+        )
 
         if has_rhaieng_blocker:
             info.has_tracker = True
@@ -542,17 +553,13 @@ Environment variables:
                             added to tracker Contributors (union with children)
   JIRA_RUNNER_ACCOUNT_ID    Optional. Override accountId for authenticated user
                             (default: resolved via /rest/api/3/myself)
-"""
+""",
     )
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Show what would be created without making changes")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be created without making changes")
     parser.add_argument("--cve", help="Create tracker for specific CVE ID only")
-    parser.add_argument("--list-only", action="store_true",
-                        help="List orphan CVEs without creating trackers")
-    parser.add_argument("--max-results", type=int, default=1000,
-                        help="Maximum issues to fetch (default: 1000)")
-    parser.add_argument("--no-link", action="store_true",
-                        help="Create trackers but don't link to child issues")
+    parser.add_argument("--list-only", action="store_true", help="List orphan CVEs without creating trackers")
+    parser.add_argument("--max-results", type=int, default=1000, help="Maximum issues to fetch (default: 1000)")
+    parser.add_argument("--no-link", action="store_true", help="Create trackers but don't link to child issues")
     return parser.parse_args()
 
 

--- a/scripts/cve/cve_due_dates.py
+++ b/scripts/cve/cve_due_dates.py
@@ -31,7 +31,7 @@ Requires:
 import argparse
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, date
+from datetime import date, datetime
 
 from scripts.cve import extract_cve_id
 from scripts.cve.jira_auth import JiraAuthError
@@ -41,6 +41,7 @@ from scripts.cve.jira_client import JiraClient
 @dataclass
 class TrackerInfo:
     """Information about a CVE tracker and its linked issues."""
+
     key: str
     summary: str
     cve_id: str | None = None
@@ -66,7 +67,6 @@ class TrackerInfo:
     def needs_due_date_sync(self) -> bool:
         """True if tracker has no due date but linked issues do."""
         return self.due_date is None and self.earliest_child_due_date is not None
-
 
 
 def parse_date(date_str: str | None) -> date | None:
@@ -147,7 +147,7 @@ def fetch_child_due_dates(client: JiraClient, trackers: list[TrackerInfo]) -> No
     batch_size = 50
 
     for i in range(0, len(keys_list), batch_size):
-        batch_keys = keys_list[i:i + batch_size]
+        batch_keys = keys_list[i : i + batch_size]
         jql = f"key in ({','.join(batch_keys)})"
         issues = client.search_issues(jql, fields="key,duedate", max_results=len(batch_keys))
 
@@ -160,7 +160,7 @@ def fetch_child_due_dates(client: JiraClient, trackers: list[TrackerInfo]) -> No
     for tracker in trackers:
         child_dates = []
         for child_key in tracker.linked_issues:
-            if child_key in child_due_dates and child_due_dates[child_key]:
+            if child_due_dates.get(child_key):
                 child_dates.append(child_due_dates[child_key])
 
         if child_dates:
@@ -286,20 +286,16 @@ Environment variables:
   JIRA_API_TOKEN          Atlassian API token (recommended for scripts/CI)
   JIRA_TOKEN              Legacy Bearer token (issues.redhat.com PAT)
   JIRA_OAUTH_CLIENT_SECRET  OAuth 2.0 client secret (interactive browser flow)
-"""
+""",
     )
-    parser.add_argument("--list-overdue", action="store_true",
-                        help="List trackers that are past their due date")
-    parser.add_argument("--list-missing-dates", action="store_true",
-                        help="List trackers missing due dates but with child due dates")
-    parser.add_argument("--sync-dates", action="store_true",
-                        help="Sync due dates from child issues to trackers")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Show what would be done without making changes")
-    parser.add_argument("--summary", action="store_true",
-                        help="Show summary statistics")
-    parser.add_argument("--max-results", type=int, default=500,
-                        help="Maximum trackers to fetch (default: 500)")
+    parser.add_argument("--list-overdue", action="store_true", help="List trackers that are past their due date")
+    parser.add_argument(
+        "--list-missing-dates", action="store_true", help="List trackers missing due dates but with child due dates"
+    )
+    parser.add_argument("--sync-dates", action="store_true", help="Sync due dates from child issues to trackers")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+    parser.add_argument("--summary", action="store_true", help="Show summary statistics")
+    parser.add_argument("--max-results", type=int, default=500, help="Maximum trackers to fetch (default: 500)")
     return parser.parse_args()
 
 

--- a/scripts/cve/jira_auth.py
+++ b/scripts/cve/jira_auth.py
@@ -19,7 +19,10 @@ See jira_auth.spec.md for the full requirements document.
 
 from __future__ import annotations
 
+import argparse
 import base64
+import contextlib
+import getpass
 import hashlib
 import json
 import os
@@ -31,7 +34,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import webbrowser
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -48,7 +51,7 @@ _CALLBACK_PORT = 8080
 
 # Atlassian OAuth 2.0 endpoints and defaults
 _ATLASSIAN_AUTH_URL = "https://auth.atlassian.com/authorize"
-_ATLASSIAN_TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+_ATLASSIAN_TOKEN_URL = "https://auth.atlassian.com/oauth/token"  # noqa: S105
 _ATLASSIAN_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
 _ATLASSIAN_SCOPES = "read:jira-work write:jira-work read:me offline_access"
 _DEFAULT_CLIENT_ID = "Vy2kiBP7sPj6HfgxCXam8iGutRps5Xsu"
@@ -61,6 +64,7 @@ class JiraAuthError(RuntimeError):
 # ---------------------------------------------------------------------------
 # Public entry points
 # ---------------------------------------------------------------------------
+
 
 def get_auth_headers(jira_url: str) -> dict[str, str]:
     """Return HTTP headers sufficient to authenticate against *jira_url*.
@@ -80,9 +84,7 @@ def get_auth_headers(jira_url: str) -> dict[str, str]:
     # --- Method 1a: API token from env vars ---
     if email or api_token:
         if not (email and api_token):
-            raise JiraAuthError(
-                "Set both JIRA_EMAIL and JIRA_API_TOKEN together, or unset both to use keyring/OAuth."
-            )
+            raise JiraAuthError("Set both JIRA_EMAIL and JIRA_API_TOKEN together, or unset both to use keyring/OAuth.")
         return _basic_auth_header(email, api_token)
 
     # --- Method 1b: API token from keyring ---
@@ -128,21 +130,19 @@ def get_auth_headers(jira_url: str) -> dict[str, str]:
 
 def _basic_auth_header(email: str, api_token: str) -> dict[str, str]:
     """Build a Basic auth header from email and API token."""
-    raw = f"{email}:{api_token}".encode("utf-8")
+    raw = f"{email}:{api_token}".encode()
     encoded = base64.b64encode(raw).decode("ascii")
     return {"Authorization": f"Basic {encoded}"}
 
 
 def _load_api_token() -> dict[str, str] | None:
     """Load stored API token from keyring, returning None if unavailable."""
-    try:
+    with contextlib.suppress(Exception):
         raw = keyring.get_password(_KEYRING_SERVICE, "api-token")
         if raw:
             data = json.loads(raw)
             if data.get("email") and data.get("api_token"):
                 return data
-    except Exception:
-        pass
     return None
 
 
@@ -186,22 +186,15 @@ def resolve_cloud_base_url(access_token: str, jira_url: str) -> str:
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # ruff: ignore[suspicious-url-open-usage]
             sites = json.loads(resp.read())
     except urllib.error.HTTPError as e:
-        raise JiraAuthError(
-            f"Failed to resolve cloud ID: HTTP {e.code} from {_ATLASSIAN_RESOURCES_URL}"
-        ) from e
+        raise JiraAuthError(f"Failed to resolve cloud ID: HTTP {e.code} from {_ATLASSIAN_RESOURCES_URL}") from e
     except Exception as e:
-        raise JiraAuthError(
-            f"Failed to resolve cloud ID from {_ATLASSIAN_RESOURCES_URL}: {e}"
-        ) from e
+        raise JiraAuthError(f"Failed to resolve cloud ID from {_ATLASSIAN_RESOURCES_URL}: {e}") from e
 
     if not sites:
-        raise JiraAuthError(
-            "No accessible Atlassian sites found. "
-            "Ensure your OAuth app has site access granted."
-        )
+        raise JiraAuthError("No accessible Atlassian sites found. Ensure your OAuth app has site access granted.")
 
     jira_url_stripped = jira_url.rstrip("/")
     cloud_id = None
@@ -213,10 +206,7 @@ def resolve_cloud_base_url(access_token: str, jira_url: str) -> str:
 
     if not cloud_id:
         available = ", ".join(s.get("url", "?") for s in sites)
-        raise JiraAuthError(
-            f"No Atlassian site matching {jira_url} found. "
-            f"Available sites: {available}"
-        )
+        raise JiraAuthError(f"No Atlassian site matching {jira_url} found. Available sites: {available}")
 
     return f"https://api.atlassian.com/ex/jira/{cloud_id}"
 
@@ -224,6 +214,7 @@ def resolve_cloud_base_url(access_token: str, jira_url: str) -> str:
 # ---------------------------------------------------------------------------
 # OAuth 2.0 browser redirect flow with PKCE
 # ---------------------------------------------------------------------------
+
 
 def _get_oauth_token(client_id: str, client_secret: str, jira_url: str) -> str:
     """Return a valid OAuth access token, using cache if possible."""
@@ -291,7 +282,7 @@ def _do_oauth_flow(client_id: str, client_secret: str) -> dict[str, Any]:
     event = threading.Event()
 
     class _CallbackHandler(BaseHTTPRequestHandler):
-        def do_GET(self):  # noqa: N802
+        def do_GET(self):
             parsed = urllib.parse.urlparse(self.path)
             if parsed.path != "/callback":
                 self.send_response(404)
@@ -332,18 +323,14 @@ def _do_oauth_flow(client_id: str, client_secret: str) -> dict[str, Any]:
         opened = webbrowser.open(auth_url)
         if not opened:
             print(
-                "\nCould not open browser automatically. Visit this URL to authenticate:\n"
-                f"  {auth_url}\n",
+                f"\nCould not open browser automatically. Visit this URL to authenticate:\n  {auth_url}\n",
                 flush=True,
             )
         else:
             print("Opening browser for Jira authentication...", flush=True)
 
         if not event.wait(timeout=_OAUTH_TIMEOUT_S):
-            raise JiraAuthError(
-                f"OAuth flow timed out after {_OAUTH_TIMEOUT_S} seconds. "
-                "Please try again."
-            )
+            raise JiraAuthError(f"OAuth flow timed out after {_OAUTH_TIMEOUT_S} seconds. Please try again.")
     finally:
         server.shutdown()
         server.server_close()
@@ -362,28 +349,36 @@ def _do_oauth_flow(client_id: str, client_secret: str) -> dict[str, Any]:
 
 
 def _exchange_code(
-    client_id: str, client_secret: str, code: str, redirect_uri: str, code_verifier: str,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
 ) -> dict[str, Any]:
     """Exchange an authorization code for tokens."""
-    payload = json.dumps({
-        "grant_type": "authorization_code",
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "code": code,
-        "redirect_uri": redirect_uri,
-        "code_verifier": code_verifier,
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+    ).encode("utf-8")
     return _post_token_endpoint(payload)
 
 
 def _refresh_oauth_token(client_id: str, client_secret: str, refresh_token: str) -> dict[str, Any]:
     """Exchange a refresh token for a new access token."""
-    payload = json.dumps({
-        "grant_type": "refresh_token",
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "refresh_token": refresh_token,
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        }
+    ).encode("utf-8")
     return _post_token_endpoint(payload)
 
 
@@ -395,7 +390,7 @@ def _post_token_endpoint(payload: bytes) -> dict[str, Any]:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # ruff: ignore[suspicious-url-open-usage]
             data = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         body = e.read().decode()
@@ -412,7 +407,7 @@ def _post_token_endpoint(payload: bytes) -> dict[str, Any]:
     except (TypeError, ValueError) as e:
         raise JiraAuthError(f"Token exchange failed: invalid expires_in={data.get('expires_in')!r}") from e
 
-    expires_at = datetime.now(tz=timezone.utc).replace(microsecond=0) + timedelta(seconds=expires_in)
+    expires_at = datetime.now(tz=UTC).replace(microsecond=0) + timedelta(seconds=expires_in)
 
     return {
         "access_token": access_token,
@@ -424,6 +419,7 @@ def _post_token_endpoint(payload: bytes) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Token storage — keyring with file fallback
 # ---------------------------------------------------------------------------
+
 
 def _load_token(jira_url: str) -> dict[str, Any] | None:
     """Load cached OAuth token data, returning None if unavailable/invalid."""
@@ -445,7 +441,7 @@ def _load_token(jira_url: str) -> dict[str, Any] | None:
         if not isinstance(data, dict) or "access_token" not in data:
             return None
         return data
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError, ValueError:
         return None
 
 
@@ -505,13 +501,14 @@ def _write_token_file(jira_url: str, raw: str) -> None:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _parse_expires_at(value: str) -> datetime | None:
     if not value:
         return None
     try:
         dt = datetime.fromisoformat(value)
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
+            dt = dt.replace(tzinfo=UTC)
         return dt
     except ValueError:
         return None
@@ -519,7 +516,7 @@ def _parse_expires_at(value: str) -> datetime | None:
 
 def _not_expired(expires_at: datetime) -> bool:
     """Return True if the token is still valid with the expiry buffer."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     return expires_at > now + timedelta(seconds=_TOKEN_EXPIRY_BUFFER_S)
 
 
@@ -535,9 +532,8 @@ def get_cached_api_base_url(jira_url: str) -> str | None:
 # CLI entry point: python -m scripts.cve.jira_auth store-token
 # ---------------------------------------------------------------------------
 
-def _cli() -> None:
-    import argparse
 
+def _cli() -> None:
     parser = argparse.ArgumentParser(
         prog="python -m scripts.cve.jira_auth",
         description="Manage Jira API tokens in the OS keychain",
@@ -558,8 +554,9 @@ def _cli() -> None:
         if args.token:
             api_token = args.token
         else:
-            import getpass
-            api_token = getpass.getpass("API token (from https://id.atlassian.com/manage-profile/security/api-tokens): ")
+            api_token = getpass.getpass(
+                "API token (from https://id.atlassian.com/manage-profile/security/api-tokens): "
+            )
         store_api_token(email, api_token.strip())
 
     elif args.command == "clear-token":
@@ -571,7 +568,7 @@ def _cli() -> None:
 
         if os.environ.get("JIRA_EMAIL") and os.environ.get("JIRA_API_TOKEN"):
             print("Auth: API token (from env vars JIRA_EMAIL + JIRA_API_TOKEN)")
-        elif (stored := _load_api_token()):
+        elif stored := _load_api_token():
             print(f"Auth: API token (from keychain, email={stored['email']})")
         elif os.environ.get("JIRA_TOKEN"):
             print("Auth: Legacy Bearer token (from env var JIRA_TOKEN)")

--- a/scripts/cve/jira_client.py
+++ b/scripts/cve/jira_client.py
@@ -16,6 +16,7 @@ from scripts.cve.jira_auth import (
 
 try:
     import requests
+
     HAS_REQUESTS = True
 except ImportError:
     import urllib.request
@@ -28,9 +29,17 @@ _SSL_CONTEXT = create_ssl_context() if not HAS_REQUESTS else None
 JIRA_DEFAULT_URL = "https://redhat.atlassian.net"
 
 # Keys set explicitly by create_issue(); extra_fields may not override these.
-_CREATE_ISSUE_PROTECTED_FIELD_KEYS = frozenset({
-    "project", "summary", "issuetype", "description", "labels", "components", "security",
-})
+_CREATE_ISSUE_PROTECTED_FIELD_KEYS = frozenset(
+    {
+        "project",
+        "summary",
+        "issuetype",
+        "description",
+        "labels",
+        "components",
+        "security",
+    }
+)
 
 
 class JiraClient:
@@ -95,18 +104,17 @@ class JiraClient:
             query_string = "&".join(f"{k}={urllib.parse.quote(str(v))}" for k, v in params.items())
             url = f"{url}?{query_string}"
 
-        req = urllib.request.Request(url, headers=self.headers, method=method)
+        req = urllib.request.Request(url, headers=self.headers, method=method)  # ruff: ignore[suspicious-url-open-usage]
         if data:
             req.data = json.dumps(data).encode("utf-8")
 
-        with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=30) as resp:
+        with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=30) as resp:  # ruff: ignore[suspicious-url-open-usage]
             content = resp.read().decode()
             if content:
                 return json.loads(content)
             return {}
 
-    def search_issues(self, jql: str, fields: str,
-                      max_results: int = 500) -> list[dict]:
+    def search_issues(self, jql: str, fields: str, max_results: int = 500) -> list[dict]:
         """Search for issues using JQL (API v3, token-based pagination)."""
         all_issues: list[dict] = []
         next_page_token: str | None = None
@@ -138,11 +146,17 @@ class JiraClient:
         params = {"fields": fields}
         return self._request("GET", f"/rest/api/3/issue/{issue_key}", params=params)
 
-    def create_issue(self, project_key: str, summary: str, issue_type: str,
-                     description: dict | None = None, labels: list[str] | None = None,
-                     components: list[str] | None = None,
-                     security_level: str | None = None,
-                     extra_fields: dict[str, Any] | None = None) -> dict:
+    def create_issue(
+        self,
+        project_key: str,
+        summary: str,
+        issue_type: str,
+        description: dict | None = None,
+        labels: list[str] | None = None,
+        components: list[str] | None = None,
+        security_level: str | None = None,
+        extra_fields: dict[str, Any] | None = None,
+    ) -> dict:
         """Create a new Jira issue (API v3, ADF description).
 
         ``extra_fields`` are merged into the REST ``fields`` object for custom
@@ -168,11 +182,7 @@ class JiraClient:
             fields["security"] = {"name": security_level}
 
         if extra_fields:
-            fields.update({
-                k: v
-                for k, v in extra_fields.items()
-                if k not in _CREATE_ISSUE_PROTECTED_FIELD_KEYS
-            })
+            fields.update({k: v for k, v in extra_fields.items() if k not in _CREATE_ISSUE_PROTECTED_FIELD_KEYS})
 
         data = {"fields": fields}
         return self._request("POST", "/rest/api/3/issue", data=data)

--- a/scripts/cve/sbom_analyze.py
+++ b/scripts/cve/sbom_analyze.py
@@ -32,7 +32,6 @@ import argparse
 import json
 import re
 import sys
-from pathlib import Path
 from typing import Any
 
 
@@ -229,15 +228,15 @@ def print_package_results(results: list[dict], package_name: str) -> None:
     for r in results:
         print(f"  {r['name']}@{r['version']}")
         print(f"    Type: {r['type']}")
-        if r.get('foundBy'):
+        if r.get("foundBy"):
             print(f"    Found by: {r['foundBy']}")
-        if r.get('locations'):
+        if r.get("locations"):
             print("    Locations:")
-            for loc in r['locations']:
+            for loc in r["locations"]:
                 print(f"      - {loc}")
-        if r.get('sourceInfo'):
+        if r.get("sourceInfo"):
             print(f"    Source: {r['sourceInfo']}")
-        if r.get('purl'):
+        if r.get("purl"):
             print(f"    PURL: {r['purl']}")
         print()
 
@@ -251,10 +250,10 @@ def print_path_results(results: list[dict], path_pattern: str) -> None:
     print(f"  Found {len(results)} package(s) at path matching '{path_pattern}':\n")
     for r in results:
         print(f"  {r['name']}@{r['version']} ({r['type']})")
-        if r.get('locations'):
-            for loc in r['locations']:
+        if r.get("locations"):
+            for loc in r["locations"]:
                 print(f"    - {loc}")
-        elif r.get('sourceInfo'):
+        elif r.get("sourceInfo"):
             print(f"    Source: {r['sourceInfo']}")
 
 

--- a/scripts/get_playwright_version.py
+++ b/scripts/get_playwright_version.py
@@ -34,9 +34,7 @@ def extract_playwright_version(manifest: Path) -> str:
     text = manifest.read_text(encoding="utf-8")
     match = _VERSION_RE.search(text)
     if match is None:
-        raise ValueError(
-            f"Failed to extract valid @playwright/test version from {manifest}"
-        )
+        raise ValueError(f"Failed to extract valid @playwright/test version from {manifest}")
     return match.group(1)
 
 

--- a/scripts/index_url_resolver.py
+++ b/scripts/index_url_resolver.py
@@ -253,9 +253,9 @@ def validated_index_probe_url(index_url: str) -> str:
 
 @cache
 def index_url_exists(index_url: str) -> bool:
-    request = Request(validated_index_probe_url(index_url), method="HEAD")  # noqa: S310
+    request = Request(validated_index_probe_url(index_url), method="HEAD")  # ruff: ignore[suspicious-url-open-usage]
     try:
-        with urlopen(request, timeout=INDEX_CHECK_TIMEOUT_SECONDS) as response:  # noqa: S310
+        with urlopen(request, timeout=INDEX_CHECK_TIMEOUT_SECONDS) as response:  # ruff: ignore[suspicious-url-open-usage]
             return 200 <= response.status < 400
     except HTTPError:
         return False
@@ -329,8 +329,7 @@ def _resolve_from_base_image_ref(
         release = parse_release_override(release_override, conf_file)
     else:
         raise IndexResolutionError(
-            f"Digest-pinned BASE_IMAGE in {conf_file} requires RELEASE for index "
-            f"resolution fallback: {base_image}"
+            f"Digest-pinned BASE_IMAGE in {conf_file} requires RELEASE for index resolution fallback: {base_image}"
         )
     release_candidates = [release]
     if accelerator.startswith("rocm"):

--- a/scripts/lockfile-generators/create-artifact-lockfile.py
+++ b/scripts/lockfile-generators/create-artifact-lockfile.py
@@ -24,12 +24,13 @@ Usage:
   python3 scripts/lockfile-generators/create-artifact-lockfile.py \\
       --artifact-input path/to/artifacts.in.yaml
 """
+
 import argparse
 import hashlib
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import yaml
 
@@ -61,9 +62,9 @@ def download_file(url: str, target_path: Path) -> None:
     try:
         subprocess.run(cmd, check=True)
     except FileNotFoundError:
-        raise RuntimeError("wget not found: please install wget")
+        raise RuntimeError("wget not found: please install wget") from None
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"wget failed for {url}: exit code {e.returncode}")
+        raise RuntimeError(f"wget failed for {url}: exit code {e.returncode}") from e
 
 
 def normalize_checksum(checksum: str) -> str:
@@ -99,7 +100,7 @@ def load_artifact_input(input_path: Path) -> list[Any]:
     return items
 
 
-def process_artifact(item: dict[str, Any], seen_filenames: set[str]) -> Optional[dict[str, Any]]:
+def process_artifact(item: dict[str, Any], seen_filenames: set[str]) -> dict[str, Any] | None:
     """Process a single artifact item. Skips duplicate filenames."""
     url = item.get("url")
     if not url:
@@ -190,7 +191,8 @@ def main():
     with open(output_path, "w", encoding="utf-8") as f:
         f.write("---\n")
         yaml.dump(
-            lock_data, f,
+            lock_data,
+            f,
             Dumper=_IndentDumper,
             default_flow_style=False,
             sort_keys=False,

--- a/scripts/lockfile-generators/helpers/download-pip-packages.py
+++ b/scripts/lockfile-generators/helpers/download-pip-packages.py
@@ -18,6 +18,7 @@ Supports two index backends:
 Usage:
   python3 download-pip-packages.py [--arch ARCH] [-o OUTPUT_DIR] requirements.txt
 """
+
 from __future__ import annotations
 
 import argparse
@@ -25,6 +26,7 @@ import concurrent.futures
 import hashlib
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -32,7 +34,7 @@ import urllib.request
 from pathlib import Path, PurePosixPath
 from urllib.parse import urljoin
 
-from packaging.markers import Marker
+from packaging.markers import Marker, default_environment
 
 OUT_DIR = Path("cachi2/output/deps/pip")
 PYPI_JSON = "https://pypi.org/pypi/{name}/{version}/json"
@@ -64,9 +66,15 @@ def get_args():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("requirements", type=Path, help="Path to requirements.txt")
     parser.add_argument("-o", "--output-dir", type=Path, default=OUT_DIR, help=f"Output directory (default: {OUT_DIR})")
-    parser.add_argument("--arch", type=str, default=None, help="Target architecture (default: from BUILD_ARCH env or uname -m)")
-    parser.add_argument("--python-version", type=str, default=None,
-                        help="Target Python version, e.g. 3.12 (default: from RELEASE_PYTHON_VERSION env or current)")
+    parser.add_argument(
+        "--arch", type=str, default=None, help="Target architecture (default: from BUILD_ARCH env or uname -m)"
+    )
+    parser.add_argument(
+        "--python-version",
+        type=str,
+        default=None,
+        help="Target Python version, e.g. 3.12 (default: from RELEASE_PYTHON_VERSION env or current)",
+    )
     args = parser.parse_args()
 
     if args.arch is None:
@@ -75,11 +83,12 @@ def get_args():
             raw = build_arch.split("/")[-1]
             args.arch = {"amd64": "x86_64", "arm64": "aarch64"}.get(raw, raw)
         else:
-            import platform
             args.arch = platform.machine()
 
     if args.python_version is None:
-        args.python_version = os.environ.get("RELEASE_PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}")
+        args.python_version = os.environ.get(
+            "RELEASE_PYTHON_VERSION", f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
 
     req_path = args.requirements.resolve()
     if not req_path.is_file():
@@ -104,7 +113,7 @@ def parse_requirements(req_path: Path) -> list[tuple[str, str, set[str], str]]:
     packages = []
     for line in text.split("\n"):
         line = line.strip()
-        if not line or line.startswith("#") or line.startswith("--"):
+        if not line or line.startswith(("#", "--")):
             continue
         hash_parts = line.split("--hash=")
         name_ver_marker = hash_parts[0].strip()
@@ -134,16 +143,15 @@ class _PoisonString(str):
         return obj
 
     def _boom(self, *args, **kwargs):
-        raise _UnexpectedKeyAccess(super().__getattribute__("_key_name"))
+        raise _UnexpectedKeyAccessError(super().__getattribute__("_key_name"))
 
 
-class _UnexpectedKeyAccess(Exception):
+class _UnexpectedKeyAccessError(Exception):
     pass
 
 
 # Poison all comparison/operator dunders so any use in marker evaluation explodes
-for _op in ("__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__",
-            "__contains__", "__hash__"):
+for _op in ("__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__", "__contains__", "__hash__"):
     setattr(_PoisonString, _op, _PoisonString._boom)
 
 
@@ -170,12 +178,11 @@ def should_skip_for_marker(marker: str, arch: str, python_version: str) -> bool:
         "sys_platform": "linux",
     }
     # Poison any key from default_environment() that we don't explicitly control
-    from packaging.markers import default_environment
     env = {k: _PoisonString(k) for k in default_environment()}
     env.update(controlled_env)
     try:
         return not Marker(marker).evaluate(env)
-    except _UnexpectedKeyAccess as e:
+    except _UnexpectedKeyAccessError as e:
         print(f"  WARN: marker touches uncontrolled key '{e}', not skipping: {marker}", file=sys.stderr)
         return False
     except Exception:
@@ -199,12 +206,14 @@ def should_keep_for_arch(filename: str, arch: str, skip_sdists: bool) -> bool:
     return any(a in platform_tag for a in ARCH_ALIASES.get(arch, [arch]))
 
 
-def fetch_simple_index_urls(index_url: str, name: str, version: str, wanted_hashes: set[str]) -> list[tuple[str, str, str]]:
+def fetch_simple_index_urls(
+    index_url: str, name: str, version: str, wanted_hashes: set[str]
+) -> list[tuple[str, str, str]]:
     normalized = re.sub(r"[-_.]+", "-", name).lower()
     page_url = f"{index_url.rstrip('/')}/{normalized}/"
     try:
-        req = urllib.request.Request(page_url, headers={"Accept": "text/html", "User-Agent": "prefetch/1.0"})
-        with urllib.request.urlopen(req, timeout=30) as r:
+        req = urllib.request.Request(page_url, headers={"Accept": "text/html", "User-Agent": "prefetch/1.0"})  # ruff: ignore[suspicious-url-open-usage]
+        with urllib.request.urlopen(req, timeout=30) as r:  # ruff: ignore[suspicious-url-open-usage]
             html = r.read().decode()
     except Exception as e:
         print(f"  WARN: failed to fetch index page for {name}: {e}", file=sys.stderr)
@@ -225,8 +234,8 @@ def fetch_simple_index_urls(index_url: str, name: str, version: str, wanted_hash
 def fetch_pypi_urls(name: str, version: str, wanted_hashes: set[str]) -> list[tuple[str, str, str]]:
     url = PYPI_JSON.format(name=name, version=version)
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "prefetch/1.0"})
-        with urllib.request.urlopen(req, timeout=30) as r:
+        req = urllib.request.Request(url, headers={"User-Agent": "prefetch/1.0"})  # ruff: ignore[suspicious-url-open-usage]
+        with urllib.request.urlopen(req, timeout=30) as r:  # ruff: ignore[suspicious-url-open-usage]
             data = json.loads(r.read().decode())
     except Exception as e:
         print(f"  WARN: failed to fetch PyPI metadata for {name}: {e}", file=sys.stderr)
@@ -272,13 +281,19 @@ def download_one(args: tuple) -> tuple[bool, str]:
     try:
         subprocess.run(
             [
-                "wget", "-q", "-O", str(dest_path),
-                "--tries=3", "--waitretry=2",
+                "wget",
+                "-q",
+                "-O",
+                str(dest_path),
+                "--tries=3",
+                "--waitretry=2",
                 f"--timeout={WGET_NETWORK_TIMEOUT_SECONDS}",
                 url,
             ],
-            check=True, timeout=DOWNLOAD_PROCESS_TIMEOUT_SECONDS,
-            capture_output=True, text=True,
+            check=True,
+            timeout=DOWNLOAD_PROCESS_TIMEOUT_SECONDS,
+            capture_output=True,
+            text=True,
         )
     except subprocess.TimeoutExpired:
         Path(dest_path).unlink(missing_ok=True)
@@ -315,7 +330,7 @@ def main():
     is_aipcc = index_url is not None and "packages.redhat.com/api/pypi/" in index_url
     skip_sdists = is_aipcc
 
-    print(f"=== download-pip-packages.py ===")
+    print("=== download-pip-packages.py ===")
     print(f"  requirements: {req_path}")
     print(f"  output:       {out_dir}")
     print(f"  arch:         {arch}")
@@ -383,14 +398,16 @@ def main():
         if pass_num == 1:
             print(f"\nPhase 5: Downloading {len(pending)} files ({workers} parallel)...")
         else:
-            print(f"\nPhase 5 (retry {pass_num - 1}/{DOWNLOAD_MAX_PASSES - 1}): "
-                  f"{len(pending)} failed download(s), retrying sequentially...")
+            print(
+                f"\nPhase 5 (retry {pass_num - 1}/{DOWNLOAD_MAX_PASSES - 1}): "
+                f"{len(pending)} failed download(s), retrying sequentially..."
+            )
 
         retry: list[tuple[str, Path, str]] = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
             results = list(executor.map(download_one, pending))
 
-        for item, (ok, msg) in zip(pending, results):
+        for item, (ok, msg) in zip(pending, results, strict=True):
             if ok:
                 downloaded += 1
             else:

--- a/scripts/lockfile-generators/helpers/pylock-to-requirements.py
+++ b/scripts/lockfile-generators/helpers/pylock-to-requirements.py
@@ -37,6 +37,7 @@ Output format:
     If index-url is provided, it is emitted as the first line:
         --index-url https://...
 """
+
 import re
 import sys
 import tomllib
@@ -71,8 +72,7 @@ def extract_default_index_from_pylock(pylock_path: Path) -> str:
 
 def main():
     if len(sys.argv) < 3:
-        print(f"Usage: {sys.argv[0]} <pylock.toml> <requirements.txt> [index-url]",
-              file=sys.stderr)
+        print(f"Usage: {sys.argv[0]} <pylock.toml> <requirements.txt> [index-url]", file=sys.stderr)
         sys.exit(1)
 
     pylock_path = Path(sys.argv[1])
@@ -101,10 +101,7 @@ def main():
         archive = pkg.get("archive")
         if isinstance(archive, dict) and (archive_url := (archive.get("url") or "").strip()):
             # Direct URL (not on PyPI): PEP 508 "name @ URL" so prefetchers fetch this file.
-            hashes = [
-                f"--hash={algo}:{digest}"
-                for algo, digest in archive.get("hashes", {}).items()
-            ]
+            hashes = [f"--hash={algo}:{digest}" for algo, digest in archive.get("hashes", {}).items()]
             entry = f"{name} @ {archive_url}"
             if marker:
                 entry += f" ; {marker}"

--- a/scripts/monitor_resources.py
+++ b/scripts/monitor_resources.py
@@ -1,13 +1,12 @@
 #! /usr/bin/env python3
 
-import signal
 import shutil
+import signal
 import subprocess
 import sys
 import time
 
 import structlog
-
 from ci.logging_config import configure_logging
 
 configure_logging()
@@ -40,6 +39,7 @@ def get_memory_usage() -> dict[str, str]:
         result = subprocess.run(
             ["free", "-h"],
             capture_output=True,
+            check=False,
             text=True,
             timeout=5,
         )

--- a/scripts/monitor_resources.py
+++ b/scripts/monitor_resources.py
@@ -7,6 +7,7 @@ import sys
 import time
 
 import structlog
+
 from ci.logging_config import configure_logging
 
 configure_logging()

--- a/scripts/new_python_based_image.py
+++ b/scripts/new_python_based_image.py
@@ -9,7 +9,6 @@ import sys
 from dataclasses import dataclass
 
 import structlog
-
 from ci.logging_config import configure_logging
 
 LOGGER = structlog.get_logger()
@@ -30,6 +29,7 @@ class Args:
     """
     Class to encapsulate command-line arguments.
     """
+
     context_dir: str
     source: str
     target: str
@@ -46,24 +46,14 @@ def extract_input_args() -> Args:
     """
     parser = argparse.ArgumentParser(
         description="Script to create a new Python-based image from an existing one.",
-        usage="python script.py --context-dir <directory> --source <python_version_source> --target <python_version_target> --match <match> [--log-level <level>]"
+        usage="python script.py --context-dir <directory> --source <python_version_source> --target <python_version_target> --match <match> [--log-level <level>]",
     )
 
-    parser.add_argument(
-        "--context-dir",
-        help="The directory to be the context for searching.")
-    parser.add_argument(
-        "--source",
-        help="The Python version to base the new image from.")
-    parser.add_argument(
-        "--target",
-        help="The Python version to be used in the new image.")
-    parser.add_argument(
-        "--match",
-        help="The string to match with the paths to base the new image from.")
-    parser.add_argument(
-        "--log-level", default="INFO",
-        help="Set the logging level. Default: %(default)s.")
+    parser.add_argument("--context-dir", help="The directory to be the context for searching.")
+    parser.add_argument("--source", help="The Python version to base the new image from.")
+    parser.add_argument("--target", help="The Python version to be used in the new image.")
+    parser.add_argument("--match", help="The string to match with the paths to base the new image from.")
+    parser.add_argument("--log-level", default="INFO", help="Set the logging level. Default: %(default)s.")
 
     args = parser.parse_args()
 
@@ -96,9 +86,8 @@ def check_python_version(version: str) -> None:
     Args:
         version: The Python version string to validate.
     """
-    if not re.match(r'^\d+\.\d+$', version):
-        LOGGER.error(
-            f"Invalid Python version format: '{version}'. Expected format is <major>.<minor> (e.g., '3.9').")
+    if not re.match(r"^\d+\.\d+$", version):
+        LOGGER.error(f"Invalid Python version format: '{version}'. Expected format is <major>.<minor> (e.g., '3.9').")
         sys.exit(1)
 
 
@@ -134,8 +123,7 @@ def check_os_linux() -> None:
     """
     LOGGER.debug(f"Operating system: {platform.system()}")
     if platform.system() != "Linux":
-        LOGGER.error(
-            "This script can only be run on a Linux operating system.")
+        LOGGER.error("This script can only be run on a Linux operating system.")
         sys.exit(1)
 
 
@@ -175,13 +163,7 @@ def find_matching_paths(context_dir: str, source_version: str, match: str) -> li
     Returns:
         A list of directories that match the criteria and contain a Dockerfile.
     """
-    blocklist = [os.path.join(".", path) for path in [".git",
-                                                      ".github",
-                                                      "ci",
-                                                      "docs",
-                                                      "manifests",
-                                                      "scripts",
-                                                      "tests"]]
+    blocklist = [os.path.join(".", path) for path in [".git", ".github", "ci", "docs", "manifests", "scripts", "tests"]]
     matching_paths = []
     processed_dirs = set()
 
@@ -242,8 +224,7 @@ def copy_paths(paths_dict: dict) -> tuple[list[str], list[str]]:
                 success_paths.append(dst_path)
                 LOGGER.debug(f"Path '{src_path}' copied to {dst_path}")
             except Exception as e:
-                LOGGER.error(
-                    f"Error copying '{src_path}' to '{dst_path}': {e}")
+                LOGGER.error(f"Error copying '{src_path}' to '{dst_path}': {e}")
                 failed_paths.append(dst_path)
 
     return success_paths, failed_paths
@@ -264,8 +245,7 @@ def replace_python_version_in_file(file_path: str, source_version: str, target_v
         with open(file_path, "r") as file:
             content = file.read()
 
-        content = replace_python_version_in_content(
-            content, source_version, target_version)
+        content = replace_python_version_in_content(content, source_version, target_version)
 
         with open(file_path, "w") as file:
             file.write(content)
@@ -289,21 +269,16 @@ def replace_python_version_in_content(content: str, source_version: str, target_
     target_major, target_minor = extract_python_version(target_version)
 
     # Example: 3.9 -> 3.11
-    result = content.replace(source_version,
-                             target_version)
+    result = content.replace(source_version, target_version)
 
     # Example: 3-9 -> 3-11
-    result = result.replace(
-        f"{source_major}-{source_minor}",
-        f"{target_major}-{target_minor}")
+    result = result.replace(f"{source_major}-{source_minor}", f"{target_major}-{target_minor}")
 
     # Example: python-39 -> python-311
-    result = result.replace(f"python-{source_major}{source_minor}",
-                            f"python-{target_major}{target_minor}")
+    result = result.replace(f"python-{source_major}{source_minor}", f"python-{target_major}{target_minor}")
 
     # Example: py39 -> py-311
-    result = result.replace(f"py{source_major}{source_minor}",
-                            f"py{target_major}{target_minor}")
+    result = result.replace(f"py{source_major}{source_minor}", f"py{target_major}{target_minor}")
 
     return result
 
@@ -320,9 +295,9 @@ def dict_to_str(dictionary: dict, enumerate_lines=False) -> str:
         The string representation of the dictionary.
     """
     if enumerate_lines:
-        return '\n'.join(f"{i + 1}. '{k}' -> '{v}'" for i, (k, v) in enumerate(dictionary.items()))
+        return "\n".join(f"{i + 1}. '{k}' -> '{v}'" for i, (k, v) in enumerate(dictionary.items()))
     else:
-        return '\n'.join(f"'{k}' -> '{v}'" for k, v in dictionary.items())
+        return "\n".join(f"'{k}' -> '{v}'" for k, v in dictionary.items())
 
 
 def list_to_str(lst: list, enumerate_lines=False) -> str:
@@ -345,8 +320,8 @@ def list_to_str(lst: list, enumerate_lines=False) -> str:
 @contextlib.contextmanager
 def logged_execution(title: str):
     """Usage:
-            > with logged_execution("launching rockets"):
-            > ...     result = launch_rockets()
+    > with logged_execution("launching rockets"):
+    > ...     result = launch_rockets()
     """
     LOGGER.info(f"{title}...")
     try:
@@ -371,37 +346,24 @@ def replace_version_in_directory(directory_path: str, source_version: str, targe
 
     def rename_file_and_replace_python_version(path, filename, source_version, target_version, is_file=True) -> str:
         old_path = os.path.join(path, filename)
-        new_filename = replace_python_version_in_content(filename,
-                                                         source_version,
-                                                         target_version)
+        new_filename = replace_python_version_in_content(filename, source_version, target_version)
         new_path = os.path.join(path, new_filename)
 
         if old_path != new_path:
             os.rename(old_path, new_path)
-            LOGGER.debug(
-                f"Renamed {'file' if is_file else 'directory'}: {old_path} -> {new_path}")
+            LOGGER.debug(f"Renamed {'file' if is_file else 'directory'}: {old_path} -> {new_path}")
 
         if is_file:
-            replace_python_version_in_file(new_path,
-                                           source_version,
-                                           target_version)
+            replace_python_version_in_file(new_path, source_version, target_version)
 
         return new_path
 
     for root, dirs, files in os.walk(directory_path, topdown=False):
         for file_name in files:
-            rename_file_and_replace_python_version(root,
-                                                   file_name,
-                                                   source_version,
-                                                   target_version,
-                                                   is_file=True)
+            rename_file_and_replace_python_version(root, file_name, source_version, target_version, is_file=True)
 
         for dir_name in dirs:
-            rename_file_and_replace_python_version(root,
-                                                   dir_name,
-                                                   source_version,
-                                                   target_version,
-                                                   is_file=False)
+            rename_file_and_replace_python_version(root, dir_name, source_version, target_version, is_file=False)
 
 
 def process_paths(copied_paths: list, source_version: str, target_version: str) -> tuple[list[str], list[str]]:
@@ -472,10 +434,9 @@ def run_pipenv_lock(pipfile_path: str, target_version: str) -> bool:
             ["pipenv", "lock", "--python", target_version],
             cwd=os.path.dirname(pipfile_path),
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             env=env,
-            encoding="utf-8"
+            encoding="utf-8",
         )
         LOGGER.debug(result.stdout)
         return True
@@ -496,7 +457,7 @@ def manual_checks() -> list[str]:
         "Check if the Python version replacements have been performed correctly on the new files.",
         "Review and make the appropriate changes in the Makefile and CI-related files.",
         "Push the changes to a new branch on your fork to build the new images with GitHub workflows.",
-        "Test the new images."
+        "Test the new images.",
     ]
 
 
@@ -511,43 +472,42 @@ def main():
     with logged_execution(f"Finding matching paths with '{args.match}' and Python {args.source}"):
         paths = find_matching_paths(args.context_dir, args.source, args.match)
 
-    paths_dict = replace_python_version_on_paths(paths,
-                                                 args.source,
-                                                 args.target)
+    paths_dict = replace_python_version_on_paths(paths, args.source, args.target)
 
     if len(paths_dict) == 0:
         LOGGER.info("No paths found to copy.")
         sys.exit(1)
 
-    LOGGER.info(
-        f"New folder(s) based on the input args:\n{dict_to_str(paths_dict, enumerate_lines=True)}")
+    LOGGER.info(f"New folder(s) based on the input args:\n{dict_to_str(paths_dict, enumerate_lines=True)}")
 
     with logged_execution(f"Trying to copy {len(paths_dict)} folder(s)"):
         success_copied_paths, failed_copied_paths = copy_paths(paths_dict)
 
     LOGGER.info(
-        f"{len(success_copied_paths)} folder(s) have been copied successfully whereas {len(failed_copied_paths)} failed.")
+        f"{len(success_copied_paths)} folder(s) have been copied successfully whereas {len(failed_copied_paths)} failed."
+    )
 
     exit_code = 0
 
     if len(failed_copied_paths) > 0:
         LOGGER.warning(
-            f"Failed to copy the following folder(s):\n{list_to_str(failed_copied_paths, enumerate_lines=True)}")
+            f"Failed to copy the following folder(s):\n{list_to_str(failed_copied_paths, enumerate_lines=True)}"
+        )
         exit_code = 1
 
     if len(success_copied_paths) > 0:
         with logged_execution("Processing copied folders"):
-            _, failed_processed = process_paths(success_copied_paths,
-                                                args.source,
-                                                args.target)
+            _, failed_processed = process_paths(success_copied_paths, args.source, args.target)
 
         if len(failed_processed) > 0:
             LOGGER.warning(
-                f"Failed to process the following lock files:\n{list_to_str(failed_processed, enumerate_lines=True)}")
+                f"Failed to process the following lock files:\n{list_to_str(failed_processed, enumerate_lines=True)}"
+            )
             exit_code = 1
 
     LOGGER.info(
-        f"Manual checks to perform after the script execution:\n{list_to_str(manual_checks(), enumerate_lines=True)}")
+        f"Manual checks to perform after the script execution:\n{list_to_str(manual_checks(), enumerate_lines=True)}"
+    )
 
     sys.exit(exit_code)
 

--- a/scripts/new_python_based_image.py
+++ b/scripts/new_python_based_image.py
@@ -9,6 +9,7 @@ import sys
 from dataclasses import dataclass
 
 import structlog
+
 from ci.logging_config import configure_logging
 
 LOGGER = structlog.get_logger()

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -128,6 +128,8 @@ class IndexMode(StrEnum):
     auto = "auto"
     rh_index = "rh-index"
     public_index = "public-index"
+
+
 # endregion
 
 
@@ -180,6 +182,8 @@ class LogBuffer:
             sys.stdout.write("\n".join(self._lines) + "\n")
             sys.stdout.flush()
             self._lines.clear()
+
+
 # endregion
 
 
@@ -247,7 +251,7 @@ def _list_changed_files(from_ref: str, to_ref: str = "HEAD") -> list[str]:
     cached_builds = ROOT_DIR / "ci" / "cached-builds"
     if str(cached_builds) not in sys.path:
         sys.path.insert(0, str(cached_builds))
-    import gha_pr_changed_files
+    import gha_pr_changed_files  # ruff: ignore[import-outside-top-level]
 
     return gha_pr_changed_files.list_changed_files(from_ref, to_ref)
 
@@ -402,6 +406,8 @@ def resolve_exclude_newer(
         return live_timestamp
     parsed = parse_exclude_newer_from_lockfile(lockfile)
     return parsed if parsed is not None else live_timestamp
+
+
 # endregion
 
 
@@ -519,9 +525,7 @@ def run_lock(
     cmd.extend(["--constraints", relative_constraints, "--override", relative_overrides])
 
     lock_path = project_dir / output
-    exclude_newer = resolve_exclude_newer(
-        lock_path, ci_check=ci_check, live_timestamp=live_timestamp
-    )
+    exclude_newer = resolve_exclude_newer(lock_path, ci_check=ci_check, live_timestamp=live_timestamp)
     cmd.append(f"--exclude-newer={exclude_newer}")
 
     cmd.extend(index_flags)
@@ -534,15 +538,9 @@ def run_lock(
     extra_idx = lock_extra_index_flags_from_env()
     if extra_idx:
         cmd.extend(extra_idx)
-        log.print(
-            "  📎 Extra lock indexes from UV_LOCK_EXTRA_INDEX_URL / PIP_LOCK_EXTRA_INDEX_URL"
-        )
+        log.print("  📎 Extra lock indexes from UV_LOCK_EXTRA_INDEX_URL / PIP_LOCK_EXTRA_INDEX_URL")
 
-    compile_env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in ("UV_EXTRA_INDEX_URL", "PIP_EXTRA_INDEX_URL")
-    }
+    compile_env = {k: v for k, v in os.environ.items() if k not in ("UV_EXTRA_INDEX_URL", "PIP_EXTRA_INDEX_URL")}
 
     try:
         result = subprocess.run(
@@ -585,9 +583,7 @@ def generate_requirements_txt(
 
     cmd = [sys.executable, str(PYLOCK_TO_REQUIREMENTS), str(pylock_path), str(requirements_path)]
     if resolved is None:
-        log.warning(
-            f"Falling back to --default-index recorded in {pylock_path} for requirements generation."
-        )
+        log.warning(f"Falling back to --default-index recorded in {pylock_path} for requirements generation.")
     else:
         cmd.append(resolved.index_url)
 
@@ -691,6 +687,8 @@ def process_directory(
                 dir_success = False
 
     return tdir, dir_success, log
+
+
 # endregion
 
 
@@ -702,11 +700,13 @@ def main(
     index_mode: Annotated[
         IndexMode, typer.Argument(help="Index mode: auto, rh-index, or public-index")
     ] = IndexMode.auto,
-    target_dir: Annotated[
-        Path | None, typer.Argument(help="Specific project directory to process")
-    ] = None,
+    target_dir: Annotated[Path | None, typer.Argument(help="Specific project directory to process")] = None,
     requirements_only: Annotated[
-        bool, typer.Option("--requirements-only", help="Only regenerate requirements.txt from existing pylock files, skip lock generation")
+        bool,
+        typer.Option(
+            "--requirements-only",
+            help="Only regenerate requirements.txt from existing pylock files, skip lock generation",
+        ),
     ] = False,
     pr_base: Annotated[
         str | None,
@@ -803,7 +803,9 @@ def main(
         log.warning("Failed lock generation for:")
         for d in sorted(failed_dirs):
             log.print(f"  • {d}")
-            log.print("Please comment out the missing package to continue and report the missing package to the RH index maintainers")
+            log.print(
+                "Please comment out the missing package to continue and report the missing package to the RH index maintainers"
+            )
         raise SystemExit(1)
 
 

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -8,11 +8,11 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import cast, Literal
+from typing import Literal, cast
 
 import structlog
-
 from ci.logging_config import configure_logging
+
 from scripts.buildinputs_runner import buildinputs
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
@@ -29,19 +29,19 @@ class Args(argparse.Namespace):
 def main() -> int:
     p = argparse.ArgumentParser(allow_abbrev=False)
     p.add_argument("--dockerfile", type=pathlib.Path, required=True)
-    p.add_argument("--platform", type=str,
-                   choices=["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"],
-                   required=True)
-    p.add_argument('remaining', nargs=argparse.REMAINDER)
+    p.add_argument(
+        "--platform", type=str, choices=["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"], required=True
+    )
+    p.add_argument("remaining", nargs=argparse.REMAINDER)
 
-    args = cast(Args, p.parse_args())
+    args = cast("Args", p.parse_args())
 
     print(f"{__file__=} started with {args=}")
 
     if not args.remaining or args.remaining[0] != "--":
         print("must specify command to execute after double dashes at the end, such as `-- command --args ...`")
         return 1
-    if not "{};" in args.remaining:
+    if "{};" not in args.remaining:
         print("must give a `{};` parameter that will be replaced with new build context")
         return 1
 
@@ -113,11 +113,11 @@ def _ignored_dir_names(root: pathlib.Path) -> tuple[set[str], set[str]]:
 
 
 def _ignore_dirname(
-        dirname: str,
-        *,
-        root_only_ignore: set[str],
-        any_depth_ignore: set[str],
-        parent_at_repo_root: bool,
+    dirname: str,
+    *,
+    root_only_ignore: set[str],
+    any_depth_ignore: set[str],
+    parent_at_repo_root: bool,
 ) -> bool:
     if dirname in any_depth_ignore:
         return True
@@ -125,12 +125,12 @@ def _ignore_dirname(
 
 
 def _copy_tree(
-        src: pathlib.Path,
-        dst: pathlib.Path,
-        *,
-        repo_base_rel: pathlib.Path | None = None,
-        root_only_ignore: set[str] | None = None,
-        any_depth_ignore: set[str] | None = None,
+    src: pathlib.Path,
+    dst: pathlib.Path,
+    *,
+    repo_base_rel: pathlib.Path | None = None,
+    root_only_ignore: set[str] | None = None,
+    any_depth_ignore: set[str] | None = None,
 ):
     """Copy a directory tree, copying only file content (no metadata/xattrs).
 
@@ -164,13 +164,13 @@ def _copy_tree(
 
 
 def _copy_tree_dir(
-        src_dir: pathlib.Path,
-        dst_dir: pathlib.Path,
-        rel: pathlib.Path,
-        repo_base_rel: pathlib.Path,
-        root_only_ignore: set[str],
-        any_depth_ignore: set[str],
-        ancestor_realpaths: frozenset[str],
+    src_dir: pathlib.Path,
+    dst_dir: pathlib.Path,
+    rel: pathlib.Path,
+    repo_base_rel: pathlib.Path,
+    root_only_ignore: set[str],
+    any_depth_ignore: set[str],
+    ancestor_realpaths: frozenset[str],
 ) -> None:
     real_dir = os.path.realpath(src_dir)
     if real_dir in ancestor_realpaths:
@@ -232,7 +232,7 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
         # The buildinputs tool emits these patterns verbatim from COPY/ADD directives,
         # so we must expand them here before the existence check — a literal path like
         # "patches/*.patch" does not exist on disk and would otherwise trigger sys.exit(1).
-        if any(c in str(dep) for c in ('*', '?', '[')):
+        if any(c in str(dep) for c in ("*", "?", "[")):
             matched = sorted(glob.glob(str(dep)))
             if not matched:
                 log.warning(f"glob pattern matched no files: {dep}")
@@ -253,7 +253,9 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
             continue
 
         if not dep.exists():
-            log.error(f"File or directory '{dep}' referenced in the Dockerfile was not found on disk. Please ensure the file exists.")
+            log.error(
+                f"File or directory '{dep}' referenced in the Dockerfile was not found on disk. Please ensure the file exists."
+            )
             sys.exit(1)
 
         if dep.is_dir():
@@ -269,6 +271,6 @@ def setup_sandbox(prereqs: list[pathlib.Path], tmpdir: pathlib.Path):
             shutil.copy(dep, tmpdir / dep.parent)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     configure_logging()
     sys.exit(main())

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -11,8 +11,8 @@ import tempfile
 from typing import Literal, cast
 
 import structlog
-from ci.logging_config import configure_logging
 
+from ci.logging_config import configure_logging
 from scripts.buildinputs_runner import buildinputs
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -1,13 +1,17 @@
 #! /usr/bin/env python3
+from __future__ import annotations
 
 import pathlib
 import tempfile
+from typing import TYPE_CHECKING
 
-import pyfakefs.fake_filesystem
 import pytest
-
 from ci.logging_config import configure_logging
+
 from scripts.sandbox import _copy_tree, _ignored_dir_names, _load_dockerignore, setup_sandbox
+
+if TYPE_CHECKING:
+    import pyfakefs.fake_filesystem
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
 
@@ -67,9 +71,7 @@ class TestLoadDockerignore:
         assert _load_dockerignore(repo_root) == []
 
     def test_skips_comments_and_blank_lines(self, repo_root: pathlib.Path):
-        (repo_root / ".dockerignore").write_text(
-            "# this is a comment\n\n**/node_modules/\n  \n.pnpm-store/\n"
-        )
+        (repo_root / ".dockerignore").write_text("# this is a comment\n\n**/node_modules/\n  \n.pnpm-store/\n")
         result = _load_dockerignore(repo_root)
         assert result == ["**/node_modules/", ".pnpm-store/"]
 
@@ -112,10 +114,21 @@ class TestIgnoredDirNames:
     def test_real_dockerignore(self):
         root_only, any_depth = _ignored_dir_names(ROOT_DIR)
         assert root_only == {
-            "bin", "ci", "tests", ".idea", "env", "venv", ".venv", "docs", "examples",
+            "bin",
+            "ci",
+            "tests",
+            ".idea",
+            "env",
+            "venv",
+            ".venv",
+            "docs",
+            "examples",
         }
         assert any_depth == {
-            "node_modules", ".mypy_cache", ".pytest_cache", "__pycache__",
+            "node_modules",
+            ".mypy_cache",
+            ".pytest_cache",
+            "__pycache__",
         }
 
 

--- a/scripts/sandbox_tests.py
+++ b/scripts/sandbox_tests.py
@@ -6,8 +6,8 @@ import tempfile
 from typing import TYPE_CHECKING
 
 import pytest
-from ci.logging_config import configure_logging
 
+from ci.logging_config import configure_logging
 from scripts.sandbox import _copy_tree, _ignored_dir_names, _load_dockerignore, setup_sandbox
 
 if TYPE_CHECKING:

--- a/scripts/test_buildinputs_runner.py
+++ b/scripts/test_buildinputs_runner.py
@@ -85,9 +85,7 @@ def test_local_buildinputs(monkeypatch, tmp_path):
 
 def test_buildinputs_dispatches_to_container_in_ci(monkeypatch):
     monkeypatch.setenv("CI", "true")
-    monkeypatch.setattr(
-        buildinputs_runner, "containarized_buildinputs", lambda *a, **kw: '["a.txt"]\n'
-    )
+    monkeypatch.setattr(buildinputs_runner, "containarized_buildinputs", lambda *a, **kw: '["a.txt"]\n')
 
     result = buildinputs_runner.buildinputs("Dockerfile")
     assert result == [pathlib.Path("a.txt")]
@@ -95,9 +93,7 @@ def test_buildinputs_dispatches_to_container_in_ci(monkeypatch):
 
 def test_buildinputs_dispatches_to_local_outside_ci(monkeypatch):
     monkeypatch.delenv("CI", raising=False)
-    monkeypatch.setattr(
-        buildinputs_runner, "local_buildinputs", lambda *a, **kw: '["b.txt"]\n'
-    )
+    monkeypatch.setattr(buildinputs_runner, "local_buildinputs", lambda *a, **kw: '["b.txt"]\n')
 
     result = buildinputs_runner.buildinputs("Dockerfile")
     assert result == [pathlib.Path("b.txt")]

--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -53,6 +53,7 @@ import urllib.parse
 import urllib.request
 
 import structlog
+
 from ci.logging_config import configure_logging
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent

--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -38,6 +38,7 @@ Usage (run from the repo root):
   # Both variants at once:
   ./uv run scripts/update-commit-latest-env.py --variant both
 """
+
 from __future__ import annotations
 
 import argparse
@@ -52,7 +53,6 @@ import urllib.parse
 import urllib.request
 
 import structlog
-
 from ci.logging_config import configure_logging
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent
@@ -179,9 +179,9 @@ def write_commit_env(entries: list[tuple[str, str]], dest: pathlib.Path) -> None
 
 
 def _fetch_quay_json(url: str) -> dict:
-    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})  # ruff: ignore[suspicious-url-open-usage]
     try:
-        with urllib.request.urlopen(request, timeout=SKOPEO_TIMEOUT_SEC) as response:
+        with urllib.request.urlopen(request, timeout=SKOPEO_TIMEOUT_SEC) as response:  # ruff: ignore[suspicious-url-open-usage]
             payload = json.loads(response.read().decode())
     except (urllib.error.URLError, TimeoutError) as exc:
         msg = f"Quay API request failed for {url}: {exc}"
@@ -203,8 +203,7 @@ async def quay_list_matching_tags(repository: str, pattern: re.Pattern) -> list[
 
     while page <= MAX_QUAY_PAGES:
         url = (
-            f"{QUAY_API_BASE}/repository/{namespace}/{repo}/tag/"
-            f"?limit={QUAY_PAGE_SIZE}&page={page}&onlyActiveTags=true"
+            f"{QUAY_API_BASE}/repository/{namespace}/{repo}/tag/?limit={QUAY_PAGE_SIZE}&page={page}&onlyActiveTags=true"
         )
         try:
             payload = await asyncio.to_thread(_fetch_quay_json, url)
@@ -283,9 +282,12 @@ async def skopeo_inspect_config(
 ) -> tuple[str, dict | None]:
     """Return (image_url, config) from skopeo inspect --config, or (image_url, None) on failure."""
     cmd = [
-        "skopeo", "inspect",
-        "--override-os=linux", "--override-arch=amd64",
-        "--retry-times=3", "--config",
+        "skopeo",
+        "inspect",
+        "--override-os=linux",
+        "--override-arch=amd64",
+        "--retry-times=3",
+        "--config",
         f"docker://{image_url}",
     ]
     try:
@@ -311,7 +313,7 @@ async def skopeo_inspect_config(
         log.error("failed to parse skopeo JSON", image=image_url)
         return image_url, None
     except Exception:
-        log.error("unexpected error", image=image_url, exc_info=True)
+        log.exception("unexpected error", image=image_url)
         return image_url, None
 
 
@@ -328,9 +330,9 @@ async def find_latest_tag_by_skopeo_created(
         return None
 
     log.info("found candidate tags via skopeo", image=image, count=len(matching))
-    inspected = await asyncio.gather(*[
-        skopeo_inspect_config(f"{image}:{tag}", semaphore, log_failure=False) for tag in matching
-    ])
+    inspected = await asyncio.gather(
+        *[skopeo_inspect_config(f"{image}:{tag}", semaphore, log_failure=False) for tag in matching]
+    )
 
     best_tag: str | None = None
     best_created = ""
@@ -410,9 +412,7 @@ async def find_latest_rhoai_tag_by_created(
         return None
 
     log.info("found RHOAI candidate tags", image=image, count=len(matching))
-    inspected = await asyncio.gather(*[
-        skopeo_inspect_config(f"{image}:{tag}", semaphore) for tag in matching
-    ])
+    inspected = await asyncio.gather(*[skopeo_inspect_config(f"{image}:{tag}", semaphore) for tag in matching])
 
     best_tag: str | None = None
     best_created = ""
@@ -443,9 +443,7 @@ async def collect_odh_entries(
             return None
         return commit_env_key(variable), vcs_ref
 
-    results = await asyncio.gather(*[
-        process_one(variable, odh_url) for variable, odh_url in workbench_images
-    ])
+    results = await asyncio.gather(*[process_one(variable, odh_url) for variable, odh_url in workbench_images])
     if any(result is None for result in results):
         return None
     return list(results)
@@ -494,9 +492,7 @@ async def collect_rhoai_entries(
             return None
         return commit_env_key(variable), vcs_ref[:7]
 
-    results = await asyncio.gather(*[
-        process_one(variable, odh_url) for variable, odh_url in workbench_images
-    ])
+    results = await asyncio.gather(*[process_one(variable, odh_url) for variable, odh_url in workbench_images])
     if any(result is None for result in results):
         return None
     entries = [entry for entry in results if entry and entry[0]]

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -74,8 +74,8 @@ MAKEFILE_ASSIGNMENT_RE = re.compile(r"^(?P<prefix>\s*(?P<key>[A-Za-z_][A-Za-z0-9
 
 BASE_IMAGE_SCHEMA = {
     "cpu": CPU_BASE_IMAGE_SCHEMA,
-    "cuda": {flavor: None for flavor in GPU_FLAVORS["cuda"]},
-    "rocm": {flavor: None for flavor in GPU_FLAVORS["rocm"]},
+    "cuda": dict.fromkeys(GPU_FLAVORS["cuda"]),
+    "rocm": dict.fromkeys(GPU_FLAVORS["rocm"]),
 }
 
 ROOT_SCHEMA = {
@@ -148,7 +148,7 @@ class VersionsConfig:
             raise ValueError("CPU does not use acc_version")
         if flavor is None:
             raise ValueError(f"Flavor is required for accelerator '{accelerator}'")
-        return self.gpu_acc_versions[(accelerator, flavor)]
+        return self.gpu_acc_versions[accelerator, flavor]
 
 
 @dataclass(frozen=True)
@@ -533,7 +533,7 @@ def normalize_base_image_config(
                 release=release,
             )
             normalized_base_image[accelerator][flavor] = normalized_flavor
-            gpu_acc_versions[(accelerator, flavor)] = shared_version
+            gpu_acc_versions[accelerator, flavor] = shared_version
 
     return normalized_base_image, gpu_acc_versions
 
@@ -868,7 +868,7 @@ def inspect_image_config(image: str, *, warning_color: str | None = None) -> dic
     return payload
 
 
-def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | None | object:
+def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | object | None:
     config_payload = inspect_image_config(image, warning_color="red")
     if config_payload is None:
         return _STABLE_ACC_VERSION_INSPECT_FAILED
@@ -909,8 +909,8 @@ def inspect_rhds_stable_acc_version(image: str, accelerator: str) -> str | None 
 def cached_rhds_stable_acc_version(
     image: str,
     accelerator: str,
-    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
-) -> str | None | object:
+    stable_acc_version_cache: dict[tuple[str, str], str | object | None],
+) -> str | object | None:
     cache_key = (image, accelerator)
     if cache_key not in stable_acc_version_cache:
         stable_acc_version_cache[cache_key] = inspect_rhds_stable_acc_version(image, accelerator)
@@ -944,7 +944,7 @@ def resolve_matching_published_rhds_stable_image(
     accelerator: str,
     configured_acc_version: str,
     tag_cache: dict[str, tuple[str, ...]] | None,
-    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
+    stable_acc_version_cache: dict[tuple[str, str], str | object | None],
 ) -> str:
     configured_normalized = normalize_stream_version(configured_acc_version)
     candidates = sorted(
@@ -1298,7 +1298,7 @@ def resolve_rhds_base_image(
     state: TargetState,
     release: ReleaseConfig,
     tag_cache: dict[str, tuple[str, ...]],
-    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
+    stable_acc_version_cache: dict[tuple[str, str], str | object | None],
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
     stable_repo_overrides: dict[str, str] | None = None,
@@ -1351,7 +1351,8 @@ def resolve_rhds_base_image(
         candidate = f"{repository}:{build_rhds_seed_tag(target_release_version, bundle_seed_phase)}"
     elif treat_as_rhds_stable_tag(current_base_image, current_tag):
         stable_match = RHDS_STABLE_TAG_RE.fullmatch(current_tag)
-        assert stable_match is not None
+        if stable_match is None:
+            raise ValueError(f"stable tag did not match expected pattern: {current_tag}")
         current_version = parse_release_version(stable_match.group("version"))
         target_version = parse_release_version(target_release_version)
         if current_version > target_version:
@@ -1426,7 +1427,7 @@ def build_target_base_image(
     state: TargetState,
     release: ReleaseConfig,
     tag_cache: dict[str, tuple[str, ...]],
-    stable_acc_version_cache: dict[tuple[str, str], str | None | object],
+    stable_acc_version_cache: dict[tuple[str, str], str | object | None],
     rhds_bundle_phase_known: bool,
     rhds_bundle_phase: str | None,
     stable_repo_overrides: dict[str, str] | None = None,
@@ -1535,7 +1536,7 @@ def plan_updates(
 ) -> list[PlannedUpdate]:
     states: list[TargetState] = []
     tag_cache: dict[str, tuple[str, ...]] = {}
-    stable_acc_version_cache: dict[tuple[str, str], str | None | object] = {}
+    stable_acc_version_cache: dict[tuple[str, str], str | object | None] = {}
     source_tag_by_digest: dict[str, str] = {}
     digest_cache: dict[str, str] = {}
     digest_to_tag_by_repository: dict[str, dict[str, str]] = {}


### PR DESCRIPTION
Closes #4270

## Summary

The Ruff pre-commit hooks currently skip every Python file under `scripts/`, so the repository's normal `prek --all-files` check does not cover that directory. This adds `scripts` to both the `ruff-check` and `ruff-format` file scopes and to `pyproject.toml`'s `[tool.ruff] include` list.

Bringing an unlinted directory under Ruff immediately surfaces every pre-existing violation, so this PR also fixes the ~20 affected files in `scripts/` (formatting, unused imports, exception handling, argument wrapping, etc.) so that `ruff check` and `ruff format --check` pass on the new scope. It is not a pure config-scope change.

## Testing

- `ruff check scripts/` — all checks pass
- `ruff format --check scripts/` — all files already formatted
- `ruff check .` on the full repo shows no new failures introduced by this change
- `pytest scripts/sandbox_tests.py scripts/test_buildinputs_runner.py scripts/ci/` — 27 passed
- `pytest tests/unit/scripts/` (CVE test suite, covers the `scripts/cve/__init__.py` → `common.py` split and `jira_auth.py`/`jira_client.py` changes) — 308 passed

Signed-off-by: tomatotomata <tomatotomata@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated formatting and linting checks for Python and type stub files in the `scripts/` directory.
  * Improved validation error reporting and lint handling without changing expected script behavior.
  * Standardized formatting across maintenance scripts and tests for improved consistency.
  * Clarified handling of subprocess results and unexpected errors in maintenance tooling.
  * Refined type annotations and validation logic for more consistent static analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
