### PR TITLE
ISSUE #4374: fix(renovate): follow-up on separateMinorPatch review findings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -206,8 +206,13 @@
       "versioning": "semver",
     },
     {
+      // Excludes the ODH quay.io/opendatahub BASE_IMAGE manager, which is pinned
+      // to the literal "latest" tag and has no minor/patch axis; this rule only
+      // needs to apply to the release-versioned quay.io/aipcc and
+      // registry.redhat.io/rhai images.
       "description": "Separate minor and patch base image upgrades",
       "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["!/^quay\\.io\\/opendatahub\\//"],
       "separateMinorPatch": true,
     },
     {
@@ -271,7 +276,8 @@
     //   - Local dry-runs (--platform=local) cannot evaluate matchBaseBranches;
     //     this is a known limitation of local mode.
     {
-      // Re-enables the major/minor updates that packageRules[4] blocks by default.
+      // Re-enables the major/minor updates that the "Block major/minor base
+      // image version upgrades (default)" rule above blocks by default.
       "description": "Allow major/minor base image upgrades on upstream main",
       "matchManagers": ["custom.regex"],
       "matchUpdateTypes": ["major", "minor"],

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -23,6 +23,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # No secrets needed — safe to run on fork PRs too, unlike the dry-run job below.
+  validate-renovate-config:
+    if: >-
+      github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io'
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
+      - name: Validate renovate.json5 semantics
+        run: ./uv run python scripts/ci/validate_renovate_config.py
+
   validate-renovate-dry-run:
     if: >-
       (github.event_name != 'schedule' || github.repository_owner == 'opendatahub-io')
@@ -43,9 +63,6 @@ jobs:
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
-
-      - name: Validate renovate.json5 semantics
-        run: ./uv run python scripts/ci/validate_renovate_config.py
 
       - name: Remote Renovate dry-run prefix checks
         env:

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -29,6 +29,7 @@ ODH_BASE_ENABLE_RULE_DESCRIPTION = "ODH BASE_IMAGE digest updates on opendatahub
 ODH_BASE_MANAGER_DESCRIPTION = "Update BASE_IMAGE in ODH (non-konflux) build-args conf files"
 ODH_BASE_MANAGER_FILE_PATTERN = "/(jupyter|codeserver|runtimes)/.+/build-args/(cpu|cuda|rocm)\\.conf$/"
 ODH_BASE_PACKAGE_PATTERN = "/^quay\\.io\\/opendatahub\\//"
+SEPARATE_MINOR_PATCH_RULE_DESCRIPTION = "Separate minor and patch base image upgrades"
 
 
 @dataclass(frozen=True)
@@ -213,6 +214,22 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
             errors.append("CentOS Stream pin rule must set pinDigests: true")
 
     errors.extend(validate_odh_base_image_policy(config.get("customManagers"), package_rules))
+
+    separate_minor_patch_rule = next(
+        (
+            rule
+            for rule in package_rules
+            if isinstance(rule, dict) and rule.get("description", "").startswith(SEPARATE_MINOR_PATCH_RULE_DESCRIPTION)
+        ),
+        None,
+    )
+    if separate_minor_patch_rule is None:
+        errors.append(f"missing packageRule: {SEPARATE_MINOR_PATCH_RULE_DESCRIPTION!r}")
+    else:
+        if separate_minor_patch_rule.get("matchManagers") != ["custom.regex"]:
+            errors.append("separateMinorPatch rule must match custom.regex manager only")
+        if separate_minor_patch_rule.get("separateMinorPatch") is not True:
+            errors.append("separateMinorPatch rule must set separateMinorPatch: true")
 
     return errors
 

--- a/scripts/ci/validate_renovate_config.py
+++ b/scripts/ci/validate_renovate_config.py
@@ -30,6 +30,7 @@ ODH_BASE_MANAGER_DESCRIPTION = "Update BASE_IMAGE in ODH (non-konflux) build-arg
 ODH_BASE_MANAGER_FILE_PATTERN = "/(jupyter|codeserver|runtimes)/.+/build-args/(cpu|cuda|rocm)\\.conf$/"
 ODH_BASE_PACKAGE_PATTERN = "/^quay\\.io\\/opendatahub\\//"
 SEPARATE_MINOR_PATCH_RULE_DESCRIPTION = "Separate minor and patch base image upgrades"
+SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES = [f"!{ODH_BASE_PACKAGE_PATTERN}"]
 
 
 @dataclass(frozen=True)
@@ -228,6 +229,12 @@ def validate_config(config: dict[str, Any], *, config_dir: Path = ROOT / ".githu
     else:
         if separate_minor_patch_rule.get("matchManagers") != ["custom.regex"]:
             errors.append("separateMinorPatch rule must match custom.regex manager only")
+        if separate_minor_patch_rule.get("matchPackageNames") != SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES:
+            errors.append(
+                "separateMinorPatch rule matchPackageNames must be "
+                f"{SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES!r} (exclude ODH BASE_IMAGE, no minor/patch axis), "
+                f"got {separate_minor_patch_rule.get('matchPackageNames')!r}"
+            )
         if separate_minor_patch_rule.get("separateMinorPatch") is not True:
             errors.append("separateMinorPatch rule must set separateMinorPatch: true")
 

--- a/scripts/ci/validate_renovate_dry_run.py
+++ b/scripts/ci/validate_renovate_dry_run.py
@@ -29,6 +29,8 @@ KNOWN_CONFIG_WARNINGS = (
 
 RunSubprocess = Callable[..., subprocess.CompletedProcess[str]]
 
+SEPARATE_MINOR_PATCH_RULE_DESCRIPTION = "Separate minor and patch base image upgrades"
+
 
 def _subprocess_stream_text(data: str | bytes | None) -> str:
     if not data:
@@ -95,8 +97,8 @@ def _rule_description(rule: dict) -> str:
     return description if isinstance(description, str) else ""
 
 
-def extract_combined_prefix_rule(records: list[dict]) -> dict | None:
-    """Return the PR-title prefix packageRule from Renovate's Combined config log."""
+def extract_combined_rule_by_description(records: list[dict], description: str) -> dict | None:
+    """Return the first packageRule from Renovate's Combined config log matching a description prefix."""
     for record in records:
         if record.get("msg") != "Combined config":
             continue
@@ -106,9 +108,37 @@ def extract_combined_prefix_rule(records: list[dict]) -> dict | None:
         for rule in config.get("packageRules", []):
             if not isinstance(rule, dict):
                 continue
-            if _rule_description(rule).startswith("Prefix PR titles with branch name for non-main branches"):
+            if _rule_description(rule).startswith(description):
                 return rule
     return None
+
+
+def extract_combined_prefix_rule(records: list[dict]) -> dict | None:
+    """Return the PR-title prefix packageRule from Renovate's Combined config log."""
+    return extract_combined_rule_by_description(records, "Prefix PR titles with branch name for non-main branches")
+
+
+def validate_separate_minor_patch_rule(records: list[dict]) -> list[str]:
+    """Confirm real Renovate loads and merges the separateMinorPatch packageRule correctly.
+
+    custom.regex is excluded from RENOVATE_ENABLED_MANAGERS in these dry runs (see
+    build_dry_run_env), so this only checks the rule survives Renovate's config
+    merge — it does not exercise the manager itself or assert on real branches.
+    """
+    errors: list[str] = []
+    rule = extract_combined_rule_by_description(records, SEPARATE_MINOR_PATCH_RULE_DESCRIPTION)
+    if rule is None:
+        errors.append("Combined config is missing the separateMinorPatch packageRule")
+        return errors
+    if rule.get("matchManagers") != ["custom.regex"]:
+        errors.append(
+            f"separateMinorPatch rule matchManagers must be ['custom.regex'], got {rule.get('matchManagers')!r}"
+        )
+    if rule.get("separateMinorPatch") is not True:
+        errors.append(
+            f"separateMinorPatch rule must set separateMinorPatch: true, got {rule.get('separateMinorPatch')!r}"
+        )
+    return errors
 
 
 def is_known_config_warning(message: str) -> bool:
@@ -249,6 +279,7 @@ def validate_dry_runs(
             continue
 
         errors.extend(f"{scenario.name}: unexpected config warning: {msg}" for msg in fatal_config_warnings(records))
+        errors.extend(f"{scenario.name}: {msg}" for msg in validate_separate_minor_patch_rule(records))
         errors.extend(
             validate_scenario_titles(
                 scenario,

--- a/scripts/ci/validate_renovate_dry_run.py
+++ b/scripts/ci/validate_renovate_dry_run.py
@@ -30,6 +30,7 @@ KNOWN_CONFIG_WARNINGS = (
 RunSubprocess = Callable[..., subprocess.CompletedProcess[str]]
 
 SEPARATE_MINOR_PATCH_RULE_DESCRIPTION = "Separate minor and patch base image upgrades"
+SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES = ["!/^quay\\.io\\/opendatahub\\//"]
 
 
 def _subprocess_stream_text(data: str | bytes | None) -> str:
@@ -133,6 +134,11 @@ def validate_separate_minor_patch_rule(records: list[dict]) -> list[str]:
     if rule.get("matchManagers") != ["custom.regex"]:
         errors.append(
             f"separateMinorPatch rule matchManagers must be ['custom.regex'], got {rule.get('matchManagers')!r}"
+        )
+    if rule.get("matchPackageNames") != SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES:
+        errors.append(
+            "separateMinorPatch rule matchPackageNames must be "
+            f"{SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES!r}, got {rule.get('matchPackageNames')!r}"
         )
     if rule.get("separateMinorPatch") is not True:
         errors.append(

--- a/tests/test_renovate_config.py
+++ b/tests/test_renovate_config.py
@@ -7,7 +7,3 @@ def test_repo_renovate_json5_passes_semantic_validation() -> None:
     config = validate_renovate_config.load_config(validate_renovate_config.DEFAULT_CONFIG)
     errors = validate_renovate_config.validate_config(config)
     assert errors == [], f"Expected no semantic validation errors, got: {errors}"
-    assert any(
-        rule.get("matchManagers") == ["custom.regex"] and rule.get("separateMinorPatch") is True
-        for rule in config["packageRules"]
-    )

--- a/tests/unit/scripts/ci/renovate_config_testdata.py
+++ b/tests/unit/scripts/ci/renovate_config_testdata.py
@@ -16,6 +16,7 @@ from scripts.ci.validate_renovate_config import (
     ODH_REPO,
     PREFIX_RULE_DESCRIPTION,
     REQUIRED_ENABLED_MANAGERS,
+    SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES,
     SEPARATE_MINOR_PATCH_RULE_DESCRIPTION,
     MintMakerRepoPolicy,
 )
@@ -98,6 +99,7 @@ def separate_minor_patch_rule() -> dict[str, Any]:
     return {
         "description": SEPARATE_MINOR_PATCH_RULE_DESCRIPTION,
         "matchManagers": ["custom.regex"],
+        "matchPackageNames": list(SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES),
         "separateMinorPatch": True,
     }
 

--- a/tests/unit/scripts/ci/renovate_config_testdata.py
+++ b/tests/unit/scripts/ci/renovate_config_testdata.py
@@ -16,6 +16,7 @@ from scripts.ci.validate_renovate_config import (
     ODH_REPO,
     PREFIX_RULE_DESCRIPTION,
     REQUIRED_ENABLED_MANAGERS,
+    SEPARATE_MINOR_PATCH_RULE_DESCRIPTION,
     MintMakerRepoPolicy,
 )
 
@@ -93,6 +94,14 @@ def odh_base_image_enable_rule() -> dict[str, Any]:
     }
 
 
+def separate_minor_patch_rule() -> dict[str, Any]:
+    return {
+        "description": SEPARATE_MINOR_PATCH_RULE_DESCRIPTION,
+        "matchManagers": ["custom.regex"],
+        "separateMinorPatch": True,
+    }
+
+
 def minimal_valid_config(*extra_rules: dict[str, Any]) -> dict[str, Any]:
     package_rules: list[dict[str, Any]] = [prefix_rule()]
     for policy in MINTMAKER_POLICIES:
@@ -101,6 +110,7 @@ def minimal_valid_config(*extra_rules: dict[str, Any]) -> dict[str, Any]:
     package_rules.append(centos_stream_pin_rule())
     package_rules.append(odh_base_image_disable_rule())
     package_rules.append(odh_base_image_enable_rule())
+    package_rules.append(separate_minor_patch_rule())
     package_rules.extend(extra_rules)
     return {
         "enabledManagers": list(REQUIRED_ENABLED_MANAGERS),

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -132,6 +132,25 @@ def test_minimal_valid_config_passes_validation() -> None:
             ["separateMinorPatch rule must set separateMinorPatch: true"],
             id="separate-minor-patch-rule-disabled",
         ),
+        pytest.param(
+            lambda config: {
+                **config,
+                "packageRules": [
+                    {k: v for k, v in rule.items() if k != "matchPackageNames"}
+                    if rule.get("description", "").startswith(validator.SEPARATE_MINOR_PATCH_RULE_DESCRIPTION)
+                    else rule
+                    for rule in config["packageRules"]
+                ],
+            },
+            [
+                (
+                    "separateMinorPatch rule matchPackageNames must be "
+                    f"{validator.SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES!r} "
+                    "(exclude ODH BASE_IMAGE, no minor/patch axis), got None"
+                ),
+            ],
+            id="separate-minor-patch-rule-missing-package-names",
+        ),
     ],
 )
 def test_validate_config_reports_expected_errors(

--- a/tests/unit/scripts/ci/test_validate_renovate_config.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_config.py
@@ -111,6 +111,27 @@ def test_minimal_valid_config_passes_validation() -> None:
             [f"missing packageRule: {validator.ODH_BASE_ENABLE_RULE_DESCRIPTION!r}"],
             id="missing-odh-base-enable",
         ),
+        pytest.param(
+            lambda config: testdata.with_package_rules_removed(
+                config,
+                lambda rule: rule.get("description", "").startswith(validator.SEPARATE_MINOR_PATCH_RULE_DESCRIPTION),
+            ),
+            [f"missing packageRule: {validator.SEPARATE_MINOR_PATCH_RULE_DESCRIPTION!r}"],
+            id="missing-separate-minor-patch-rule",
+        ),
+        pytest.param(
+            lambda config: {
+                **config,
+                "packageRules": [
+                    {**rule, "separateMinorPatch": False}
+                    if rule.get("description", "").startswith(validator.SEPARATE_MINOR_PATCH_RULE_DESCRIPTION)
+                    else rule
+                    for rule in config["packageRules"]
+                ],
+            },
+            ["separateMinorPatch rule must set separateMinorPatch: true"],
+            id="separate-minor-patch-rule-disabled",
+        ),
     ],
 )
 def test_validate_config_reports_expected_errors(

--- a/tests/unit/scripts/ci/test_validate_renovate_dry_run.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_dry_run.py
@@ -75,6 +75,34 @@ def test_validate_scenario_titles_empty_without_prefix_rule_fails() -> None:
     assert "missing the PR-title prefix packageRule" in errors[0], f"Unexpected error: {errors[0]}"
 
 
+def test_validate_separate_minor_patch_rule_passes() -> None:
+    records = dry_run.parse_json_log_lines(
+        """
+{"msg":"Combined config","config":{"packageRules":[{"description":"Separate minor and patch base image upgrades","matchManagers":["custom.regex"],"separateMinorPatch":true}]}}
+"""
+    )
+    errors = dry_run.validate_separate_minor_patch_rule(records)
+    assert errors == [], f"Expected valid separateMinorPatch rule to pass, got: {errors}"
+
+
+def test_validate_separate_minor_patch_rule_missing() -> None:
+    records = dry_run.parse_json_log_lines('{"msg":"Combined config","config":{"packageRules":[]}}')
+    errors = dry_run.validate_separate_minor_patch_rule(records)
+    assert len(errors) == 1, f"Expected exactly one validation error, got: {errors}"
+    assert "missing the separateMinorPatch packageRule" in errors[0], f"Unexpected error: {errors[0]}"
+
+
+def test_validate_separate_minor_patch_rule_disabled() -> None:
+    records = dry_run.parse_json_log_lines(
+        """
+{"msg":"Combined config","config":{"packageRules":[{"description":"Separate minor and patch base image upgrades","matchManagers":["custom.regex"],"separateMinorPatch":false}]}}
+"""
+    )
+    errors = dry_run.validate_separate_minor_patch_rule(records)
+    assert len(errors) == 1, f"Expected exactly one validation error, got: {errors}"
+    assert "must set separateMinorPatch: true" in errors[0], f"Unexpected error: {errors[0]}"
+
+
 def test_fatal_config_warnings_ignores_known_cosmetic() -> None:
     records = dry_run.parse_json_log_lines(MAIN_FIXTURE)
     warnings = dry_run.fatal_config_warnings(records)

--- a/tests/unit/scripts/ci/test_validate_renovate_dry_run.py
+++ b/tests/unit/scripts/ci/test_validate_renovate_dry_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 
 import pytest
@@ -75,12 +76,23 @@ def test_validate_scenario_titles_empty_without_prefix_rule_fails() -> None:
     assert "missing the PR-title prefix packageRule" in errors[0], f"Unexpected error: {errors[0]}"
 
 
+def _combined_config_record(rule: dict) -> str:
+    return json.dumps({"msg": "Combined config", "config": {"packageRules": [rule]}})
+
+
+def _separate_minor_patch_rule(**overrides: object) -> dict:
+    rule = {
+        "description": dry_run.SEPARATE_MINOR_PATCH_RULE_DESCRIPTION,
+        "matchManagers": ["custom.regex"],
+        "matchPackageNames": dry_run.SEPARATE_MINOR_PATCH_MATCH_PACKAGE_NAMES,
+        "separateMinorPatch": True,
+    }
+    rule.update(overrides)
+    return rule
+
+
 def test_validate_separate_minor_patch_rule_passes() -> None:
-    records = dry_run.parse_json_log_lines(
-        """
-{"msg":"Combined config","config":{"packageRules":[{"description":"Separate minor and patch base image upgrades","matchManagers":["custom.regex"],"separateMinorPatch":true}]}}
-"""
-    )
+    records = dry_run.parse_json_log_lines(_combined_config_record(_separate_minor_patch_rule()))
     errors = dry_run.validate_separate_minor_patch_rule(records)
     assert errors == [], f"Expected valid separateMinorPatch rule to pass, got: {errors}"
 
@@ -94,13 +106,20 @@ def test_validate_separate_minor_patch_rule_missing() -> None:
 
 def test_validate_separate_minor_patch_rule_disabled() -> None:
     records = dry_run.parse_json_log_lines(
-        """
-{"msg":"Combined config","config":{"packageRules":[{"description":"Separate minor and patch base image upgrades","matchManagers":["custom.regex"],"separateMinorPatch":false}]}}
-"""
+        _combined_config_record(_separate_minor_patch_rule(separateMinorPatch=False))
     )
     errors = dry_run.validate_separate_minor_patch_rule(records)
     assert len(errors) == 1, f"Expected exactly one validation error, got: {errors}"
     assert "must set separateMinorPatch: true" in errors[0], f"Unexpected error: {errors[0]}"
+
+
+def test_validate_separate_minor_patch_rule_missing_package_names() -> None:
+    rule = _separate_minor_patch_rule()
+    del rule["matchPackageNames"]
+    records = dry_run.parse_json_log_lines(_combined_config_record(rule))
+    errors = dry_run.validate_separate_minor_patch_rule(records)
+    assert len(errors) == 1, f"Expected exactly one validation error, got: {errors}"
+    assert "matchPackageNames must be" in errors[0], f"Unexpected error: {errors[0]}"
 
 
 def test_fatal_config_warnings_ignores_known_cosmetic() -> None:


### PR DESCRIPTION
## Description

Follow-up on the [code review](https://github.com/opendatahub-io/notebooks/pull/4392#pullrequestreview-4981435735) of #4392 (`separateMinorPatch: true`). The core fix from #4392 was verified sound by actually running Renovate against real registry data; this PR addresses the 6 non-blocking findings from that review:

1. **`.github/renovate.json5`**: scope the `separateMinorPatch` rule away from the ODH `quay.io/opendatahub` BASE_IMAGE manager, which is pinned to the literal `latest` tag and has no minor/patch axis — it was previously matched incidentally since the rule had no `matchPackageNames`/`matchDatasources` filter.
2. **`.github/renovate.json5`**: fix a stale comment referencing `packageRules[4]` by array index (already wrong before this PR, and further drifted by #4392's insertion) — now references the rule by name instead, so it can't drift again.
3. **`scripts/ci/validate_renovate_config.py`**: move the `separateMinorPatch` invariant into `validate_config()`, matching every other semantic check in this file. Previously it lived only as a bare `tests/test_renovate_config.py` assert, so the standalone CLI entrypoint (what `validate-renovate-config.yaml` actually runs) would print `OK` even if the rule were later broken.
4. **`tests/test_renovate_config.py`**: removed the now-redundant bare `assert any(...)` — it used a non-selective predicate (matched 8/20 packageRules) and gave no failure message on failure. Coverage moved to `validate_config()` (point 3) with proper description-based matching and messages, plus new parametrized unit tests in `tests/unit/scripts/ci/test_validate_renovate_config.py`.
5. **`.github/workflows/validate-renovate-config.yaml`**: split the single job into `validate-renovate-config` (static, no secrets — now runs on fork PRs too) and `validate-renovate-dry-run` (needs `RENOVATE_TOKEN` — still restricted to same-repo PRs). Previously the whole job, including the free static check, was skipped for fork PRs (as seen on #4392 itself, which was from a fork).
6. **`scripts/ci/validate_renovate_dry_run.py`**: added a live check that real Renovate (v43) correctly loads and merges the `separateMinorPatch` packageRule via its "Combined config" log output. `custom.regex` is still excluded from `RENOVATE_ENABLED_MANAGERS` in these dry runs (asserting on real update branches would be flaky, since it depends on which images happen to have pending patch/minor candidates at test time), but this closes the "zero live signal, for anyone" gap for at least config-merge correctness.

## How Has This Been Tested?

- `uv run pytest tests/test_renovate_config.py tests/unit/scripts/ci/test_validate_renovate_config.py tests/unit/scripts/ci/test_validate_renovate_dry_run.py` — 31 passed, including new tests for the moved invariant and the new live-check helper.
- `uv run python scripts/ci/validate_renovate_config.py` — `OK` against the real `.github/renovate.json5`.
- `uv run ruff check` / `uv run ruff format --check` — clean.
- `yamllint .github/workflows/validate-renovate-config.yaml` — clean.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated base-image upgrade handling to exclude packages without minor or patch version axes.
  - Improved Renovate configuration validation to require separate minor and patch upgrades for applicable packages.

- **Tests**
  - Added coverage for missing, disabled, or incomplete upgrade-separation rules.
  - Added fork-safe CI checks to validate Renovate configuration semantics consistently across dry-run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->