### PR TITLE
RHAIENG-6297: ci(.tekton/): raise minimal-rocm and tensorflow-cuda build ephemeral to 80Gi

### DIFF
--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -85,11 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -98,11 +98,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -85,11 +85,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -84,11 +84,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -97,11 +97,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -93,11 +93,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -94,11 +94,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -77,11 +77,11 @@ spec:
         requests:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
         limits:
           cpu: '4'
           memory: 8Gi
-          ephemeral-storage: 64Gi
+          ephemeral-storage: 80Gi
     - name: prepare-sboms
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -81,11 +81,11 @@ spec:
             requests:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 64Gi
+              ephemeral-storage: 80Gi
             limits:
               cpu: '4'
               memory: 8Gi
-              ephemeral-storage: 64Gi
+              ephemeral-storage: 80Gi
     - pipelineTaskName: clair-scan
       computeResources:
         requests:


### PR DESCRIPTION
## Summary

Raise Konflux `build-images` step `ephemeral-storage` from **64Gi → 80Gi** for `odh-workbench-jupyter-minimal-rocm-py312-ubi9` and `tensorflow-cuda` (workbench + pipeline-runtime) pipelines. Both image families were failing on `linux/x86_64` with `Pod ephemeral local storage usage exceeds the total limit of containers 64Gi`, blocking ODH 3.6-EA1 image publication.

## Root cause

Konflux `build-images` task runs on in-cluster `linux/x86_64` nodes with Guaranteed QoS (`requests == limits`). The `build` step carries an explicit `ephemeral-storage` cap; when the built image plus SBOM generation (`syft` in `sbom-syft-generate`) exceeds that cap, the pod is evicted.

- **minimal-rocm:** Retriggered builds for the 3.6-EA1 release repeatedly failed during **Generate SBOM / Running syft on the image** ([PipelineRun `odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-on-push-8t57x`](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-builds/pipelineruns/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-on-push-8t57x)). CUDA and CPU minimal 3.6.ea1 tags were already on Quay; ROCm was not.
- **tensorflow-cuda:** Same eviction signature on the stable CI pipeline ([PipelineRun `odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-on-pusmlcb4`](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-builds/pipelineruns/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-on-pusmlcb4/)).

This is the same failure class fixed for other ROCm images in [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002) (#3994): `pytorch-rocm`, `tensorflow-rocm`, and `rocm-7-14` base were raised to 80Gi after `PodEvicted` at 64Gi. `minimal-rocm` and `tensorflow-cuda` were still at 64Gi.

## Related issue

[RHAIENG-6297](https://redhat.atlassian.net/browse/RHAIENG-6297) — Release notebooks for ODH 3.6-EA1 (blocked downstream consumers waiting on minimal-rocm Quay tags).

Prior art: [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002) / ADR 0016 (`docs/architecture/decisions/0016-route-amd64-konflux-builds-to-in-cluster-x86-64.md`).

## Test plan

- [x] Verified all nine touched `.tekton/*` files only change `ephemeral-storage: 64Gi` → `80Gi` on the `build` step (requests + limits)
- [ ] Merge and retrigger Konflux PipelineRuns:
  - `odh-workbench-jupyter-minimal-rocm-py312-ubi9` (push/CI)
  - `odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci`
- [ ] Confirm `3.6_ea1` (or current release) tag appears on [quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9](https://quay.io/repository/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9)
- [ ] Confirm tensorflow-cuda stable CI build completes through SBOM/clair stages (CI)

<details>
<summary>Plan</summary>

1. Identify failing PipelineRuns from internal Slack thread (minimal-rocm missing 3.6.ea1 tag; tensorflow-cuda CI eviction).
2. Compare ephemeral-storage settings across `.tekton/` — note ROCm siblings already at 80Gi from [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002).
3. Raise `build` step `ephemeral-storage` to 80Gi in push, pull-request, and ci-push pipelines for:
   - `odh-workbench-jupyter-minimal-rocm-py312-ubi9` (3 files)
   - `odh-workbench-jupyter-tensorflow-cuda-py312-ubi9` (3 files)
   - `odh-pipeline-runtime-tensorflow-cuda-py312-ubi9` (3 files; keep runtime in sync)
4. Open PR; after merge, retrigger failed Konflux builds.

</details>

<details>
<summary>Trajectory</summary>

1. Pulled context from Slack thread on Universal Training images waiting for ODH 3.6-EA1 minimal notebook alignment — ROCm was the only minimal variant without a release tag on Quay.
2. Linked Konflux UI failure for minimal-rocm: eviction at 64Gi during `syft` SBOM step after repeated retriggers on 2026-08-21.
3. Grepped `.tekton/` for `ephemeral-storage` — minimal-rocm still at 64Gi while `pytorch-rocm`, `tensorflow-rocm`, `rocm-7-14` base already at 80Gi (commits `e9a17a3d`, `c8abe913` on [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002)).
4. Applied 64Gi → 80Gi on minimal-rocm push/PR/CI pipelines.
5. User reported a second failure on `odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-on-pusmlcb4` with the same 64Gi eviction message.
6. Extended the same 80Gi bump to all six tensorflow-cuda pipeline variants (workbench + pipeline-runtime × push/PR/CI).
7. No generator change: these per-image overrides are hand-maintained in `.tekton/` (same as [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002)).

</details>

Made with [Cursor](https://cursor.com)

[RHAIENG-6002]: https://redhat.atlassian.net/browse/RHAIENG-6002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Increased temporary storage capacity for image builds from 64 GiB to 80 GiB across TensorFlow CUDA and ROCm-based build pipelines.
  * Improves reliability for builds that require additional workspace during image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->