### PR TITLE
ci: add GitHub Code Quality coverage (Python + Go) alongside Codecov

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -184,6 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false  # don't leave the (code-quality:write) token in .git/config for PR code
           # PR head (not the merge commit) so Go coverage maps to head.sha (see pytest-tests note).
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -78,6 +78,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      code-quality: write  # upload coverage to GitHub Code Quality
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -142,6 +143,24 @@ jobs:
           flags: python
           fail_ci_if_error: false
 
+      # --- GitHub Code Quality: native code coverage on PRs (complements Codecov) ---
+      # One-time repo setup: Settings > Security > Code quality > Enable code quality.
+      # Needs (1) a Cobertura XML report -- coverage.xml, produced above by pytest-cov
+      # via PYTEST_ADDOPTS -- and (2) code-quality:write, granted on this job's perms.
+      # Fork PRs and merge_group runs are skipped by the action itself (read-only token).
+      # Feature docs:   https://docs.github.com/en/code-security/code-quality
+      # Setup guide:    https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage
+      # Enable feature: https://docs.github.com/en/code-security/how-tos/maintain-quality-code/enable-code-quality
+      # Upload action:  https://github.com/actions/upload-code-coverage
+      - name: Upload Python coverage to GitHub Code Quality
+        if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
+        uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1  # v1.4.1
+        with:
+          file: coverage.xml
+          language: Python
+          label: code-coverage/python
+          fail-on-error: false  # non-blocking, matching the Codecov steps
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
@@ -153,6 +172,7 @@ jobs:
     runs-on: ubuntu-26.04
     permissions:
       contents: read
+      code-quality: write  # upload coverage to GitHub Code Quality
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -174,6 +194,18 @@ jobs:
         run: gotestsum --junitfile=junit-go.xml -- -coverprofile=coverage-go.out -covermode=atomic ./...
         working-directory: scripts/buildinputs
 
+      - name: Convert Go coverage to Cobertura XML
+        if: ${{ !cancelled() }}
+        # upload-code-coverage only accepts Cobertura; Codecov reads the native .out directly.
+        # GitHub's documented Go recipe (see the "set-up-code-coverage" guide, language table):
+        #   go test -coverprofile=cover.out && gocover-cobertura < cover.out > coverage.xml
+        # https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage
+        # https://github.com/boumenot/gocover-cobertura
+        run: |
+          go install github.com/boumenot/gocover-cobertura@v1.5.0
+          "$(go env GOPATH)/bin/gocover-cobertura" < coverage-go.out > coverage-go.xml
+        working-directory: scripts/buildinputs
+
       - name: Upload Go coverage to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
@@ -183,6 +215,15 @@ jobs:
           files: scripts/buildinputs/coverage-go.out
           flags: go
           fail_ci_if_error: false
+
+      - name: Upload Go coverage to GitHub Code Quality
+        if: ${{ !cancelled() }}
+        uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1  # v1.4.1
+        with:
+          file: scripts/buildinputs/coverage-go.xml
+          language: Go
+          label: code-coverage/go
+          fail-on-error: false  # non-blocking, matching the Codecov steps
 
       - name: Upload Go test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -156,16 +156,12 @@ jobs:
       # Setup guide:    https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage
       # Enable feature: https://docs.github.com/en/code-security/how-tos/maintain-quality-code/enable-code-quality
       # Upload action:  https://github.com/actions/upload-code-coverage
-      # SECURITY: the ref_name guards below work around a script injection in upstream
-      # actions/upload-code-coverage -- on push it interpolates github.ref_name/github.ref
-      # into a shell `run:` block, so a branch named e.g. rhoai-$(...) would execute code.
-      # `if:` is a GHA-expression (non-shell) context, so we safely skip the upload when the
-      # branch name contains a shell metacharacter ($ ` " \). Drop once upstream injects via env.
+      # NOTE: on push/workflow_dispatch this action interpolates github.ref_name/github.ref into a
+      # shell run: (upstream script injection: https://github.com/actions/upload-code-coverage/issues/26).
+      # Only reachable with write access (which already grants CI code execution), so no marginal
+      # risk here; the fix belongs upstream (pass those values via env:).
       - name: Upload Python coverage to GitHub Code Quality
-        if: >-
-          ${{ !cancelled() && steps.install-deps.conclusion == 'success'
-          && !contains(github.ref_name, '$') && !contains(github.ref_name, '`')
-          && !contains(github.ref_name, '"') && !contains(github.ref_name, '\') }}
+        if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
         uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1  # v1.4.1
         with:
           file: coverage.xml
@@ -233,12 +229,9 @@ jobs:
           flags: go
           fail_ci_if_error: false
 
-      # SECURITY: see the ref_name-guard note on the Python upload above (same upstream injection).
+      # See the upstream-injection note on the Python upload above (github.com/actions/upload-code-coverage/issues/26).
       - name: Upload Go coverage to GitHub Code Quality
-        if: >-
-          ${{ !cancelled() && steps.go-cobertura.outcome == 'success'
-          && !contains(github.ref_name, '$') && !contains(github.ref_name, '`')
-          && !contains(github.ref_name, '"') && !contains(github.ref_name, '\') }}
+        if: ${{ !cancelled() && steps.go-cobertura.outcome == 'success' }}
         uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1  # v1.4.1
         with:
           file: scripts/buildinputs/coverage-go.xml

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -86,6 +86,10 @@ jobs:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
           # Full history so tests/test_pylock_downgrade.py can `git show origin/main:…/pylock.toml`.
           fetch-depth: 0
+          # Check out the PR head (not the merge commit) so coverage maps to head.sha, which is
+          # what upload-code-coverage attributes the report to (matches the action's README
+          # example). On push, head.sha is empty -> falls back to github.sha (unchanged).
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Login to GitHub Container Registry
         if: ${{ github.repository != 'opendatahub-io/notebooks' }}
@@ -152,8 +156,16 @@ jobs:
       # Setup guide:    https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage
       # Enable feature: https://docs.github.com/en/code-security/how-tos/maintain-quality-code/enable-code-quality
       # Upload action:  https://github.com/actions/upload-code-coverage
+      # SECURITY: the ref_name guards below work around a script injection in upstream
+      # actions/upload-code-coverage -- on push it interpolates github.ref_name/github.ref
+      # into a shell `run:` block, so a branch named e.g. rhoai-$(...) would execute code.
+      # `if:` is a GHA-expression (non-shell) context, so we safely skip the upload when the
+      # branch name contains a shell metacharacter ($ ` " \). Drop once upstream injects via env.
       - name: Upload Python coverage to GitHub Code Quality
-        if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}
+        if: >-
+          ${{ !cancelled() && steps.install-deps.conclusion == 'success'
+          && !contains(github.ref_name, '$') && !contains(github.ref_name, '`')
+          && !contains(github.ref_name, '"') && !contains(github.ref_name, '\') }}
         uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1  # v1.4.1
         with:
           file: coverage.xml
@@ -175,6 +187,9 @@ jobs:
       code-quality: write  # upload coverage to GitHub Code Quality
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # PR head (not the merge commit) so Go coverage maps to head.sha (see pytest-tests note).
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
@@ -195,7 +210,9 @@ jobs:
         working-directory: scripts/buildinputs
 
       - name: Convert Go coverage to Cobertura XML
+        id: go-cobertura
         if: ${{ !cancelled() }}
+        continue-on-error: true  # optional coverage tooling must not fail the go-tests job
         # upload-code-coverage only accepts Cobertura; Codecov reads the native .out directly.
         # GitHub's documented Go recipe (see the "set-up-code-coverage" guide, language table):
         #   go test -coverprofile=cover.out && gocover-cobertura < cover.out > coverage.xml
@@ -216,8 +233,12 @@ jobs:
           flags: go
           fail_ci_if_error: false
 
+      # SECURITY: see the ref_name-guard note on the Python upload above (same upstream injection).
       - name: Upload Go coverage to GitHub Code Quality
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{ !cancelled() && steps.go-cobertura.outcome == 'success'
+          && !contains(github.ref_name, '$') && !contains(github.ref_name, '`')
+          && !contains(github.ref_name, '"') && !contains(github.ref_name, '\') }}
         uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1  # v1.4.1
         with:
           file: scripts/buildinputs/coverage-go.xml


### PR DESCRIPTION
## Description

Report code coverage to **GitHub Code Quality** (the native, first-party coverage view on PRs, GA July 2026) **in addition to** the existing Codecov uploads. The `actions/upload-code-coverage` steps are added *next to* the Codecov steps in the two jobs of `code-quality.yaml` that already generate coverage — no tests are re-run.

### What changed (`.github/workflows/code-quality.yaml`)

- **`pytest-tests`** — reuses the `coverage.xml` (Cobertura) already produced by `pytest-cov` via `PYTEST_ADDOPTS`; uploads it with `language: Python`, `label: code-coverage/python`.
- **`go-tests`** — `upload-code-coverage` only accepts Cobertura, while `go test`/Codecov use the native `.out`. Adds a conversion step (`gocover-cobertura` — GitHub's documented Go recipe, pinned `@v1.5.0`) → `coverage-go.xml`, then uploads with `language: Go`, `label: code-coverage/go`.
- Adds the **`code-quality: write`** permission to both jobs.
- Uploads are **non-blocking** (`fail-on-error: false`, matching the existing `fail_ci_if_error: false` Codecov steps). The action self-skips fork PRs (read-only token) and merge-queue runs.
- **Checkout of the PR head** (`ref: ${{ github.event.pull_request.head.sha || github.sha }}`) in both coverage jobs, so reports map to the commit the action attributes them to (matches the action's README example).
- **`persist-credentials: false`** on the go-tests checkout (matches every other checkout here; avoids leaving the `code-quality:write` token in `.git/config` for PR code).
- The Go **conversion step is non-blocking** (`continue-on-error: true`) and the Go upload is gated on its success, so optional coverage tooling can't fail the `go-tests` job.

> **Repo prerequisite:** Code Quality must be enabled once — **Settings → Security → Code quality → Enable code quality**. If it isn't, the upload API returns 404, which is non-blocking (logged as a warning).

Docs: [set-up-code-coverage](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage) · [enable-code-quality](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/enable-code-quality) · [actions/upload-code-coverage](https://github.com/actions/upload-code-coverage)

### Known upstream limitations (tracked, not blocking)

Both live in the same `gh pr list --head "${{ github.ref_name }}"` line of `actions/upload-code-coverage` and only affect the **push** path:

- **Script injection** — the action interpolates `github.ref_name`/`github.ref` into a shell `run:`. Reachable only with write access (which already grants CI code execution), so no marginal risk here. Reported upstream: **[actions/upload-code-coverage#26](https://github.com/actions/upload-code-coverage/issues/26)**. (An earlier local metachar-denylist guard was reverted as security theater.)
- **Cross-repo PR misattribution** — `gh pr list --head` matches by branch name only, so a fork PR whose head branch shares a pushed branch's name can capture the push's coverage and prevent the branch baseline from being recorded. Upstream: **[actions/upload-code-coverage#14](https://github.com/actions/upload-code-coverage/issues/14)**. Intermittent, non-security, non-blocking. The action exposes no input to pass an explicit ref, so we'll adopt the upstream fix when it lands.

## How Has This Been Tested?

- `yamllint --strict --config-file ci/yamllint-config.yaml` passes on the edited workflow; `actionlint` accepts the workflow (its only complaints are the stale-schema `code-quality`-scope false positive — the scope is real but predates the bundled SchemaStore/actionlint definitions — and a pre-existing SC2038 unrelated to this PR).
- `actions/upload-code-coverage@v1.4.1` was smoke-tested end-to-end on a fork branch: it generates and posts the report; the only failure mode was `HTTP 404` when Code Quality isn't enabled on the repo (expected, non-blocking).
- This PR's own `code-quality.yaml` run exercises the real path (same-repo PR → has `code-quality:write` + `CODECOV_TOKEN`).

> Note: `make test` was not run locally — this is a CI-workflow-only change with no product code touched.

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
