### PR TITLE
NO-JIRA: docs: fix update script usage examples

### DIFF
--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -26,17 +26,17 @@ Pipeline runtime images are intentionally skipped (only odh-workbench-* processe
 Usage (run from the repo root):
 
   # ODH only — quay.io/opendatahub, no auth required:
-  ./uv run scripts/update-commit-latest-env.py --variant odh
+  uv run scripts/update-commit-latest-env.py --variant odh
 
   # RHOAI only — quay.io/rhoai, requires prior skopeo login:
   skopeo login quay.io --username <bot-user> --password <bot-token>
-  ./uv run scripts/update-commit-latest-env.py --variant rhoai
+  uv run scripts/update-commit-latest-env.py --variant rhoai
 
   # Pin a specific RHOAI tag instead of auto-detecting:
-  ./uv run scripts/update-commit-latest-env.py --variant rhoai --rhoai-version-tag rhoai-3.5
+  uv run scripts/update-commit-latest-env.py --variant rhoai --rhoai-version-tag rhoai-3.5
 
   # Both variants at once:
-  ./uv run scripts/update-commit-latest-env.py --variant both
+  uv run scripts/update-commit-latest-env.py --variant both
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Description

Fixes #4241.

Removes the invalid `./` prefix from all four `uv run` examples in the update script's module docstring. Because that docstring is also the `argparse` description, the corrected commands now appear in `--help` output and can be copied directly from the repository root.

## How Has This Been Tested?

- `gmake test` — 469 passed
- `uvx prek run --files scripts/update-commit-latest-env.py` — all applicable checks passed
- `uv run --locked scripts/update-commit-latest-env.py --help` — passed and displayed the corrected commands
- `git diff --check` — passed

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples to use the correct `uv run` invocation across supported usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->