### PR TITLE
chore(ci): drop swap tuning from install-podman-action

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -5,13 +5,43 @@ List for
 and for
 [private repositories](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for--private-repositories).
 
-- **Linux**: `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-24.04-arm`
+- **Linux**: `ubuntu-26.04`, `ubuntu-26.04-arm`
 
 We have [IBM PowerPC and Z runners](https://community.ibm.com/community/user/blogs/elizabeth-k-joseph1/2025/05/19/expanding-open-source-access-hosted-github-actions) available through
 
 * https://github.com/IBM/actionspz/issues/63
 
 - **Linux**: `ubuntu-24.04-ppc64le`, `ubuntu-24.04-s390x`
+
+## Podman on CI
+
+Notebook builds and RPM lock renewal use [`.github/actions/install-podman-action`](actions/install-podman-action/action.yml) on `ubuntu-26.04` runners.
+It configures the **system Podman** package shipped on the runner image (5.7+), starts the rootful API socket, and exports `PODMAN_SOCK` and `CONTAINER_HOST` to `$GITHUB_ENV`.
+
+`ci/cached-builds/containers.conf` sets explicit `dns_servers` because GHA runners use
+`systemd-resolved` (`127.0.0.53`), which is unreachable from container network namespaces
+and breaks hermetic prefetch (`cdn.redhat.com`). See [podman #17075](https://github.com/containers/podman/issues/17075)
+and pasta/systemd-resolved notes in [podman networking](https://sanj.dev/post/podman-pasta-vs-slirp4netns-networking/).
+
+The install action also sets `iptables -P FORWARD ACCEPT` and `net.ipv4.ip_forward=1`
+because Docker on GHA runners sets `FORWARD DROP`, which breaks rootful netavark egress
+([podman #24486](https://github.com/containers/podman/issues/24486),
+[runner-images #13422](https://github.com/actions/runner-images/issues/13422)).
+
+On ephemeral runners the install action also applies best-effort host I/O greed
+(`nobarrier`/`nodiscard`/`commit` remounts, WBT off) and
+`ci/cached-builds/storage.conf` sets overlay `mountopt=nodev,metacopy=off,redirect_dir=off`
+so Podman can use native overlay diff for faster layer commits.
+
+`test-install-podman` validates container IP and DNS reachability (TCP `nc`, HTTP `wget`, `dig` UDP/TCP) after configure.
+
+## buildinputs image
+
+The `build-buildinputs` workflow publishes a multi-arch helper image at
+`ghcr.io/${{ github.repository }}/buildinputs`. It is tagged with the commit SHA
+for reproducibility and `main` on the main branch. Downstream jobs should prefer
+the published image digest when they need `scripts/buildinputs` instead of
+building the Go helper locally.
 
 We have considered investigating custom runners, either just plain containers/VMs, or something fronting an OpenShift cluster, in
 

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -1,113 +1,124 @@
 ---
-name: 'Install Podman'
-description: 'Installs Podman from Homebrew'
+name: 'Configure Podman'
+description: 'Configure rootful Podman from the ubuntu-26.04 runner image (Podman 5.7+)'
 inputs:
   platform:
-    description: 'Target platform for Podman installation (linux/amd64, linux/s390x, linux/ppc64le, linux/arm64)'
+    description: 'Target platform for builds (linux/amd64, linux/s390x, linux/ppc64le, linux/arm64)'
     required: true
 runs:
-  using: "composite"
+  using: composite
   steps:
-    # https://github.com/containers/buildah/issues/2521#issuecomment-884779112
-    - name: Workaround https://github.com/containers/podman/issues/22152#issuecomment-2027705598
-      shell: bash
-      run: sudo apt-get -qq remove podman crun
-
-    # Ensure parent dir exists and is runner-owned so cache restore can set file modes (avoids "Cannot change mode: Operation not permitted").
-    - name: Prepare .linuxbrew parent for cache
+    - name: Ensure socket ACL dependency
       shell: bash
       run: |
-        sudo mkdir -p /home/linuxbrew
-        sudo chown -R "$(whoami):$(whoami)" /home/linuxbrew
+        set -Eeuxo pipefail
+        command -v setfacl >/dev/null || {
+          echo "setfacl is required on the supported ubuntu-26.04 runners" >&2
+          exit 1
+        }
 
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-      # https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
-      # https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
-      id: cached-linuxbrew
-      with:
-        path: /home/linuxbrew/.linuxbrew
-        key: linuxbrew-${{ runner.os }}-${{ runner.arch }}
-
-    # Restored cache can have wrong ownership or immutable flags; fix so brew/podman and mode changes work.
-    - name: Fix .linuxbrew ownership and permissions after cache restore
-      if: steps.cached-linuxbrew.outputs.cache-hit == 'true'
+    # ubuntu-26.04 AppArmor: podman profile cannot SIGTERM pasta without this peer rule.
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1100135
+    - name: Fix AppArmor pasta/podman signal conflict
       shell: bash
       run: |
-        if [[ -d /home/linuxbrew/.linuxbrew ]]; then
-          sudo chattr -R -i /home/linuxbrew/.linuxbrew 2>/dev/null || true
-          sudo chown -R "$(whoami):$(whoami)" /home/linuxbrew/.linuxbrew
-          sudo chmod -R u+rwX,go=rX /home/linuxbrew/.linuxbrew
+        set -Eeuxo pipefail
+        if [[ -f /etc/apparmor.d/abstractions/pasta ]] && ! grep -q 'peer=podman' /etc/apparmor.d/abstractions/pasta; then
+          echo '  signal (receive) peer=podman,' | sudo tee -a /etc/apparmor.d/abstractions/pasta
+          sudo apparmor_parser -r /etc/apparmor.d/usr.bin.pasta
         fi
 
-    - name: Install podman (linux/amd64, or qemu-user emulation)
-      if: contains(fromJSON('["linux/amd64", "linux/s390x", "linux/ppc64le"]'), inputs.platform) && steps.cached-linuxbrew.outputs.cache-hit != 'true'
+    - name: Tune ephemeral host I/O for CI builds
       shell: bash
       run: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        /home/linuxbrew/.linuxbrew/bin/brew install podman
+        set -Eeuxo pipefail
 
-    # Warning: Your CPU architecture (arm64) is not supported. We only support
-    # x86_64 CPU architectures. You will be unable to use binary packages (bottles).
-    #
-    # This is a Tier 2 configuration:
-    #  https://docs.brew.sh/Support-Tiers#tier-2
-    # Do not report any issues to Homebrew/* repositories!
-    # Read the above document instead before opening any issues or PRs.
-    - name: Install podman (linux/arm64)
-      if: inputs.platform == 'linux/arm64' && steps.cached-linuxbrew.outputs.cache-hit != 'true'
-      # Error: podman: no bottle available!
-      # If you're feeling brave, you can try to install from source with:
-      shell: bash
-      run: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        /home/linuxbrew/.linuxbrew/bin/brew install --build-from-source podman
+        # Ephemeral runners: favor build throughput over durability guarantees.
+        remount_greed() {
+          local target="$1"
+          if mountpoint -q "${target}"; then
+            if ! sudo mount -o remount,nobarrier,nodiscard,commit=600 "${target}"; then
+              echo "warning: remount greed options failed for ${target}" >&2
+            fi
+          fi
+        }
 
-    - name: Add linuxbrew to PATH
-      shell: bash
-      run: echo "/home/linuxbrew/.linuxbrew/bin/" >> $GITHUB_PATH
+        graphroot=/mnt/containers/storage
+        sudo mkdir -p "${graphroot}"
+        # Single-disk runners resolve graphroot to /; remounting both is idempotent.
+        remount_greed "$(findmnt -n -o TARGET --target "${graphroot}")"
+        remount_greed "$(findmnt -n -o TARGET --target /)"
+
+        for wbt in /sys/block/*/queue/wbt_lat_usec; do
+          [[ -f "${wbt}" ]] || continue
+          echo 0 | sudo tee "${wbt}" >/dev/null || true
+        done
 
     - name: Configure Podman
       shell: bash
       run: |
         set -Eeuxo pipefail
 
-        # podman running as service ignores the TMPDIR env var here, let's give it a bind-mount to /var/tmp
-        mkdir -p $TMPDIR
-        sudo mount --bind -o rw,noexec,nosuid,nodev,bind $TMPDIR /var/tmp
+        podman --version
 
-        # podman from brew has its own /etc (was giving me Failed to obtain podman configuration: runroot must be set)
-        # the (default) config location is also where cri-o gets its storage defaults (that can be overriden in crio.conf)
-        sudo cp ci/cached-builds/containers.conf /etc/containers.conf
-        sudo cp ci/cached-builds/containers.conf /home/linuxbrew/.linuxbrew/opt/podman/etc/containers.conf
+        # Podman 5.x reads /etc/containers/containers.conf (not /etc/containers.conf).
+        # /etc/containers/ is also where cri-o gets storage defaults (overridable in crio.conf).
+        sudo mkdir -p /etc/containers
+        sudo cp ci/cached-builds/containers.conf /etc/containers/containers.conf
         sudo cp ci/cached-builds/storage.conf /etc/containers/storage.conf
-        sudo cp ci/cached-builds/storage.conf /home/linuxbrew/.linuxbrew/opt/podman/etc/containers/storage.conf
         sudo cp ci/cached-builds/registries.conf /etc/containers/registries.conf
-        sudo cp ci/cached-builds/registries.conf /home/linuxbrew/.linuxbrew/opt/podman/etc/containers/registries.conf
 
         # should reset storage when changing storage.conf
-        mkdir -p $HOME/.local/share/containers/storage/tmp
+        sudo mkdir -p /mnt/containers/storage/tmp
         # remote (CONTAINER_HOST) podman does not do reset (and refuses --force option)
-        sudo /home/linuxbrew/.linuxbrew/opt/podman/bin/podman system reset --force
+        sudo podman system reset --force
 
         # https://github.com/containers/podman/pull/25504
         # podman 5.5.0: The podman system reset command no longer removes the user's podman.sock API socket
         sudo rm -rf /var/run/podman
+        sudo mkdir -p /mnt/containers/storage/tmp
+        sudo chown -R "${USER}:${USER}" /mnt/containers/storage
 
+        # Rootful bridge egress needs forwarding + FORWARD accept. Docker on GHA sets FORWARD DROP
+        # which breaks netavark MASQUERADE silently (podman #24486, runner-images #13422).
+        # Same pattern as provision-k8s and microk8s workarounds in this repo.
+        # Use iptables, not nft: ubuntu-26.04 is nftables-backed but exposes iptables-nft;
+        # netavark installs rules through that API, so this matches what Podman expects.
+        sudo modprobe br_netfilter
+        sudo sysctl -w net.ipv4.ip_forward=1
+        sudo iptables -P FORWARD ACCEPT
+
+        # Override distro units (linuxbrew path used /usr/local/lib/systemd/system/ too).
         # https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md
-        # since `brew services start podman` is buggy, let's do our own brew-compatible service
-        # Regarding directory paths, see https://unix.stackexchange.com/questions/224992/where-do-i-put-my-systemd-unit-file
         sudo mkdir -p /usr/local/lib/systemd/system/
         sudo cp ci/cached-builds/podman.service /usr/local/lib/systemd/system/podman.service
         sudo cp ci/cached-builds/podman.socket /usr/local/lib/systemd/system/podman.socket
         sudo systemctl daemon-reload
-        sudo systemctl unmask --now podman.service podman.socket
-        sudo systemctl start podman.socket
+        sudo systemctl unmask podman.service podman.socket
+        sudo systemctl enable --now podman.socket
 
-        # needed (much) later for trivy
-        echo "PODMAN_SOCK=/var/run/podman/podman.sock" >> $GITHUB_ENV
+        # Grant runner user access without sudo for CONTAINER_HOST clients
+        sudo setfacl -m "u:${USER}:x" /var/run/podman
+        sudo setfacl -m "u:${USER}:rw" /var/run/podman/podman.sock
+
+        # needed (much) later for trivy; CONTAINER_HOST makes podman a remote client to rootful socket
+        podman_sock=/var/run/podman/podman.sock
+        echo "PODMAN_SOCK=${podman_sock}" >> "$GITHUB_ENV"
+        echo "CONTAINER_HOST=unix://${podman_sock}" >> "$GITHUB_ENV"
 
         # quick check podman works
         podman ps
+
+        # Docker may reset FORWARD DROP after podman starts; re-apply before container egress.
+        sudo iptables -P FORWARD ACCEPT
+
+        # Reload netavark rules after FORWARD policy fix (only when a network already exists).
+        if [[ -n "$(podman network ls -q)" ]]; then
+          podman network reload --all
+        fi
+
+    - run: podman system info
+      shell: bash
 
     - name: Show error logs (on failure)
       if: ${{ failure() }}
@@ -118,3 +129,5 @@ runs:
         journalctl -xe
         ls -AlF /var/run/podman/podman.sock || echo "Socket /var/run/podman/podman.sock not found"
         sudo ss -xlpn | grep 'podman.sock' || echo "No active listener found for podman.sock via ss"
+        sudo iptables -S FORWARD || true
+        podman network inspect podman 2>/dev/null || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,23 @@ Key CI files:
 - `ci/` - Custom CI scripts and configurations
 - `scripts/ci/renovate_run.py` - Self-hosted Renovate (Podman or Docker via `CONTAINER_ENGINE`, same detection order as the Makefile); see `.github/workflows/renovate-self-hosted.yaml` and ADR 0013
 
+### Running Container Images
+
+Notebook images have an entrypoint (`start-notebook.sh`) that launches
+Jupyter Lab.  When you need to inspect the image (check installed RPMs,
+list files, run a shell), **override the entrypoint**:
+
+```bash
+# Interactive shell — won't start Jupyter
+podman run --rm -it --entrypoint="" quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.12-latest bash
+
+# One-off command
+podman run --rm --entrypoint="" <image> rpm -qa | sort
+```
+
+Without `--entrypoint=""`, `podman run <image> rpm -qa` is passed as
+arguments to `start-notebook.sh`, which ignores them and starts Jupyter.
+
 ### Deployment
 
 1. **Local Development**:


### PR DESCRIPTION
## Summary

Follow-up to #4266: remove `swapoff` / `vm.swappiness=0` from `install-podman-action`. On fresh GHA runners swap is usually unused, so this tuning is unlikely to save wall-clock time and adds maintenance noise. Keeps the I/O remount/WBT tuning and overlay `mountopt` changes.

cc @vsok @ysok for review (podman CI tuning context)

## Test plan

- [ ] `Test Install Podman` workflow passes on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Actions guidance for Ubuntu 26.04 runners.
  * Added setup instructions for Podman-based CI, including networking, storage, performance tuning, and multi-architecture build images.
  * Added instructions for inspecting container images by overriding their default entrypoint.

* **Chores**
  * Updated automated container build configuration to use rootful Podman on Ubuntu 26.04.
  * Improved Podman networking, storage, socket access, validation, and failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->