### PR TITLE
fix(jupyter): use startup probes for slow workbench startup

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,24 +32,29 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
-          # Generous delays for slow or constrained nodes (e.g. ppc64le in CI).
-          # Liveness must allow Jupyter + datascience deps to bind before first check (avoids restart loops).
+          # Allow up to 180 seconds for startup on slow or constrained nodes (e.g. ppc64le in CI).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 18
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 120
-            periodSeconds: 10
+            initialDelaySeconds: 5
+            periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 90
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
           # Jupyter + papermill share the pod cgroup; keep headroom for datascience tests on ppc64le CI.
           resources:
             limits:

--- a/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,23 +32,29 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
-          # Generous delays for slow or constrained nodes (e.g. ppc64le in CI)
+          # Allow up to 90 seconds for startup on slow or constrained nodes (e.g. ppc64le in CI).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 9
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 5
+            periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 45
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## Description

Adds dedicated `startupProbe`s to the Minimal and Datascience Jupyter StatefulSets so slow startup is handled separately from normal health checks.

- Minimal allows approximately 90 seconds for startup.
- Datascience allows approximately 180 seconds for slower or constrained environments such as ppc64le CI.
- Restores prompt liveness and readiness checks after startup succeeds.

Fixes #4255

## How Has This Been Tested?

* Ran `gmake test` — 430 tests passed.
* Rendered both updated Kustomize bases successfully.
* Verified the expected startup, liveness, and readiness probe values.
* Ran `git diff --check` successfully.

Self checklist (all need to be checked):

* [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
* [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

* [x] The commits are squashed in a cohesive manner and have meaningful messages.
* [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
* [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook startup detection with dedicated startup checks.
  * Updated health checks to detect unresponsive notebook containers sooner.
  * Reduced readiness delays so available notebooks can become ready faster.
  * Applied tailored startup time allowances for data science and minimal notebook environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->