### PR TITLE
RHAIENG-6389: fix(jupyter-baseline): stop sourced setup scripts from enabling nounset

### DIFF
--- a/jupyter/baseline/ubi9-python-3.12/setup-elyra.sh
+++ b/jupyter/baseline/ubi9-python-3.12/setup-elyra.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -euo pipefail
+# Sourced by start-notebook.sh — do not use `set -u` here (nounset leaks into the
+# parent shell and breaks optional NOTEBOOK_* env vars). Match datascience: set -x only.
+set -x
 
 # Set the elyra config on the right path
 # RHOAIENG-15626: Always copy our custom config to ensure it's up to date (install -D creates directory if needed)

--- a/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -euo pipefail
+# Sourced by start-notebook.sh — do not use `set -u` here (nounset leaks into the
+# parent shell and breaks optional NOTEBOOK_* env vars). Match datascience: set -x only.
+set -x
 
 # Runtime configuration for Kubeflow Kale JupyterLab extension
 # This script configures Kale to connect to KFP by reading Elyra runtime config

--- a/jupyter/minimal/ubi9-python-3.12/start-notebook.sh
+++ b/jupyter/minimal/ubi9-python-3.12/start-notebook.sh
@@ -15,18 +15,19 @@ fi
 # Initialize notebooks arguments array
 NOTEBOOK_PROGRAM_ARGS=()
 
-# Set default ServerApp.port value if NOTEBOOK_PORT variable is defined
-if [ -n "${NOTEBOOK_PORT}" ]; then
+# Set default ServerApp.port value if NOTEBOOK_PORT variable is defined.
+# Use ${VAR:-} so these checks stay safe if a sourced setup script enables nounset.
+if [ -n "${NOTEBOOK_PORT:-}" ]; then
     NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.port=${NOTEBOOK_PORT}")
 fi
 
 # Set default ServerApp.base_url value if NOTEBOOK_BASE_URL variable is defined
-if [ -n "${NOTEBOOK_BASE_URL}" ]; then
+if [ -n "${NOTEBOOK_BASE_URL:-}" ]; then
     NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.base_url=${NOTEBOOK_BASE_URL}")
 fi
 
 # Set default ServerApp.root_dir value if NOTEBOOK_ROOT_DIR variable is defined
-if [ -n "${NOTEBOOK_ROOT_DIR}" ]; then
+if [ -n "${NOTEBOOK_ROOT_DIR:-}" ]; then
     NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.root_dir=${NOTEBOOK_ROOT_DIR}")
 else
     NOTEBOOK_PROGRAM_ARGS+=("--ServerApp.root_dir=${HOME}")
@@ -34,7 +35,7 @@ fi
 
 # Add additional arguments if NOTEBOOK_ARGS variable is defined
 # Word-splitting is intentional: NOTEBOOK_ARGS is newline- or space-separated (see kustomize statefulset.yaml)
-if [ -n "${NOTEBOOK_ARGS}" ]; then
+if [ -n "${NOTEBOOK_ARGS:-}" ]; then
     while IFS= read -r line || [ -n "${line}" ]; do
         if [ -n "${line}" ]; then
             read -ra _line_args <<< "${line}"


### PR DESCRIPTION
## Summary
- Follow-up to #4323: CI showed jupyter-baseline containers exiting immediately with `NOTEBOOK_PORT: unbound variable`
- Root cause: `setup-elyra.sh` / `setup-kale.sh` use `set -euo pipefail` but are **sourced** by `start-notebook.sh`, so nounset leaks into the entrypoint
- Align those scripts with datascience (`set -x` only) and harden optional `NOTEBOOK_*` checks in `start-notebook.sh` with `${VAR:-}`

## Test plan
- [ ] Confirm local: `bash -c 'source jupyter/baseline/ubi9-python-3.12/setup-elyra.sh; [ -n "${NOTEBOOK_PORT:-}" ] || echo ok'` does not abort
- [ ] Rebuild and run container tests: `make jupyter-baseline-ubi9-python-3.12` then `make test-integration PYTEST_ARGS="--image=<image>"`
- [ ] CI: jupyter-baseline odh/rhoai jobs pass entrypoint / JupyterLab readiness tests


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook startup reliability when configuration values are unset.
  * Preserved handling of notebook ports, base URLs, root directories, and additional startup arguments.
  * Updated environment setup scripts to avoid failures caused by unset shell variables while retaining command tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->