### PR TITLE
Throttle the code-server npm install fan-out and skip optional

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -58,7 +58,9 @@ ENV NPM_CONFIG_AUDIT=false \
     NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
     NPM_CONFIG_FETCH_TIMEOUT=600000 \
-    NPM_CONFIG_NODEDIR=/usr
+    NPM_CONFIG_MAXSOCKETS=5 \
+    NPM_CONFIG_NODEDIR=/usr \
+    VSCODE_NPM_INSTALL_CONCURRENCY=4
 
 ARG BASE_IMAGE
 ARG GHA_BUILD=false
@@ -107,7 +109,7 @@ RUN chmod 755 ${CODESERVER_PATCHES}/*.sh
 # Keep this in a helper script; Hadolint on the hosted CI runner misparses the
 # inline patch loop heredoc in this Dockerfile.
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && GHA_BUILD="${GHA_BUILD}" "${CODESERVER_PATCHES}/apply-patch.sh"
-RUN /bin/bash -lc 'cd "${CODESERVER_SOURCE_SUBMODULE}" && if [[ "$(uname -m)" == "ppc64le" ]] || [[ "$(uname -m)" == "s390x" ]]; then PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci --no-audit --no-fund; else npm ci --no-audit --no-fund; fi'
+RUN /bin/bash -lc 'cd "${CODESERVER_SOURCE_SUBMODULE}" && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 PLAYWRIGHT_SKIP_FFMPEG_INSTALL=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci --no-audit --no-fund'
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && npm run build
 RUN cd ${CODESERVER_SOURCE_SUBMODULE} && \
     (ulimit -n 65536 2>/dev/null || ulimit -n 16384 2>/dev/null || true) && \

--- a/codeserver-baseline/ubi9-python-3.12/patches/code-server-v4.122.1/lib/vscode/build/npm/postinstall.ts
+++ b/codeserver-baseline/ubi9-python-3.12/patches/code-server-v4.122.1/lib/vscode/build/npm/postinstall.ts
@@ -315,7 +315,10 @@ async function main() {
 	}
 
 	// JS-only dirs run in parallel
-	const concurrency = Math.min(os.cpus().length, 8);
+	// Allow the container build to reduce npm fan-out on slower CI networks.
+	const configuredConcurrency = Number.parseInt(process.env['VSCODE_NPM_INSTALL_CONCURRENCY'] || '', 10);
+	const concurrencyLimit = Number.isFinite(configuredConcurrency) && configuredConcurrency > 0 ? configuredConcurrency : 8;
+	const concurrency = Math.max(1, Math.min(os.cpus().length, concurrencyLimit));
 	log('.', `Running ${parallelTasks.length} npm installs with concurrency ${concurrency}...`);
 	await runWithConcurrency(parallelTasks, concurrency);
 


### PR DESCRIPTION
Playwright/Electron payload downloads in codeserver-baseline.

This reduces non-hermetic network pressure during the Konflux build path that was timing out against registry.npmjs.org.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm installation reliability by consistently skipping unnecessary browser, media, and Electron downloads.
  * Added configurable npm installation concurrency, with safeguards based on available CPU resources.

* **Performance**
  * Improved build efficiency through better npm socket and directory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->