### PR TITLE
avoid electron binary download

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -50,6 +50,16 @@ ENV CODESERVER_SOURCE_CODE=${HOME}/${CODESERVER_CONTEXT}
 ENV CODESERVER_SOURCE_SUBMODULE=${CODESERVER_SOURCE_CODE}/code-server
 ENV CODESERVER_PATCHES=${CODESERVER_SOURCE_CODE}/patches
 
+# Phase 1 is intentionally online; Konflux egress can be flaky.
+# Configure npm to be more resilient and to avoid extra registry calls.
+ENV NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
+    NPM_CONFIG_FETCH_TIMEOUT=600000 \
+    NPM_CONFIG_NODEDIR=/usr
+
 ARG BASE_IMAGE
 ARG GHA_BUILD=false
 
@@ -78,6 +88,9 @@ RUN dnf install -y \
         jq patch libtool rsync gettext git-lfs gcc-toolset-14 gcc-toolset-14-libatomic-devel \
         krb5-devel libX11-devel libxkbfile-devel && \
     dnf clean all
+
+# RHEL's packaged node-gyp makefile can exec gyp_main.py directly; ensure it's executable.
+RUN chmod 755 /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py || true
 # Git metadata needed by code-server's build scripts (version detection, submodules).
 COPY .git /root/.git
 COPY ${CODESERVER_CONTEXT}/code-server/ ${CODESERVER_SOURCE_SUBMODULE}/
@@ -94,7 +107,7 @@ RUN chmod 755 ${CODESERVER_PATCHES}/*.sh
 # Keep this in a helper script; Hadolint on the hosted CI runner misparses the
 # inline patch loop heredoc in this Dockerfile.
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && GHA_BUILD="${GHA_BUILD}" "${CODESERVER_PATCHES}/apply-patch.sh"
-RUN /bin/bash -lc 'cd "${CODESERVER_SOURCE_SUBMODULE}" && if [[ "$(uname -m)" == "ppc64le" ]] || [[ "$(uname -m)" == "s390x" ]]; then PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci; else npm ci; fi'
+RUN /bin/bash -lc 'cd "${CODESERVER_SOURCE_SUBMODULE}" && if [[ "$(uname -m)" == "ppc64le" ]] || [[ "$(uname -m)" == "s390x" ]]; then PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci --no-audit --no-fund; else npm ci --no-audit --no-fund; fi'
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && npm run build
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && \
     (ulimit -n 65536 2>/dev/null || ulimit -n 16384 2>/dev/null || true) && \

--- a/codeserver-baseline/ubi9-python-3.12/patches/apply-patch.sh
+++ b/codeserver-baseline/ubi9-python-3.12/patches/apply-patch.sh
@@ -9,6 +9,23 @@ while IFS= read -r src_patch || [[ -n "$src_patch" ]]; do
     patch -p1 < "patches/$src_patch"
 done < patches/series
 
+# ppc64le/s390x: @vscode/vsce-sign (dep of @vscode/vsce) has a postinstall script
+# that hard-fails on unsupported arches, even though code-server doesn't need it.
+# The hermetic codeserver flow patches this via cachi2 tarballs; for phase-1 online
+# builds, neutralize it via the lockfile metadata so npm doesn't run the script.
+ARCH="$(uname -m)"
+if [[ "$ARCH" == "ppc64le" || "$ARCH" == "s390x" ]]; then
+    while IFS= read -r -d '' lockfile; do
+        if jq -e '.packages["node_modules/@vscode/vsce-sign"]' "$lockfile" >/dev/null 2>&1; then
+            echo "Patching vsce-sign hasInstallScript=false in ${lockfile}"
+            jq '
+                (.packages["node_modules/@vscode/vsce-sign"].hasInstallScript = false) |
+                del(.packages["node_modules/@vscode/vsce-sign"].integrity)
+            ' "$lockfile" > /tmp/lock-tmp.json && mv /tmp/lock-tmp.json "$lockfile"
+        fi
+    done < <(find lib/vscode -name package-lock.json -type f -print0)
+fi
+
 npm cache clean --force
 
 if [[ "${GHA_BUILD:-false}" == "true" ]]; then

--- a/codeserver-baseline/ubi9-python-3.12/patches/code-server-v4.122.1/lib/vscode/build/gulpfile.reh.ts
+++ b/codeserver-baseline/ubi9-python-3.12/patches/code-server-v4.122.1/lib/vscode/build/gulpfile.reh.ts
@@ -200,24 +200,30 @@ function nodejs(platform: string, arch: string): NodeJS.ReadWriteStream | undefi
 		arch = 'x64';
 	}
 
-	log(`Downloading node.js ${nodeVersion} ${platform} ${arch} from ${product.nodejsRepository}...`);
+	// Node publishes linux-ppc64le tarballs, but process.arch on ppc64le hosts is ppc64.
+	const nodeArtifactArch = platform === 'linux' && arch === 'ppc64' ? 'ppc64le' : arch;
+	if (nodeArtifactArch !== arch) {
+		log(`Downloading node.js ${nodeVersion} ${platform} ${nodeArtifactArch} for runtime arch ${arch} from ${product.nodejsRepository}...`);
+	} else {
+		log(`Downloading node.js ${nodeVersion} ${platform} ${arch} from ${product.nodejsRepository}...`);
+	}
 
 	const glibcPrefix = process.env['VSCODE_NODE_GLIBC'] ?? '';
 	let expectedName: string | undefined;
 	switch (platform) {
 		case 'win32':
 			expectedName = product.nodejsRepository !== 'https://nodejs.org' ?
-				`win-${arch}-node.exe` : `win-${arch}/node.exe`;
+				`win-${nodeArtifactArch}-node.exe` : `win-${nodeArtifactArch}/node.exe`;
 			break;
 
 		case 'darwin':
-			expectedName = `node-v${nodeVersion}-${platform}-${arch}.tar.gz`;
+			expectedName = `node-v${nodeVersion}-${platform}-${nodeArtifactArch}.tar.gz`;
 			break;
 		case 'linux':
-			expectedName = `node-v${nodeVersion}${glibcPrefix}-${platform}-${arch}.tar.gz`;
+			expectedName = `node-v${nodeVersion}${glibcPrefix}-${platform}-${nodeArtifactArch}.tar.gz`;
 			break;
 		case 'alpine':
-			expectedName = `node-v${nodeVersion}-linux-${arch}-musl.tar.gz`;
+			expectedName = `node-v${nodeVersion}-linux-${nodeArtifactArch}-musl.tar.gz`;
 			break;
 	}
 	const checksumSha256 = expectedName ? getNodeChecksum(expectedName) : undefined;
@@ -232,13 +238,13 @@ function nodejs(platform: string, arch: string): NodeJS.ReadWriteStream | undefi
 		case 'win32':
 			return (product.nodejsRepository !== 'https://nodejs.org' ?
 				fetchGithub(product.nodejsRepository, { version: `${nodeVersion}-${internalNodeVersion}`, name: expectedName!, checksumSha256 }) :
-				fetchUrls(`/dist/v${nodeVersion}/win-${arch}/node.exe`, { base: 'https://nodejs.org', checksumSha256 }))
+				fetchUrls(`/dist/v${nodeVersion}/win-${nodeArtifactArch}/node.exe`, { base: 'https://nodejs.org', checksumSha256 }))
 				.pipe(rename('node.exe'));
 		case 'darwin':
 		case 'linux':
 			return (product.nodejsRepository !== 'https://nodejs.org' ?
 				fetchGithub(product.nodejsRepository, { version: `${nodeVersion}-${internalNodeVersion}`, name: expectedName!, checksumSha256 }) :
-				fetchUrls(`/dist/v${nodeVersion}/node-v${nodeVersion}-${platform}-${arch}.tar.gz`, { base: 'https://nodejs.org', checksumSha256 })
+				fetchUrls(`/dist/v${nodeVersion}/node-v${nodeVersion}-${platform}-${nodeArtifactArch}.tar.gz`, { base: 'https://nodejs.org', checksumSha256 })
 			).pipe(flatmap(stream => stream.pipe(gunzip()).pipe(untar())))
 				.pipe(filter('**/node'))
 				.pipe(util.setExecutableBit('**'))

--- a/codeserver-baseline/ubi9-python-3.12/patches/code-server-v4.122.1/lib/vscode/build/npm/postinstall.ts
+++ b/codeserver-baseline/ubi9-python-3.12/patches/code-server-v4.122.1/lib/vscode/build/npm/postinstall.ts
@@ -1,0 +1,363 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import path from 'path';
+import * as os from 'os';
+import * as child_process from 'child_process';
+import { dirs } from './dirs.ts';
+import { root, stateFile, stateContentsFile, computeState, computeContents, isUpToDate } from './installStateHash.ts';
+
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const rootNpmrcConfigKeys = getNpmrcConfigKeys(path.join(root, '.npmrc'));
+
+function log(dir: string, message: string) {
+	if (process.stdout.isTTY) {
+		console.log(`\x1b[34m[${dir}]\x1b[0m`, message);
+	} else {
+		console.log(`[${dir}]`, message);
+	}
+}
+
+function run(command: string, args: string[], opts: child_process.SpawnSyncOptions) {
+	log(opts.cwd as string || '.', '$ ' + command + ' ' + args.join(' '));
+
+	const result = child_process.spawnSync(command, args, opts);
+
+	if (result.error) {
+		console.error(`ERR Failed to spawn process: ${result.error}`);
+		process.exit(1);
+	} else if (result.status !== 0) {
+		console.error(`ERR Process exited with code: ${result.status}`);
+		process.exit(result.status);
+	}
+}
+
+function spawnAsync(command: string, args: string[], opts: child_process.SpawnOptions): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = child_process.spawn(command, args, { ...opts, stdio: ['ignore', 'pipe', 'pipe'] });
+		let output = '';
+		child.stdout?.on('data', (data: Buffer) => { output += data.toString(); });
+		child.stderr?.on('data', (data: Buffer) => { output += data.toString(); });
+		child.on('error', reject);
+		child.on('close', (code) => {
+			if (code !== 0) {
+				reject(new Error(`Process exited with code: ${code}\n${output}`));
+			} else {
+				resolve(output);
+			}
+		});
+	});
+}
+
+async function npmInstallAsync(dir: string, opts?: child_process.SpawnOptions): Promise<void> {
+	const finalOpts: child_process.SpawnOptions = {
+		env: { ...process.env },
+		...(opts ?? {}),
+		cwd: path.join(root, dir),
+		shell: true,
+	};
+
+	const command = process.env['npm_command'] || 'install';
+
+	if (process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME'] && /^(.build\/distro\/npm\/)?remote$/.test(dir)) {
+		const syncOpts: child_process.SpawnSyncOptions = {
+			env: finalOpts.env,
+			cwd: root,
+			stdio: 'inherit',
+			shell: true,
+		};
+		const userinfo = os.userInfo();
+		log(dir, `Installing dependencies inside container ${process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME']}...`);
+
+		if (process.env['npm_config_arch'] === 'arm64') {
+			run('sudo', ['docker', 'run', '--rm', '--privileged', 'vscodehub.azurecr.io/multiarch/qemu-user-static@sha256:fe60359c92e86a43cc87b3d906006245f77bfc0565676b80004cc666e4feb9f0', '--reset', '-p', 'yes'], syncOpts);
+		}
+		run('sudo', [
+			'docker', 'run',
+			'-e', 'GITHUB_TOKEN',
+			'-v', `${process.env['VSCODE_HOST_MOUNT']}:/root/vscode`,
+			'-v', `${process.env['VSCODE_HOST_MOUNT']}/.build/.netrc:/root/.netrc`,
+			'-v', `${process.env['VSCODE_NPMRC_PATH']}:/root/.npmrc`,
+			'-w', path.resolve('/root/vscode', dir),
+			process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME'],
+			'sh', '-c', `\"chown -R root:root ${path.resolve('/root/vscode', dir)} && export PATH="/root/vscode/.build/nodejs-musl/usr/local/bin:$PATH" && npm i -g node-gyp-build && npm ci\"`
+		], syncOpts);
+		run('sudo', ['chown', '-R', `${userinfo.uid}:${userinfo.gid}`, `${path.resolve(root, dir)}`], syncOpts);
+	} else {
+		log(dir, 'Installing dependencies...');
+		const output = await spawnAsync(npm, command.split(' '), finalOpts);
+		if (output.trim()) {
+			for (const line of output.trim().split('\n')) {
+				log(dir, line);
+			}
+		}
+	}
+	removeParcelWatcherPrebuild(dir);
+}
+
+function setNpmrcConfig(dir: string, env: NodeJS.ProcessEnv) {
+	const npmrcPath = path.join(root, dir, '.npmrc');
+	const lines = fs.readFileSync(npmrcPath, 'utf8').split('\n');
+
+	for (const line of lines) {
+		const trimmedLine = line.trim();
+		if (trimmedLine && !trimmedLine.startsWith('#')) {
+			const [key, value] = trimmedLine.split('=');
+			env[`npm_config_${key}`] = value.replace(/^"(.*)"$/, '$1');
+		}
+	}
+
+	// Use our bundled node-gyp version
+	env['npm_config_node_gyp'] =
+		process.platform === 'win32'
+			? path.join(import.meta.dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd')
+			: path.join(import.meta.dirname, 'gyp', 'node_modules', '.bin', 'node-gyp');
+
+	// Force node-gyp to use process.config on macOS
+	// which defines clang variable as expected. Otherwise we
+	// run into compilation errors due to incorrect compiler
+	// configuration.
+	// NOTE: This means the process.config should contain
+	// the correct clang variable. So keep the version check
+	// in preinstall sync with this logic.
+	// Change was first introduced in https://github.com/nodejs/node/commit/6e0a2bb54c5bbeff0e9e33e1a0c683ed980a8a0f
+	if ((dir === 'remote' || dir === 'build') && process.platform === 'darwin') {
+		env['npm_config_force_process_config'] = 'true';
+	} else {
+		delete env['npm_config_force_process_config'];
+	}
+
+	if (dir === 'build') {
+		env['npm_config_target'] = process.versions.node;
+		env['npm_config_arch'] = process.arch;
+	}
+}
+
+function removeParcelWatcherPrebuild(dir: string) {
+	const parcelModuleFolder = path.join(root, dir, 'node_modules', '@parcel');
+	if (!fs.existsSync(parcelModuleFolder)) {
+		return;
+	}
+
+	const parcelModules = fs.readdirSync(parcelModuleFolder);
+	for (const moduleName of parcelModules) {
+		if (moduleName.startsWith('watcher-')) {
+			const modulePath = path.join(parcelModuleFolder, moduleName);
+			fs.rmSync(modulePath, { recursive: true, force: true });
+			log(dir, `Removed @parcel/watcher prebuilt module ${modulePath}`);
+		}
+	}
+}
+
+function getNpmrcConfigKeys(npmrcPath: string): string[] {
+	if (!fs.existsSync(npmrcPath)) {
+		return [];
+	}
+	const lines = fs.readFileSync(npmrcPath, 'utf8').split('\n');
+	const keys: string[] = [];
+	for (const line of lines) {
+		const trimmedLine = line.trim();
+		if (trimmedLine && !trimmedLine.startsWith('#')) {
+			const eqIndex = trimmedLine.indexOf('=');
+			if (eqIndex > 0) {
+				keys.push(trimmedLine.substring(0, eqIndex).trim());
+			}
+		}
+	}
+	return keys;
+}
+
+function clearInheritedNpmrcConfig(dir: string, env: NodeJS.ProcessEnv): void {
+	const dirNpmrcPath = path.join(root, dir, '.npmrc');
+	if (fs.existsSync(dirNpmrcPath)) {
+		return;
+	}
+
+	for (const key of rootNpmrcConfigKeys) {
+		const envKey = `npm_config_${key.replace(/-/g, '_')}`;
+		delete env[envKey];
+	}
+}
+
+function ensureAgentHarnessLink(sourceRelativePath: string, linkPath: string): 'existing' | 'junction' | 'symlink' | 'hard link' {
+	if (fs.existsSync(linkPath)) {
+		return 'existing';
+	}
+
+	const sourcePath = path.resolve(path.dirname(linkPath), sourceRelativePath);
+	const isDirectory = fs.statSync(sourcePath).isDirectory();
+
+	try {
+		if (process.platform === 'win32' && isDirectory) {
+			fs.symlinkSync(sourcePath, linkPath, 'junction');
+			return 'junction';
+		}
+
+		fs.symlinkSync(sourceRelativePath, linkPath, isDirectory ? 'dir' : 'file');
+		return 'symlink';
+	} catch (error) {
+		if (process.platform === 'win32' && !isDirectory && (error as NodeJS.ErrnoException).code === 'EPERM') {
+			fs.linkSync(sourcePath, linkPath);
+			return 'hard link';
+		}
+
+		throw error;
+	}
+}
+
+async function runWithConcurrency(tasks: (() => Promise<void>)[], concurrency: number): Promise<void> {
+	const errors: Error[] = [];
+	let index = 0;
+
+	async function worker() {
+		while (index < tasks.length) {
+			const i = index++;
+			try {
+				await tasks[i]();
+			} catch (err) {
+				errors.push(err as Error);
+			}
+		}
+	}
+
+	await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, () => worker()));
+
+	if (errors.length > 0) {
+		for (const err of errors) {
+			console.error(err.message);
+		}
+		process.exit(1);
+	}
+}
+
+async function main() {
+	if (!process.env['VSCODE_FORCE_INSTALL'] && isUpToDate()) {
+		log('.', 'All dependencies up to date, skipping postinstall.');
+		child_process.execSync('git config pull.rebase merges');
+		child_process.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
+		return;
+	}
+
+	const _state = computeState();
+
+	const nativeTasks: (() => Promise<void>)[] = [];
+	const parallelTasks: (() => Promise<void>)[] = [];
+
+	for (const dir of dirs) {
+		if (dir === '') {
+			removeParcelWatcherPrebuild(dir);
+			continue; // already executed in root
+		}
+
+		if (dir === 'build') {
+			nativeTasks.push(() => {
+				const env: NodeJS.ProcessEnv = { ...process.env };
+				if (process.env['CC']) { env['CC'] = 'gcc'; }
+				if (process.env['CXX']) { env['CXX'] = 'g++'; }
+				if (process.env['CXXFLAGS']) { env['CXXFLAGS'] = ''; }
+				if (process.env['LDFLAGS']) { env['LDFLAGS'] = ''; }
+				setNpmrcConfig('build', env);
+
+				// ODH: @vscode/vsce-sign (a transitive dependency of @vscode/vsce) has a
+				// postinstall script that hard-fails on unsupported arches (ppc64le/s390x).
+				// VS Code desktop packaging uses it, but code-server's REH build does not.
+				// Disable scripts only for the build/ toolchain install on those arches.
+				if (process.platform === 'linux' && (process.arch === 'ppc64' || process.arch === 's390x')) {
+					env['npm_config_ignore_scripts'] = 'true';
+					log('build', `ODH: npm_config_ignore_scripts=true on ${process.platform}/${process.arch} (vsce-sign unsupported arch)`);
+				}
+
+				return npmInstallAsync('build', { env });
+			});
+			continue;
+		}
+
+		if (/^(.build\/distro\/npm\/)?remote$/.test(dir)) {
+			const remoteDir = dir;
+			nativeTasks.push(() => {
+				const env: NodeJS.ProcessEnv = { ...process.env };
+				if (process.env['VSCODE_REMOTE_CC']) {
+					env['CC'] = process.env['VSCODE_REMOTE_CC'];
+				} else {
+					delete env['CC'];
+				}
+				if (process.env['VSCODE_REMOTE_CXX']) {
+					env['CXX'] = process.env['VSCODE_REMOTE_CXX'];
+				} else {
+					delete env['CXX'];
+				}
+				if (process.env['CXXFLAGS']) { delete env['CXXFLAGS']; }
+				if (process.env['CFLAGS']) { delete env['CFLAGS']; }
+				if (process.env['LDFLAGS']) { delete env['LDFLAGS']; }
+				if (process.env['VSCODE_REMOTE_CXXFLAGS']) { env['CXXFLAGS'] = process.env['VSCODE_REMOTE_CXXFLAGS']; }
+				if (process.env['VSCODE_REMOTE_LDFLAGS']) { env['LDFLAGS'] = process.env['VSCODE_REMOTE_LDFLAGS']; }
+				if (process.env['VSCODE_REMOTE_NODE_GYP']) { env['npm_config_node_gyp'] = process.env['VSCODE_REMOTE_NODE_GYP']; }
+				setNpmrcConfig('remote', env);
+				return npmInstallAsync(remoteDir, { env });
+			});
+			continue;
+		}
+
+		const taskDir = dir;
+		parallelTasks.push(() => {
+			const env = { ...process.env };
+			clearInheritedNpmrcConfig(taskDir, env);
+			return npmInstallAsync(taskDir, { env });
+		});
+	}
+
+	// Native dirs (build, remote) run sequentially to avoid node-gyp conflicts
+	for (const task of nativeTasks) {
+		await task();
+	}
+
+	// JS-only dirs run in parallel
+	const concurrency = Math.min(os.cpus().length, 8);
+	log('.', `Running ${parallelTasks.length} npm installs with concurrency ${concurrency}...`);
+	await runWithConcurrency(parallelTasks, concurrency);
+
+	child_process.execSync('git config pull.rebase merges');
+	child_process.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
+
+	fs.writeFileSync(stateFile, JSON.stringify(_state));
+	fs.writeFileSync(stateContentsFile, JSON.stringify(computeContents()));
+
+	// Symlink .claude/ files to their canonical locations to test Claude agent harness
+	const claudeDir = path.join(root, '.claude');
+	fs.mkdirSync(claudeDir, { recursive: true });
+
+	const claudeMdLink = path.join(claudeDir, 'CLAUDE.md');
+	const claudeMdLinkType = ensureAgentHarnessLink(path.join('..', '.github', 'copilot-instructions.md'), claudeMdLink);
+	if (claudeMdLinkType !== 'existing') {
+		log('.', `Created ${claudeMdLinkType} .claude/CLAUDE.md -> .github/copilot-instructions.md`);
+	}
+
+	const claudeSkillsLink = path.join(claudeDir, 'skills');
+	const claudeSkillsLinkType = ensureAgentHarnessLink(path.join('..', '.agents', 'skills'), claudeSkillsLink);
+	if (claudeSkillsLinkType !== 'existing') {
+		log('.', `Created ${claudeSkillsLinkType} .claude/skills -> .agents/skills`);
+	}
+
+	// Temporary: patch @github/copilot-sdk session.js to fix ESM import
+	// (missing .js extension on vscode-jsonrpc/node). Fixed upstream in v0.1.32.
+	// TODO: Remove once @github/copilot-sdk is updated to >=0.1.32
+	for (const dir of ['', 'remote']) {
+		const sessionFile = path.join(root, dir, 'node_modules', '@github', 'copilot-sdk', 'dist', 'session.js');
+		if (fs.existsSync(sessionFile)) {
+			const content = fs.readFileSync(sessionFile, 'utf8');
+			const patched = content.replace(/from "vscode-jsonrpc\/node"/g, 'from "vscode-jsonrpc/node.js"');
+			if (content !== patched) {
+				fs.writeFileSync(sessionFile, patched);
+				log(dir || '.', 'Patched @github/copilot-sdk session.js (vscode-jsonrpc ESM import fix)');
+			}
+		}
+	}
+}
+
+main().catch(err => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved the reliability of code-server image builds, especially on `ppc64le` and `s390x` systems.
  - Added more resilient package installation behavior, including retries and timeout handling for network interruptions.
  - Improved compatibility with architecture-specific Node.js downloads and native dependencies.
  - Prevented unsupported browser and desktop binary downloads on selected architectures, reducing unnecessary build failures and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->