### PR TITLE
RHAIENG-7079: feat: add fix-cve wrapper skills for Claude Code and Cu…

### DIFF
--- a/.agents/plugins/cve-resolution/skills/fix-cve/SKILL.md
+++ b/.agents/plugins/cve-resolution/skills/fix-cve/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: cve-resolution
+name: fix-cve
 description: Autonomously resolve Python CVE tickets from Jira - groups CVEs by package+branch, creates PRs, monitors Konflux builds, and updates tickets. Requires Atlassian MCP.
 ---
 
-# CVE Resolution Skill
+# Fix CVE skill
 
 Execute the **complete CVE resolution workflow** autonomously — from Jira triage
 through fix, PR creation, Konflux build monitoring, and summary message for Slack. No questions asked.

--- a/.claude/skills/fix-cve
+++ b/.claude/skills/fix-cve
@@ -1,0 +1,1 @@
+../../.agents/plugins/cve-resolution/skills/fix-cve

--- a/.cursor/skills/fix-cve
+++ b/.cursor/skills/fix-cve
@@ -1,0 +1,1 @@
+../../.agents/plugins/cve-resolution/skills/fix-cve


### PR DESCRIPTION
## Summary

This work will improve the skill, as described in [RHAIENG-7079](https://redhat.atlassian.net/browse/RHAIENG-7079)

The `/fix-cve` CVE resolution skill lives in `.agents/plugins/cve-resolution/skills/cve-resolution/SKILL.md`, but neither Claude Code nor Cursor discover skills from `.agents/` — they only look in their own directories (`.claude/skills/` and `.cursor/skills/`).

This PR adds symlinks from both tool directories to the canonical skill, so `/fix-cve` is available in both tools with zero duplication.

## Changes

- renamed the `cve-resolution` skill to `fix-cve` (same as the command that is executed)
- `.claude/skills/fix-cve` → symlink to `../../.agents/plugins/cve-resolution/skills/fix-cve`
- `.cursor/skills/fix-cve` → symlink to `../../.agents/plugins/cve-resolution/skills/fix-cve`

Both tools now read the canonical `SKILL.md` directly. Updating the shared file in `.agents/` is the only change needed to update behavior everywhere.

## How Has This Been Tested?
Locally, by opening both Claude Code and Cursor and verifying that the skill `/fix-cve` is available without need of a setup

```
$ claude
/fix-cve
```

and

```
$ cursor .
/fix-cve
```

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


[RHAIENG-7079]: https://redhat.atlassian.net/browse/RHAIENG-7079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Fix CVE” workflow to supported development tools.
  * Standardized access to security vulnerability remediation guidance across development environments.
* **Documentation**
  * Updated the workflow name and heading to make CVE-fixing guidance easier to identify and use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->