### PR TITLE
fix(tests/containers): retry rhoai digest inspection from quay and fix imagestream typos

### DIFF
--- a/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "ROCm", "version": "v7.14"},
+            {"name": "ROCm", "version": "7.14"},
             {"name": "Python", "version": "v3.12"},
             {"name": "ROCm-PyTorch", "version": "2.11"}
           ]

--- a/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "ROCm", "version": "v7.14"},
+            {"name": "ROCm", "version": "7.14"},
             {"name": "Python", "version": "v3.12"},
             {"name": "TensorFlow-ROCm", "version": "2.19"}
           ]

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "ROCm", "version": "v7.14"},
+            {"name": "ROCm", "version": "7.14"},
             {"name": "Python", "version": "v3.12"},
             {"name": "ROCm-PyTorch", "version": "2.11"}
           ]

--- a/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "ROCm", "version": "v7.14"},
+            {"name": "ROCm", "version": "7.14"},
             {"name": "Python", "version": "v3.12"},
             {"name": "TensorFlow-ROCm", "version": "2.19"}
           ]

--- a/tests/containers/manifest_validation_test.py
+++ b/tests/containers/manifest_validation_test.py
@@ -120,6 +120,13 @@ def _strip_tag_if_digest(image_ref: str) -> str:
     return image_ref
 
 
+def _rhoai_quay_fallback_ref(image_ref: str) -> str:
+    """Map registry.redhat.io/rhoai refs to quay.io/rhoai for pre-release digests."""
+    if image_ref.startswith("registry.redhat.io/rhoai/"):
+        return image_ref.replace("registry.redhat.io/rhoai/", "quay.io/rhoai/", 1)
+    return image_ref
+
+
 def _resolve_amd64(image_ref: str) -> str:
     """Resolve a multi-arch manifest list to the amd64 image digest.
 
@@ -127,13 +134,27 @@ def _resolve_amd64(image_ref: str) -> str:
     Requires ``skopeo`` on PATH.
     """
     image_ref = _strip_tag_if_digest(image_ref)
-    raw = subprocess.run(
-        ["skopeo", "inspect", "--raw", f"docker://{image_ref}"],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=30,
-    )
+    try:
+        raw = subprocess.run(
+            ["skopeo", "inspect", "--raw", f"docker://{image_ref}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError:
+        fallback_ref = _rhoai_quay_fallback_ref(image_ref)
+        if fallback_ref == image_ref:
+            raise
+        _LOG.info(f"Primary registry lookup failed, retrying with '{fallback_ref}'")
+        raw = subprocess.run(
+            ["skopeo", "inspect", "--raw", f"docker://{fallback_ref}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        image_ref = fallback_ref
     manifest = json.loads(raw.stdout)
     if "manifests" in manifest:
         amd64 = next(


### PR DESCRIPTION
## Summary

This PR includes two related fixes for manifest validation for image references:

- **Fix manifest validation fetch path for RHOAI digests**  
  Updates `tests/containers/manifest_validation_test.py` so `skopeo` retries `registry.redhat.io/rhoai/...@sha256:...` refs via `quay.io/rhoai/...` when the digest is not yet published in RH registry.
- **Fix imagestream typos**  
  Corrects typos in imagestream metadata/annotations to align manifest content with expected validation behavior.

## Why

CI was failing in `test_old_tag_annotations_match_quay` because several `3.5` RHOAI digest refs were not resolvable from `registry.redhat.io` yet, even though they are available from Quay in pre-release flow.  
Additionally, typos in imagestream files caused avoidable validation mismatches/noise.

## Test plan

- [ ] Run: `pytest tests/containers/manifest_validation_test.py::test_old_tag_annotations_match_quay -v`
- [ ] Verify RHOAI `3.5` refs no longer fail at the Quay fetch step when RH registry digest is unavailable
- [ ] Verify imagestream typo-related validation mismatches are resolved
- [ ] Confirm no regressions in other manifest validation checks (`odh` and `rhoai`)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ROCm version metadata for PyTorch and TensorFlow notebook images by removing the outdated `v` prefix.
  * Improved notebook image validation by retrying against an alternate registry when the primary registry lookup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->