### PR TITLE
ISSUE #4374: fix(renovate): separate minor and patch base image updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -206,6 +206,11 @@
       "versioning": "semver",
     },
     {
+      "description": "Separate minor and patch base image upgrades",
+      "matchManagers": ["custom.regex"],
+      "separateMinorPatch": true,
+    },
+    {
       // One PR per quay.io/aipcc image (cpu, cuda-*, …); registry.redhat.io/rhai
       // uses the packageRule below.
       "description": "Group konflux build-args by image (custom.regex / docker)",

--- a/tests/test_renovate_config.py
+++ b/tests/test_renovate_config.py
@@ -7,3 +7,7 @@ def test_repo_renovate_json5_passes_semantic_validation() -> None:
     config = validate_renovate_config.load_config(validate_renovate_config.DEFAULT_CONFIG)
     errors = validate_renovate_config.validate_config(config)
     assert errors == [], f"Expected no semantic validation errors, got: {errors}"
+    assert any(
+        rule.get("matchManagers") == ["custom.regex"] and rule.get("separateMinorPatch") is True
+        for rule in config["packageRules"]
+    )


### PR DESCRIPTION
Fixes #4374.

Configure Renovate to keep `custom.regex` minor and patch updates in separate candidates. This allows release branches to receive permitted patch-level AIPCC/RHAI base-image updates even when a newer, policy-blocked minor version exists.

### Validation

- Renovate semantic configuration validation passed
- Focused configuration tests: 15 passed
- Repository hooks, Ruff, Pyright, and secret detection passed
- Renovate lookup dry-run against `rhoai-3.4` completed successfully
- Full static pytest run: 433 passed; 10 Make-dependent tests could not run because GNU Make 4/`gmake` is unavailable locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for base-image upgrades by separating minor and patch updates.

* **Tests**
  * Added validation to ensure the updated dependency-management rule remains enabled and correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->