### PR TITLE
NO-JIRA: chore: add c9s tag to sclorg base FROM pins and document renovate regex limits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -122,6 +122,8 @@
         // Workbenches and runtimes only — excludes base-images/
         "/(jupyter|codeserver|runtimes)/.+/build-args/konflux\\..+\\.conf$/",
       ],
+      // Requires repo:tag (not digest-only repo@sha256); registry hosts with
+      // embedded ports (host:5000/…) are out of scope for quay.io / registry.redhat.io.
       "matchStrings": [
         "BASE_IMAGE=(?<depName>[^:@\\s]+(?:/[^:@\\s]+)+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?",
       ],

--- a/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
@@ -8,7 +8,7 @@ COPY base-images/utils/fix-permissions /mnt/usr/bin/
 # base             #
 ####################
 # quay.io/sclorg/python-312-c9s:c9s
-FROM quay.io/sclorg/python-312-c9s@sha256:34c5b605918f850e3801a109aa4ea717bd3a3999f8f1e192f4f7a6c88a1cf710 AS base
+FROM quay.io/sclorg/python-312-c9s:c9s@sha256:34c5b605918f850e3801a109aa4ea717bd3a3999f8f1e192f4f7a6c88a1cf710 AS base
 
 USER 0
 ARG TARGETARCH

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -8,7 +8,7 @@ COPY base-images/utils/fix-permissions /mnt/usr/bin/
 # base             #
 ####################
 # quay.io/sclorg/python-312-c9s:c9s
-FROM quay.io/sclorg/python-312-c9s@sha256:34c5b605918f850e3801a109aa4ea717bd3a3999f8f1e192f4f7a6c88a1cf710 AS base
+FROM quay.io/sclorg/python-312-c9s:c9s@sha256:34c5b605918f850e3801a109aa4ea717bd3a3999f8f1e192f4f7a6c88a1cf710 AS base
 
 USER 0
 ARG TARGETARCH

--- a/base-images/rocm/7.14/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/7.14/c9s-python-3.12/Dockerfile.rocm
@@ -8,7 +8,7 @@ COPY base-images/utils/fix-permissions /mnt/usr/bin/
 # base             #
 ####################
 # quay.io/sclorg/python-312-c9s:c9s
-FROM quay.io/sclorg/python-312-c9s@sha256:34c5b605918f850e3801a109aa4ea717bd3a3999f8f1e192f4f7a6c88a1cf710 AS base
+FROM quay.io/sclorg/python-312-c9s:c9s@sha256:34c5b605918f850e3801a109aa4ea717bd3a3999f8f1e192f4f7a6c88a1cf710 AS base
 
 USER 0
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Add explicit `:c9s` tag to digest-pinned `quay.io/sclorg/python-312-c9s` `FROM` lines in c9s base-image Dockerfiles (cuda 12.9/13.0, rocm 7.14).
- Document konflux `BASE_IMAGE` custom-regex limitations in `.github/renovate.json5` (requires `repo:tag`, no port-qualified registries).

## Test plan
- [ ] CI `validate-renovate-config` / `pytest-tests` pass
- [ ] No functional image change expected (same digest pinned)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated CUDA and ROCm Python 3.12 base image references to include the `c9s` tag while preserving the existing image digests.
* **Documentation**
  * Clarified supported base-image matching syntax, including required repository tags and limitations for digest-only references and registries using embedded ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->