### PR TITLE
ci(security): scan rhoai-* branches, sweep active releases on schedule

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -5,11 +5,16 @@ name: Security
   push:
     branches:
       - main
+      - stable
+      - 'rhoai-*'
   pull_request:
+  schedule:
+    - cron: '0 5 * * 3'
   workflow_dispatch:
 jobs:
   build:
     name: Trivy scan (fs)
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-26.04
     permissions:
       contents: read
@@ -33,3 +38,49 @@ jobs:
         uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
         with:
           sarif_file: 'trivy-results.sarif'
+
+  scheduled-scan:
+    name: Trivy scan (fs) [${{ matrix.ref }}]
+    # `schedule` only ever fires against the default branch, so a plain cron
+    # trigger would never re-scan the rhoai-* release branches once they go
+    # quiet. Sweep the active ones explicitly instead. Those branches only
+    # exist on the downstream repo, so skip this on forks/upstream.
+    if: github.event_name == 'schedule' && github.repository == 'red-hat-data-services/notebooks'
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [main, rhoai-3.5, rhoai-3.4, rhoai-3.3, rhoai-2.25]
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Resolve checked-out commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          version: 'v0.73.0'
+          scan-type: 'fs'
+          trivy-config: trivy.yaml
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '0'
+
+      - name: Update Security tab
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
+        with:
+          sarif_file: 'trivy-results.sarif'
+          # Required here (unlike the push/pull_request job above): matrix.ref
+          # points at a branch other than the one that triggered this run, so
+          # the commit info can't be inferred from github context.
+          ref: refs/heads/${{ matrix.ref }}
+          sha: ${{ steps.commit.outputs.sha }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Trivy scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
@@ -60,6 +62,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ matrix.ref }}
+          persist-credentials: false
 
       - name: Resolve checked-out commit
         id: commit


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C096ZR053RQ/p1786519913865509

## Description

Two changes to `.github/workflows/security.yaml` (Trivy fs scan):

1. **Push trigger** now also covers `stable` and `rhoai-*` branches, matching the convention already used by `gitleaks.yaml`, `codeql.yaml`, and most other CI workflows in this repo.
2. **Weekly schedule** (`0 5 * * 3`) added for periodic scanning. Since GitHub's `schedule` event only ever fires against the default branch, a plain cron trigger would never re-scan the `rhoai-*` release branches once they go quiet between pushes. To cover that gap, the job is split in two:
   - `build`: unchanged logic, runs on push/PR/`workflow_dispatch`, skipped on `schedule`.
   - `scheduled-scan`: runs only on `schedule`, matrixed over the currently active release branches (`rhoai-3.5`, `rhoai-3.4`, `rhoai-3.3`, `rhoai-2.25`) plus `main`. It resolves the checked-out commit itself and passes `ref`/`sha` explicitly to `upload-sarif`, since that action can't infer the right commit from `github` context when the checked-out ref differs from the one that triggered the run. Restricted to `red-hat-data-services/notebooks` since those release branches don't exist upstream or on forks.

## How Has This Been Tested?

Validated the YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`). Not run in CI yet — will observe on merge (push trigger) and on the next Wednesday cron fire.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review (N/A, CI workflow YAML only)
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Expanded automated vulnerability scanning for stable and active development branches.
  * Added scheduled and manually triggered security checks.
  * Improved scan reporting with clearer branch and commit context.
  * Security checks now cover relevant downstream branch revisions more consistently.
  * Enhanced scan coverage across selected branch revisions for more reliable security results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->