### PR TITLE
fix(base-images/copr): patch thrift rebuild for EL9

### DIFF
--- a/base-images/copr/README.md
+++ b/base-images/copr/README.md
@@ -58,12 +58,31 @@ Run `--dry-run` first to verify the plan.
 | `nvr` | yes | Fedora Name-Version-Release (e.g. `hdf5-1.14.6-6.fc43`) |
 | `note` | no | Why this package is needed |
 | `skip_tests` | no | Skip `%check` section (default: false) |
+| `spec_replacements` | no | Literal `.spec` text replacements applied before build |
 
 Top-level manifest fields: `copr_project`, `koji_tag`, `chroots`, `chroot_packages`, `build_timeout`.
 
 ### Skipping tests
 
 Some packages have test suites that are too slow or fail on EL9. Set `skip_tests: true` to inject `exit 0` after `%check` in the spec file via Copr custom builds.
+
+### Spec replacements
+
+Some Fedora SRPMs need small spec-file adjustments to rebuild on EL9, such as
+renaming a `BuildRequires` package that has a different name in the target
+buildroot. Set `spec_replacements` to apply literal text replacements to the
+extracted `.spec` file before Copr builds it:
+
+```yaml
+packages:
+  - name: thrift
+    nvr: thrift-0.24.0-1.fc46
+    spec_replacements:
+      - old: "BuildRequires: openssl3-devel"
+        new: "BuildRequires: openssl-devel"
+```
+
+Packages with either `skip_tests` or `spec_replacements` use Copr custom builds.
 
 ## How it works
 

--- a/base-images/copr/spec.md
+++ b/base-images/copr/spec.md
@@ -26,6 +26,8 @@ The tool reads from a declarative YAML manifest file that lists all packages to 
 - The source package name
 - The exact Fedora build version to use (Name-Version-Release)
 - An optional human-readable note explaining why the package is needed
+- Optional per-package build customizations such as skipping `%check` or applying
+  literal spec-file replacements for EL9 compatibility
 
 The manifest also declares the target Copr project and the Fedora tag to pull SRPMs from.
 
@@ -98,14 +100,24 @@ When an operation fails, the tool displays a clear, human-readable error message
 - If manifest loading fails, the validation error is reported immediately.
 - All error output is written to stderr with a consistent `Error:` prefix, and the tool exits with a non-zero status code.
 
-### R12: Skipping Package Tests
+### R12: Custom Spec Adjustments
 
-Some Fedora SRPMs have `%check` sections that are too slow or fail when rebuilt on EL9. The manifest supports an optional `skip_tests` flag per package (default: false). When set to `true`, the tool uses Copr's custom build method (`copr-cli buildcustom`) with a generated script that:
+Some Fedora SRPMs need small adjustments when rebuilt on EL9. The manifest
+supports optional per-package customizations that use Copr's custom build method
+(`copr-cli buildcustom`) with a generated script. Supported customizations are:
+
+- `skip_tests` -- inject `exit 0` after `%check`
+- `spec_replacements` -- apply literal text replacements to the extracted `.spec`
+  file before build (for example, renaming a Fedora-only `BuildRequires` to its
+  EL9 equivalent)
+
+The generated script:
 
 1. Downloads the SRPM from Koji (with retry for robustness)
 2. Extracts it with `rpm2cpio` / `cpio`
 3. Deletes the original `.src.rpm` so Copr doesn't use it
-4. Patches the `.spec` file to insert `exit 0` immediately after `%check`
+4. Applies any requested literal `.spec` replacements
+5. Optionally patches the `.spec` file to insert `exit 0` immediately after `%check`
 
 Copr then builds directly from the unpacked `.spec` and source files in the result directory (`.`), without needing `rpmbuild -bs` repacking. The custom build uses `--enable-net on` (so the script can download the SRPM) and declares `curl rpm cpio` as script build dependencies.
 
@@ -151,5 +163,5 @@ The dry-run output indicates which packages will skip tests.
 5. Invalid manifests are rejected before any external service calls
 6. A failed Copr build halts the process immediately with a clear error identifying the failed build
 7. All failures produce actionable error messages (with the underlying cause from the build service), not raw stack traces
-8. Build environment differences between Fedora and EL9 (e.g. autoconf version) are handled declaratively through the manifest, without per-SRPM patching
+8. Build environment differences between Fedora and EL9 (e.g. autoconf version or small spec-file renames) are handled declaratively through the manifest
 9. Packages with long-running test suites (e.g. HDF5 MPI tests) can skip `%check` via the manifest's `skip_tests` flag, or use an extended build timeout

--- a/base-images/copr/src/copr_rebuild/copr_client.py
+++ b/base-images/copr/src/copr_rebuild/copr_client.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shlex
@@ -22,17 +23,51 @@ _FAILED = "failed"
 _CANCELED = "canceled"
 _TERMINAL_STATUSES = frozenset({_SUCCEEDED, _FAILED, _CANCELED})
 
-_SKIP_TESTS_SCRIPT_TEMPLATE = """\
-#!/bin/bash
-set -Eeuxo pipefail
-curl --retry 5 --retry-delay 3 --fail -L -o original.src.rpm {srpm_url}
-rpm2cpio original.src.rpm | cpio -idmv
-rm original.src.rpm
-sed -i '/^%check/a exit 0' *.spec
-"""
-
 _SCRIPT_CHROOT = "fedora-rawhide-x86_64"
-_SCRIPT_BUILDDEPS = "curl rpm cpio"
+_SCRIPT_BUILDDEPS = "curl rpm cpio python3"
+
+
+def build_custom_build_script(
+    srpm_url: str,
+    *,
+    skip_tests: bool = False,
+    spec_replacements: tuple[tuple[str, str], ...] = (),
+) -> str:
+    """Build the Copr custom-build script for an extracted SRPM."""
+
+    script_lines = [
+        "#!/bin/bash",
+        "set -Eeuxo pipefail",
+        f"curl --retry 5 --retry-delay 3 --fail -L -o original.src.rpm {shlex.quote(srpm_url)}",
+        "rpm2cpio original.src.rpm | cpio -idmv",
+        "rm original.src.rpm",
+    ]
+
+    if spec_replacements:
+        script_lines.extend(
+            [
+                "python3 - <<'PY'",
+                "from pathlib import Path",
+                "",
+                "spec_paths = sorted(Path('.').glob('*.spec'))",
+                "if len(spec_paths) != 1:",
+                "    raise SystemExit(f'Expected exactly one spec file, found {len(spec_paths)}')",
+                "spec_path = spec_paths[0]",
+                "spec_text = spec_path.read_text(encoding='utf-8')",
+                f"replacements = {json.dumps(spec_replacements)}",
+                "for old, new in replacements:",
+                "    if old not in spec_text:",
+                "        raise SystemExit(f'Expected spec text not found: {old!r}')",
+                "    spec_text = spec_text.replace(old, new)",
+                "spec_path.write_text(spec_text, encoding='utf-8')",
+                "PY",
+            ]
+        )
+
+    if skip_tests:
+        script_lines.append("sed -i '/^%check/a exit 0' *.spec")
+
+    return "\n".join(script_lines) + "\n"
 
 
 class CoprBuildError(Exception):
@@ -178,17 +213,22 @@ class CoprClient:
         srpm_url: str,
         *,
         timeout: int | None = None,
+        skip_tests: bool = False,
+        spec_replacements: tuple[tuple[str, str], ...] = (),
         with_build_id: int | None = None,
         after_build_id: int | None = None,
     ) -> int:
-        """Submit a custom build that patches the spec to skip %check.
+        """Submit a custom build that patches the extracted spec before build.
 
-        Downloads the SRPM, extracts it, injects ``exit 0`` after ``%check``
-        in the spec file, and lets Copr build from the unpacked content.
+        Downloads the SRPM, extracts it, optionally applies literal spec-file
+        replacements, optionally injects ``exit 0`` after ``%check``, and lets
+        Copr build from the unpacked content.
 
         Args:
             srpm_url: URL to the source RPM to download and patch.
             timeout: Build timeout in seconds.
+            skip_tests: Whether to inject ``exit 0`` after ``%check``.
+            spec_replacements: Literal spec-file replacements to apply before build.
             with_build_id: Add this build to the same batch as the given build ID.
             after_build_id: Chain this build after the given build ID's batch.
 
@@ -199,8 +239,18 @@ class CoprClient:
             RuntimeError: If the build ID cannot be parsed from copr-cli output.
             CoprCliError: If copr-cli returns a non-zero exit code.
         """
-        logger.info("Submitting custom build (skip_tests) to %s: %s", self.project, srpm_url)
-        script_content = _SKIP_TESTS_SCRIPT_TEMPLATE.format(srpm_url=shlex.quote(srpm_url))
+        logger.info(
+            "Submitting custom build to %s: %s (skip_tests=%s, spec_replacements=%d)",
+            self.project,
+            srpm_url,
+            skip_tests,
+            len(spec_replacements),
+        )
+        script_content = build_custom_build_script(
+            srpm_url,
+            skip_tests=skip_tests,
+            spec_replacements=spec_replacements,
+        )
 
         fd, script_path = tempfile.mkstemp(suffix=".sh", prefix="copr_skip_tests_")
         try:
@@ -323,6 +373,7 @@ class CoprClient:
         *,
         timeout: int | None = None,
         skip_tests_names: frozenset[str] = frozenset(),
+        spec_replacements_by_name: dict[str, tuple[tuple[str, str], ...]] | None = None,
     ) -> list[list[int]]:
         """Submit all build waves at once using Copr batch ordering.
 
@@ -331,18 +382,23 @@ class CoprClient:
         is chained after the previous wave's batch (``--after-build-id``)
         so Copr enforces the correct build order server-side.
 
-        Packages whose names appear in ``skip_tests_names`` are submitted
-        via ``submit_custom_build`` (which patches ``%check`` to skip tests).
+        Packages whose names appear in ``skip_tests_names`` or
+        ``spec_replacements_by_name`` are submitted via ``submit_custom_build``.
 
         Args:
             waves: List of waves, where each wave is a list of
                 ``(package_name, srpm_url)`` tuples.
             timeout: Build timeout in seconds per build.
             skip_tests_names: Package names that should skip ``%check``.
+            spec_replacements_by_name: Literal spec-file replacements keyed by
+                package name.
 
         Returns:
             List of lists of Copr build IDs (one inner list per wave).
         """
+        if spec_replacements_by_name is None:
+            spec_replacements_by_name = {}
+
         all_wave_ids: list[list[int]] = []
         prev_wave_anchor: int | None = None
 
@@ -351,18 +407,37 @@ class CoprClient:
             wave_anchor: int | None = None
 
             for i, (name, url) in enumerate(wave_items):
-                submit = self.submit_custom_build if name in skip_tests_names else self.submit_build
+                skip_tests = name in skip_tests_names
+                spec_replacements = spec_replacements_by_name.get(name, ())
+                use_custom_build = skip_tests or bool(spec_replacements)
                 if i == 0:
                     # First build in the wave: chain after previous wave (if any)
-                    build_id = submit(
+                    if use_custom_build:
+                        build_id = self.submit_custom_build(
+                            url,
+                            timeout=timeout,
+                            skip_tests=skip_tests,
+                            spec_replacements=spec_replacements,
+                            after_build_id=prev_wave_anchor,
+                        )
+                    else:
+                        build_id = self.submit_build(
+                            url,
+                            timeout=timeout,
+                            after_build_id=prev_wave_anchor,
+                        )
+                    wave_anchor = build_id
+                # Subsequent builds: same batch as the first build in this wave
+                elif use_custom_build:
+                    build_id = self.submit_custom_build(
                         url,
                         timeout=timeout,
-                        after_build_id=prev_wave_anchor,
+                        skip_tests=skip_tests,
+                        spec_replacements=spec_replacements,
+                        with_build_id=wave_anchor,
                     )
-                    wave_anchor = build_id
                 else:
-                    # Subsequent builds: same batch as the first build in this wave
-                    build_id = submit(
+                    build_id = self.submit_build(
                         url,
                         timeout=timeout,
                         with_build_id=wave_anchor,

--- a/base-images/copr/src/copr_rebuild/manifest_schema.json
+++ b/base-images/copr/src/copr_rebuild/manifest_schema.json
@@ -26,6 +26,14 @@
           "description": "Skip the %check section when building (injects 'exit 0' after %check in the spec)",
           "title": "Skip Tests",
           "type": "boolean"
+        },
+        "spec_replacements": {
+          "description": "Literal text replacements to apply to the extracted .spec file before build",
+          "items": {
+            "$ref": "#/$defs/SpecReplacement"
+          },
+          "title": "Spec Replacements",
+          "type": "array"
         }
       },
       "required": [
@@ -33,6 +41,28 @@
         "nvr"
       ],
       "title": "PackageEntry",
+      "type": "object"
+    },
+    "SpecReplacement": {
+      "additionalProperties": false,
+      "description": "A literal text replacement applied to the spec file before build.",
+      "properties": {
+        "old": {
+          "description": "Literal text to replace in the spec file",
+          "title": "Old",
+          "type": "string"
+        },
+        "new": {
+          "description": "Replacement text for the spec file",
+          "title": "New",
+          "type": "string"
+        }
+      },
+      "required": [
+        "old",
+        "new"
+      ],
+      "title": "SpecReplacement",
       "type": "object"
     }
   },

--- a/base-images/copr/src/copr_rebuild/models.py
+++ b/base-images/copr/src/copr_rebuild/models.py
@@ -7,6 +7,15 @@ from pydantic import BaseModel, Field
 from pydantic.json_schema import GenerateJsonSchema
 
 
+class SpecReplacement(BaseModel):
+    """A literal text replacement applied to the spec file before build."""
+
+    model_config = {"extra": "forbid"}
+
+    old: str = Field(description="Literal text to replace in the spec file")
+    new: str = Field(description="Replacement text for the spec file")
+
+
 class PackageEntry(BaseModel):
     """A single entry in the rebuild manifest."""
 
@@ -18,6 +27,10 @@ class PackageEntry(BaseModel):
     skip_tests: bool = Field(
         default=False,
         description="Skip the %check section when building (injects 'exit 0' after %check in the spec)",
+    )
+    spec_replacements: list[SpecReplacement] = Field(
+        default_factory=list,
+        description="Literal text replacements to apply to the extracted .spec file before build",
     )
 
 

--- a/base-images/copr/src/copr_rebuild/packages.yaml
+++ b/base-images/copr/src/copr_rebuild/packages.yaml
@@ -43,3 +43,18 @@ packages:
   - name: zeromq
     nvr: zeromq-4.3.5-22.fc43
     note: "provides libzmq >= 4.3.5 for pyzmq"
+  - name: thrift
+    nvr: thrift-0.24.0-1.fc46
+    note: "provides libthrift-0.24.0.so required by pyarrow 24.x/25.x"
+    spec_replacements:
+      - old: "BuildRequires: openssl3-devel"
+        new: "BuildRequires: openssl-devel"
+      - old: |-
+          # explicitly set python3
+          shopt -s globstar
+          sed -i -E 's@^(#!.*/env) *python *$@\1 python3@' **/*.py
+        new: |-
+          # explicitly set python3
+          shopt -s globstar
+          sed -i -E 's@^(#!.*/env) *python *$@\1 python3@' **/*.py
+          sed -i "s|from setuptools.errors import CompileError, ExecError, PlatformError|from distutils.errors import CompileError, DistutilsExecError as ExecError, DistutilsPlatformError as PlatformError|" lib/py/setup.py

--- a/base-images/copr/src/copr_rebuild/rebuild.py
+++ b/base-images/copr/src/copr_rebuild/rebuild.py
@@ -36,14 +36,16 @@ def load_manifest(path: Path) -> Manifest:
 def resolve_package_metadata(
     manifest: Manifest,
     koji_client: KojiClient,
-) -> tuple[dict[str, PackageMetadata], frozenset[str]]:
+) -> tuple[dict[str, PackageMetadata], frozenset[str], dict[str, tuple[tuple[str, str], ...]]]:
     """Query Koji for metadata of all packages in the manifest.
 
     Returns:
-        Tuple of (packages dict keyed by name, frozenset of names with skip_tests).
+        Tuple of (packages dict keyed by name, frozenset of names with
+        skip_tests, spec replacements keyed by package name).
     """
     packages: dict[str, PackageMetadata] = {}
     skip_tests_names: set[str] = set()
+    spec_replacements_by_name: dict[str, tuple[tuple[str, str], ...]] = {}
     for entry in manifest.packages:
         logger.info("Querying Koji for %s ...", entry.nvr)
         meta = koji_client.get_package_metadata(entry.nvr)
@@ -56,7 +58,9 @@ def resolve_package_metadata(
         packages[meta.name] = meta
         if entry.skip_tests:
             skip_tests_names.add(meta.name)
-    return packages, frozenset(skip_tests_names)
+        if entry.spec_replacements:
+            spec_replacements_by_name[meta.name] = tuple((item.old, item.new) for item in entry.spec_replacements)
+    return packages, frozenset(skip_tests_names), spec_replacements_by_name
 
 
 def configure_chroots(manifest: Manifest, copr: CoprClient) -> None:
@@ -79,7 +83,7 @@ def run_dry_run(manifest: Manifest, koji_client: KojiClient) -> None:
         manifest: The validated manifest.
         koji_client: Client for querying Koji metadata.
     """
-    packages, _ = resolve_package_metadata(manifest, koji_client)
+    packages, _, _ = resolve_package_metadata(manifest, koji_client)
     waves = compute_build_waves(packages)
 
     print("Build plan:")
@@ -102,6 +106,8 @@ def run_dry_run(manifest: Manifest, koji_client: KojiClient) -> None:
             print(f"      SRPM: {meta.srpm_url}")
             if entries_by_name[pkg_name].skip_tests:
                 print("      [skip_tests: %check disabled]")
+            if entries_by_name[pkg_name].spec_replacements:
+                print(f"      [spec_replacements: {len(entries_by_name[pkg_name].spec_replacements)}]")
 
 
 def run_rebuild(manifest: Manifest, koji_client: KojiClient) -> None:
@@ -116,7 +122,7 @@ def run_rebuild(manifest: Manifest, koji_client: KojiClient) -> None:
         manifest: The validated manifest.
         koji_client: Client for querying Koji metadata.
     """
-    packages, skip_tests_names = resolve_package_metadata(manifest, koji_client)
+    packages, skip_tests_names, spec_replacements_by_name = resolve_package_metadata(manifest, koji_client)
     waves = compute_build_waves(packages)
 
     copr = CoprClient(project=manifest.copr_project)
@@ -133,6 +139,7 @@ def run_rebuild(manifest: Manifest, koji_client: KojiClient) -> None:
         wave_items,
         timeout=manifest.build_timeout,
         skip_tests_names=frozenset(skip_tests_names),
+        spec_replacements_by_name=spec_replacements_by_name,
     )
 
     # Report submitted build IDs

--- a/base-images/utils/aipcc.sh
+++ b/base-images/utils/aipcc.sh
@@ -72,7 +72,8 @@ function install_packages() {
     # PyArrow
     PKGS+=(
         "utf8proc"
-        # RHELAI
+        # EPEL 9 thrift-0.15.0 is too old for current AIPCC pyarrow wheels;
+        # the Copr rebuild provides libthrift-0.24.0.so instead.
         "re2" "thrift"
     )
 
@@ -478,6 +479,10 @@ function main() {
     if [[ "$(get_os_vendor)" == "centos" ]]; then
         if ! test -f /usr/lib64/libhdf5.so.310; then
             echo "Error: libhdf5.so.310 was not found after installation (see https://github.com/opendatahub-io/notebooks/issues/2944)"
+            exit 1
+        fi
+        if ! test -f /usr/lib64/libthrift-0.24.0.so; then
+            echo "Error: libthrift-0.24.0.so was not found after installation (current pyarrow wheels require it)"
             exit 1
         fi
     fi


### PR DESCRIPTION
Use Copr custom builds to rewrite Fedora-only thrift build steps that break on EL9, including the openssl build requirement and the Python setuptools error import. Also fail the ODH base-image install early if libthrift-0.24.0.so is still missing for pyarrow at runtime.

Once this PR be merged we will rebuild the ODH base images. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for literal spec-file replacements in package build manifests.
  * Custom builds can now apply spec replacements and optionally skip tests.
  * Added the Thrift 0.24.0 package with compatibility adjustments.
* **Bug Fixes**
  * Improved EL9 compatibility for packages requiring dependency and Python import rewrites.
  * Added validation that the required Thrift library is installed on CentOS.
* **Documentation**
  * Documented spec replacements, custom builds, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->