### PR TITLE
Revert the outdated annotation on 25.2 versions as we still want to retain them

### DIFF
--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -133,7 +133,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-codeserver-datascience-cpu-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
@@ -162,7 +162,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-datascience-cpu-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -93,7 +93,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cuda-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-minimal-cuda-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
@@ -92,7 +92,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-minimal-cpu-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -180,7 +180,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -176,7 +176,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -93,7 +93,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-minimal-rocm-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-minimal-rocm-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -168,7 +168,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -162,7 +162,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -176,7 +176,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -177,7 +177,7 @@ spec:
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
-        opendatahub.io/image-tag-outdated: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
       from:
         kind: DockerImage
         name: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-2025-2_PLACEHOLDER


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

follow up for: https://github.com/opendatahub-io/notebooks/pull/4280
 
## Description
<!--- Describe your changes in detail -->
The `manifests/tools/rollout_tag_on_imagestreams.py` script, which runs during the release kickoff process, follows the **default behavior** of keeping only the current (N) and previous (N-1) release tags visible. 

However, we have an exception for the product that requires retaining the 2025.2 tags as well. This PR reintroduces those tags after the rollout process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On cluster:
1. Install the latest manifest: `./scripts/apply-manifests-dev.sh --platform [rhoai|odh] apply`
2. Revert changes from the cluster: `./scripts/apply-manifests-dev.sh revert --clean-test`

<img width="788" height="369" alt="Screenshot 2026-08-04 at 12 05 16" src="https://github.com/user-attachments/assets/b82cb9d6-0609-4a69-a3c3-a87120aa0a48" />


Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
