### PR TITLE
fix(manifests): add JupyterLab and Codeflare-SDK to code-server 3.5 annotations

### DIFF
--- a/manifests/odh/base/code-server-notebook-imagestream.yaml
+++ b/manifests/odh/base/code-server-notebook-imagestream.yaml
@@ -59,6 +59,7 @@ spec:
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "Boto3", "version": "1.43"},
+            {"name": "Codeflare-SDK", "version": "0.38"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.11"},
             {"name": "Numpy", "version": "2.5"},
@@ -67,6 +68,7 @@ spec:
             {"name": "Scipy", "version": "1.18"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.3"},
+            {"name": "JupyterLab", "version": "4.6"},
             {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.63"}

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -59,6 +59,7 @@ spec:
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "Boto3", "version": "1.43"},
+            {"name": "Codeflare-SDK", "version": "0.38"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.11"},
             {"name": "Numpy", "version": "2.5"},
@@ -67,6 +68,7 @@ spec:
             {"name": "Scipy", "version": "1.18"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.3"},
+            {"name": "JupyterLab", "version": "4.6"},
             {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.63"}


### PR DESCRIPTION
## Summary

- Add `JupyterLab` (4.6) and `Codeflare-SDK` (0.38) to **tag 3.5** `notebook-python-dependencies` in ODH and RHOAI `code-server-notebook-imagestream.yaml`.
- Versions match the published 3.5 image lockfile at `commit-3-5` (`fb31a5a`).

## Context

`validation-of-sw-versions-in-imagestreams` fails `test_old_tag_annotations_match_quay` because the 3.5 Quay image contains `jupyterlab` and `codeflare-sdk` (from #3586 / #4020) but manifest annotations were never backfilled when tag 3.5 was created (#3442). Pre-existing on `main`; unrelated to #4281 / RHAIENG-6366.

## Test plan

- [ ] `validation-of-sw-versions-in-imagestreams` passes for code-server tag 3.5 (ODH + RHOAI)
- [ ] `make test` static manifest checks unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated notebook image dependency metadata to include Codeflare-SDK 0.38 and JupyterLab 4.6.
  * Applied the updates to the N−1 and 3.5 Code Server notebook images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->