### PR TITLE
RHOAIENG-80337: Enable kale by default

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -167,7 +167,6 @@ sed -i -e "s/Python.*/$(python --version | cut -d '.' -f-2)\",/" \
 install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 /opt/app-root/bin/utils/addons/apply.sh
 /usr/local/bin/ensure-openshift-site-packages.sh

--- a/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
@@ -3,7 +3,6 @@ set -x
 
 # Runtime configuration for Kubeflow Kale JupyterLab extension
 # This script configures Kale to connect to KFP by reading Elyra runtime config
-# Note: The extension is disabled by default at build time (see Dockerfile)
 
 # Read Elyra config and copy the relevant information to Kale config
 # Extract KFP configuration from Elyra runtime configs if available

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -192,8 +192,6 @@ install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Disable kale extension
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -174,8 +174,6 @@ install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Disable kale extension
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -174,8 +174,6 @@ install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Disable kale extension
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -190,8 +190,6 @@ install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Disable kale extension
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -191,8 +191,6 @@ install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Disable kale extension
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -199,8 +199,6 @@ install -D -m 0664 /opt/app-root/bin/utils/jupyter_server_config.py \
   /opt/app-root/etc/jupyter/jupyter_server_config.py
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
-# Disable kale extension
-jupyter labextension disable jupyterlab-kubeflow-kale
 chmod g+w /opt/app-root/etc/jupyter/labconfig
 # Apply JupyterLab addons
 /opt/app-root/bin/utils/addons/apply.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Deletes default disable of Kale extension in all images 
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the Kubeflow Kale extension in JupyterLab-based data science, PyTorch, TensorFlow, TrustyAI, and ROCm environments.
  * The announcements extension remains disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->