### PR TITLE
add _kale output directory in Kale setup

### DIFF
--- a/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
@@ -43,3 +43,10 @@ export KALE_SECURITY_CONTEXT_ENABLED=false
 
 # Set default image
 export KALE_DEFAULT_BASE_IMAGE=ubi9/python-312
+
+# Set the default pipeline output directory to _kale/ (instead of the default .kale/ 
+# since users can't see hidden files on notebooks)
+# Written as a JupyterLab user-settings file so Kale picks it up on startup.
+KALE_SETTINGS_DIR="${HOME}/.jupyter/lab/user-settings/jupyterlab-kubeflow-kale"
+mkdir -p "${KALE_SETTINGS_DIR}"
+echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"

--- a/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
@@ -41,3 +41,9 @@ export KALE_SECURITY_CONTEXT_ENABLED=false
 
 # Set default image
 export KALE_DEFAULT_BASE_IMAGE=ubi9/python-312
+
+# Set the default pipeline output directory to _kale/ (instead of the default .kale/)
+# Written as a JupyterLab user-settings file so the extension picks it up on startup.
+KALE_SETTINGS_DIR="${HOME}/.jupyter/lab/user-settings/jupyterlab-kubeflow-kale"
+mkdir -p "${KALE_SETTINGS_DIR}"
+echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add _kale as output directory for compiled DSL files in Kale.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
