### PR TITLE
Set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 for npm ci on s390x and ppc64l…

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -94,7 +94,7 @@ RUN chmod 755 ${CODESERVER_PATCHES}/*.sh
 # Keep this in a helper script; Hadolint on the hosted CI runner misparses the
 # inline patch loop heredoc in this Dockerfile.
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && GHA_BUILD="${GHA_BUILD}" "${CODESERVER_PATCHES}/apply-patch.sh"
-RUN cd ${CODESERVER_SOURCE_SUBMODULE} && npm ci
+RUN /bin/bash -lc 'cd "${CODESERVER_SOURCE_SUBMODULE}" && if [[ "$(uname -m)" == "ppc64le" ]] || [[ "$(uname -m)" == "s390x" ]]; then PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci; else npm ci; fi'
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && npm run build
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && \
     (ulimit -n 65536 2>/dev/null || ulimit -n 16384 2>/dev/null || true) && \


### PR DESCRIPTION
…e to avoid Playwright attempting to fetch Chromium binaries that aren’t available on those architectures and causing Konflux build failures.

This will fix the downstream build failures for ppc and s390x https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-6-ea-1/pipelineruns/odh-workbench-codeserver-baseline-cpu-py312-v3-6-ea-1-on-pvq546 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation compatibility for `ppc64le` and `s390x` platforms by skipping unnecessary Playwright browser downloads.
  * Preserved standard dependency installation behavior on other architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->