### PR TITLE
ci(renovate): manage ODH BASE_IMAGE digests on upstream main

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,7 +111,7 @@
     ],
   },
 
-  // Track BASE_IMAGE references in konflux build-args conf files.
+  // Track BASE_IMAGE references in build-args conf files.
   // These files use shell-variable syntax (BASE_IMAGE=registry/repo:tag)
   // which the built-in dockerfile manager cannot parse.
   "customManagers": [
@@ -138,6 +138,22 @@
       // still treating EA tags as unstable for ignoreUnstable gating.
       // This RE2-safe form avoids duplicate named capture groups.
       "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?:-ea\\.(?<prerelease>\\d+-\\d+)|-(?<build>\\d+))$",
+    },
+    {
+      // ODH PRODUCT=odh pins (cpu.conf / cuda.conf / rocm.conf) use :latest@sha256.
+      // Separate from the konflux manager: docker versioning, not AIPCC EA regex.
+      // Enabled only on opendatahub-io/notebooks @ main via packageRules below.
+      "customType": "regex",
+      "description": "Update BASE_IMAGE in ODH (non-konflux) build-args conf files",
+      "managerFilePatterns": [
+        "/(jupyter|codeserver|runtimes)/.+/build-args/(cpu|cuda|rocm)\\.conf$/",
+      ],
+      "matchStrings": [
+        "BASE_IMAGE=(?<depName>[^:@\\s]+(?:/[^:@\\s]+)+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?",
+      ],
+      "autoReplaceStringTemplate": "BASE_IMAGE={{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
     },
   ],
 
@@ -198,6 +214,29 @@
       "matchPackageNames": ["/^quay\\.io\\/aipcc\\//"],
       "groupName": "konflux BASE_IMAGE {{{depNameSanitized}}}",
       "pinDigests": true,
+      "recreateWhen": "always",
+      "semanticCommits": "enabled",
+    },
+    {
+      // Shared renovate.json5 is also used on RHDS release branches; keep ODH
+      // quay pins off everywhere until explicitly re-enabled for upstream main.
+      "description": "Disable ODH quay.io/opendatahub BASE_IMAGE updates by default",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["/^quay\\.io\\/opendatahub\\//"],
+      "enabled": false,
+    },
+    {
+      "description": "ODH BASE_IMAGE digest updates on opendatahub-io/notebooks main only",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["/^quay\\.io\\/opendatahub\\//"],
+      "matchRepositories": ["opendatahub-io/notebooks"],
+      "matchBaseBranches": ["main"],
+      "enabled": true,
+      "groupName": "odh BASE_IMAGE {{{depNameSanitized}}}",
+      "pinDigests": true,
+      "allowedVersions": "/^latest$/",
       "recreateWhen": "always",
       "semanticCommits": "enabled",
     },

--- a/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
+++ b/docs/architecture/decisions/0013-renovate-mintmaker-and-self-hosted-github-actions.md
@@ -24,9 +24,11 @@ repository and branches—not only committing `renovate.json5` to the repo.
 ### Repository config (this repo)
 
 The bot reads **`.github/renovate.json5`**. It extends MintMaker-oriented settings and
-enables managers for **Tekton** (`.tekton/**`), **Dockerfile** `FROM` updates, a
-**custom regex** manager for `BASE_IMAGE=` in Konflux `build-args/konflux.*.conf` files,
-and **GitHub Actions** digest pinning (see [ADR 0008](0008-harden-github-actions-pin-sha-digests.md)).
+enables managers for **Tekton** (`.tekton/**`), **Dockerfile** `FROM` updates,
+**custom regex** managers for `BASE_IMAGE=` in Konflux `build-args/konflux.*.conf`
+(AIPCC) and ODH `build-args/{cpu,cuda,rocm}.conf` (`quay.io/opendatahub/…:latest@sha256`,
+enabled only on `opendatahub-io/notebooks` @ `main`), and **GitHub Actions** digest
+pinning (see [ADR 0008](0008-harden-github-actions-pin-sha-digests.md)).
 Python notebook lockfiles are **not** managed by Renovate; they are refreshed by
 `make refresh-lock-files` and
 [`piplock-renewal.yaml`](../../../.github/workflows/piplock-renewal.yaml).

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -69,12 +69,17 @@ def find_repo_rule(
     enabled: bool,
     require_match_base_branches: bool | None = None,
 ) -> dict[str, Any] | None:
+    """Find a repo-wide MintMaker gate rule (no manager/package filters)."""
     for rule in package_rules:
         if not isinstance(rule, dict):
             continue
         if rule.get("matchRepositories") != [repository]:
             continue
         if rule.get("enabled") is not enabled:
+            continue
+        # Manager-scoped rules (e.g. ODH BASE_IMAGE enable) share matchRepositories
+        # with the repo-wide MintMaker gates; only the unscoped gates qualify here.
+        if "matchManagers" in rule or "matchPackageNames" in rule:
             continue
         has_match_base_branches = "matchBaseBranches" in rule
         if require_match_base_branches is True and not has_match_base_branches:
@@ -226,8 +231,7 @@ def validate_odh_base_image_policy(
         (
             manager
             for manager in custom_managers
-            if isinstance(manager, dict)
-            and manager.get("description", "").startswith(ODH_BASE_MANAGER_DESCRIPTION)
+            if isinstance(manager, dict) and manager.get("description", "").startswith(ODH_BASE_MANAGER_DESCRIPTION)
         ),
         None,
     )
@@ -247,8 +251,7 @@ def validate_odh_base_image_policy(
         (
             rule
             for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("description", "").startswith(ODH_BASE_DISABLE_RULE_DESCRIPTION)
+            if isinstance(rule, dict) and rule.get("description", "").startswith(ODH_BASE_DISABLE_RULE_DESCRIPTION)
         ),
         None,
     )
@@ -267,8 +270,7 @@ def validate_odh_base_image_policy(
         (
             rule
             for rule in package_rules
-            if isinstance(rule, dict)
-            and rule.get("description", "").startswith(ODH_BASE_ENABLE_RULE_DESCRIPTION)
+            if isinstance(rule, dict) and rule.get("description", "").startswith(ODH_BASE_ENABLE_RULE_DESCRIPTION)
         ),
         None,
     )

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -24,6 +24,11 @@ EXPECTED_PREFIX_MATCH_BASE = ["!/^main$/"]
 EXPECTED_COMMIT_MESSAGE_PREFIX = "[{{{baseBranch}}}]"
 CENTOS_STREAM_RULE_DESCRIPTION = "Pin CentOS Stream base to stream9 (c9s only; no stream10)"
 CENTOS_STREAM_ALLOWED_VERSIONS = "/^stream9$/"
+ODH_BASE_DISABLE_RULE_DESCRIPTION = "Disable ODH quay.io/opendatahub BASE_IMAGE updates by default"
+ODH_BASE_ENABLE_RULE_DESCRIPTION = "ODH BASE_IMAGE digest updates on opendatahub-io/notebooks main only"
+ODH_BASE_MANAGER_DESCRIPTION = "Update BASE_IMAGE in ODH (non-konflux) build-args conf files"
+ODH_BASE_MANAGER_FILE_PATTERN = "/(jupyter|codeserver|runtimes)/.+/build-args/(cpu|cuda|rocm)\\.conf$/"
+ODH_BASE_PACKAGE_PATTERN = "/^quay\\.io\\/opendatahub\\//"
 
 
 @dataclass(frozen=True)
@@ -201,6 +206,94 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
             )
         if centos_stream_pin.get("pinDigests") is not True:
             errors.append("CentOS Stream pin rule must set pinDigests: true")
+
+    errors.extend(validate_odh_base_image_policy(config.get("customManagers"), package_rules))
+
+    return errors
+
+
+def validate_odh_base_image_policy(
+    custom_managers: object,
+    package_rules: list[Any],
+) -> list[str]:
+    errors: list[str] = []
+
+    if not isinstance(custom_managers, list):
+        errors.append("customManagers must be a list")
+        return errors
+
+    odh_manager = next(
+        (
+            manager
+            for manager in custom_managers
+            if isinstance(manager, dict)
+            and manager.get("description", "").startswith(ODH_BASE_MANAGER_DESCRIPTION)
+        ),
+        None,
+    )
+    if odh_manager is None:
+        errors.append(f"missing customManager: {ODH_BASE_MANAGER_DESCRIPTION!r}")
+    else:
+        patterns = odh_manager.get("managerFilePatterns")
+        if patterns != [ODH_BASE_MANAGER_FILE_PATTERN]:
+            errors.append(
+                "ODH BASE_IMAGE customManager managerFilePatterns must be "
+                f"{[ODH_BASE_MANAGER_FILE_PATTERN]!r}, got {patterns!r}"
+            )
+        if odh_manager.get("versioningTemplate") != "docker":
+            errors.append("ODH BASE_IMAGE customManager must use versioningTemplate: docker")
+
+    disable_rule = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("description", "").startswith(ODH_BASE_DISABLE_RULE_DESCRIPTION)
+        ),
+        None,
+    )
+    if disable_rule is None:
+        errors.append(f"missing packageRule: {ODH_BASE_DISABLE_RULE_DESCRIPTION!r}")
+    else:
+        if disable_rule.get("enabled") is not False:
+            errors.append("ODH BASE_IMAGE disable rule must set enabled: false")
+        if disable_rule.get("matchPackageNames") != [ODH_BASE_PACKAGE_PATTERN]:
+            errors.append(
+                "ODH BASE_IMAGE disable rule matchPackageNames must be "
+                f"{[ODH_BASE_PACKAGE_PATTERN]!r}, got {disable_rule.get('matchPackageNames')!r}"
+            )
+
+    enable_rule = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict)
+            and rule.get("description", "").startswith(ODH_BASE_ENABLE_RULE_DESCRIPTION)
+        ),
+        None,
+    )
+    if enable_rule is None:
+        errors.append(f"missing packageRule: {ODH_BASE_ENABLE_RULE_DESCRIPTION!r}")
+    else:
+        if enable_rule.get("enabled") is not True:
+            errors.append("ODH BASE_IMAGE enable rule must set enabled: true")
+        if enable_rule.get("matchRepositories") != [ODH_REPO]:
+            errors.append(
+                "ODH BASE_IMAGE enable rule matchRepositories must be "
+                f"{[ODH_REPO]!r}, got {enable_rule.get('matchRepositories')!r}"
+            )
+        if enable_rule.get("matchBaseBranches") != ["main"]:
+            errors.append(
+                "ODH BASE_IMAGE enable rule matchBaseBranches must be ['main'], "
+                f"got {enable_rule.get('matchBaseBranches')!r}"
+            )
+        if enable_rule.get("pinDigests") is not True:
+            errors.append("ODH BASE_IMAGE enable rule must set pinDigests: true")
+        if enable_rule.get("allowedVersions") != "/^latest$/":
+            errors.append(
+                "ODH BASE_IMAGE enable rule allowedVersions must be '/^latest$/', "
+                f"got {enable_rule.get('allowedVersions')!r}"
+            )
 
     return errors
 

--- a/scripts/ci/validate_renovate_dry_run.py
+++ b/scripts/ci/validate_renovate_dry_run.py
@@ -88,6 +88,29 @@ def extract_pr_titles(records: list[dict]) -> list[str]:
     return titles
 
 
+def _rule_description(rule: dict) -> str:
+    description = rule.get("description", "")
+    if isinstance(description, list):
+        return description[0] if description and isinstance(description[0], str) else ""
+    return description if isinstance(description, str) else ""
+
+
+def extract_combined_prefix_rule(records: list[dict]) -> dict | None:
+    """Return the PR-title prefix packageRule from Renovate's Combined config log."""
+    for record in records:
+        if record.get("msg") != "Combined config":
+            continue
+        config = record.get("config")
+        if not isinstance(config, dict):
+            continue
+        for rule in config.get("packageRules", []):
+            if not isinstance(rule, dict):
+                continue
+            if _rule_description(rule).startswith("Prefix PR titles with branch name for non-main branches"):
+                return rule
+    return None
+
+
 def is_known_config_warning(message: str) -> bool:
     return any(known in message for known in KNOWN_CONFIG_WARNINGS)
 
@@ -107,10 +130,35 @@ def fatal_config_warnings(records: list[dict]) -> list[str]:
     return warnings
 
 
-def validate_scenario_titles(scenario: DryRunScenario, titles: list[str]) -> list[str]:
+def validate_scenario_titles(
+    scenario: DryRunScenario,
+    titles: list[str],
+    *,
+    records: list[dict] | None = None,
+) -> list[str]:
     errors: list[str] = []
     if not titles:
-        errors.append(f"{scenario.name}: no prTitle values found in Renovate dry-run output")
+        # No pending updates on this branch — cannot assert on live PR titles.
+        # Fall back to confirming Renovate loaded the prefix packageRule.
+        if records is None:
+            errors.append(f"{scenario.name}: no prTitle values found in Renovate dry-run output")
+            return errors
+        prefix_rule = extract_combined_prefix_rule(records)
+        if prefix_rule is None:
+            errors.append(
+                f"{scenario.name}: no prTitle values and Combined config is missing the PR-title prefix packageRule"
+            )
+            return errors
+        if prefix_rule.get("commitMessagePrefix") != "[{{{baseBranch}}}]":
+            errors.append(
+                f"{scenario.name}: Combined config prefix rule commitMessagePrefix must be "
+                f"'[{{{{baseBranch}}}}]', got {prefix_rule.get('commitMessagePrefix')!r}"
+            )
+        if prefix_rule.get("matchBaseBranches") != ["!/^main$/"]:
+            errors.append(
+                f"{scenario.name}: Combined config prefix rule matchBaseBranches must be "
+                f'["!/^main$/"], got {prefix_rule.get("matchBaseBranches")!r}'
+            )
         return errors
 
     if scenario.require_prefix is None:
@@ -201,7 +249,13 @@ def validate_dry_runs(
             continue
 
         errors.extend(f"{scenario.name}: unexpected config warning: {msg}" for msg in fatal_config_warnings(records))
-        errors.extend(validate_scenario_titles(scenario, extract_pr_titles(records)))
+        errors.extend(
+            validate_scenario_titles(
+                scenario,
+                extract_pr_titles(records),
+                records=records,
+            )
+        )
     return errors
 
 

--- a/tests/unit/scripts/ci/renovate_config_testdata.py
+++ b/tests/unit/scripts/ci/renovate_config_testdata.py
@@ -8,6 +8,12 @@ from scripts.ci.validate_renovate_config import (
     EXPECTED_COMMIT_MESSAGE_PREFIX,
     EXPECTED_PREFIX_MATCH_BASE,
     MINTMAKER_POLICIES,
+    ODH_BASE_DISABLE_RULE_DESCRIPTION,
+    ODH_BASE_ENABLE_RULE_DESCRIPTION,
+    ODH_BASE_MANAGER_DESCRIPTION,
+    ODH_BASE_MANAGER_FILE_PATTERN,
+    ODH_BASE_PACKAGE_PATTERN,
+    ODH_REPO,
     PREFIX_RULE_DESCRIPTION,
     REQUIRED_ENABLED_MANAGERS,
     MintMakerRepoPolicy,
@@ -54,15 +60,51 @@ def centos_stream_pin_rule() -> dict[str, Any]:
     }
 
 
+def odh_base_image_custom_manager() -> dict[str, Any]:
+    return {
+        "customType": "regex",
+        "description": ODH_BASE_MANAGER_DESCRIPTION,
+        "managerFilePatterns": [ODH_BASE_MANAGER_FILE_PATTERN],
+        "versioningTemplate": "docker",
+    }
+
+
+def odh_base_image_disable_rule() -> dict[str, Any]:
+    return {
+        "description": ODH_BASE_DISABLE_RULE_DESCRIPTION,
+        "matchManagers": ["custom.regex"],
+        "matchDatasources": ["docker"],
+        "matchPackageNames": [ODH_BASE_PACKAGE_PATTERN],
+        "enabled": False,
+    }
+
+
+def odh_base_image_enable_rule() -> dict[str, Any]:
+    return {
+        "description": ODH_BASE_ENABLE_RULE_DESCRIPTION,
+        "matchManagers": ["custom.regex"],
+        "matchDatasources": ["docker"],
+        "matchPackageNames": [ODH_BASE_PACKAGE_PATTERN],
+        "matchRepositories": [ODH_REPO],
+        "matchBaseBranches": ["main"],
+        "enabled": True,
+        "pinDigests": True,
+        "allowedVersions": "/^latest$/",
+    }
+
+
 def minimal_valid_config(*extra_rules: dict[str, Any]) -> dict[str, Any]:
     package_rules: list[dict[str, Any]] = [prefix_rule()]
     for policy in MINTMAKER_POLICIES:
         package_rules.extend(mintmaker_gate_rules(policy))
     package_rules.append(github_actions_group_rule())
     package_rules.append(centos_stream_pin_rule())
+    package_rules.append(odh_base_image_disable_rule())
+    package_rules.append(odh_base_image_enable_rule())
     package_rules.extend(extra_rules)
     return {
         "enabledManagers": list(REQUIRED_ENABLED_MANAGERS),
+        "customManagers": [odh_base_image_custom_manager()],
         "packageRules": package_rules,
     }
 
@@ -83,10 +125,19 @@ def policy_by_label(label: str) -> MintMakerRepoPolicy:
     raise KeyError(msg)
 
 
+def _is_mintmaker_repo_gate(rule: dict[str, Any], policy: MintMakerRepoPolicy) -> bool:
+    """True for repo-wide MintMaker gates (not manager-scoped packageRules)."""
+    return (
+        rule.get("matchRepositories") == [policy.repository]
+        and "matchManagers" not in rule
+        and "matchPackageNames" not in rule
+    )
+
+
 def remove_mintmaker_disable(config: dict[str, Any], policy: MintMakerRepoPolicy) -> dict[str, Any]:
     return with_package_rules_removed(
         config,
-        lambda rule: rule.get("matchRepositories") == [policy.repository] and rule.get("enabled") is False,
+        lambda rule: _is_mintmaker_repo_gate(rule, policy) and rule.get("enabled") is False,
     )
 
 
@@ -94,9 +145,7 @@ def remove_mintmaker_enable(config: dict[str, Any], policy: MintMakerRepoPolicy)
     return with_package_rules_removed(
         config,
         lambda rule: (
-            rule.get("matchRepositories") == [policy.repository]
-            and rule.get("enabled") is True
-            and "matchBaseBranches" in rule
+            _is_mintmaker_repo_gate(rule, policy) and rule.get("enabled") is True and "matchBaseBranches" in rule
         ),
     )
 
@@ -111,11 +160,7 @@ def mintmaker_enable_with_branches(
         if not isinstance(rule, dict):
             updated_rules.append(rule)
             continue
-        if (
-            rule.get("matchRepositories") == [policy.repository]
-            and rule.get("enabled") is True
-            and "matchBaseBranches" in rule
-        ):
+        if _is_mintmaker_repo_gate(rule, policy) and rule.get("enabled") is True and "matchBaseBranches" in rule:
             updated_rules.append({**rule, "matchBaseBranches": branches})
             continue
         updated_rules.append(rule)

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -90,6 +90,27 @@ def test_minimal_valid_config_passes_validation() -> None:
             [f"missing CentOS Stream pin packageRule: {validator.CENTOS_STREAM_RULE_DESCRIPTION!r}"],
             id="missing-centos-stream-pin",
         ),
+        pytest.param(
+            lambda config: {**config, "customManagers": []},
+            [f"missing customManager: {validator.ODH_BASE_MANAGER_DESCRIPTION!r}"],
+            id="missing-odh-base-manager",
+        ),
+        pytest.param(
+            lambda config: testdata.with_package_rules_removed(
+                config,
+                lambda rule: rule.get("description", "").startswith(validator.ODH_BASE_DISABLE_RULE_DESCRIPTION),
+            ),
+            [f"missing packageRule: {validator.ODH_BASE_DISABLE_RULE_DESCRIPTION!r}"],
+            id="missing-odh-base-disable",
+        ),
+        pytest.param(
+            lambda config: testdata.with_package_rules_removed(
+                config,
+                lambda rule: rule.get("description", "").startswith(validator.ODH_BASE_ENABLE_RULE_DESCRIPTION),
+            ),
+            [f"missing packageRule: {validator.ODH_BASE_ENABLE_RULE_DESCRIPTION!r}"],
+            id="missing-odh-base-enable",
+        ),
     ],
 )
 def test_validate_config_reports_expected_errors(

--- a/tests/unit/scripts/ci/test_validate_renovate_dry_run.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_dry_run.py
@@ -56,6 +56,25 @@ def test_validate_scenario_titles_detects_missing_prefix() -> None:
     assert "expected at least one PR title" in errors[0], f"Unexpected validation error message: {errors[0]}"
 
 
+def test_validate_scenario_titles_empty_falls_back_to_combined_config() -> None:
+    scenario = dry_run.SCENARIOS[1]
+    records = dry_run.parse_json_log_lines(
+        """
+{"msg":"Combined config","config":{"packageRules":[{"description":"Prefix PR titles with branch name for non-main branches","matchBaseBranches":["!/^main$/"],"commitMessagePrefix":"[{{{baseBranch}}}]"}]}}
+"""
+    )
+    errors = dry_run.validate_scenario_titles(scenario, [], records=records)
+    assert errors == [], f"Expected empty titles to pass via Combined config fallback, got: {errors}"
+
+
+def test_validate_scenario_titles_empty_without_prefix_rule_fails() -> None:
+    scenario = dry_run.SCENARIOS[1]
+    records = dry_run.parse_json_log_lines('{"msg":"Combined config","config":{"packageRules":[]}}')
+    errors = dry_run.validate_scenario_titles(scenario, [], records=records)
+    assert len(errors) == 1, f"Expected exactly one validation error, got: {errors}"
+    assert "missing the PR-title prefix packageRule" in errors[0], f"Unexpected error: {errors[0]}"
+
+
 def test_fatal_config_warnings_ignores_known_cosmetic() -> None:
     records = dry_run.parse_json_log_lines(MAIN_FIXTURE)
     warnings = dry_run.fatal_config_warnings(records)


### PR DESCRIPTION
## Summary
- Extend Renovate `customManagers` to track `BASE_IMAGE=` in ODH `build-args/{cpu,cuda,rocm}.conf` (`:latest@sha256`).
- Disable `quay.io/opendatahub/*` updates by default; re-enable only on `opendatahub-io/notebooks` @ `main` (one PR per image, digests pinned, tag locked to `latest`).
- Semantic validation + ADR 0013 note.

Validated by running Renovate locally (`scripts/ci/renovate_run.py remote`, ide-developer token) with this config mounted; it opened the first ODH digest bump PRs:

- https://github.com/opendatahub-io/notebooks/pull/4336 (cpu)
- https://github.com/opendatahub-io/notebooks/pull/4337 (cuda)
- https://github.com/opendatahub-io/notebooks/pull/4338 (rocm)

Those PRs target `main` and do not depend on merging this config PR first (they were produced from a local config mount). After this lands, self-hosted / MintMaker runs will keep proposing the same class of updates.

## Test plan
- [x] `uv run python scripts/ci/validate_renovate_config.py`
- [x] `uv run pytest tests/test_renovate_config.py`
- [x] Local real Renovate run produced #4336 / #4337 / #4338
- [ ] After merge, scheduled Renovate (self-hosted) continues to list ODH base images on the Dependency Dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated tracking for ODH base-image versions and digests in Renovate.
  * Enabled latest-tag digest updates for the notebooks project on its main branch.

* **Documentation**
  * Updated architecture documentation to describe the expanded Renovate and GitHub Actions configuration.

* **Bug Fixes**
  * Improved dry-run validation when no pull request titles are available.
  * Strengthened validation of required Renovate policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->