### PR TITLE
RHOAIENG-81891: chore: remove Kubeflow-Training v1 SDK annotations from imagestreams

### DIFF
--- a/manifests/odh/base/code-server-notebook-imagestream.yaml
+++ b/manifests/odh/base/code-server-notebook-imagestream.yaml
@@ -71,7 +71,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.3"},
             {"name": "JupyterLab", "version": "4.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.63"}
           ]

--- a/manifests/odh/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-datascience-notebook-imagestream.yaml
@@ -79,7 +79,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9

--- a/manifests/odh/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -95,7 +95,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Transformers", "version": "5.10"}
           ]

--- a/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -88,7 +88,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9

--- a/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -86,7 +86,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9

--- a/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -88,8 +88,7 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "MLflow", "version": "3.14"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
         opendatahub.io/workbench-image-recommended: 'false'

--- a/manifests/odh/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -88,7 +88,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.64"}
           ]

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -71,7 +71,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.3"},
             {"name": "JupyterLab", "version": "4.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.63"}
           ]
@@ -102,7 +101,6 @@ spec:
             {"name": "Scipy", "version": "1.17"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.2"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
@@ -132,8 +130,7 @@ spec:
             {"name": "Scikit-learn", "version": "1.7"},
             {"name": "Scipy", "version": "1.16"},
             {"name": "Sklearn-onnx", "version": "1.19"},
-            {"name": "ipykernel", "version": "6.30"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "ipykernel", "version": "6.30"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
@@ -163,8 +160,7 @@ spec:
             {"name": "Scikit-learn", "version": "1.6"},
             {"name": "Scipy", "version": "1.15"},
             {"name": "Sklearn-onnx", "version": "1.18"},
-            {"name": "ipykernel", "version": "6.29"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "ipykernel", "version": "6.29"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py311-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-codeserver-datascience-cpu-py311-ubi9-commit-2025-1_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
@@ -79,7 +79,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
@@ -118,7 +117,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
@@ -156,8 +154,7 @@ spec:
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.4"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.4"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-datascience-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
@@ -193,8 +190,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.3"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py311-rhel9
         opendatahub.io/image-tag-outdated: 'true'

--- a/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -93,7 +93,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
@@ -134,7 +133,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"},
             {"name": "Codeflare-SDK", "version": "0.36"}
           ]
@@ -177,8 +175,7 @@ spec:
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.4"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.4"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-commit-2025-2_PLACEHOLDER

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -88,7 +88,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
@@ -129,7 +128,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
@@ -170,8 +168,7 @@ spec:
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.4"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.4"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-cuda-py312-ubi9-commit-2025-2_PLACEHOLDER
@@ -211,8 +208,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.3"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py311-rhel9
         opendatahub.io/image-tag-outdated: 'true'

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -86,7 +86,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
@@ -125,7 +124,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
@@ -164,8 +162,7 @@ spec:
             {"name": "Feast", "version": "0.59"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.4"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.4"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-pytorch-rocm-py312-ubi9-commit-2025-2_PLACEHOLDER
@@ -203,8 +200,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.3"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py311-rhel9
         opendatahub.io/image-tag-outdated: 'true'

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -88,8 +88,7 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "MLflow", "version": "3.14"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MLflow", "version": "3.14"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
         opendatahub.io/workbench-image-recommended: 'false'
@@ -129,7 +128,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9

--- a/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -88,7 +88,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.7"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.64"}
           ]
@@ -130,7 +129,6 @@ spec:
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "Psycopg", "version": "3.3"},
             {"name": "MySQL Connector/Python", "version": "9.6"},
-            {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.10"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
@@ -171,8 +169,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.34"},
             {"name": "Sklearn-onnx", "version": "1.19"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.4"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.4"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
         opendatahub.io/notebook-build-commit: odh-workbench-jupyter-trustyai-cpu-py312-ubi9-commit-2025-2_PLACEHOLDER
@@ -213,8 +210,7 @@ spec:
             {"name": "Codeflare-SDK", "version": "0.30"},
             {"name": "Sklearn-onnx", "version": "1.18"},
             {"name": "Psycopg", "version": "3.2"},
-            {"name": "MySQL Connector/Python", "version": "9.3"},
-            {"name": "Kubeflow-Training", "version": "1.9"}
+            {"name": "MySQL Connector/Python", "version": "9.3"}
           ]
         openshift.io/imported-from: registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py311-rhel9
         opendatahub.io/image-tag-outdated: 'true'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-6366

## Description

Follow-up to [#4281](https://github.com/opendatahub-io/notebooks/pull/4281) which removed the `kubeflow-training` v1 SDK package from notebook images.

This PR removes the leftover `{"name": "Kubeflow-Training", "version": "1.9"}` entries from imagestream annotations (both ODH and RHOAI). The SDK is no longer installed, so advertising it in the dashboard metadata is misleading.

Ref: [RHOAIENG-81891](https://redhat.atlassian.net/browse/RHOAIENG-81891)

## How Has This Been Tested?

- Annotation-only change — no build/runtime impact
- Verified zero remaining `Kubeflow-Training` references across all imagestreams
- JSON array structure validated (trailing commas handled correctly)

[RHOAIENG-81891]: https://redhat.atlassian.net/browse/RHOAIENG-81891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ