### PR TITLE
chore(ci/agentic-reviewer): pass `--allow-escape-sequences` to gh job log fetch

### DIFF
--- a/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
+++ b/ci/agentic-reviewer/src/odh_ci_agent/github_api.py
@@ -220,6 +220,9 @@ def gh_job_log(repository: str, job_id: int, *, timeout: int = DEFAULT_TIMEOUT_S
             "GET",
             "-H",
             "Accept: application/vnd.github+json",
+            # CI logs often include FORCE_COLOR/pytest ANSI output; without this flag
+            # gh refuses to print the response and local log grounding fails.
+            "--allow-escape-sequences",
         ],
         timeout=timeout,
     )

--- a/ci/agentic-reviewer/tests/unit/test_github_api.py
+++ b/ci/agentic-reviewer/tests/unit/test_github_api.py
@@ -116,6 +116,30 @@ def test_authenticated_user_login_reraises_non_forbidden_api_errors(monkeypatch:
         github_api.authenticated_user_login.cache_clear()
 
 
+def test_gh_job_log_requests_allow_escape_sequences() -> None:
+    with patch("odh_ci_agent.github_api.run_command") as mock_run_command:
+        mock_run_command.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="log line\n",
+            stderr="",
+        )
+        result = github_api.gh_job_log("owner/repo", 42)
+
+    assert result == "log line\n"
+    command = mock_run_command.call_args.args[0]
+    assert command == [
+        "gh",
+        "api",
+        "repos/owner/repo/actions/jobs/42/logs",
+        "--method",
+        "GET",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "--allow-escape-sequences",
+    ]
+
+
 def test_authenticated_user_login_prefers_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
     github_api.authenticated_user_login.cache_clear()
     monkeypatch.setenv("REVIEW_AUTHOR_LOGIN", "custom-bot[bot]")

--- a/ci/agentic-reviewer/tests/unit/test_prepare_ci_run_context.py
+++ b/ci/agentic-reviewer/tests/unit/test_prepare_ci_run_context.py
@@ -9,6 +9,12 @@ def test_strip_gh_log_prefix_removes_job_columns_and_timestamp() -> None:
     assert prepare.strip_gh_log_prefix(line) == "Error: FetchError: exception_name: ClientResponseError"
 
 
+def test_strip_gh_log_prefix_strips_ansi_color_codes() -> None:
+    line = "job\tUNKNOWN STEP\t2026-06-05T17:33:52.4163444Z \x1b[31mFAILED\x1b[0m tests/test_foo.py::test_bar"
+
+    assert prepare.strip_gh_log_prefix(line) == "FAILED tests/test_foo.py::test_bar"
+
+
 def test_failed_step_name_prefers_failed_step() -> None:
     job = {
         "steps": [


### PR DESCRIPTION
## Summary

- Add `--allow-escape-sequences` to `gh_job_log()` so `gh api …/actions/jobs/{id}/logs` succeeds when CI output contains ANSI color codes (`FORCE_COLOR=1` pytest).
- Without this flag, `gh` refuses to print the response and Antigravity CI summaries end up with empty `log_excerpt` values, triggering the broken MCP fallback described in #4334.
- Add unit tests for the CLI flag and ANSI stripping in log excerpt normalization.

## Context

Observed on [PR #4321](https://github.com/opendatahub-io/notebooks/pull/4321#issuecomment-5228506026): CI summary reported *"job log retrieval via the GitHub CLI encountered terminal escape sequence errors and the log excerpts are empty"* despite concrete test failures in the workflow logs.

Fixes the primary failure mode in #4334. Follow-up items in that issue (MCP parameter docs, error sanitization) are out of scope here.

## Test plan

- [x] `uv sync --locked --all-packages && uv run pytest ci/agentic-reviewer/tests/unit/test_github_api.py ci/agentic-reviewer/tests/unit/test_prepare_ci_run_context.py`
- [x] Manual: `gh_job_log('opendatahub-io/notebooks', 93161683709)` returns ~929 KB log and produces a non-empty failed-step excerpt (e.g. `libthrift-0.15.0.so` import error) for PR #4321 job


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI job log retrieval to preserve logs containing ANSI escape sequences.
  * Ensured color formatting codes are removed when processing logs, while keeping the message content intact.

* **Tests**
  * Added coverage for ANSI-formatted log retrieval and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->