### PR TITLE
chore(base-images): sync INDEX_URL from versions_config aipcc_wheel_index

### DIFF
--- a/base-images/README.md
+++ b/base-images/README.md
@@ -30,7 +30,7 @@ Tag bumps for `quay.io/centos/centos` are blocked by `allowedVersions` in
 | `cpu/` | CPU-only base image |
 | `cuda/` | NVIDIA CUDA (12.9, 13.0) |
 | `rocm/` | AMD ROCm (6.4, 7.1) |
-| `build-args/` | `.conf` files with `INDEX_URL` per variant |
+| `build-args/` | `.conf` files with `INDEX_URL` per variant (managed by `versions_config.yml` → `make sync-build-args-from-versions`) |
 | `utils/` | Shared scripts: `aipcc.sh`, `dnf-helper.sh`, `fix-permissions`, `pip.conf.in`, `uv.toml.in` |
 | `copr/` | Tool to rebuild Fedora SRPMs for EL9 ([README](copr/README.md)) |
 
@@ -89,5 +89,7 @@ Steps:
 1. Copy an existing version directory (e.g. `cuda/12.9/` -> `cuda/13.1/`)
 2. Update the Dockerfile stages from the upstream vendor Dockerfiles for the new SDK version
 3. Update `cuda-repos/` repo files if needed (GPG keys, baseurls)
-4. Create `build-args/<variant>.conf` with the correct `INDEX_URL`
+4. Set `release.aipcc_wheel_index` in `versions_config.yml` and run
+   `make sync-build-args-from-versions` so `build-args/<variant>.conf` gets the
+   correct `INDEX_URL` (do not hand-edit those confs)
 5. Add Tekton pipeline YAMLs in `.tekton/`

--- a/ci/versions_config.schema.json
+++ b/ci/versions_config.schema.json
@@ -2,6 +2,34 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "versions_config.schema.json",
   "$defs": {
+    "AipccWheelIndex": {
+      "additionalProperties": false,
+      "description": "AIPCC wheel index stream baked into ODH base-images INDEX_URL build-args.",
+      "properties": {
+        "stream": {
+          "description": "AIPCC public-rhai rhoai path segment for base-images INDEX_URL (for example \"3.5-EA2\" or \"3.5\"). Independent of release.full_version.",
+          "examples": [
+            "3.5-EA2",
+            "3.6-EA1",
+            "3.5"
+          ],
+          "pattern": "^[0-9]+\\.[0-9]+(-EA[0-9]+)?$",
+          "title": "AIPCC wheel index stream",
+          "type": "string"
+        },
+        "use_test": {
+          "description": "When true, use *-ubi9-test simple indexes; when false, use prod *-ubi9 indexes.",
+          "title": "Use test index",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "stream",
+        "use_test"
+      ],
+      "title": "AipccWheelIndex",
+      "type": "object"
+    },
     "Artifacts": {
       "additionalProperties": false,
       "description": "Artifact groups managed by the versions sync flow.",
@@ -213,12 +241,18 @@
           "pattern": "^[0-9]+\\.[0-9]+$",
           "title": "Python version",
           "type": "string"
+        },
+        "aipcc_wheel_index": {
+          "$ref": "#/$defs/AipccWheelIndex",
+          "description": "Operator input for base-images/build-args/*.conf INDEX_URL. Synced by make sync-build-args-from-versions.",
+          "title": "AIPCC wheel index"
         }
       },
       "required": [
         "full_version",
         "rhds_os_base",
-        "python_version"
+        "python_version",
+        "aipcc_wheel_index"
       ],
       "title": "Release",
       "type": "object"
@@ -338,7 +372,11 @@
       "release": {
         "full_version": "3.5.0",
         "rhds_os_base": "el9.6",
-        "python_version": "3.12"
+        "python_version": "3.12",
+        "aipcc_wheel_index": {
+          "stream": "3.5-EA2",
+          "use_test": true
+        }
       },
       "artifacts": {
         "base_image": {

--- a/ci/versions_config_schema.py
+++ b/ci/versions_config_schema.py
@@ -72,6 +72,19 @@ AccVersion = Annotated[
         examples=["13.0", "7.14"],
     ),
 ]
+AIPCC_WHEEL_INDEX_STREAM_PATTERN = r"^[0-9]+\.[0-9]+(-EA[0-9]+)?$"
+AipccWheelIndexStream = Annotated[
+    str,
+    StringConstraints(pattern=AIPCC_WHEEL_INDEX_STREAM_PATTERN),
+    Field(
+        title="AIPCC wheel index stream",
+        description=(
+            "AIPCC public-rhai rhoai path segment for base-images INDEX_URL "
+            '(for example "3.5-EA2" or "3.5"). Independent of release.full_version.'
+        ),
+        examples=["3.5-EA2", "3.6-EA1", "3.5"],
+    ),
+]
 OdhOrigin = Literal["in-house", "midstream"]
 SchemaVersion = Literal[1]
 
@@ -80,6 +93,16 @@ class StrictModel(BaseModel):
     """Strict structural shapes for operator-edited YAML (feeds JSON Schema)."""
 
     model_config = STRICT_CONFIG
+
+
+class AipccWheelIndex(StrictModel):
+    """AIPCC wheel index stream baked into ODH base-images INDEX_URL build-args."""
+
+    stream: AipccWheelIndexStream
+    use_test: bool = Field(
+        title="Use test index",
+        description='When true, use *-ubi9-test simple indexes; when false, use prod *-ubi9 indexes.',
+    )
 
 
 class Release(StrictModel):
@@ -92,6 +115,13 @@ class Release(StrictModel):
     )
     rhds_os_base: RhdsOsBase
     python_version: PythonVersion
+    aipcc_wheel_index: AipccWheelIndex = Field(
+        title="AIPCC wheel index",
+        description=(
+            "Operator input for base-images/build-args/*.conf INDEX_URL. "
+            "Synced by make sync-build-args-from-versions."
+        ),
+    )
 
 
 class RhdsFastCpuPolicy(StrictModel):
@@ -226,6 +256,7 @@ def build_json_schema() -> dict[str, Any]:
             "full_version": "3.5.0",
             "rhds_os_base": "el9.6",
             "python_version": "3.12",
+            "aipcc_wheel_index": {"stream": "3.5-EA2", "use_test": True},
         },
         "artifacts": {
             "base_image": {

--- a/ci/versions_config_schema.py
+++ b/ci/versions_config_schema.py
@@ -101,7 +101,7 @@ class AipccWheelIndex(StrictModel):
     stream: AipccWheelIndexStream
     use_test: bool = Field(
         title="Use test index",
-        description='When true, use *-ubi9-test simple indexes; when false, use prod *-ubi9 indexes.',
+        description="When true, use *-ubi9-test simple indexes; when false, use prod *-ubi9 indexes.",
     )
 
 
@@ -118,8 +118,7 @@ class Release(StrictModel):
     aipcc_wheel_index: AipccWheelIndex = Field(
         title="AIPCC wheel index",
         description=(
-            "Operator input for base-images/build-args/*.conf INDEX_URL. "
-            "Synced by make sync-build-args-from-versions."
+            "Operator input for base-images/build-args/*.conf INDEX_URL. Synced by make sync-build-args-from-versions."
         ),
     )
 

--- a/docs/base_image_versions_update_configuration.md
+++ b/docs/base_image_versions_update_configuration.md
@@ -28,17 +28,27 @@ The sync flow manages:
 - `RELEASE` in managed `build-args/*.conf` files when that key is already present
 - root `Makefile` `RELEASE`
 - root `Makefile` `RELEASE_PYTHON_VERSION`
+- `INDEX_URL` in `base-images/build-args/{cpu,cuda12.9,cuda13.0,rocm7.14}.conf`
+  from `release.aipcc_wheel_index`
 
 It does not update unrelated files or regenerate lock files. If the image update
 also requires Python lock refreshes, run `make refresh-lock-files` separately.
 
-The script only manages known build-args filenames:
+The script only manages known build-args filenames under notebook trees:
 
 - `cpu.conf`, `cuda.conf`, `rocm.conf`
 - `konflux.cpu.conf`, `konflux.cuda.conf`, `konflux.rocm.conf`
 
-If an unexpected `build-args` filename appears in a managed tree, the sync fails
-early instead of guessing.
+For ODH base images it manages exactly these `INDEX_URL` conf files:
+
+- `base-images/build-args/cpu.conf`
+- `base-images/build-args/cuda12.9.conf`
+- `base-images/build-args/cuda13.0.conf`
+- `base-images/build-args/rocm7.14.conf`
+
+If an unexpected `build-args` filename appears in a managed tree (or an unexpected
+or missing file under `base-images/build-args/`), the sync fails early instead of
+guessing.
 
 ## Prerequisites
 
@@ -98,6 +108,9 @@ release:
   full_version: "3.5.0"
   rhds_os_base: "el9.6"
   python_version: "3.12"
+  aipcc_wheel_index:
+    stream: "3.5-EA2"
+    use_test: true
 
 artifacts:
   base_image:
@@ -126,6 +139,11 @@ artifacts:
   `el9.6`
 - `release.python_version` selects the managed `RELEASE_PYTHON_VERSION` value and
   drives CPU ODH repository naming
+- `release.aipcc_wheel_index.stream` is the AIPCC `public-rhai/rhoai/<stream>/…`
+  path segment for ODH base-image `INDEX_URL` values (independent of
+  `full_version`; for example `3.5-EA2` or `3.6-EA1`)
+- `release.aipcc_wheel_index.use_test` selects `*-ubi9-test` indexes when true,
+  otherwise prod `*-ubi9` indexes
 
 ### Policy Keys
 

--- a/scripts/update_build_args_from_versions.py
+++ b/scripts/update_build_args_from_versions.py
@@ -4,11 +4,12 @@
 
 This flow validates the root config, scans managed image-tree ``build-args``
 files, rewrites managed ``BASE_IMAGE`` and ``RELEASE`` assignments plus the
-root ``Makefile`` release defaults, resolves newer RHDS ``channel: fast``
-releases to the highest already-published phase per target repository, uses
-``skopeo`` to select the latest build in the chosen release-and-phase family,
-and pins each resolved ``BASE_IMAGE`` to an immutable
-``repository:tag@sha256:…`` reference.
+root ``Makefile`` release defaults, rewrites ``INDEX_URL`` in
+``base-images/build-args/*.conf`` from ``release.aipcc_wheel_index``, resolves
+newer RHDS ``channel: fast`` releases to the highest already-published phase
+per target repository, uses ``skopeo`` to select the latest build in the
+chosen release-and-phase family, and pins each resolved ``BASE_IMAGE`` to an
+immutable ``repository:tag@sha256:…`` reference.
 """
 
 from __future__ import annotations
@@ -25,9 +26,20 @@ from typing import Any
 
 import yaml
 
+from scripts.index_url_resolver import build_rhoai_index_url, build_rhoai_test_index_url
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_CONFIG_PATH = ROOT_DIR / "versions_config.yml"
 MANAGED_ROOTS = ("jupyter", "runtimes", "codeserver")
+BASE_IMAGES_BUILD_ARGS_DIR = Path("base-images") / "build-args"
+# Tekton --build-arg-file inputs for ODH base images (INDEX_URL only).
+BASE_IMAGES_INDEX_CONFS: dict[str, str] = {
+    "cpu.conf": "cpu",
+    "cuda12.9.conf": "cuda12.9",
+    "cuda13.0.conf": "cuda13.0",
+    "rocm7.14.conf": "rocm7.14",
+}
+AIPCC_WHEEL_INDEX_STREAM_RE = re.compile(r"^[0-9]+\.[0-9]+(-EA[0-9]+)?$")
 POLICY_SCHEMA = object()
 GPU_FLAVORS = {
     "cuda": ("minimal", "pytorch", "pytorch-llmcompressor", "tensorflow"),
@@ -84,6 +96,10 @@ ROOT_SCHEMA = {
         "full_version": None,
         "rhds_os_base": None,
         "python_version": None,
+        "aipcc_wheel_index": {
+            "stream": None,
+            "use_test": None,
+        },
     },
     "artifacts": {
         "base_image": BASE_IMAGE_SCHEMA,
@@ -110,10 +126,17 @@ _STABLE_ACC_VERSION_INSPECT_FAILED = object()
 
 
 @dataclass(frozen=True)
+class AipccWheelIndexConfig:
+    stream: str
+    use_test: bool
+
+
+@dataclass(frozen=True)
 class ReleaseConfig:
     full_version: str
     rhds_os_base: str
     python_version: str
+    aipcc_wheel_index: AipccWheelIndexConfig
 
 
 @dataclass(frozen=True)
@@ -549,10 +572,12 @@ def load_versions_config(path: Path) -> VersionsConfig:
         raise ValueError(f"Unsupported schema_version in {path}: {data['schema_version']!r}")
 
     release_data = data["release"]
+    aipcc_wheel_index = parse_aipcc_wheel_index(release_data["aipcc_wheel_index"])
     release = ReleaseConfig(
         full_version=scalar_to_string(release_data["full_version"]),
         rhds_os_base=scalar_to_string(release_data["rhds_os_base"]),
         python_version=scalar_to_string(release_data["python_version"]),
+        aipcc_wheel_index=aipcc_wheel_index,
     )
     parse_release_version(release.full_version)
     if not release.rhds_os_base:
@@ -561,6 +586,65 @@ def load_versions_config(path: Path) -> VersionsConfig:
 
     base_image, gpu_acc_versions = normalize_base_image_config(data["artifacts"]["base_image"], release)
     return VersionsConfig(release=release, base_image=base_image, gpu_acc_versions=gpu_acc_versions)
+
+
+def parse_aipcc_wheel_index(raw: object) -> AipccWheelIndexConfig:
+    if not isinstance(raw, dict):
+        raise ValueError("Expected mapping at release.aipcc_wheel_index")
+    stream = scalar_to_string(raw["stream"])
+    if not AIPCC_WHEEL_INDEX_STREAM_RE.fullmatch(stream):
+        raise ValueError(
+            "release.aipcc_wheel_index.stream must look like '3.5' or '3.5-EA2', " f"got {stream!r}"
+        )
+    use_test = raw["use_test"]
+    if not isinstance(use_test, bool):
+        raise ValueError(
+            "release.aipcc_wheel_index.use_test must be a boolean, " f"got {type(use_test).__name__}"
+        )
+    return AipccWheelIndexConfig(stream=stream, use_test=use_test)
+
+
+def build_base_images_index_url(*, stream: str, accelerator: str, use_test: bool) -> str:
+    if use_test:
+        return build_rhoai_test_index_url(release=stream, accelerator=accelerator)
+    return build_rhoai_index_url(release=stream, accelerator=accelerator)
+
+
+def plan_base_images_index_updates(root_dir: Path, config: VersionsConfig) -> list[PlannedUpdate]:
+    build_args_dir = root_dir / BASE_IMAGES_BUILD_ARGS_DIR
+    if not build_args_dir.is_dir():
+        # Unit-test fixtures often omit base-images/; real checkouts always have it.
+        return []
+
+    found = {path.name: path for path in sorted(build_args_dir.glob("*.conf"))}
+    unexpected = sorted(set(found) - set(BASE_IMAGES_INDEX_CONFS))
+    missing = sorted(set(BASE_IMAGES_INDEX_CONFS) - set(found))
+    if unexpected:
+        raise ValueError(
+            "Unexpected base-images/build-args conf file(s): "
+            f"{', '.join(unexpected)}; expected only {', '.join(sorted(BASE_IMAGES_INDEX_CONFS))}"
+        )
+    if missing:
+        raise ValueError(f"Missing base-images/build-args conf file(s): {', '.join(missing)}")
+
+    wheel_index = config.release.aipcc_wheel_index
+    updates: list[PlannedUpdate] = []
+    for conf_name, accelerator in BASE_IMAGES_INDEX_CONFS.items():
+        path = found[conf_name]
+        original_text = path.read_text(encoding="utf-8")
+        index_url = build_base_images_index_url(
+            stream=wheel_index.stream,
+            accelerator=accelerator,
+            use_test=wheel_index.use_test,
+        )
+        updates.append(
+            PlannedUpdate(
+                path=path,
+                original_text=original_text,
+                updated_text=rewrite_conf_text(original_text, {"INDEX_URL": index_url}),
+            )
+        )
+    return updates
 
 
 def classify_conf_name(name: str) -> tuple[str, str] | None:
@@ -1611,6 +1695,8 @@ def plan_updates(
                 updated_text=rewrite_makefile_text(original_text, build_makefile_replacements(config.release)),
             )
         )
+
+    updates.extend(plan_base_images_index_updates(root_dir, config))
 
     return updates
 

--- a/tests/test_versions_config_schema.py
+++ b/tests/test_versions_config_schema.py
@@ -32,6 +32,7 @@ def _minimal_valid_config() -> dict:
             "full_version": "3.5.0",
             "rhds_os_base": "el9.6",
             "python_version": "3.12",
+            "aipcc_wheel_index": {"stream": "3.5-EA2", "use_test": True},
         },
         "artifacts": {
             "base_image": {

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -199,8 +199,11 @@ def write_versions_config(
     full_version: str = "3.6.0",
     rhds_os_base: str = "el9.6",
     python_version: str = "3.12",
+    aipcc_wheel_index_stream: str = "3.5-EA2",
+    aipcc_wheel_index_use_test: bool = True,
     replacements: list[tuple[str, str]] | None = None,
 ) -> None:
+    use_test_yaml = "true" if aipcc_wheel_index_use_test else "false"
     text = textwrap.dedent(
         f"""\
         schema_version: {schema_version}
@@ -209,6 +212,9 @@ def write_versions_config(
           full_version: "{full_version}"
           rhds_os_base: "{rhds_os_base}"
           python_version: "{python_version}"
+          aipcc_wheel_index:
+            stream: "{aipcc_wheel_index_stream}"
+            use_test: {use_test_yaml}
 
         artifacts:
           base_image:
@@ -296,6 +302,9 @@ def test_load_versions_config_rejects_unexpected_keys(tmp_path: Path) -> None:
               full_version: "3.5.0"
               rhds_os_base: "el9.6"
               python_version: "3.12"
+              aipcc_wheel_index:
+                stream: "3.5-EA2"
+                use_test: true
 
             artifacts:
               base_image:
@@ -356,6 +365,8 @@ def test_load_versions_config_accepts_schema_version_one(tmp_path: Path) -> None
 
     assert loaded.release.full_version == "3.6.0"
     assert loaded.release.python_version == "3.12"
+    assert loaded.release.aipcc_wheel_index.stream == "3.5-EA2"
+    assert loaded.release.aipcc_wheel_index.use_test is True
 
 
 def test_load_versions_config_accepts_shared_gpu_acc_version_layout(tmp_path: Path) -> None:
@@ -407,7 +418,12 @@ def test_load_versions_config_rejects_schema_version_two(tmp_path: Path) -> None
 
 def test_resolve_version_uses_full_version_placeholder() -> None:
     updater = load_updater()
-    release = updater.ReleaseConfig(full_version="3.6.0", rhds_os_base="el9.6", python_version="3.12")
+    release = updater.ReleaseConfig(
+        full_version="3.6.0",
+        rhds_os_base="el9.6",
+        python_version="3.12",
+        aipcc_wheel_index=updater.AipccWheelIndexConfig(stream="3.5-EA2", use_test=True),
+    )
 
     assert updater.resolve_version("<full_version>", release) == "3.6.0"
 
@@ -442,6 +458,9 @@ def test_load_versions_config_rejects_non_scalar_cpu_version(tmp_path: Path) -> 
               full_version: "3.5.0"
               rhds_os_base: "el9.6"
               python_version: "3.12"
+              aipcc_wheel_index:
+                stream: "3.5-EA2"
+                use_test: true
 
             artifacts:
               base_image:
@@ -848,7 +867,12 @@ def test_select_latest_matching_rhds_tag_prefers_highest_build_in_same_family() 
 
 def test_build_rhds_pinned_tag_targets_ga_family_on_rollback() -> None:
     updater = load_updater()
-    release = updater.ReleaseConfig(full_version="3.4.0", rhds_os_base="el9.6", python_version="3.12")
+    release = updater.ReleaseConfig(
+        full_version="3.4.0",
+        rhds_os_base="el9.6",
+        python_version="3.12",
+        aipcc_wheel_index=updater.AipccWheelIndexConfig(stream="3.5-EA2", use_test=True),
+    )
 
     tag = updater.build_rhds_pinned_tag("3.5.0-ea.2-1777919771", release.full_version)
 
@@ -2186,3 +2210,97 @@ def test_main_updates_cuda_stable_with_rhds_stable_repo_override(
         "PYLOCK_FLAVOR=cuda",
         "RELEASE=3.5",
     ]
+
+
+def _write_base_images_index_confs(root: Path, *, index_url_by_conf: dict[str, str] | None = None) -> dict[str, Path]:
+    build_args = root / "base-images" / "build-args"
+    build_args.mkdir(parents=True)
+    defaults = {
+        "cpu.conf": "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/",
+        "cuda12.9.conf": "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda12.9-ubi9-test/simple/",
+        "cuda13.0.conf": "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cuda13.0-ubi9-test/simple/",
+        "rocm7.14.conf": "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5/rocm7.14-ubi9/simple/",
+    }
+    urls = index_url_by_conf or defaults
+    paths: dict[str, Path] = {}
+    for name, url in urls.items():
+        path = build_args / name
+        path.write_text(f"INDEX_URL={url}\n", encoding="utf-8")
+        paths[name] = path
+    return paths
+
+
+def test_plan_base_images_index_updates_rewrites_index_urls(tmp_path: Path) -> None:
+    updater = load_updater()
+    config_path = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config_path,
+        aipcc_wheel_index_stream="3.6-EA1",
+        aipcc_wheel_index_use_test=True,
+    )
+    paths = _write_base_images_index_confs(tmp_path)
+    config = updater.load_versions_config(config_path)
+
+    updates = updater.plan_base_images_index_updates(tmp_path, config)
+    by_name = {update.path.name: update for update in updates}
+
+    assert set(by_name) == set(updater.BASE_IMAGES_INDEX_CONFS)
+    for conf_name, accelerator in updater.BASE_IMAGES_INDEX_CONFS.items():
+        expected = updater.build_rhoai_test_index_url(release="3.6-EA1", accelerator=accelerator)
+        assert f"INDEX_URL={expected}" in by_name[conf_name].updated_text
+        assert by_name[conf_name].original_text == paths[conf_name].read_text(encoding="utf-8")
+
+
+def test_plan_base_images_index_updates_supports_prod_indexes(tmp_path: Path) -> None:
+    updater = load_updater()
+    config_path = tmp_path / "versions_config.yml"
+    write_versions_config(
+        config_path,
+        aipcc_wheel_index_stream="3.5",
+        aipcc_wheel_index_use_test=False,
+    )
+    _write_base_images_index_confs(tmp_path)
+    config = updater.load_versions_config(config_path)
+
+    updates = updater.plan_base_images_index_updates(tmp_path, config)
+    cpu_update = next(update for update in updates if update.path.name == "cpu.conf")
+    assert (
+        "INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/"
+        in cpu_update.updated_text
+    )
+
+
+def test_plan_base_images_index_updates_rejects_unexpected_conf(tmp_path: Path) -> None:
+    updater = load_updater()
+    config_path = tmp_path / "versions_config.yml"
+    write_versions_config(config_path)
+    _write_base_images_index_confs(tmp_path)
+    (tmp_path / "base-images" / "build-args" / "extra.conf").write_text(
+        "INDEX_URL=https://example.invalid/simple/\n",
+        encoding="utf-8",
+    )
+    config = updater.load_versions_config(config_path)
+
+    with pytest.raises(ValueError, match="Unexpected base-images/build-args"):
+        updater.plan_base_images_index_updates(tmp_path, config)
+
+
+def test_plan_base_images_index_updates_rejects_missing_conf(tmp_path: Path) -> None:
+    updater = load_updater()
+    config_path = tmp_path / "versions_config.yml"
+    write_versions_config(config_path)
+    paths = _write_base_images_index_confs(tmp_path)
+    paths["rocm7.14.conf"].unlink()
+    config = updater.load_versions_config(config_path)
+
+    with pytest.raises(ValueError, match="Missing base-images/build-args"):
+        updater.plan_base_images_index_updates(tmp_path, config)
+
+
+def test_load_versions_config_rejects_invalid_aipcc_stream(tmp_path: Path) -> None:
+    updater = load_updater()
+    config = tmp_path / "versions_config.yml"
+    write_versions_config(config, aipcc_wheel_index_stream="not-a-stream")
+
+    with pytest.raises(ValueError, match="aipcc_wheel_index.stream"):
+        updater.load_versions_config(config)

--- a/tests/unit/scripts/test_update_build_args_from_versions.py
+++ b/tests/unit/scripts/test_update_build_args_from_versions.py
@@ -2302,5 +2302,5 @@ def test_load_versions_config_rejects_invalid_aipcc_stream(tmp_path: Path) -> No
     config = tmp_path / "versions_config.yml"
     write_versions_config(config, aipcc_wheel_index_stream="not-a-stream")
 
-    with pytest.raises(ValueError, match="aipcc_wheel_index.stream"):
+    with pytest.raises(ValueError, match=r"aipcc_wheel_index\.stream"):
         updater.load_versions_config(config)

--- a/versions_config.yml
+++ b/versions_config.yml
@@ -16,6 +16,10 @@ release:
   full_version: "3.6.0"
   rhds_os_base: "el9.6"
   python_version: "3.12"
+  # AIPCC public-rhai stream for ODH base-images INDEX_URL (independent of full_version).
+  aipcc_wheel_index:
+    stream: "3.6-EA1"
+    use_test: true
 
 artifacts:
   base_image:


### PR DESCRIPTION
## Summary
- Add `release.aipcc_wheel_index.{stream,use_test}` to `versions_config.yml` / schema.
- Extend `make sync-build-args-from-versions` to rewrite `base-images/build-args/*.conf` `INDEX_URL` via `index_url_resolver` helpers.
- Seed to `3.5-EA2` / `use_test: true` (normalizes ROCm onto the shared test stream; content bump to `3.6-EA1` is a separate PR).

Fixes https://github.com/opendatahub-io/notebooks/issues/4330

## Companion
Direct INDEX_URL bump to `3.6-EA1-test`: https://github.com/opendatahub-io/notebooks/pull/4331 — prefer merging that first if base rebuilds are urgent.

## Test plan
- [ ] `uv run pytest tests/test_versions_config_schema.py tests/unit/scripts/test_update_build_args_from_versions.py`
- [ ] After merge, mid-release index changes are `edit versions_config.yml` + `make sync-build-args-from-versions` only