### PR TITLE
fix(jupyter): extend startupProbe to remaining workbench StatefulSets

### DIFF
--- a/jupyter/baseline/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/baseline/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -35,24 +35,29 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
-          # Generous delays for slow or constrained nodes (e.g. ppc64le in CI).
-          # Liveness must allow Jupyter + baseline deps to bind before first check (avoids restart loops).
+          # Allow up to 180 seconds for startup on slow or constrained nodes (e.g. ppc64le in CI).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 18
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 120
-            periodSeconds: 10
+            initialDelaySeconds: 0
+            periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 90
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
           # Jupyter + papermill share the pod cgroup; keep headroom for baseline tests on ppc64le CI.
           resources:
             limits:

--- a/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3

--- a/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,12 +32,18 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Allow up to 50 seconds for startup (preserves prior 15s + 3×10s budget).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 0
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -45,9 +51,8 @@ spec:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           resources:

--- a/jupyter/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,12 +32,18 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Allow up to 50 seconds for startup (preserves prior 15s + 3×10s budget).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 0
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -45,9 +51,8 @@ spec:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           resources:

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,10 +32,17 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Allow up to 20 seconds for startup (preserves prior 5s + 3×5s budget).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 2
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,12 +32,18 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Allow up to 50 seconds for startup (preserves prior 15s + 3×10s budget).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 0
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -45,9 +51,8 @@ spec:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           resources:

--- a/jupyter/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/tensorflow/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,10 +32,17 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Allow up to 20 seconds for startup (preserves prior 5s + 3×5s budget).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 2
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3

--- a/jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -32,10 +32,17 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Allow up to 20 seconds for startup (preserves prior 5s + 3×5s budget).
+          startupProbe:
+            tcpSocket:
+              port: notebook-port
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 2
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3


### PR DESCRIPTION
## Description

Follow-up to #4324 / #4255. Extends the `startupProbe` pattern to every remaining Jupyter workbench StatefulSet, and drops the redundant post-start liveness delay on minimal/datascience.

* **baseline** — 180s startup budget (same as datascience)
* **pytorch, pytorch+llmcompressor, rocm/tensorflow** — 50s startup budget
* **tensorflow, trustyai, rocm/pytorch** — 20s startup budget
* **minimal, datascience** — `livenessProbe.initialDelaySeconds: 5` → `0` (startupProbe already gates)

Post-start probes are aligned everywhere: liveness `initialDelaySeconds: 0`, readiness `10`, period `5`, failureThreshold `3`. TCP for startup/liveness; HTTP for readiness.

Fixes #4255

## How Has This Been Tested?

* https://github.com/opendatahub-io/notebooks/actions/runs/31614117400

* Inspected rendered probe blocks on all 9 `jupyter/**/statefulset.yaml` files
* Confirmed startup budgets preserve prior effective kill windows
* Relies on existing container/CI coverage for workbench StatefulSets (same as #4324)

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved notebook startup and health monitoring across supported Python 3.12 environments.
* Added startup checks to allow containers sufficient time to initialize before ongoing health evaluation begins.
* Liveness and readiness checks now begin sooner and run more frequently, helping detect unavailable notebook services faster.
* Adjusted probe timing and failure thresholds to improve reliability during startup and normal operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->