### PR TITLE
RHOAIENG-81302: Add _kale output directory in Kale setup

### DIFF
--- a/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
@@ -49,4 +49,6 @@ export KALE_DEFAULT_BASE_IMAGE=ubi9/python-312
 # Written as a JupyterLab user-settings file so Kale picks it up on startup.
 KALE_SETTINGS_DIR="${HOME}/.jupyter/lab/user-settings/jupyterlab-kubeflow-kale"
 mkdir -p "${KALE_SETTINGS_DIR}"
-echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"
+if [ ! -f "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings" ]; then
+    echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"
+fi

--- a/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/baseline/ubi9-python-3.12/setup-kale.sh
@@ -43,3 +43,10 @@ export KALE_SECURITY_CONTEXT_ENABLED=false
 
 # Set default image
 export KALE_DEFAULT_BASE_IMAGE=ubi9/python-312
+
+# Set the default pipeline output directory to _kale/ (instead of the default .kale/
+# since users can't see hidden files on notebooks)
+# Written as a JupyterLab user-settings file so Kale picks it up on startup.
+KALE_SETTINGS_DIR="${HOME}/.jupyter/lab/user-settings/jupyterlab-kubeflow-kale"
+mkdir -p "${KALE_SETTINGS_DIR}"
+echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"

--- a/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
@@ -46,4 +46,6 @@ export KALE_DEFAULT_BASE_IMAGE=ubi9/python-312
 # Written as a JupyterLab user-settings file so the extension picks it up on startup.
 KALE_SETTINGS_DIR="${HOME}/.jupyter/lab/user-settings/jupyterlab-kubeflow-kale"
 mkdir -p "${KALE_SETTINGS_DIR}"
-echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"
+if [ ! -f "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings" ]; then
+    echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"
+fi

--- a/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
+++ b/jupyter/datascience/ubi9-python-3.12/setup-kale.sh
@@ -41,3 +41,9 @@ export KALE_SECURITY_CONTEXT_ENABLED=false
 
 # Set default image
 export KALE_DEFAULT_BASE_IMAGE=ubi9/python-312
+
+# Set the default pipeline output directory to _kale/ (instead of the default .kale/)
+# Written as a JupyterLab user-settings file so the extension picks it up on startup.
+KALE_SETTINGS_DIR="${HOME}/.jupyter/lab/user-settings/jupyterlab-kubeflow-kale"
+mkdir -p "${KALE_SETTINGS_DIR}"
+echo '{"outputPath": "_kale"}' > "${KALE_SETTINGS_DIR}/kale-settings.jupyterlab-settings"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add _kale output directory for compiled DSL files in Kale setup.
<!--- Describe your changes in detail -->

## How Has This Been Tested?
tested on RHOAI with image 
quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:on-pr-595644eaa49a126243410f97ae30a79d29591fad
confirmed that compiled output automatically goes to _kale visible directory:
<img width="1667" height="376" alt="image" src="https://github.com/user-attachments/assets/c734e43f-1b4f-4353-843a-210ad05af6e4" />

/build-datascience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configured Kale to use `_kale` as the default directory for generated pipeline outputs in JupyterLab.
  * Applied the setting to baseline and data science Python 3.12 environments.
  * Preserved existing user settings when the configuration is already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->