### PR TITLE
RHAIENG-4344: fix: change healthz endpoint for CodeServer culling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,7 +194,7 @@ a three-process stack per workbench container:
   the IDE's heartbeat (Code-Server)
 
 Key files:
-- `codeserver/*/nginx/api/kernels/access.cgi` — polls `localhost:8888/codeserver/healthz`,
+- `codeserver/*/nginx/api/kernels/access.cgi` — polls `localhost:8787/healthz`,
   converts heartbeat to Jupyter kernel format
 - `codeserver/*/nginx/httpconf/http.conf` — custom nginx log format producing JSON with
   `last_activity` in ISO 8601 format

--- a/codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi
+++ b/codeserver/ubi9-python-3.12/nginx/api/kernels/access.cgi
@@ -14,13 +14,14 @@ echo "Content-type: application/json"
 echo
 
 # --- Fetch code-server heartbeat ---
-# Poll through nginx on 8888 using the same probe path as notebook-controller:
-#   ${NB_PREFIX}/api  ->  ${NB_PREFIX}/codeserver/healthz/
-# A bare /codeserver/healthz curl fails when NB_PREFIX is set because nginx only
-# routes prefixed /codeserver/* to code-server. -L follows the probe redirect chain.
-NB_PREFIX="${NB_PREFIX:-}"
-HEALTHZ=$(curl -sLf --max-time 5 "http://localhost:8888${NB_PREFIX}/api")
+# Talk to code-server directly on its bind address (nginx upstream workbench_server).
+# Do NOT go through nginx:8888 — that path is NB_PREFIX-routed for external probes
+# and CGI does not need (or reliably have) NB_PREFIX.
 # Example HEALTHZ JSON: {"status":"alive","lastHeartbeat":1742345025123}
+HEALTHZ=$(curl -sLf --max-time 5 "http://127.0.0.1:8787/healthz") || true
+if [ -z "$HEALTHZ" ]; then
+    echo "access.cgi: healthz fetch failed (http://127.0.0.1:8787/healthz)" >&2
+fi
 
 # --- Derive last_activity (RFC3339 / ISO 8601) ---
 # lastHeartbeat is milliseconds since epoch. The culler expects seconds in ISO format.

--- a/tests/containers/workbenches/culling_api_test.py
+++ b/tests/containers/workbenches/culling_api_test.py
@@ -216,10 +216,18 @@ class TestCullingApi:
             _wait_for_healthz(container, nb_prefix=nb_prefix)
             _install_culling_stack(container)
 
+            healthz = _fetch_healthz(container, nb_prefix=nb_prefix)
             status, kernels = _get_kernels_via_http(container, kernels_path=f"{nb_prefix}/api/kernels/")
             assert status == 200, f"expected 200 for prefixed kernels URL, got {status}"
             assert kernels is not None and len(kernels) == 1
             _assert_valid_kernel_record(kernels[0])
+            # Fresh pod healthz is expired (lastHeartbeat=0). CGI polls code-server
+            # directly on :8787 (not nginx), so NB_PREFIX must not affect this mapping.
+            expected_state = "busy" if healthz.get("status") == "alive" else "idle"
+            assert kernels[0]["execution_state"] == expected_state, (
+                f"CGI must map healthz status={healthz.get('status')!r} to "
+                f"execution_state={expected_state!r} (got {kernels[0]!r}; healthz={healthz!r})."
+            )
 
             legacy_status, legacy_kernels = _get_kernels_via_http(container, kernels_path="/api/kernels/")
             assert legacy_status == 404, f"expected 404 for legacy kernels URL under NB_PREFIX, got {legacy_status}"


### PR DESCRIPTION
PR #4065 aimed to change the URL that access.cgi script uses to reach to CodeServer's healthz endpoint, but CodeServer has 2 web servers to provide the culling, in such way that the communication between the different services uses the following pattern:

<div align="center">
<code class="notranslate">notebooks-controller</code> > <code class="notranslate">nginx (pod routing)</code> > <code class="notranslate">httpd (container routing)</code> > <code class="notranslate">access.cgi</code>
</div><br />

This means that the `access.cgi` will only access the container from within, without the need to use to the `NB_PREFIX` environment variable, as it will reach via `localhost:8787`.

This PR aims to change back the endpoint to `localhost:8787` and fix the culling API endpoint.

## How Has This Been Tested?
This has been tested in the team's cluster.

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health monitoring for Code-Server to use the correct health endpoint.
  * Kernel status now accurately reflects Code-Server health, reporting active services as busy and unavailable services as idle.
  * Health-check failures are handled gracefully without disrupting kernel information.

* **Documentation**
  * Updated architecture documentation with the current Code-Server health-check endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->