### PR TITLE
RHAIENG-6391: fix(codeserver-baseline): carry over culling and code-server copilot enablement

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/nginx/api/kernels/access.cgi
+++ b/codeserver-baseline/ubi9-python-3.12/nginx/api/kernels/access.cgi
@@ -14,13 +14,14 @@ echo "Content-type: application/json"
 echo
 
 # --- Fetch code-server heartbeat ---
-# Poll through nginx on 8888 using the same probe path as notebook-controller:
-#   ${NB_PREFIX}/api  ->  ${NB_PREFIX}/codeserver/healthz/
-# A bare /codeserver/healthz curl fails when NB_PREFIX is set because nginx only
-# routes prefixed /codeserver/* to code-server. -L follows the probe redirect chain.
-NB_PREFIX="${NB_PREFIX:-}"
-HEALTHZ=$(curl -sLf --max-time 5 "http://localhost:8888${NB_PREFIX}/api")
+# Talk to code-server directly on its bind address (nginx upstream workbench_server).
+# Do NOT go through nginx:8888 -- that path is NB_PREFIX-routed for external probes
+# and CGI does not need (or reliably have) NB_PREFIX.
 # Example HEALTHZ JSON: {"status":"alive","lastHeartbeat":1742345025123}
+HEALTHZ=$(curl -sLf --max-time 5 "http://127.0.0.1:8787/healthz") || true
+if [ -z "$HEALTHZ" ]; then
+    echo "access.cgi: healthz fetch failed (http://127.0.0.1:8787/healthz)" >&2
+fi
 
 # --- Derive last_activity (RFC3339 / ISO 8601) ---
 # lastHeartbeat is milliseconds since epoch. The culler expects seconds in ISO format.

--- a/codeserver-baseline/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver-baseline/ubi9-python-3.12/run-code-server.sh
@@ -59,9 +59,12 @@ universal_json_settings='// vscode settings are written in json-with-comments
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
 
-  // Disable GitHub Copilot in code-server
+  // RHAIENG-6400 / RHAISTRAT-2209: enable Copilot Chat surfaces for Device Code auth validation.
+  // Customer GA still gated by Legal RHAI-113; preferDeviceCodeFlow so UrlHandler/OAuth
+  // redirects are not tried first behind Kubeflow OAuth / kube-rbac-proxy.
   // official doc https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code
-  "chat.disableAIFeatures": true,
+  "chat.disableAIFeatures": false,
+  "github-authentication.preferDeviceCodeFlow": true,
 
   // RHOAIENG-14518: Disable the "Do you trust the authors [...]" startup prompt
   "security.workspace.trust.enabled": false,

--- a/tests/containers/workbenches/culling_api_test.py
+++ b/tests/containers/workbenches/culling_api_test.py
@@ -15,13 +15,12 @@ from tests.containers import conftest, docker_utils
 from tests.containers.workbenches.workbench_image_test import WorkbenchContainer
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest import Subtests
 
-CODESERVER_ROOT = PROJECT_ROOT / "codeserver/ubi9-python-3.12"
-ACCESS_CGI_PATH = CODESERVER_ROOT / "nginx/api/kernels/access.cgi"
-HTTPD_CONF_PATH = CODESERVER_ROOT / "httpd/httpd.conf"
-PROXY_TEMPLATE_PATH = CODESERVER_ROOT / "nginx/serverconf/proxy.conf.template"
-PROXY_TEMPLATE_NBPREFIX_PATH = CODESERVER_ROOT / "nginx/serverconf/proxy.conf.template_nbprefix"
+CODESERVER_WORKSPACE_ROOT = PROJECT_ROOT / "codeserver/ubi9-python-3.12"
+CODESERVER_BASELINE_WORKSPACE_ROOT = PROJECT_ROOT / "codeserver-baseline/ubi9-python-3.12"
 
 # date -Iseconds output: 2026-03-18T01:23:45+00:00
 RFC3339_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$")
@@ -78,19 +77,29 @@ def _fetch_healthz(container: WorkbenchContainer, *, nb_prefix: str | None = Non
     return json.loads(output.decode())
 
 
-def _install_culling_stack(container: WorkbenchContainer) -> None:
+def _codeserver_workspace_root(codeserver_image: conftest.Image) -> Path:
+    image_refs = " ".join((codeserver_image.name, codeserver_image.labels.get("name", "")))
+    if "codeserver-baseline" in image_refs:
+        return CODESERVER_BASELINE_WORKSPACE_ROOT
+    return CODESERVER_WORKSPACE_ROOT
+
+
+def _install_culling_stack(container: WorkbenchContainer, codeserver_image: conftest.Image) -> None:
     """Install workspace CGI + httpd + nginx proxy templates and reload the serving stack.
 
     Baked images may lag workspace; tests must exercise current routing, not only CGI bash logic.
     """
+    codeserver_root = _codeserver_workspace_root(codeserver_image)
+    access_cgi_path = codeserver_root / "nginx/api/kernels/access.cgi"
+    httpd_conf_path = codeserver_root / "httpd/httpd.conf"
+    proxy_template_path = codeserver_root / "nginx/serverconf/proxy.conf.template"
+    proxy_template_nbprefix_path = codeserver_root / "nginx/serverconf/proxy.conf.template_nbprefix"
     wrapped = container.get_wrapped_container()
-    docker_utils.container_cp(wrapped, str(ACCESS_CGI_PATH), "/opt/app-root/api/kernels", user=1001, group=0)
-    docker_utils.container_cp(wrapped, str(HTTPD_CONF_PATH), "/etc/httpd/conf", user=1001, group=0)
+    docker_utils.container_cp(wrapped, str(access_cgi_path), "/opt/app-root/api/kernels", user=1001, group=0)
+    docker_utils.container_cp(wrapped, str(httpd_conf_path), "/etc/httpd/conf", user=1001, group=0)
+    docker_utils.container_cp(wrapped, str(proxy_template_path), "/opt/app-root/etc/nginx.default.d", user=1001, group=0)
     docker_utils.container_cp(
-        wrapped, str(PROXY_TEMPLATE_PATH), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
-    )
-    docker_utils.container_cp(
-        wrapped, str(PROXY_TEMPLATE_NBPREFIX_PATH), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
+        wrapped, str(proxy_template_nbprefix_path), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
     )
 
     # Mirror run-nginx.sh template selection, then reload nginx and httpd.
@@ -214,7 +223,7 @@ class TestCullingApi:
                 container.with_env(key, value)
             container.start(wait_for_readiness=False)
             _wait_for_healthz(container, nb_prefix=nb_prefix)
-            _install_culling_stack(container)
+            _install_culling_stack(container, codeserver_image)
 
             healthz = _fetch_healthz(container, nb_prefix=nb_prefix)
             status, kernels = _get_kernels_via_http(container, kernels_path=f"{nb_prefix}/api/kernels/")
@@ -258,7 +267,7 @@ class TestCullingApi:
                         container.with_env(key, value)
                     container.start(wait_for_readiness=False)
                     _wait_for_healthz(container, nb_prefix=nb_prefix or None)
-                    _install_culling_stack(container)
+                    _install_culling_stack(container, codeserver_image)
 
                     healthz = _fetch_healthz(container, nb_prefix=nb_prefix or None)
                     assert healthz.get("lastHeartbeat") == 0, f"expected fresh-pod lastHeartbeat 0, got {healthz!r}"
@@ -276,9 +285,10 @@ class TestCullingApi:
             # Controlled healthz stub cannot be injected through httpd's CGI child PATH.
             with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
                 container.start(wait_for_readiness=False)
+                access_cgi_path = _codeserver_workspace_root(codeserver_image) / "nginx/api/kernels/access.cgi"
                 docker_utils.container_cp(
                     container.get_wrapped_container(),
-                    str(ACCESS_CGI_PATH),
+                    str(access_cgi_path),
                     "/opt/app-root/api/kernels",
                     user=1001,
                     group=0,
@@ -298,7 +308,7 @@ class TestCullingApi:
         with WorkbenchContainer(image=codeserver_image.name, user=1000, group_add=[0]) as container:
             container.start(wait_for_readiness=False)
             _wait_for_healthz(container)
-            _install_culling_stack(container)
+            _install_culling_stack(container, codeserver_image)
 
             status, kernels = _get_kernels_via_http(container, kernels_path="/api/kernels/")
             assert status == 200, f"expected 200 for legacy kernels URL, got {status}"

--- a/tests/containers/workbenches/culling_api_test.py
+++ b/tests/containers/workbenches/culling_api_test.py
@@ -97,7 +97,9 @@ def _install_culling_stack(container: WorkbenchContainer, codeserver_image: conf
     wrapped = container.get_wrapped_container()
     docker_utils.container_cp(wrapped, str(access_cgi_path), "/opt/app-root/api/kernels", user=1001, group=0)
     docker_utils.container_cp(wrapped, str(httpd_conf_path), "/etc/httpd/conf", user=1001, group=0)
-    docker_utils.container_cp(wrapped, str(proxy_template_path), "/opt/app-root/etc/nginx.default.d", user=1001, group=0)
+    docker_utils.container_cp(
+        wrapped, str(proxy_template_path), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
+    )
     docker_utils.container_cp(
         wrapped, str(proxy_template_nbprefix_path), "/opt/app-root/etc/nginx.default.d", user=1001, group=0
     )


### PR DESCRIPTION

related to: https://redhat.atlassian.net/browse/RHAIENG-6391 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Follow-up to #4304. While `codeserver-baseline` was in flight, two runtime fixes landed in `codeserver` image and were not carried into baseline:

- **[RHAIENG-6400](https://redhat.atlassian.net/browse/RHAIENG-6400) / #4252** — enable Copilot chat surfaces and prefer GitHub Device Code Flow in default code-server user settings (`run-code-server.sh`).
- **[RHAIENG-4344](https://redhat.atlassian.net/browse/RHAIENG-4344) / #4315** — fix culling heartbeat probing by having `access.cgi` talk directly to `http://127.0.0.1:8787/healthz` instead of routing through nginx `${NB_PREFIX}/api`.

This PR ports both behaviors into `codeserver-baseline/ubi9-python-3.12` and updates `tests/containers/workbenches/culling_api_test.py` so baseline image runs install workspace files from `codeserver-baseline/ubi9-python-3.12` rather than always copying from `codeserver/ubi9-python-3.12`.

## Test plan

- [x] GHA green: https://github.com/opendatahub-io/notebooks/actions/runs/31167969678/job/92833223726?pr=4317 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


[RHAIENG-6400]: https://redhat.atlassian.net/browse/RHAIENG-6400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4344]: https://redhat.atlassian.net/browse/RHAIENG-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ