### PR TITLE
Fix manifests tests

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -27,14 +27,8 @@ set -euo pipefail
 # When PRODUCT=rhoai, validate the RHOAI manifests; otherwise default to ODH.
 if [ "${PRODUCT:-odh}" = 'rhoai' ]; then
     _MANIFESTS_VARIANT="rhoai"
-    # This value needs to be updated everytime we deliberately change number of the
-    # images we want to have in the commit env files.
-    EXPECTED_COMMIT_NUM_RECORDS=43
 else
     _MANIFESTS_VARIANT="odh"
-    # This value needs to be updated everytime we deliberately change number of the
-    # images we want to have in the commit env files.
-    EXPECTED_COMMIT_NUM_RECORDS=22
 fi
 
 COMMIT_LATEST_ENV_PATH="manifests/${_MANIFESTS_VARIANT}/base/commit-latest.env"
@@ -139,6 +133,13 @@ function check_variables_uniq() {
 
     echo "---------------------------------------------"
     return "${ret_code}"
+}
+
+function discover_expected_commit_num_records() {
+    # Commit env files track only workbench images. Derive the expected number
+    # from params files and exclude pipeline runtime entries.
+    sed '/^$/d;/^[[:space:]]*#/d' "${PARAMS_ENV_PATH}" "${PARAMS_LATEST_ENV_PATH}" \
+        | awk -F '=' '$1 !~ /^odh-pipeline-runtime-/ { count++ } END { print count + 0 }'
 }
 
 function check_image_variable_matches_name_and_commitref_and_size() {
@@ -1024,7 +1025,8 @@ ret_code=0
 echo "Starting check of image references in files: '${COMMIT_LATEST_ENV_PATH}', '${COMMIT_ENV_PATH}' , '${PARAMS_LATEST_ENV_PATH}' and '${PARAMS_ENV_PATH}'"
 echo "---------------------------------------------"
 
-EXPECTED_NUM_RECORDS="${EXPECTED_COMMIT_NUM_RECORDS}"
+EXPECTED_NUM_RECORDS=$(discover_expected_commit_num_records)
+echo "Discovered expected commit record count: '${EXPECTED_NUM_RECORDS}'"
 check_variables_uniq "${COMMIT_ENV_PATH}" "${COMMIT_LATEST_ENV_PATH}" "true" "true" || {
     echo "ERROR: Variable names in the '${COMMIT_ENV_PATH}' & '${COMMIT_LATEST_ENV_PATH}' file failed validation!"
     echo "----------------------------------------------------"

--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -142,6 +142,20 @@ function discover_expected_commit_num_records() {
         | awk -F '=' '$1 !~ /^odh-pipeline-runtime-/ { count++ } END { print count + 0 }'
 }
 
+function get_rhoai_quay_fallback_image_url() {
+    local image_url="${1}"
+
+    if [ "${_MANIFESTS_VARIANT}" != "rhoai" ]; then
+        return 0
+    fi
+
+    if [[ "${image_url}" != registry.redhat.io/rhoai/*@sha256:* ]]; then
+        return 0
+    fi
+
+    echo "${image_url}" | sed 's#^registry.redhat.io/rhoai/#quay.io/rhoai/#'
+}
+
 function check_image_variable_matches_name_and_commitref_and_size() {
     local image_variable="${1}"
     local image_name="${2}"
@@ -892,6 +906,7 @@ function check_image_repo_name() {
 function check_image() {
     local image_variable="${1}"
     local image_url="${2}"
+    local image_url_for_inspect="${image_url}"
 
     echo "Checking metadata for image '${image_variable}' with URL '${image_url}'"
 
@@ -901,10 +916,21 @@ function check_image() {
     local image_commitref
     local image_created
 
-    image_metadata_config="$(skopeo inspect --retry-times "${SKOPEO_RETRY}" --override-arch amd64 --override-os linux --config "docker://${image_url}")" || {
-        echo "Couldn't download image config metadata with skopeo tool!"
-        return 1
-    }
+    if ! image_metadata_config="$(skopeo inspect --retry-times "${SKOPEO_RETRY}" --override-arch amd64 --override-os linux --config "docker://${image_url_for_inspect}")"; then
+        local fallback_image_url
+        fallback_image_url="$(get_rhoai_quay_fallback_image_url "${image_url_for_inspect}")"
+        if test -n "${fallback_image_url}"; then
+            echo "Primary registry lookup failed, retrying with '${fallback_image_url}'"
+            image_metadata_config="$(skopeo inspect --retry-times "${SKOPEO_RETRY}" --override-arch amd64 --override-os linux --config "docker://${fallback_image_url}")" || {
+                echo "Couldn't download image config metadata with skopeo tool!"
+                return 1
+            }
+            image_url_for_inspect="${fallback_image_url}"
+        else
+            echo "Couldn't download image config metadata with skopeo tool!"
+            return 1
+        fi
+    fi
     image_name=$(echo "${image_metadata_config}" | jq --exit-status --raw-output '.config.Labels.name') || {
         echo "Couldn't parse '.config.Labels.name' from image metadata!"
         return 1
@@ -965,7 +991,7 @@ function check_image() {
     local image_repo
     local platform_image_metadata
 
-    image_metadata="$(skopeo inspect --retry-times "${SKOPEO_RETRY}" --override-arch amd64 --override-os linux --raw "docker://${image_url}")" || {
+    image_metadata="$(skopeo inspect --retry-times "${SKOPEO_RETRY}" --override-arch amd64 --override-os linux --raw "docker://${image_url_for_inspect}")" || {
         echo "Couldn't download image metadata with skopeo tool!"
         return 1
     }
@@ -976,7 +1002,7 @@ function check_image() {
     image_size=$(echo "${image_metadata}" | jq --exit-status '[ .layers[]?.size ] | add') ||  {
         manifest_digest=$(echo "${image_metadata}" | jq --exit-status --raw-output '[.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="amd64") | .digest] | first // empty') || manifest_digest=""
         if test -n "${manifest_digest}"; then
-            image_repo="${image_url%@*}"
+            image_repo="${image_url_for_inspect%@*}"
             image_repo="${image_repo%:*}"
             platform_image_metadata="$(skopeo inspect --retry-times "${SKOPEO_RETRY}" --override-arch amd64 --override-os linux --raw "docker://${image_repo}@${manifest_digest}")" || {
                 echo "Couldn't download image metadata for manifest digest '${manifest_digest}'!"


### PR DESCRIPTION
## Summary

Fixes two failures in `PRODUCT=rhoai ./ci/check-params-env.sh` when validating manifests for new release image keys (e.g. `-3-5`):

- **Derive expected commit record count from manifests** — removes hardcoded `EXPECTED_COMMIT_NUM_RECORDS` (`43`/`22`) and computes the expected number of entries in `commit.env` + `commit-latest.env` from `params.env` + `params-latest.env`, excluding `odh-pipeline-runtime-*` keys (commit files only track workbench images).
- **Fallback RHOAI digest inspections to Quay** — when `skopeo` cannot read a digest from `registry.redhat.io/rhoai/...` (`manifest unknown`), retry the same digest against `quay.io/rhoai/...`. This mirrors cluster behavior where ICSP redirects unpublished RH registry refs to Quay during pre-release rollout.

## Problem

The manifests check was failing in two ways:

1. **Stale record count** — expected `43` commit records while manifests had grown (e.g. to `54` after adding `-3-5` workbench keys).
2. **Unpublished RH registry digests** — new `-3-5` images are referenced as `registry.redhat.io/rhoai/...@sha256:...` in `params.env` but are not yet published to the RH registry; metadata inspection fails even though the same digest exists on Quay.

## Changes

All changes are in `ci/check-params-env.sh`:

- Add `discover_expected_commit_num_records()` and log the discovered count before validation.
- Add `get_rhoai_quay_fallback_image_url()` for RHOAI digest refs.
- Update `check_image()` to retry config/raw metadata inspection via Quay when the primary registry lookup fails.

## Out of scope / follow-up

- Adding new `-3-5` keys to `params.env` still requires matching `-commit-3-5` entries in `commit.env` (or validation will fail at commit-ID lookup). This PR does not auto-populate commit env files.
- `params-latest.env` image validation remains skipped (existing behavior for moving `-n` targets).

## Test plan

- [ ] Run `PRODUCT=rhoai ./ci/check-params-env.sh` locally against current RHOAI manifests
- [ ] Confirm commit record count is derived (log: `Discovered expected commit record count: '...'`) instead of using a hardcoded value
- [ ] For unpublished `-3-5` RH registry digests, confirm log shows `Primary registry lookup failed, retrying with 'quay.io/rhoai/...'` and metadata inspection succeeds
- [ ] Verify ODH path still works: `./ci/check-params-env.sh`
- [ ] Confirm CI manifests/params check passes on the PR

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest validation by deriving expected parameter records automatically.
  * Added fallback handling for image metadata lookups when the primary registry is unavailable.
  * Improved duplicate-value validation for compatible image families while continuing to reject conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->