### PR TITLE
chore(base-images): bump AIPCC INDEX_URL to 3.6-EA1-test

### DIFF
--- a/base-images/build-args/cpu.conf
+++ b/base-images/build-args/cpu.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/
+INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.6-EA1/cpu-ubi9-test/simple/

--- a/base-images/build-args/cuda12.9.conf
+++ b/base-images/build-args/cuda12.9.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda12.9-ubi9-test/simple/
+INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9-test/simple/

--- a/base-images/build-args/cuda13.0.conf
+++ b/base-images/build-args/cuda13.0.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda13.0-ubi9-test/simple/
+INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9-test/simple/

--- a/base-images/build-args/rocm7.14.conf
+++ b/base-images/build-args/rocm7.14.conf
@@ -1,1 +1,1 @@
-INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5/rocm7.14-ubi9/simple/
+INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9-test/simple/


### PR DESCRIPTION
## Summary
- Point ODH `base-images/build-args/{cpu,cuda12.9,cuda13.0,rocm7.14}.conf` `INDEX_URL` at AIPCC `3.6-EA1` `*-ubi9-test` indexes so baked `PIP_INDEX_URL` matches current hermetic lock streams.
- Conf values were generated with the sync helpers from the companion automation PR (not hand-typed).

Fixes https://github.com/opendatahub-io/notebooks/issues/4330

## Companion
Automation so release kickoff keeps these confs in sync: https://github.com/opendatahub-io/notebooks/pull/4332

## Test plan
- [ ] Konflux rebuilds the four ODH base images after merge
- [ ] Confirm `com.redhat.aiplatform.index_url` on new bases is `3.6-EA1 *-ubi9-test`
- [ ] Follow-up: sync workbench digests; relax Elyra pins on #4329 once baked indexes match locks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package sources for CPU, CUDA 12.9, CUDA 13.0, and ROCm 7.14 environments.
  * Builds now use the RHOAI 3.6-EA1 repositories instead of older 3.5 repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->