### PR TITLE
chore(ci): drop swap tuning from install-podman-action

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -29,7 +29,7 @@ because Docker on GHA runners sets `FORWARD DROP`, which breaks rootful netavark
 [runner-images #13422](https://github.com/actions/runner-images/issues/13422)).
 
 On ephemeral runners the install action also applies best-effort host I/O greed
-(`swapoff`, `vm.swappiness=0`, `nobarrier`/`nodiscard`/`commit` remounts, WBT off) and
+(`nobarrier`/`nodiscard`/`commit` remounts, WBT off) and
 `ci/cached-builds/storage.conf` sets overlay `mountopt=nodev,metacopy=off,redirect_dir=off`
 so Podman can use native overlay diff for faster layer commits.
 

--- a/.github/actions/install-podman-action/action.yml
+++ b/.github/actions/install-podman-action/action.yml
@@ -28,15 +28,12 @@ runs:
           sudo apparmor_parser -r /etc/apparmor.d/usr.bin.pasta
         fi
 
-    - name: Tune ephemeral host I/O and memory for CI builds
+    - name: Tune ephemeral host I/O for CI builds
       shell: bash
       run: |
         set -Eeuxo pipefail
 
         # Ephemeral runners: favor build throughput over durability guarantees.
-        sudo swapoff -a 2>/dev/null || true
-        sudo sysctl -w vm.swappiness=0 || true
-
         remount_greed() {
           local target="$1"
           if mountpoint -q "${target}"; then


### PR DESCRIPTION
## Summary

Remove `swapoff` / `vm.swappiness=0` from `install-podman-action` (#4266 follow-up). On fresh GHA runners swap is usually unused, so this tuning is unlikely to help and adds noise. Keeps I/O remount/WBT tuning and overlay `mountopt`.

(Replaces #4287, which was accidentally based on a stale fork `main` and picked up unrelated rewrites.)

cc @vsok @ysok

## Test plan

- [x] `Test Install Podman` workflow passes on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Podman CI documentation to reflect the current host I/O tuning settings.
* **Chores**
  * Simplified ephemeral runner setup by removing swap-disabling and swappiness configuration steps.
  * Retained remount and writeback-throttling optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->