### PR TITLE
RHAIENG-6849: rebuild apply-seccomp for FIPS check-payload

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -62,6 +62,7 @@ RUN dnf module enable nodejs:22 -y
 RUN dnf install -y \
         nodejs nodejs-devel npm \
         jq patch libtool rsync gettext git-lfs gcc-toolset-14 gcc-toolset-14-libatomic-devel \
+        libseccomp-devel \
         krb5-devel libX11-devel libxkbfile-devel && \
     dnf clean all
 
@@ -80,6 +81,7 @@ COPY ${CODESERVER_CONTEXT}/prefetch-input/code-server/ ${CODESERVER_SOURCE_PREFE
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/code-server-${CODESERVER_VERSION}/ ${CODESERVER_SOURCE_PREFETCH}/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/setup-offline-binaries.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/replace-aipcc-ripgrep.sh ${CODESERVER_SOURCE_CODE}/patches/
+COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/rebuild-apply-seccomp.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/codeserver-offline-env.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/tweak-gha.sh ${CODESERVER_SOURCE_CODE}/patches/
 COPY ${CODESERVER_CONTEXT}/prefetch-input/patches/apply-patch.sh ${CODESERVER_SOURCE_CODE}/
@@ -122,7 +124,9 @@ RUN . ${CODESERVER_SOURCE_CODE}/patches/codeserver-offline-env.sh && cd ${CODESE
 RUN . ${CODESERVER_SOURCE_CODE}/patches/codeserver-offline-env.sh && \
     export KEEP_MODULES=1 && cd ${CODESERVER_SOURCE_PREFETCH} && \
     npm run release && \
-    "${CODESERVER_SOURCE_CODE}/patches/replace-aipcc-ripgrep.sh" "${CODESERVER_SOURCE_PREFETCH}/release"
+    "${CODESERVER_SOURCE_CODE}/patches/replace-aipcc-ripgrep.sh" "${CODESERVER_SOURCE_PREFETCH}/release" && \
+    . /opt/rh/gcc-toolset-14/enable && \
+    "${CODESERVER_SOURCE_CODE}/patches/rebuild-apply-seccomp.sh" "${CODESERVER_SOURCE_PREFETCH}/release"
 
 # Sentinel file: downstream stages use COPY --from=rpm-base /tmp/control to wait for this stage.
 RUN echo "done" > /tmp/control
@@ -212,6 +216,7 @@ RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 PACKAGES=(
     nodejs
+    libseccomp
     jq git-lfs libsndfile
     # provides envsubst which is required by run-nginx.sh
     gettext

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml
@@ -112,6 +112,8 @@ packages:
   - mesa-libGL
 
   # Dev libraries
+  - libseccomp-devel
+  - libseccomp
   - openssl-devel
   - zlib-devel
   - boost-devel

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -165,13 +165,6 @@ arches:
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 216292
-    checksum: sha256:3fd73bd271e9c04dc297eb08c3829d276faee372f77666aad29f4b676ea220f4
-    name: gawk-all-langpacks
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-13-13.0-2.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 11890
@@ -1803,13 +1796,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pyproject-srpm-macros-1.18.5-1.el9.noarch.rpm
-    repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 12794
-    checksum: sha256:de04df6652bd69cd9e30603c01c25924f13c847f1a1a6d89b5a3bc1283b20f40
-    name: pyproject-srpm-macros
-    evr: 1.18.5-1.el9
-    sourcerpm: pyproject-rpm-macros-1.18.5-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18705
@@ -1845,6 +1831,27 @@ arches:
     name: python3-pip
     evr: 21.3.1-2.el9_8
     sourcerpm: python-pip-21.3.1-2.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 32440
+    checksum: sha256:127b8467e15c3f233d87bdb85c57809332eefb2e7b483aca7a08790dd9b62b74
+    name: python3.12
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 338273
+    checksum: sha256:89b3da83c56d333c4e6b8f20e85d5df93560c82731a254b6e00ab91e011c61a8
+    name: python3.12-devel
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 10145691
+    checksum: sha256:cca9ebdb4242036911ccc7271de7cb9e3d621c152b402f781ae22b700ab02231
+    name: python3.12-libs
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1527128
@@ -1852,6 +1859,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 433842
+    checksum: sha256:5aa96f8ae8b358c63ad7a818a63be88646742938ab5024be04f145fb78187cff
+    name: python3.12-tkinter
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9344
@@ -2062,13 +2076,6 @@ arches:
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gawk-5.1.0-6.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 1024204
-    checksum: sha256:a4b7202ac90653a7d3e072c2444bde6a9270d6a818eb6f2ffcfcaa50774f1fad
-    name: gawk
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 60311
@@ -2139,13 +2146,6 @@ arches:
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
-    repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 169809
-    checksum: sha256:45710df49b439ddc4a2848fd3877367761b574234ae28b6be46f1cf54f3fcdca
-    name: gzip
-    evr: 1.12-1.el9
-    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/h/harfbuzz-2.7.4-10.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 643882
@@ -2699,13 +2699,13 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-11.el9.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 904777
-    checksum: sha256:62f985a87e048caa3ef883966d6176448398abc42df00ebff07e7311ff5f425d
-    name: tar
-    evr: 2:1.34-11.el9
-    sourcerpm: tar-1.34-11.el9.src.rpm
+    size: 660770
+    checksum: sha256:0fbb8043f9c02870c831da433f69b856a6674d02b60306d9cc01149ec89ed239
+    name: sqlite-libs
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1137015
@@ -3105,13 +3105,6 @@ arches:
     name: centos-logos-httpd
     evr: 90.9-1.el9
     sourcerpm: centos-logos-90.9-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/containers-common-5.8-2.el9.aarch64.rpm
-    repoid: appstream
-    size: 107740
-    checksum: sha256:59b32953d12fc9cd2d2f4212831c4e250c3dc5865ca096983d3b8ae2bae4ac93
-    name: containers-common
-    evr: 5:5.8-2.el9
-    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/cpp-11.5.0-15.el9.aarch64.rpm
     repoid: appstream
     size: 10798532
@@ -3133,13 +3126,6 @@ arches:
     name: criu-libs
     evr: 3.19-6.el9
     sourcerpm: criu-3.19-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/crun-1.28-1.el9.aarch64.rpm
-    repoid: appstream
-    size: 245612
-    checksum: sha256:7b7e080ccf4ed7b400ff42d4e0a6b202be0206f2f85c6c503bc1a19f6b313bf3
-    name: crun
-    evr: 1.28-1.el9
-    sourcerpm: crun-1.28-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/flac-libs-1.3.3-12.el9.aarch64.rpm
     repoid: appstream
     size: 196965
@@ -3154,13 +3140,13 @@ arches:
     name: freetype-devel
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/fuse-overlayfs-1.17-1.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/gawk-all-langpacks-5.1.0-7.el9.aarch64.rpm
     repoid: appstream
-    size: 65496
-    checksum: sha256:dfbef3ef0dfebf55d4d5ccda8fe3ce0f39edb074811f08d1eeab9bbe8f9b69dd
-    name: fuse-overlayfs
-    evr: 1.17-1.el9
-    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+    size: 210862
+    checksum: sha256:aed002758b3e4b08d7352686b3b9669011d56b5365882e3c03834e85d3fad050
+    name: gawk-all-langpacks
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/gcc-11.5.0-15.el9.aarch64.rpm
     repoid: appstream
     size: 31291692
@@ -3196,27 +3182,27 @@ arches:
     name: git-lfs
     evr: 3.7.1-6.el9
     sourcerpm: git-lfs-3.7.1-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/glib2-devel-2.68.4-21.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/glib2-devel-2.68.4-29.el9.aarch64.rpm
     repoid: appstream
-    size: 562475
-    checksum: sha256:7a154de9f9f024bda29d821469487b4677d35e67021d422a195e60c1cd633d64
+    size: 564041
+    checksum: sha256:c67af4c3d57dcacae61ad226c72b796312409268066992f0bcdd164dd01d2229
     name: glib2-devel
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/glibc-devel-2.34-276.el9.aarch64.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/glibc-devel-2.34-277.el9.aarch64.rpm
     repoid: appstream
-    size: 569880
-    checksum: sha256:a3f273b8c88617fb361ae9f584985542a2f97b8e6100445722b9fc70ddf92412
+    size: 569688
+    checksum: sha256:977df5d32ac8ed75a0c0f64c90f810d0d096f38f577f2c0a1a56cd5995630e63
     name: glibc-devel
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-737.el9.aarch64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-741.el9.aarch64.rpm
     repoid: appstream
-    size: 2625517
-    checksum: sha256:4a71beaaacc43882f9f04b4d9350a8f7f57c0d69a43de7442d366c238730cd06
+    size: 2662501
+    checksum: sha256:ef5aaa3045504cc0b5b6e56951d5641c3cf89ca18bd9cadab143390083405f78
     name: kernel-headers
-    evr: 5.14.0-737.el9
-    sourcerpm: kernel-5.14.0-737.el9.src.rpm
+    evr: 5.14.0-741.el9
+    sourcerpm: kernel-5.14.0-741.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-srpm-macros-1.0-16.el9.noarch.rpm
     repoid: appstream
     size: 14340
@@ -3266,6 +3252,13 @@ arches:
     name: libpng-devel
     evr: 2:1.6.37-17.el9
     sourcerpm: libpng-1.6.37-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libseccomp-devel-2.5.6-1.el9.aarch64.rpm
+    repoid: appstream
+    size: 58426
+    checksum: sha256:ed9f7cadb8013310d978a62e266ab30d874784b8c878283c36747eeac1f91d89
+    name: libseccomp-devel
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libselinux-devel-3.6-4.el9.aarch64.rpm
     repoid: appstream
     size: 161987
@@ -4134,6 +4127,13 @@ arches:
     name: policycoreutils-python-utils
     evr: 3.6-9.el9
     sourcerpm: policycoreutils-3.6-9.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/pyproject-srpm-macros-1.23.2-1.el9.noarch.rpm
+    repoid: appstream
+    size: 15069
+    checksum: sha256:2465e04e6c507d548c844f911a77411029fbef3fa7aa4810ba4182f302d1928b
+    name: pyproject-srpm-macros
+    evr: 1.23.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.23.2-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/python-unversioned-command-3.9.25-10.el9.noarch.rpm
     repoid: appstream
     size: 9302
@@ -4169,34 +4169,6 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-10.el9
     sourcerpm: python3.9-3.9.25-10.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/python3.12-3.12.13-4.el9.aarch64.rpm
-    repoid: appstream
-    size: 26092
-    checksum: sha256:e42b2e1c2321d2fddb9e71c63045df33592c47bb2eb72398fa50427edb41c6f2
-    name: python3.12
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/python3.12-devel-3.12.13-4.el9.aarch64.rpm
-    repoid: appstream
-    size: 331180
-    checksum: sha256:6ec76fb0bf9c15962faaecfbd25d32daa624b211e6bb2b7e7605afc1880f7dfb
-    name: python3.12-devel
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/python3.12-libs-3.12.13-4.el9.aarch64.rpm
-    repoid: appstream
-    size: 10140192
-    checksum: sha256:aadb873d0d0eb6758e71f68faf76f21e173447ed8573953f6d5afb455ea0d080
-    name: python3.12-libs
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/python3.12-tkinter-3.12.13-4.el9.aarch64.rpm
-    repoid: appstream
-    size: 426749
-    checksum: sha256:0288c516e705bad9ea878d8f72692691f8dadeeb90bb05349cea9e7d11848ada
-    name: python3.12-tkinter
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/redhat-rpm-config-211-1.el9.noarch.rpm
     repoid: appstream
     size: 70868
@@ -4218,20 +4190,6 @@ arches:
     name: rust-std-static
     evr: 1.97.1-3.el9
     sourcerpm: rust-1.97.1-3.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/skopeo-1.22.2-1.el9.aarch64.rpm
-    repoid: appstream
-    size: 7719042
-    checksum: sha256:0f3774ec9aa82ca5cd84a602b8f5c7ec989bb6bb658faf7e6e7c40466473f109
-    name: skopeo
-    evr: 3:1.22.2-1.el9
-    sourcerpm: skopeo-1.22.2-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/slirp4netns-1.3.4-1.el9.aarch64.rpm
-    repoid: appstream
-    size: 46734
-    checksum: sha256:bb3e4a494705141838b0820dbdea40893326871bb2c693148e80dad735043974
-    name: slirp4netns
-    evr: 1.3.4-1.el9
-    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/spirv-tools-libs-2026.1-1.el9.aarch64.rpm
     repoid: appstream
     size: 1639275
@@ -4309,6 +4267,13 @@ arches:
     name: centos-stream-repos
     evr: 9.0-38.el9
     sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/containers-common-5.8-2.el9.aarch64.rpm
+    repoid: baseos
+    size: 107740
+    checksum: sha256:59b32953d12fc9cd2d2f4212831c4e250c3dc5865ca096983d3b8ae2bae4ac93
+    name: containers-common
+    evr: 5:5.8-2.el9
+    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/coreutils-8.32-43.el9.aarch64.rpm
     repoid: baseos
     size: 1172062
@@ -4323,6 +4288,13 @@ arches:
     name: coreutils-common
     evr: 8.32-43.el9
     sourcerpm: coreutils-8.32-43.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/crun-1.29.1-1.el9.aarch64.rpm
+    repoid: baseos
+    size: 252014
+    checksum: sha256:63bcc7f8566b73e49a971a66ebde7c5828949b75524b46483e6f560a59792679
+    name: crun
+    evr: 1.29.1-1.el9
+    sourcerpm: crun-1.29.1-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/crypto-policies-20260714-1.git65b74f7.el9.noarch.rpm
     repoid: baseos
     size: 91607
@@ -4414,41 +4386,62 @@ arches:
     name: freetype
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glib2-2.68.4-21.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/fuse-overlayfs-1.17-1.el9.aarch64.rpm
     repoid: baseos
-    size: 2736631
-    checksum: sha256:58ff8d18a709e188c73f30000061325b4ef5cc1a735b66c1e484b5d478389311
+    size: 65496
+    checksum: sha256:dfbef3ef0dfebf55d4d5ccda8fe3ce0f39edb074811f08d1eeab9bbe8f9b69dd
+    name: fuse-overlayfs
+    evr: 1.17-1.el9
+    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/gawk-5.1.0-7.el9.aarch64.rpm
+    repoid: baseos
+    size: 1018579
+    checksum: sha256:fdeb8f68f67ca5ecdd080f761398df27c596510c02d2987f294444d61dd3868b
+    name: gawk
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glib2-2.68.4-29.el9.aarch64.rpm
+    repoid: baseos
+    size: 2737967
+    checksum: sha256:9a88b2b2c7de9db0045e863c7e9f2e293be367fbfba5ef5fd270da75de367a89
     name: glib2
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-2.34-276.el9.aarch64.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-2.34-277.el9.aarch64.rpm
     repoid: baseos
-    size: 1805917
-    checksum: sha256:3fb64aca42e0de4f37799b1a9390b4dadadb66c2631b39ec75403193d7940995
+    size: 1806448
+    checksum: sha256:6614c1e4fd142b8edfc3a2f115b9a8c8c2e8fb1dc31c37be2610c62258f055d9
     name: glibc
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-common-2.34-276.el9.aarch64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-common-2.34-277.el9.aarch64.rpm
     repoid: baseos
-    size: 305749
-    checksum: sha256:cb197f8c74fbca98062b73db81b4feebded8dc646176cc6b74fae56d60cb8df7
+    size: 305579
+    checksum: sha256:cdb3e54a992e8708b6b407211f2c410c8644d03f26e509ca149a73f57cfaf9b4
     name: glibc-common
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-gconv-extra-2.34-276.el9.aarch64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-gconv-extra-2.34-277.el9.aarch64.rpm
     repoid: baseos
-    size: 1825040
-    checksum: sha256:8f181b628608c876adccf57c8a63c510c76d9ff61e1be8e8af3a54140ef835f7
+    size: 1820029
+    checksum: sha256:cd7c89604ac98b5033066c9506bf32d5c63c025dc4a1875700f92be9ed50ee8e
     name: glibc-gconv-extra
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-minimal-langpack-2.34-276.el9.aarch64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/glibc-minimal-langpack-2.34-277.el9.aarch64.rpm
     repoid: baseos
-    size: 23713
-    checksum: sha256:c533d827a051827529927b3c7ecf74bbfb839aef8bd9e3b24b54849e1fbbe3d6
+    size: 23625
+    checksum: sha256:8c068eb8b0924084eb7e8ae5cf0bd19fbec8afda9a9741bb7a8103254152bd52
     name: glibc-minimal-langpack
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/gzip-1.12-2.el9.aarch64.rpm
+    repoid: baseos
+    size: 164078
+    checksum: sha256:81572274cc28e7ea447d0768384f2540bbbbb709f13ceb829014e85f612655ca
+    name: gzip
+    evr: 1.12-2.el9
+    sourcerpm: gzip-1.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/jq-1.6-21.el9.aarch64.rpm
     repoid: baseos
     size: 184566
@@ -4645,20 +4638,20 @@ arches:
     name: openldap
     evr: 2.6.13-1.el9
     sourcerpm: openldap-2.6.13-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/openssh-9.9p1-12.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/openssh-9.9p1-13.el9.aarch64.rpm
     repoid: baseos
-    size: 425369
-    checksum: sha256:6e8b14e6486f2e7f9236fb686fd9d3f6efbeb06f3741bd689ae91354dc48e675
+    size: 425977
+    checksum: sha256:169b67ff5407ca58998623fe4ca815ed2cdf9519a053d13580f029fba3fdfbff
     name: openssh
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/openssh-clients-9.9p1-12.el9.aarch64.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/openssh-clients-9.9p1-13.el9.aarch64.rpm
     repoid: baseos
-    size: 762954
-    checksum: sha256:819232b2cae69a4dc7a7895acb0c988e9983b525fc0ac3b69e0f1f622e04347c
+    size: 763761
+    checksum: sha256:9e0402369aed0e6d5d427a9344544a0b7b307e778805d7c47ab1d666d9647a2a
     name: openssh-clients
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/openssl-3.5.7-3.el9.aarch64.rpm
     repoid: baseos
     size: 1537492
@@ -4736,41 +4729,55 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-17.el9
     sourcerpm: shadow-utils-4.9-17.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/sqlite-libs-3.34.1-11.el9.aarch64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/skopeo-1.22.2-4.el9.aarch64.rpm
     repoid: baseos
-    size: 654336
-    checksum: sha256:2f65e7f2b71d9f290b3847fdc7aec651e61f867493c8fafa093f94591723f7c5
-    name: sqlite-libs
-    evr: 3.34.1-11.el9
-    sourcerpm: sqlite-3.34.1-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-252-76.el9.aarch64.rpm
+    size: 7719293
+    checksum: sha256:95eadc4874a619bcdeeb9c8cf904a4966a13068cfdfc4429e3ca80fa69f922fa
+    name: skopeo
+    evr: 3:1.22.2-4.el9
+    sourcerpm: skopeo-1.22.2-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/slirp4netns-1.3.4-1.el9.aarch64.rpm
     repoid: baseos
-    size: 4147251
-    checksum: sha256:0ae26d6e118c9b6480fab6e73722a13093dc13d6cb54e334fc3c3e5c1d54acad
+    size: 46734
+    checksum: sha256:bb3e4a494705141838b0820dbdea40893326871bb2c693148e80dad735043974
+    name: slirp4netns
+    evr: 1.3.4-1.el9
+    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-252-78.el9.aarch64.rpm
+    repoid: baseos
+    size: 4134703
+    checksum: sha256:c97950426da2186056fdf1d1900ac2c4ade8cd8db44072a8865bc52cf1b46e50
     name: systemd
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-libs-252-76.el9.aarch64.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-libs-252-78.el9.aarch64.rpm
     repoid: baseos
-    size: 637115
-    checksum: sha256:17a76067e2da2f2225926056ecc698179f02994b0df55b41fb4591e0a24634f3
+    size: 624619
+    checksum: sha256:176eab1534229e86c93e94630da085287e0a93d260bae66503b4167632eda244
     name: systemd-libs
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-pam-252-76.el9.aarch64.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-pam-252-78.el9.aarch64.rpm
     repoid: baseos
-    size: 256124
-    checksum: sha256:1be545c0c96792732fe2bd16d8774053730fbceed51053bdd2897b9e9f6bbab2
+    size: 243897
+    checksum: sha256:6845e3290cf7ce8085ea6f160681070df506b031deb1a2d1acd79b36ce5a00d6
     name: systemd-pam
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-rpm-macros-252-76.el9.noarch.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/systemd-rpm-macros-252-78.el9.noarch.rpm
     repoid: baseos
-    size: 49015
-    checksum: sha256:87cadce972e5e47b044d5f8c02f8adb23fdd16dff83aa177620178491fa47fdc
+    size: 36797
+    checksum: sha256:a0ee77264681d14a9298dc6d9e3ca4c4abb4a546619d2075b6c666e376cf78d0
     name: systemd-rpm-macros
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/tar-1.34-13.el9.aarch64.rpm
+    repoid: baseos
+    size: 902013
+    checksum: sha256:1a76f91090e909c3cac78d572e528a9047ffb9b4df80bb2c847869fe79c4ba55
+    name: tar
+    evr: 2:1.34-13.el9
+    sourcerpm: tar-1.34-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/Packages/util-linux-2.37.4-27.el9.aarch64.rpm
     repoid: baseos
     size: 2382280
@@ -4836,10 +4843,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/1b18f3e23bd825cf08d950a87c06648dc7ad04d30defea0877d34f3753c83d89-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/186e61a92931804aceabc0aae792e9beea2daa512a9219e692a6b579c12fdd21-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
-    size: 8731
-    checksum: sha256:1b18f3e23bd825cf08d950a87c06648dc7ad04d30defea0877d34f3753c83d89
+    size: 8881
+    checksum: sha256:186e61a92931804aceabc0aae792e9beea2daa512a9219e692a6b579c12fdd21
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -5007,13 +5014,6 @@ arches:
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 216324
-    checksum: sha256:f44a17730803f53266874678031b8121541b5b1a8047a3205c2576630216f468
-    name: gawk-all-langpacks
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-toolset-13-13.0-2.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 11928
@@ -6659,13 +6659,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/pyproject-srpm-macros-1.18.5-1.el9.noarch.rpm
-    repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 12794
-    checksum: sha256:de04df6652bd69cd9e30603c01c25924f13c847f1a1a6d89b5a3bc1283b20f40
-    name: pyproject-srpm-macros
-    evr: 1.18.5-1.el9
-    sourcerpm: pyproject-rpm-macros-1.18.5-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 18705
@@ -6701,6 +6694,27 @@ arches:
     name: python3-pip
     evr: 21.3.1-2.el9_8
     sourcerpm: python-pip-21.3.1-2.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 32494
+    checksum: sha256:8e3fcabf92bf5be325dbb114ab2921b92c3a3007c9bab8b24f93d3c2a5bb44c8
+    name: python3.12
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 338324
+    checksum: sha256:2b8ca99850b8755bd9fbb5394b2522bd7b104600d102fd1b48f29adb4c8c37ff
+    name: python3.12-devel
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 10093244
+    checksum: sha256:32e4a045a4ce07f8db54811f223def1404fbabe4b7b521d48a56c7480f6b1057
+    name: python3.12-libs
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 1527128
@@ -6708,6 +6722,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 432811
+    checksum: sha256:5d377e670b37718a80213b4001ce0a2a913372b04f7b60e2209bfb8bae7af814
+    name: python3.12-tkinter
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 9344
@@ -6918,13 +6939,6 @@ arches:
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gawk-5.1.0-6.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 1064251
-    checksum: sha256:b0cc389ad0855900c79f2cfa525df8cbc663093056b0b5d29ec3e36a189b325e
-    name: gawk
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 65838
@@ -6995,13 +7009,6 @@ arches:
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gzip-1.12-1.el9.ppc64le.rpm
-    repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 175705
-    checksum: sha256:55b983f08d8b2a0741b07f114cdba89a8ecb207064c001e90e4c76a13836d458
-    name: gzip
-    evr: 1.12-1.el9
-    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/h/harfbuzz-2.7.4-10.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 721789
@@ -7569,13 +7576,13 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/t/tar-1.34-11.el9.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 945887
-    checksum: sha256:cb2fe4ca6c89e1a9fff648629cc7b9b7f33a7853a8ae74c10baa1d5b731d2447
-    name: tar
-    evr: 2:1.34-11.el9
-    sourcerpm: tar-1.34-11.el9.src.rpm
+    size: 758085
+    checksum: sha256:f51af80eda44e36b51b315a90e44a0bfd2c6c7d4ce4aadd40bac23af3fc43cb8
+    name: sqlite-libs
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/t/tcl-8.6.10-7.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 1250450
@@ -7961,13 +7968,6 @@ arches:
     name: centos-logos-httpd
     evr: 90.9-1.el9
     sourcerpm: centos-logos-90.9-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/containers-common-5.8-2.el9.ppc64le.rpm
-    repoid: appstream
-    size: 107769
-    checksum: sha256:71390f141dc6420568efd2b47e4895f77c060d3d1dd8bfe5b0d99a202c524a2e
-    name: containers-common
-    evr: 5:5.8-2.el9
-    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/cpp-11.5.0-15.el9.ppc64le.rpm
     repoid: appstream
     size: 9614973
@@ -7989,13 +7989,6 @@ arches:
     name: criu-libs
     evr: 3.19-6.el9
     sourcerpm: criu-3.19-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/crun-1.28-1.el9.ppc64le.rpm
-    repoid: appstream
-    size: 286535
-    checksum: sha256:232e8216436328cf7e36e700c02625faf08a2e3d3e6a368f06f66548e388211c
-    name: crun
-    evr: 1.28-1.el9
-    sourcerpm: crun-1.28-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/flac-libs-1.3.3-12.el9.ppc64le.rpm
     repoid: appstream
     size: 230742
@@ -8010,13 +8003,13 @@ arches:
     name: freetype-devel
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/fuse-overlayfs-1.17-1.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/gawk-all-langpacks-5.1.0-7.el9.ppc64le.rpm
     repoid: appstream
-    size: 71324
-    checksum: sha256:1c612522ea42ab800d69c2da5e93194cbcade7c61af322279a4989ca0e29147f
-    name: fuse-overlayfs
-    evr: 1.17-1.el9
-    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+    size: 210894
+    checksum: sha256:31128e433f5ae4f6189e91395b952a9f4b604496170cf8601773059c20a565c9
+    name: gawk-all-langpacks
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/gcc-11.5.0-15.el9.ppc64le.rpm
     repoid: appstream
     size: 29066709
@@ -8052,27 +8045,27 @@ arches:
     name: git-lfs
     evr: 3.7.1-6.el9
     sourcerpm: git-lfs-3.7.1-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/glib2-devel-2.68.4-21.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/glib2-devel-2.68.4-29.el9.ppc64le.rpm
     repoid: appstream
-    size: 566446
-    checksum: sha256:148fa1a4e124c9c86d1d4439b3f65c64373154164952aba0156915f0946efe16
+    size: 567841
+    checksum: sha256:d9b060bb95133c633193d0b345cb76a8a33bec107b3eb1df8a84e65db1597f5e
     name: glib2-devel
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/glibc-devel-2.34-276.el9.ppc64le.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/glibc-devel-2.34-277.el9.ppc64le.rpm
     repoid: appstream
-    size: 581022
-    checksum: sha256:a6d69a3dc033f95f3512d3d1036ad7ef33265388f8b431323fe7f867cec75854
+    size: 580817
+    checksum: sha256:fbbb5ff93882067d89f939f90998d309893063d27c17a000cfd6faa4d0b70c4e
     name: glibc-devel
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/kernel-headers-5.14.0-737.el9.ppc64le.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/kernel-headers-5.14.0-741.el9.ppc64le.rpm
     repoid: appstream
-    size: 2649357
-    checksum: sha256:a649eee897ef11aa4777e813d19e61a0f24f5860c2069e33d784dfffaa624322
+    size: 2686333
+    checksum: sha256:bd0cd138e13b27c2e64cf73cfc51bbf40d2991500c0bf6cae58750940e5a23d7
     name: kernel-headers
-    evr: 5.14.0-737.el9
-    sourcerpm: kernel-5.14.0-737.el9.src.rpm
+    evr: 5.14.0-741.el9
+    sourcerpm: kernel-5.14.0-741.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/kernel-srpm-macros-1.0-16.el9.noarch.rpm
     repoid: appstream
     size: 14340
@@ -8129,6 +8122,13 @@ arches:
     name: libquadmath-devel
     evr: 11.5.0-15.el9
     sourcerpm: gcc-11.5.0-15.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/libseccomp-devel-2.5.6-1.el9.ppc64le.rpm
+    repoid: appstream
+    size: 58568
+    checksum: sha256:2dc1b7bb24887f67042678d4100b03f6e442e99f170af674384c27d8028e8024
+    name: libseccomp-devel
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/libselinux-devel-3.6-4.el9.ppc64le.rpm
     repoid: appstream
     size: 162009
@@ -8997,6 +8997,13 @@ arches:
     name: policycoreutils-python-utils
     evr: 3.6-9.el9
     sourcerpm: policycoreutils-3.6-9.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/pyproject-srpm-macros-1.23.2-1.el9.noarch.rpm
+    repoid: appstream
+    size: 15069
+    checksum: sha256:2465e04e6c507d548c844f911a77411029fbef3fa7aa4810ba4182f302d1928b
+    name: pyproject-srpm-macros
+    evr: 1.23.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.23.2-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/python-unversioned-command-3.9.25-10.el9.noarch.rpm
     repoid: appstream
     size: 9302
@@ -9032,34 +9039,6 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-10.el9
     sourcerpm: python3.9-3.9.25-10.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/python3.12-3.12.13-4.el9.ppc64le.rpm
-    repoid: appstream
-    size: 26158
-    checksum: sha256:242306b2e00b8a8ca2b1f1651481ac2538eacec73707422f503e7c5f293bf77f
-    name: python3.12
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/python3.12-devel-3.12.13-4.el9.ppc64le.rpm
-    repoid: appstream
-    size: 331286
-    checksum: sha256:faff576634565cd626b75a289b7ddc982f51a1e64175cabe7626f7e78d27ad29
-    name: python3.12-devel
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/python3.12-libs-3.12.13-4.el9.ppc64le.rpm
-    repoid: appstream
-    size: 10083489
-    checksum: sha256:45054c868df2119100b1d4ccfa65f1997f3bcbabafa5615edea057efdfa23740
-    name: python3.12-libs
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/python3.12-tkinter-3.12.13-4.el9.ppc64le.rpm
-    repoid: appstream
-    size: 425791
-    checksum: sha256:dfd113c408c5d9492c7a9dfc4d281bfbf49f8e9f98ce1ed61b94a54b2e341570
-    name: python3.12-tkinter
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/redhat-rpm-config-211-1.el9.noarch.rpm
     repoid: appstream
     size: 70868
@@ -9081,20 +9060,6 @@ arches:
     name: rust-std-static
     evr: 1.97.1-3.el9
     sourcerpm: rust-1.97.1-3.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/skopeo-1.22.2-1.el9.ppc64le.rpm
-    repoid: appstream
-    size: 7791866
-    checksum: sha256:b63583c53ba36611d89b4a0711a9523997d51c2a6d2817d4d72b6dfcb3e18880
-    name: skopeo
-    evr: 3:1.22.2-1.el9
-    sourcerpm: skopeo-1.22.2-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/slirp4netns-1.3.4-1.el9.ppc64le.rpm
-    repoid: appstream
-    size: 49097
-    checksum: sha256:55b60a136472a3958daee3a3c637052697487469133724af39e70127c39bbd61
-    name: slirp4netns
-    evr: 1.3.4-1.el9
-    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/spirv-tools-libs-2026.1-1.el9.ppc64le.rpm
     repoid: appstream
     size: 1833749
@@ -9172,6 +9137,13 @@ arches:
     name: centos-stream-repos
     evr: 9.0-38.el9
     sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/containers-common-5.8-2.el9.ppc64le.rpm
+    repoid: baseos
+    size: 107769
+    checksum: sha256:71390f141dc6420568efd2b47e4895f77c060d3d1dd8bfe5b0d99a202c524a2e
+    name: containers-common
+    evr: 5:5.8-2.el9
+    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/coreutils-8.32-43.el9.ppc64le.rpm
     repoid: baseos
     size: 1251738
@@ -9186,6 +9158,13 @@ arches:
     name: coreutils-common
     evr: 8.32-43.el9
     sourcerpm: coreutils-8.32-43.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/crun-1.29.1-1.el9.ppc64le.rpm
+    repoid: baseos
+    size: 293988
+    checksum: sha256:e7c1a3596a4a5e9c47bbe721491f8e32497062cadf05817ec6060026959a6aab
+    name: crun
+    evr: 1.29.1-1.el9
+    sourcerpm: crun-1.29.1-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/crypto-policies-20260714-1.git65b74f7.el9.noarch.rpm
     repoid: baseos
     size: 91607
@@ -9277,41 +9256,62 @@ arches:
     name: freetype
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glib2-2.68.4-21.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/fuse-overlayfs-1.17-1.el9.ppc64le.rpm
     repoid: baseos
-    size: 2882755
-    checksum: sha256:f536514d791ef2d6c7ca5762115e3bc92e9e056b3a0d9b0a192c09f1d9e7ea28
+    size: 71324
+    checksum: sha256:1c612522ea42ab800d69c2da5e93194cbcade7c61af322279a4989ca0e29147f
+    name: fuse-overlayfs
+    evr: 1.17-1.el9
+    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/gawk-5.1.0-7.el9.ppc64le.rpm
+    repoid: baseos
+    size: 1056406
+    checksum: sha256:88fa704a8e11689eb5a6952484dd057344de029638472fc9d0fa4eee5aaf6546
+    name: gawk
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glib2-2.68.4-29.el9.ppc64le.rpm
+    repoid: baseos
+    size: 2883292
+    checksum: sha256:573e20a70aab220c94a0ad8e866ac0c3a08471d0109e4244a0d80d708c2c64f7
     name: glib2
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-2.34-276.el9.ppc64le.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-2.34-277.el9.ppc64le.rpm
     repoid: baseos
-    size: 2903504
-    checksum: sha256:a0a180291eb4f5a0ac9187e91eaa7cc36d53b82e69a22f75dcfa45d51c17a586
+    size: 2902100
+    checksum: sha256:96bf39e776e4994dd852125a7ac9ec60b3d349f77f798f513c2bf3d2852f5b93
     name: glibc
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-common-2.34-276.el9.ppc64le.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-common-2.34-277.el9.ppc64le.rpm
     repoid: baseos
-    size: 332467
-    checksum: sha256:aaf3c5aa8d49d95b06cacf762a79c5e140b5fc9dd639ebdd571f61a2ebf38b67
+    size: 331768
+    checksum: sha256:d61d94d552a38ac91860ef99707b567b6a3780380690f58ae3a0b4f2ff85897f
     name: glibc-common
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-gconv-extra-2.34-276.el9.ppc64le.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-gconv-extra-2.34-277.el9.ppc64le.rpm
     repoid: baseos
-    size: 1827174
-    checksum: sha256:ffadf218fd8ba08da9a9b5fef96fa91e7cf30d690e515404222a047ac26665d0
+    size: 1826652
+    checksum: sha256:9de480cb966fa1de654bd9a40ebdb71b4f9de91b2f292e8da0b20b4f51b107ea
     name: glibc-gconv-extra
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-minimal-langpack-2.34-276.el9.ppc64le.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/glibc-minimal-langpack-2.34-277.el9.ppc64le.rpm
     repoid: baseos
-    size: 23745
-    checksum: sha256:36df08c430d19068e3b39845164c22c2e543a033bcbd002c8a0eb43954fff91f
+    size: 23657
+    checksum: sha256:55db54d310a8e22538030edd5e78d6eeb5d6dbe904c66ce7ab68e65f3e0a6c9d
     name: glibc-minimal-langpack
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/gzip-1.12-2.el9.ppc64le.rpm
+    repoid: baseos
+    size: 168977
+    checksum: sha256:e2fe02b24b5986f50639decb71ea5bc61bd63a5a5a8e6d06b50a98cc3ab3fe9b
+    name: gzip
+    evr: 1.12-2.el9
+    sourcerpm: gzip-1.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/jq-1.6-21.el9.ppc64le.rpm
     repoid: baseos
     size: 203855
@@ -9508,20 +9508,20 @@ arches:
     name: openldap
     evr: 2.6.13-1.el9
     sourcerpm: openldap-2.6.13-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/openssh-9.9p1-12.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/openssh-9.9p1-13.el9.ppc64le.rpm
     repoid: baseos
-    size: 452796
-    checksum: sha256:fda3130a8ecb8bc80e06aea6e2f520bb6a1392f235dea5b620c634d9624a65b1
+    size: 453437
+    checksum: sha256:1b2de37afba4f0f633f7b6fecd31b6259564a251afe3f38686fb71b06409fdd6
     name: openssh
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/openssh-clients-9.9p1-12.el9.ppc64le.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/openssh-clients-9.9p1-13.el9.ppc64le.rpm
     repoid: baseos
-    size: 829061
-    checksum: sha256:9725599f256018c0ff386e7cc7ec86b8e972254ddbfd786147a2d611fc84bdd7
+    size: 829535
+    checksum: sha256:4cb9a7df620a1b139bd30b01e7b4fc697f7823db5dc416582ac551786be27517
     name: openssh-clients
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/openssl-3.5.7-3.el9.ppc64le.rpm
     repoid: baseos
     size: 1562979
@@ -9599,41 +9599,55 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-17.el9
     sourcerpm: shadow-utils-4.9-17.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/sqlite-libs-3.34.1-11.el9.ppc64le.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/skopeo-1.22.2-4.el9.ppc64le.rpm
     repoid: baseos
-    size: 751747
-    checksum: sha256:4091318d42babd95dee26f567083843a46cda2c42136466b4f93d5f3f253d8be
-    name: sqlite-libs
-    evr: 3.34.1-11.el9
-    sourcerpm: sqlite-3.34.1-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-252-76.el9.ppc64le.rpm
+    size: 7792258
+    checksum: sha256:0df7734ca4e0d13efffd6c45ecc2e2eb9655acd6794bfc1971f8983ebd004ebd
+    name: skopeo
+    evr: 3:1.22.2-4.el9
+    sourcerpm: skopeo-1.22.2-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/slirp4netns-1.3.4-1.el9.ppc64le.rpm
     repoid: baseos
-    size: 4429294
-    checksum: sha256:92856451e5bcac561bf21fccb91e19d15045dfd984770804f23bb8aafaddaa4a
+    size: 49097
+    checksum: sha256:55b60a136472a3958daee3a3c637052697487469133724af39e70127c39bbd61
+    name: slirp4netns
+    evr: 1.3.4-1.el9
+    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-252-78.el9.ppc64le.rpm
+    repoid: baseos
+    size: 4415469
+    checksum: sha256:8e3ae11de3ceaa3866338d28ff08b5a7c49f5b637390e88f994360806167d87c
     name: systemd
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-libs-252-76.el9.ppc64le.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-libs-252-78.el9.ppc64le.rpm
     repoid: baseos
-    size: 702461
-    checksum: sha256:e29800eedc28ff87ae4c9c10037782368a74f3ceff2e43bfd75be160a5482d6e
+    size: 690047
+    checksum: sha256:a97ad1a4e38a1f7e670210a031ab977f0cc3785a75eb0c3f69e0b29e4ca71264
     name: systemd-libs
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-pam-252-76.el9.ppc64le.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-pam-252-78.el9.ppc64le.rpm
     repoid: baseos
-    size: 284408
-    checksum: sha256:f22abd7f702a4a535773329a992592435d7a31cd800cbf1c4eb07bdd7599dd48
+    size: 272188
+    checksum: sha256:7f97bf82cc1a37777bc6589182d910455c8b1ea62fdb11e83f15f4a430f6628d
     name: systemd-pam
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-rpm-macros-252-76.el9.noarch.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/systemd-rpm-macros-252-78.el9.noarch.rpm
     repoid: baseos
-    size: 49015
-    checksum: sha256:87cadce972e5e47b044d5f8c02f8adb23fdd16dff83aa177620178491fa47fdc
+    size: 36797
+    checksum: sha256:a0ee77264681d14a9298dc6d9e3ca4c4abb4a546619d2075b6c666e376cf78d0
     name: systemd-rpm-macros
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/tar-1.34-13.el9.ppc64le.rpm
+    repoid: baseos
+    size: 940587
+    checksum: sha256:91bf02ae134d26fbfc2f9fe07c8a5b1616398d9af0e39a85cac3ad6934b4c156
+    name: tar
+    evr: 2:1.34-13.el9
+    sourcerpm: tar-1.34-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/Packages/util-linux-2.37.4-27.el9.ppc64le.rpm
     repoid: baseos
     size: 2418969
@@ -9699,10 +9713,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/2334fe968e9d8beb21c0d33fbbfe24ade70c59d812835ee559937c3bc055f0c1-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/b6914710da3550fffebfea58344085e96016eb84c9280c98c0ea07a2b4724937-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
-    size: 9570
-    checksum: sha256:2334fe968e9d8beb21c0d33fbbfe24ade70c59d812835ee559937c3bc055f0c1
+    size: 9360
+    checksum: sha256:b6914710da3550fffebfea58344085e96016eb84c9280c98c0ea07a2b4724937
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -9870,13 +9884,6 @@ arches:
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.s390x.rpm
-    repoid: ubi-9-for-s390x-appstream-rpms
-    size: 216312
-    checksum: sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e
-    name: gawk-all-langpacks
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-toolset-13-13.0-2.el9.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 11910
@@ -11536,13 +11543,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/pyproject-srpm-macros-1.18.5-1.el9.noarch.rpm
-    repoid: ubi-9-for-s390x-appstream-rpms
-    size: 12794
-    checksum: sha256:de04df6652bd69cd9e30603c01c25924f13c847f1a1a6d89b5a3bc1283b20f40
-    name: pyproject-srpm-macros
-    evr: 1.18.5-1.el9
-    sourcerpm: pyproject-rpm-macros-1.18.5-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 18705
@@ -11578,6 +11578,27 @@ arches:
     name: python3-pip
     evr: 21.3.1-2.el9_8
     sourcerpm: python-pip-21.3.1-2.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 32298
+    checksum: sha256:1d9c6400225666643a98052596e6a10a3e0f84c81daf0fef28867331749bf2f9
+    name: python3.12
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 338253
+    checksum: sha256:3388967387eb568f8e59ef6bc06a0313794db4aa602c883fbb511f9eff70fcad
+    name: python3.12-devel
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 9974169
+    checksum: sha256:000bf9abc0a7627f453b50e1a94181a2f6729927d8d3324aa27ab8b251fb1ed1
+    name: python3.12-libs
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 1527128
@@ -11585,6 +11606,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 434493
+    checksum: sha256:a64656979e2a1228d14cac26ffb1be943df03bf37fcfd1bf548ed72fac1a3490
+    name: python3.12-tkinter
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 9344
@@ -11795,13 +11823,6 @@ arches:
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/g/gawk-5.1.0-6.el9.s390x.rpm
-    repoid: ubi-9-for-s390x-baseos-rpms
-    size: 1029188
-    checksum: sha256:d34fd3f586240f43f71bc74824ae513cba2e4a6812f0ebbd101122e7e99bafe8
-    name: gawk
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
     size: 60437
@@ -11851,13 +11872,6 @@ arches:
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/g/gzip-1.12-1.el9.s390x.rpm
-    repoid: ubi-9-for-s390x-baseos-rpms
-    size: 173101
-    checksum: sha256:50034ee6281864a218a5f3bc47de5afb434400fb8415907fd31d8351adbdc5a6
-    name: gzip
-    evr: 1.12-1.el9
-    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/i/info-6.7-15.el9.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
     size: 231965
@@ -12411,13 +12425,13 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/t/tar-1.34-11.el9.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
-    size: 907745
-    checksum: sha256:2eee88e1c470b033bd44432f4ed5b1a41ffc7132ebe51f8ce12fa9268314e841
-    name: tar
-    evr: 2:1.34-11.el9
-    sourcerpm: tar-1.34-11.el9.src.rpm
+    size: 653093
+    checksum: sha256:5897571d31b7cc9d3e8ef0e7dc9dbf8230bea207c9e926d4fef9fb635ab16f64
+    name: sqlite-libs
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/t/tcl-8.6.10-7.el9.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
     size: 1120943
@@ -12803,13 +12817,6 @@ arches:
     name: centos-logos-httpd
     evr: 90.9-1.el9
     sourcerpm: centos-logos-90.9-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/containers-common-5.8-2.el9.s390x.rpm
-    repoid: appstream
-    size: 107756
-    checksum: sha256:a76ba8b0ddd8d83124e14aa8ddeb248d28b1d9fcc56164c869d188c449071358
-    name: containers-common
-    evr: 5:5.8-2.el9
-    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/cpp-11.5.0-15.el9.s390x.rpm
     repoid: appstream
     size: 8602240
@@ -12831,13 +12838,6 @@ arches:
     name: criu-libs
     evr: 3.19-6.el9
     sourcerpm: criu-3.19-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/crun-1.28-1.el9.s390x.rpm
-    repoid: appstream
-    size: 243109
-    checksum: sha256:db01bb96521025d9f6404e9573ffbccbe59ac73a3a78302ecdecca8355386294
-    name: crun
-    evr: 1.28-1.el9
-    sourcerpm: crun-1.28-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/flac-libs-1.3.3-12.el9.s390x.rpm
     repoid: appstream
     size: 184997
@@ -12859,13 +12859,13 @@ arches:
     name: freetype-devel
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/fuse-overlayfs-1.17-1.el9.s390x.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/gawk-all-langpacks-5.1.0-7.el9.s390x.rpm
     repoid: appstream
-    size: 65649
-    checksum: sha256:c33ff4bc3eed1f1ece6c60e59fd9c50bb4a30ceeae6063ea5838ffe11b029683
-    name: fuse-overlayfs
-    evr: 1.17-1.el9
-    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+    size: 210882
+    checksum: sha256:5495ed56e803b8eb691708d171d212b6b62520abab0f1bf92e085e213313f87d
+    name: gawk-all-langpacks
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/gcc-11.5.0-15.el9.s390x.rpm
     repoid: appstream
     size: 26826027
@@ -12901,34 +12901,34 @@ arches:
     name: git-lfs
     evr: 3.7.1-6.el9
     sourcerpm: git-lfs-3.7.1-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/glib2-devel-2.68.4-21.el9.s390x.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/glib2-devel-2.68.4-29.el9.s390x.rpm
     repoid: appstream
-    size: 561724
-    checksum: sha256:933a4fc32103e83518db3b1f9405331862d9a3ee5c5f43c793c27491698c4088
+    size: 563124
+    checksum: sha256:3ab1026866f0a75b35d766747b29506ed4d4347e2d76518e99587a086a80bab5
     name: glib2-devel
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/glibc-devel-2.34-276.el9.s390x.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/glibc-devel-2.34-277.el9.s390x.rpm
     repoid: appstream
-    size: 47136
-    checksum: sha256:fed8a645d59a3c05e15643654c6cc93164ad5aee13eb3bd277990d2a23110f4e
+    size: 47060
+    checksum: sha256:288a0a2c2075764c4fc75100cd54650d65ca0e8448c4f5edaae88c721fb55a8e
     name: glibc-devel
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/glibc-headers-2.34-276.el9.s390x.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/glibc-headers-2.34-277.el9.s390x.rpm
     repoid: appstream
-    size: 550766
-    checksum: sha256:b8f024720472cba60b8ea62f1afa55821c90a0a29e6368b66e513d92b6b02200
+    size: 550536
+    checksum: sha256:7496d252197c94471f7b4ebf42cb0d35a1b88d1ca4daab564991d9d4a3ce491d
     name: glibc-headers
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/kernel-headers-5.14.0-737.el9.s390x.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/kernel-headers-5.14.0-741.el9.s390x.rpm
     repoid: appstream
-    size: 2655533
-    checksum: sha256:f97f746e27ee37493ecbfbae0320990b31ce7ac1cb3be21f54e32cd6c4145ca1
+    size: 2692505
+    checksum: sha256:8a54e2a4fd91d273470fc5d0a7bf5c35f8ec13007083fe15bb93153c9229cd44
     name: kernel-headers
-    evr: 5.14.0-737.el9
-    sourcerpm: kernel-5.14.0-737.el9.src.rpm
+    evr: 5.14.0-741.el9
+    sourcerpm: kernel-5.14.0-741.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/kernel-srpm-macros-1.0-16.el9.noarch.rpm
     repoid: appstream
     size: 14340
@@ -12985,6 +12985,13 @@ arches:
     name: libpng-devel
     evr: 2:1.6.37-17.el9
     sourcerpm: libpng-1.6.37-17.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/libseccomp-devel-2.5.6-1.el9.s390x.rpm
+    repoid: appstream
+    size: 58618
+    checksum: sha256:caefd7df3328ef8c055d7c704c50781e78ae9cb8458608fb1eb9d27dce98cbf0
+    name: libseccomp-devel
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/libselinux-devel-3.6-4.el9.s390x.rpm
     repoid: appstream
     size: 161975
@@ -13853,6 +13860,13 @@ arches:
     name: policycoreutils-python-utils
     evr: 3.6-9.el9
     sourcerpm: policycoreutils-3.6-9.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/pyproject-srpm-macros-1.23.2-1.el9.noarch.rpm
+    repoid: appstream
+    size: 15069
+    checksum: sha256:2465e04e6c507d548c844f911a77411029fbef3fa7aa4810ba4182f302d1928b
+    name: pyproject-srpm-macros
+    evr: 1.23.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.23.2-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/python-unversioned-command-3.9.25-10.el9.noarch.rpm
     repoid: appstream
     size: 9302
@@ -13888,34 +13902,6 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-10.el9
     sourcerpm: python3.9-3.9.25-10.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/python3.12-3.12.13-4.el9.s390x.rpm
-    repoid: appstream
-    size: 25961
-    checksum: sha256:db19a9afe4864c514ba794b7cae04b4eb97e9a0b746e4d11b46679919635d2ab
-    name: python3.12
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/python3.12-devel-3.12.13-4.el9.s390x.rpm
-    repoid: appstream
-    size: 331129
-    checksum: sha256:2747b1cdba968ec27495282c4b9cfd2e44554ae4d063056d6b6bed299f9c3b08
-    name: python3.12-devel
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/python3.12-libs-3.12.13-4.el9.s390x.rpm
-    repoid: appstream
-    size: 9973874
-    checksum: sha256:5cb21856eac8678f556ba8db177358a95fe9dd9d0916089178ae678f01f08f05
-    name: python3.12-libs
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/python3.12-tkinter-3.12.13-4.el9.s390x.rpm
-    repoid: appstream
-    size: 427400
-    checksum: sha256:d299b32ffc676a96eea43fd53fe9c367f55e3f05951283d9d0dd29512af5d770
-    name: python3.12-tkinter
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/redhat-rpm-config-211-1.el9.noarch.rpm
     repoid: appstream
     size: 70868
@@ -13937,20 +13923,6 @@ arches:
     name: rust-std-static
     evr: 1.97.1-3.el9
     sourcerpm: rust-1.97.1-3.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/skopeo-1.22.2-1.el9.s390x.rpm
-    repoid: appstream
-    size: 8183907
-    checksum: sha256:fb63685d57bb77dba647944272d5306f98fdcd335757ad6be4c8dd7a88eca291
-    name: skopeo
-    evr: 3:1.22.2-1.el9
-    sourcerpm: skopeo-1.22.2-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/slirp4netns-1.3.4-1.el9.s390x.rpm
-    repoid: appstream
-    size: 46652
-    checksum: sha256:732a8ee436229cc3a22d1948115c5192c34ac18c34ff8c3c5140a00ca3e56d96
-    name: slirp4netns
-    evr: 1.3.4-1.el9
-    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/spirv-tools-libs-2026.1-1.el9.s390x.rpm
     repoid: appstream
     size: 1634793
@@ -14028,6 +14000,13 @@ arches:
     name: centos-stream-repos
     evr: 9.0-38.el9
     sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/containers-common-5.8-2.el9.s390x.rpm
+    repoid: baseos
+    size: 107756
+    checksum: sha256:a76ba8b0ddd8d83124e14aa8ddeb248d28b1d9fcc56164c869d188c449071358
+    name: containers-common
+    evr: 5:5.8-2.el9
+    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/coreutils-8.32-43.el9.s390x.rpm
     repoid: baseos
     size: 1198884
@@ -14042,6 +14021,13 @@ arches:
     name: coreutils-common
     evr: 8.32-43.el9
     sourcerpm: coreutils-8.32-43.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/crun-1.29.1-1.el9.s390x.rpm
+    repoid: baseos
+    size: 249816
+    checksum: sha256:42561cda461ca088ea1c67e1de624a67c5a22a398486803f1d3bb9a8d6713925
+    name: crun
+    evr: 1.29.1-1.el9
+    sourcerpm: crun-1.29.1-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/crypto-policies-20260714-1.git65b74f7.el9.noarch.rpm
     repoid: baseos
     size: 91607
@@ -14126,41 +14112,62 @@ arches:
     name: file-libs
     evr: 5.39-19.el9
     sourcerpm: file-5.39-19.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glib2-2.68.4-21.el9.s390x.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/fuse-overlayfs-1.17-1.el9.s390x.rpm
     repoid: baseos
-    size: 2715488
-    checksum: sha256:82ba9490f7d2d32db46ae06ddd0cbd5312bedeceb6c78cec2a1b2a2bb0ceb82d
+    size: 65649
+    checksum: sha256:c33ff4bc3eed1f1ece6c60e59fd9c50bb4a30ceeae6063ea5838ffe11b029683
+    name: fuse-overlayfs
+    evr: 1.17-1.el9
+    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/gawk-5.1.0-7.el9.s390x.rpm
+    repoid: baseos
+    size: 1022681
+    checksum: sha256:a3eb63ca88209b7395f3b72f6d3b16843566a08570b16b0ba030593af5ef51bf
+    name: gawk
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glib2-2.68.4-29.el9.s390x.rpm
+    repoid: baseos
+    size: 2717002
+    checksum: sha256:9df54ea33807398d6e89f2ee8952ab718e95fa450a822396a1c4bd352feff105
     name: glib2
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-2.34-276.el9.s390x.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-2.34-277.el9.s390x.rpm
     repoid: baseos
-    size: 1784107
-    checksum: sha256:c3a8f7ca06129e0f0c0a258a8cd0f16d79c5b7d366266f16bd88807e08a1fbdc
+    size: 1784471
+    checksum: sha256:2c3e0517c5591292e2a1dc46f768791bbe37fc8e0d1fba1e06b0baa15b2db7f6
     name: glibc
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-common-2.34-276.el9.s390x.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-common-2.34-277.el9.s390x.rpm
     repoid: baseos
-    size: 319159
-    checksum: sha256:1e8fffcde85a9c2f6b8cd9eb137607e3582ede23e1975cf2a721b3c33b0a29e1
+    size: 319354
+    checksum: sha256:56795eb955440904f0e6256f4bdb74b2fc7b13b67fd040691fa9e4b3f74cc98d
     name: glibc-common
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-gconv-extra-2.34-276.el9.s390x.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-gconv-extra-2.34-277.el9.s390x.rpm
     repoid: baseos
-    size: 1746899
-    checksum: sha256:9e93208d1cecedebc1c7e7d338035deae6f2be8fc8ea02593cd5761f1cc58689
+    size: 1744801
+    checksum: sha256:7841b0dcb275d6af760c7eacfdba9989f6b42b7d3a27b4a4f0e3d919717a3b50
     name: glibc-gconv-extra
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-minimal-langpack-2.34-276.el9.s390x.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/glibc-minimal-langpack-2.34-277.el9.s390x.rpm
     repoid: baseos
-    size: 23733
-    checksum: sha256:74f4ab2f8986e21d749170470462dfc575abb06251b42b75295865ea9f3a8bda
+    size: 23645
+    checksum: sha256:a214ad7e2df501045e10e1d09d4558f873cb90dd1968b06baaadc86c70e96b47
     name: glibc-minimal-langpack
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/gzip-1.12-2.el9.s390x.rpm
+    repoid: baseos
+    size: 167126
+    checksum: sha256:c61e628ecdf982657ba6897d171b3e090d0b719f5bb3b51a94bbc6854907eaae
+    name: gzip
+    evr: 1.12-2.el9
+    sourcerpm: gzip-1.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/jq-1.6-21.el9.s390x.rpm
     repoid: baseos
     size: 200177
@@ -14343,20 +14350,20 @@ arches:
     name: openldap
     evr: 2.6.13-1.el9
     sourcerpm: openldap-2.6.13-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/openssh-9.9p1-12.el9.s390x.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/openssh-9.9p1-13.el9.s390x.rpm
     repoid: baseos
-    size: 420548
-    checksum: sha256:603726e7d7505e925b1ee75f031801c9cdb86b4fe5e1073f5e5dff5f78d2916b
+    size: 421990
+    checksum: sha256:24e13a5a51b970c1d0165d1bd7a029dba8d6a2fa561cca24cc4892e9808845d5
     name: openssh
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/openssh-clients-9.9p1-12.el9.s390x.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/openssh-clients-9.9p1-13.el9.s390x.rpm
     repoid: baseos
-    size: 741502
-    checksum: sha256:3de6a834eb8adab5656568a6d36aa5691b760c2ce232fca72b1f781cc62a3445
+    size: 742027
+    checksum: sha256:9817a60aa0fc946cfc191b22e36dc215e08e2be3f2bf1179299ceaad5a604973
     name: openssh-clients
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/openssl-3.5.7-3.el9.s390x.rpm
     repoid: baseos
     size: 1545511
@@ -14434,41 +14441,55 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-17.el9
     sourcerpm: shadow-utils-4.9-17.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/sqlite-libs-3.34.1-11.el9.s390x.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/skopeo-1.22.2-4.el9.s390x.rpm
     repoid: baseos
-    size: 645720
-    checksum: sha256:ecf4aaf07ad4cf53b96bf0f9a597936bb333091a3faa4255996227ff0c2073c8
-    name: sqlite-libs
-    evr: 3.34.1-11.el9
-    sourcerpm: sqlite-3.34.1-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-252-76.el9.s390x.rpm
+    size: 8184135
+    checksum: sha256:f1503b73c12fbe1766420474fad187b0ca266c8bdeb8f6fbdfe34d247db17633
+    name: skopeo
+    evr: 3:1.22.2-4.el9
+    sourcerpm: skopeo-1.22.2-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/slirp4netns-1.3.4-1.el9.s390x.rpm
     repoid: baseos
-    size: 4161318
-    checksum: sha256:81575bff684230a0ebc1d152a3f9a895c9599cdaeefc9863a5e10b31c56c4cc1
+    size: 46652
+    checksum: sha256:732a8ee436229cc3a22d1948115c5192c34ac18c34ff8c3c5140a00ca3e56d96
+    name: slirp4netns
+    evr: 1.3.4-1.el9
+    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-252-78.el9.s390x.rpm
+    repoid: baseos
+    size: 4150309
+    checksum: sha256:7342457c7ed8515b806f156170ce6493382f73f59d058d970e5b21c233207558
     name: systemd
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-libs-252-76.el9.s390x.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-libs-252-78.el9.s390x.rpm
     repoid: baseos
-    size: 630987
-    checksum: sha256:896d0e24112de5d1f0334ee1e2861c5a95584e09c83f33a50c8663d073a0fe7f
+    size: 618866
+    checksum: sha256:ec9a39e00b29d8b65fd7ca5efbeea13c719b7611451f5c7bdae0aa39622d0240
     name: systemd-libs
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-pam-252-76.el9.s390x.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-pam-252-78.el9.s390x.rpm
     repoid: baseos
-    size: 255712
-    checksum: sha256:551c6cad26008d612dfade8ffe570332b16c8f716eb9aa21cc9873fa9efd1a31
+    size: 243374
+    checksum: sha256:ea09ff68aab5229212b8167c1aefb2d6b4ff648a524df2adbe5c9dfad8c315c4
     name: systemd-pam
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-rpm-macros-252-76.el9.noarch.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/systemd-rpm-macros-252-78.el9.noarch.rpm
     repoid: baseos
-    size: 49015
-    checksum: sha256:87cadce972e5e47b044d5f8c02f8adb23fdd16dff83aa177620178491fa47fdc
+    size: 36797
+    checksum: sha256:a0ee77264681d14a9298dc6d9e3ca4c4abb4a546619d2075b6c666e376cf78d0
     name: systemd-rpm-macros
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/tar-1.34-13.el9.s390x.rpm
+    repoid: baseos
+    size: 903134
+    checksum: sha256:c2c23987237142f81360eb75f4bd8f6b69b24051116e565470be56a5e0f059e2
+    name: tar
+    evr: 2:1.34-13.el9
+    sourcerpm: tar-1.34-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/Packages/util-linux-2.37.4-27.el9.s390x.rpm
     repoid: baseos
     size: 2320305
@@ -14534,10 +14555,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/b57d977f15dc544204934b291a59bacc1497312c2082bec8fff74e3c110a191f-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/e2259561353bf5d6a815464a2156e9d0499b1f73bfe602eb846af711a51612c8-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
-    size: 8360
-    checksum: sha256:b57d977f15dc544204934b291a59bacc1497312c2082bec8fff74e3c110a191f
+    size: 8572
+    checksum: sha256:e2259561353bf5d6a815464a2156e9d0499b1f73bfe602eb846af711a51612c8
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -14705,13 +14726,6 @@ arches:
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 216340
-    checksum: sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1
-    name: gawk-all-langpacks
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-13-13.0-2.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 11934
@@ -16364,13 +16378,6 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pyproject-srpm-macros-1.18.5-1.el9.noarch.rpm
-    repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 12794
-    checksum: sha256:de04df6652bd69cd9e30603c01c25924f13c847f1a1a6d89b5a3bc1283b20f40
-    name: pyproject-srpm-macros
-    evr: 1.18.5-1.el9
-    sourcerpm: pyproject-rpm-macros-1.18.5-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18705
@@ -16406,6 +16413,27 @@ arches:
     name: python3-pip
     evr: 21.3.1-2.el9_8
     sourcerpm: python-pip-21.3.1-2.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 32484
+    checksum: sha256:10640d8db1555fb7ae4e63c62be4b8f341032fb3ee52cc7176047438ab893b1f
+    name: python3.12
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 338289
+    checksum: sha256:3a7a0b4139eab58579f787f806083bd622b09346c4a72a4f282b833c39b2d6b3
+    name: python3.12-devel
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 10211157
+    checksum: sha256:0eaade47a20924ba0fe3fb0a93898e053772248793069f40c1ba80c5115fddbb
+    name: python3.12-libs
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1527128
@@ -16413,6 +16441,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 434117
+    checksum: sha256:a5a2e2d32fbe9c77f08f0f594fe9d4e117cb3ac01160e409831aad994e8210c9
+    name: python3.12-tkinter
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9344
@@ -16623,13 +16658,6 @@ arches:
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gawk-5.1.0-6.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1045534
-    checksum: sha256:99fda6725a2c668bae29fbab74d1b347e074f4e8c8ed18d656cb928fb6fc92b7
-    name: gawk
-    evr: 5.1.0-6.el9
-    sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 60152
@@ -16700,13 +16728,6 @@ arches:
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 171206
-    checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
-    name: gzip
-    evr: 1.12-1.el9
-    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/h/harfbuzz-2.7.4-10.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 643610
@@ -17267,13 +17288,13 @@ arches:
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 913256
-    checksum: sha256:58b622ab7bc225731a2473e677f16c9eb51b1ed218a86a7aa039a6fed665f245
-    name: tar
-    evr: 2:1.34-11.el9
-    sourcerpm: tar-1.34-11.el9.src.rpm
+    size: 665095
+    checksum: sha256:e5c20e933ec01f746a6c59a94cb99f46c6138dab3f387f0d02dab47f356e2e98
+    name: sqlite-libs
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1152092
@@ -17673,13 +17694,6 @@ arches:
     name: centos-logos-httpd
     evr: 90.9-1.el9
     sourcerpm: centos-logos-90.9-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/containers-common-5.8-2.el9.x86_64.rpm
-    repoid: appstream
-    size: 107781
-    checksum: sha256:1f79332e4adb327d9e9c0a8340f26bfe42240a6f0839b71525b6ee70d30ebe59
-    name: containers-common
-    evr: 5:5.8-2.el9
-    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/cpp-11.5.0-15.el9.x86_64.rpm
     repoid: appstream
     size: 11221207
@@ -17701,13 +17715,6 @@ arches:
     name: criu-libs
     evr: 3.19-6.el9
     sourcerpm: criu-3.19-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/crun-1.28-1.el9.x86_64.rpm
-    repoid: appstream
-    size: 262278
-    checksum: sha256:d71eac4dc221d5de46bdb8d031c9940b1768dd8bf5c3e0134299bc7aebd09a5a
-    name: crun
-    evr: 1.28-1.el9
-    sourcerpm: crun-1.28-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/flac-libs-1.3.3-12.el9.x86_64.rpm
     repoid: appstream
     size: 223234
@@ -17722,13 +17729,13 @@ arches:
     name: freetype-devel
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/fuse-overlayfs-1.17-1.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/gawk-all-langpacks-5.1.0-7.el9.x86_64.rpm
     repoid: appstream
-    size: 69161
-    checksum: sha256:3289da24b18b68cae04c8d9ec18d927bae3abf4c74188aa6b354a884efe58dc6
-    name: fuse-overlayfs
-    evr: 1.17-1.el9
-    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+    size: 210910
+    checksum: sha256:b11f7ab2e1afd9b3c0b3779495609e31914483ecd0f9dbaa17060dbc355e7a50
+    name: gawk-all-langpacks
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/gcc-11.5.0-15.el9.x86_64.rpm
     repoid: appstream
     size: 33976498
@@ -17764,34 +17771,34 @@ arches:
     name: git-lfs
     evr: 3.7.1-6.el9
     sourcerpm: git-lfs-3.7.1-6.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/glib2-devel-2.68.4-21.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/glib2-devel-2.68.4-29.el9.x86_64.rpm
     repoid: appstream
-    size: 563281
-    checksum: sha256:5848fddf9b3a5eb9affd99ad16733ad0ed3fb7edde619ee4f6c8a7241a8b9775
+    size: 564529
+    checksum: sha256:531d382ee7a84ea0cd0b857745915109a05416f4b692ba60facba6326369a7ba
     name: glib2-devel
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/glibc-devel-2.34-276.el9.x86_64.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/glibc-devel-2.34-277.el9.x86_64.rpm
     repoid: appstream
-    size: 39363
-    checksum: sha256:2d670b03a572998c4004da93741085370694e186525dea16e2d9367b67d8fb32
+    size: 39297
+    checksum: sha256:cd724b5c357d4299e85f87ca020acd7a79722a7156ecf3936a4bf3726beb452b
     name: glibc-devel
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/glibc-headers-2.34-276.el9.x86_64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/glibc-headers-2.34-277.el9.x86_64.rpm
     repoid: appstream
-    size: 560016
-    checksum: sha256:e9acc9fe7ead2449403aff40e760ddf2b4f69260ac882fb24e7b8a05de9d780f
+    size: 559772
+    checksum: sha256:36a1febe1bb0183b6eb7429b2e2799228c2274642431a19b8d313ac84f64d6d0
     name: glibc-headers
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-headers-5.14.0-737.el9.x86_64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-headers-5.14.0-741.el9.x86_64.rpm
     repoid: appstream
-    size: 2664805
-    checksum: sha256:c7d0a45580c58744421ac1c9b23855a80d493f5298ce90e4014308fc9c31d9b8
+    size: 2701797
+    checksum: sha256:8a7b4cbcf5b8d806a97d37bce66cd756e6b6ecda07a088371e257c7627a85f6a
     name: kernel-headers
-    evr: 5.14.0-737.el9
-    sourcerpm: kernel-5.14.0-737.el9.src.rpm
+    evr: 5.14.0-741.el9
+    sourcerpm: kernel-5.14.0-741.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-srpm-macros-1.0-16.el9.noarch.rpm
     repoid: appstream
     size: 14340
@@ -17841,6 +17848,13 @@ arches:
     name: libquadmath-devel
     evr: 11.5.0-15.el9
     sourcerpm: gcc-11.5.0-15.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libseccomp-devel-2.5.6-1.el9.x86_64.rpm
+    repoid: appstream
+    size: 58807
+    checksum: sha256:b08ceeff8f1778359fae9f8dc251a3ede06af8cc671a54a6ccb662f08ce03b75
+    name: libseccomp-devel
+    evr: 2.5.6-1.el9
+    sourcerpm: libseccomp-2.5.6-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libselinux-devel-3.6-4.el9.x86_64.rpm
     repoid: appstream
     size: 162026
@@ -18702,6 +18716,13 @@ arches:
     name: policycoreutils-python-utils
     evr: 3.6-9.el9
     sourcerpm: policycoreutils-3.6-9.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/pyproject-srpm-macros-1.23.2-1.el9.noarch.rpm
+    repoid: appstream
+    size: 15069
+    checksum: sha256:2465e04e6c507d548c844f911a77411029fbef3fa7aa4810ba4182f302d1928b
+    name: pyproject-srpm-macros
+    evr: 1.23.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.23.2-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/python-unversioned-command-3.9.25-10.el9.noarch.rpm
     repoid: appstream
     size: 9302
@@ -18737,34 +18758,6 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-10.el9
     sourcerpm: python3.9-3.9.25-10.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/python3.12-3.12.13-4.el9.x86_64.rpm
-    repoid: appstream
-    size: 26139
-    checksum: sha256:ae6b3227b7a866c9087b637113846bfd06c00c5d7d731bb5337c625581b3dd52
-    name: python3.12
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/python3.12-devel-3.12.13-4.el9.x86_64.rpm
-    repoid: appstream
-    size: 331345
-    checksum: sha256:f6cf7f00ea95ca4f6415b80f94b3ca39d50a7482a466755c869b10b3cba498f7
-    name: python3.12-devel
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/python3.12-libs-3.12.13-4.el9.x86_64.rpm
-    repoid: appstream
-    size: 10207994
-    checksum: sha256:34bd6a201379ff95e79ef57faca92f58eee40a2a060fa67fd7a724b05ade3a57
-    name: python3.12-libs
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/python3.12-tkinter-3.12.13-4.el9.x86_64.rpm
-    repoid: appstream
-    size: 427031
-    checksum: sha256:b5273673b506fd8000ab137e8d935e3d6facfc70c113c387dd446f9414c74986
-    name: python3.12-tkinter
-    evr: 3.12.13-4.el9
-    sourcerpm: python3.12-3.12.13-4.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/redhat-rpm-config-211-1.el9.noarch.rpm
     repoid: appstream
     size: 70868
@@ -18786,20 +18779,6 @@ arches:
     name: rust-std-static
     evr: 1.97.1-3.el9
     sourcerpm: rust-1.97.1-3.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/skopeo-1.22.2-1.el9.x86_64.rpm
-    repoid: appstream
-    size: 8607356
-    checksum: sha256:6b39cdc102d9025ca1a5fd62fdd25da883c332456f6344886bbf7987fc42f6ba
-    name: skopeo
-    evr: 3:1.22.2-1.el9
-    sourcerpm: skopeo-1.22.2-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/slirp4netns-1.3.4-1.el9.x86_64.rpm
-    repoid: appstream
-    size: 46829
-    checksum: sha256:4c319a14b16e2e10eaa417847604d2c17da93d5b4d900f8cd454453232f9d8af
-    name: slirp4netns
-    evr: 1.3.4-1.el9
-    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/spirv-tools-libs-2026.1-1.el9.x86_64.rpm
     repoid: appstream
     size: 1666277
@@ -18877,6 +18856,13 @@ arches:
     name: centos-stream-repos
     evr: 9.0-38.el9
     sourcerpm: centos-stream-release-9.0-38.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/containers-common-5.8-2.el9.x86_64.rpm
+    repoid: baseos
+    size: 107781
+    checksum: sha256:1f79332e4adb327d9e9c0a8340f26bfe42240a6f0839b71525b6ee70d30ebe59
+    name: containers-common
+    evr: 5:5.8-2.el9
+    sourcerpm: containers-common-5.8-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/coreutils-8.32-43.el9.x86_64.rpm
     repoid: baseos
     size: 1212241
@@ -18891,6 +18877,13 @@ arches:
     name: coreutils-common
     evr: 8.32-43.el9
     sourcerpm: coreutils-8.32-43.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/crun-1.29.1-1.el9.x86_64.rpm
+    repoid: baseos
+    size: 269520
+    checksum: sha256:f6b0cd9b313e286cee2264a85946a99fd37556c54ec0da05f5ae757d2e5db866
+    name: crun
+    evr: 1.29.1-1.el9
+    sourcerpm: crun-1.29.1-1.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/crypto-policies-20260714-1.git65b74f7.el9.noarch.rpm
     repoid: baseos
     size: 91607
@@ -18982,41 +18975,62 @@ arches:
     name: freetype
     evr: 2.10.4-11.el9
     sourcerpm: freetype-2.10.4-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glib2-2.68.4-21.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/fuse-overlayfs-1.17-1.el9.x86_64.rpm
     repoid: baseos
-    size: 2767352
-    checksum: sha256:14d17524b3ebb78f5bd090092c870ef2ff22c9e7e6e76be61bef586dd6e41a9a
+    size: 69161
+    checksum: sha256:3289da24b18b68cae04c8d9ec18d927bae3abf4c74188aa6b354a884efe58dc6
+    name: fuse-overlayfs
+    evr: 1.17-1.el9
+    sourcerpm: fuse-overlayfs-1.17-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/gawk-5.1.0-7.el9.x86_64.rpm
+    repoid: baseos
+    size: 1039560
+    checksum: sha256:1d3eb37bb494a30427658c55163200c5c056368cda68faf416bccbb276763ce2
+    name: gawk
+    evr: 5.1.0-7.el9
+    sourcerpm: gawk-5.1.0-7.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glib2-2.68.4-29.el9.x86_64.rpm
+    repoid: baseos
+    size: 2769067
+    checksum: sha256:5f1f234fae95dbc35d383b0c37d0d249da5d9aaed57e92915da50edeb5ac22a5
     name: glib2
-    evr: 2.68.4-21.el9
-    sourcerpm: glib2-2.68.4-21.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-2.34-276.el9.x86_64.rpm
+    evr: 2.68.4-29.el9
+    sourcerpm: glib2-2.68.4-29.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-2.34-277.el9.x86_64.rpm
     repoid: baseos
-    size: 2075817
-    checksum: sha256:d426507e84b3c89b464b5e4149c8137d8b21facbc25ef0c56e7e342048853e8b
+    size: 2077687
+    checksum: sha256:c787e1da27f37917d23e2028ca87d87f9ed9ee78f5a43d7d417f7d45a2b19c26
     name: glibc
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-common-2.34-276.el9.x86_64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-common-2.34-277.el9.x86_64.rpm
     repoid: baseos
-    size: 315092
-    checksum: sha256:30bcfae00ae8128416a96a2df6ff4c986cce05d9ffb29d1b9e39b6c8b460ce40
+    size: 314701
+    checksum: sha256:1216f2f12e687ed00b4930bdc7d7f08d0a5e6acc0f29cb827fda335a44230314
     name: glibc-common
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-gconv-extra-2.34-276.el9.x86_64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-gconv-extra-2.34-277.el9.x86_64.rpm
     repoid: baseos
-    size: 1757666
-    checksum: sha256:99f7372a38a13fbc963d56bd019578e51a756247afe9a14a3c280341e51b3e7e
+    size: 1756942
+    checksum: sha256:02d94880ac25702d235358ee637b06a14c6e2ff640b5d4a6af282c2ea6c53cde
     name: glibc-gconv-extra
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-minimal-langpack-2.34-276.el9.x86_64.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-minimal-langpack-2.34-277.el9.x86_64.rpm
     repoid: baseos
-    size: 23761
-    checksum: sha256:a7913f2860315c9dfdf84067bed56b86eb6e01cce74118001fa2048c8f7a786a
+    size: 23673
+    checksum: sha256:b6995d3e05bfdd2b131a4de91a3887f1ec861422d57ab1dd8734be6fa71a43e5
     name: glibc-minimal-langpack
-    evr: 2.34-276.el9
-    sourcerpm: glibc-2.34-276.el9.src.rpm
+    evr: 2.34-277.el9
+    sourcerpm: glibc-2.34-277.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/gzip-1.12-2.el9.x86_64.rpm
+    repoid: baseos
+    size: 165326
+    checksum: sha256:2ee6442b3fda80cf356d62d8537f30a189196faa1d2a8325ae6c1e303608ce00
+    name: gzip
+    evr: 1.12-2.el9
+    sourcerpm: gzip-1.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/hwdata-0.348-9.24.el9.noarch.rpm
     repoid: baseos
     size: 1802687
@@ -19227,20 +19241,20 @@ arches:
     name: openldap
     evr: 2.6.13-1.el9
     sourcerpm: openldap-2.6.13-1.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/openssh-9.9p1-12.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/openssh-9.9p1-13.el9.x86_64.rpm
     repoid: baseos
-    size: 435787
-    checksum: sha256:6b3d2d6944a7d929798ea4e3ee1c9d7a8d231d8a55e8890b5be1249c36e3243d
+    size: 436266
+    checksum: sha256:2cd7761618c35a03794ea7b4673f3e443a1c6f440a3f69b5e2ca7fde8a83f281
     name: openssh
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/openssh-clients-9.9p1-12.el9.x86_64.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/openssh-clients-9.9p1-13.el9.x86_64.rpm
     repoid: baseos
-    size: 792349
-    checksum: sha256:cfc7e495f37ad805822bf1959ac581c9c6838925140af4879e2a13e1cc4fd3d4
+    size: 793295
+    checksum: sha256:bfc6d1f0b2a12b8f4355c51fff10e0aff0b2d6a37662562b47b12abe47376ca1
     name: openssh-clients
-    evr: 9.9p1-12.el9
-    sourcerpm: openssh-9.9p1-12.el9.src.rpm
+    evr: 9.9p1-13.el9
+    sourcerpm: openssh-9.9p1-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/openssl-3.5.7-3.el9.x86_64.rpm
     repoid: baseos
     size: 1560549
@@ -19318,41 +19332,55 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-17.el9
     sourcerpm: shadow-utils-4.9-17.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/sqlite-libs-3.34.1-11.el9.x86_64.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/skopeo-1.22.2-4.el9.x86_64.rpm
     repoid: baseos
-    size: 659516
-    checksum: sha256:dfdc4f315ec0723e6c2687f810bcc5a9d3cb83f4d73496734645123bd5a6f3d4
-    name: sqlite-libs
-    evr: 3.34.1-11.el9
-    sourcerpm: sqlite-3.34.1-11.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-252-76.el9.x86_64.rpm
+    size: 8607516
+    checksum: sha256:2fc2ad47942ef5aa3f04d1bdf28a7107904c047dfa96e24e2f2d00562a1ace1a
+    name: skopeo
+    evr: 3:1.22.2-4.el9
+    sourcerpm: skopeo-1.22.2-4.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/slirp4netns-1.3.4-1.el9.x86_64.rpm
     repoid: baseos
-    size: 4397528
-    checksum: sha256:c214fe776670238e53642248f9bb83a60d32f5b00d1c367b7718142167a291d0
+    size: 46829
+    checksum: sha256:4c319a14b16e2e10eaa417847604d2c17da93d5b4d900f8cd454453232f9d8af
+    name: slirp4netns
+    evr: 1.3.4-1.el9
+    sourcerpm: slirp4netns-1.3.4-1.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-252-78.el9.x86_64.rpm
+    repoid: baseos
+    size: 4384213
+    checksum: sha256:8928a714a1804b3f1e5cef750d2f3c10f3b2054c009aa11a5cb5747eb3b174a6
     name: systemd
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-libs-252-76.el9.x86_64.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-libs-252-78.el9.x86_64.rpm
     repoid: baseos
-    size: 670242
-    checksum: sha256:88339a324cf8c2862f26a90413bebb4c5ea6446d4b984ddd16c6b443cd391b09
+    size: 657517
+    checksum: sha256:10cf9e4fe79afee84cf06ea989fcb2544ada5f39fda301cda81efd970381808d
     name: systemd-libs
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-pam-252-76.el9.x86_64.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-pam-252-78.el9.x86_64.rpm
     repoid: baseos
-    size: 266522
-    checksum: sha256:608e96497269804d60632b3c13c07817f12abb08f47f37c485e4869dbf15191e
+    size: 254261
+    checksum: sha256:a1fce5fb7bf0c6ac86e738dbb21c5e02361015f1858d22b0c368de76e8a152c7
     name: systemd-pam
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-rpm-macros-252-76.el9.noarch.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/systemd-rpm-macros-252-78.el9.noarch.rpm
     repoid: baseos
-    size: 49015
-    checksum: sha256:87cadce972e5e47b044d5f8c02f8adb23fdd16dff83aa177620178491fa47fdc
+    size: 36797
+    checksum: sha256:a0ee77264681d14a9298dc6d9e3ca4c4abb4a546619d2075b6c666e376cf78d0
     name: systemd-rpm-macros
-    evr: 252-76.el9
-    sourcerpm: systemd-252-76.el9.src.rpm
+    evr: 252-78.el9
+    sourcerpm: systemd-252-78.el9.src.rpm
+  - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tar-1.34-13.el9.x86_64.rpm
+    repoid: baseos
+    size: 908457
+    checksum: sha256:f2b2023c1bf3f527851ff07c860719c70e5fed850377fee92ca599fd64aa5e1a
+    name: tar
+    evr: 2:1.34-13.el9
+    sourcerpm: tar-1.34-13.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/util-linux-2.37.4-27.el9.x86_64.rpm
     repoid: baseos
     size: 2375710
@@ -19418,10 +19446,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/1d6b98d595e18b1ead29385e6d8691510fb690b4c5db3e267bf8a55ecd513520-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/a7d1b241dd1439f2c9783b6a086ba05adea165adff9b30982ce64217da12de65-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 7998
-    checksum: sha256:1d6b98d595e18b1ead29385e6d8691510fb690b4c5db3e267bf8a55ecd513520
+    size: 8136
+    checksum: sha256:a7d1b241dd1439f2c9783b6a086ba05adea165adff9b30982ce64217da12de65
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/rebuild-apply-seccomp.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/rebuild-apply-seccomp.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Rebuild @vscode/sandbox-runtime apply-seccomp as a dynamically linked binary.
+#
+# VS Code 4.122+ ships a statically linked apply-seccomp helper under
+# node_modules/@vscode/sandbox-runtime/vendor/seccomp/{x64,arm64}/. That fails
+# Konflux FIPS check-payload (ErrNotDynLinked). Upstream intentionally builds
+# with gcc -static; we rebuild from the bundled C sources without -static so
+# the binary links against libseccomp.so.2 (RHAIENG-6849).
+#
+# On ppc64le/s390x, sandbox-runtime does not support seccomp on those arches;
+# remove the unused static x64 blobs so check-payload does not fail.
+set -euo pipefail
+
+ROOT="${1:-${CODESERVER_SOURCE_PREFETCH:-}}"
+if [[ -z "${ROOT}" || ! -d "${ROOT}" ]]; then
+  echo "ERROR: usage: $0 <code-server-source-root>" >&2
+  exit 1
+fi
+
+machine="$(uname -m)"
+case "${machine}" in
+  x86_64)
+    native_dir=x64
+    bpf_target=x86_64
+    ;;
+  aarch64)
+    native_dir=arm64
+    bpf_target=aarch64
+    ;;
+  ppc64le|s390x)
+    removed=0
+    while IFS= read -r -d '' blob; do
+      rm -f "${blob}"
+      removed=$((removed + 1))
+      echo "Removed unsupported-arch apply-seccomp: ${blob}"
+    done < <(find "${ROOT}" -type f -path '*/node_modules/@vscode/sandbox-runtime/vendor/seccomp/*/apply-seccomp' -print0 2>/dev/null)
+    if [[ "${removed}" -eq 0 ]]; then
+      echo "WARNING: no apply-seccomp binaries found under ${ROOT}" >&2
+    else
+      echo "Removed ${removed} apply-seccomp binary(ies) on ${machine}"
+    fi
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unsupported architecture ${machine}" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v gcc >/dev/null 2>&1; then
+  echo "ERROR: gcc not found (enable gcc-toolset-14 in the build stage)" >&2
+  exit 1
+fi
+if ! pkg-config --exists libseccomp 2>/dev/null && [[ ! -f /usr/include/seccomp.h ]]; then
+  echo "ERROR: libseccomp-devel not installed" >&2
+  exit 1
+fi
+
+rebuilt=0
+while IFS= read -r -d '' pkg; do
+  src="${pkg}/vendor/seccomp-src"
+  if [[ ! -f "${src}/apply-seccomp.c" || ! -f "${src}/seccomp-unix-block.c" ]]; then
+    echo "WARNING: skipping ${pkg} (missing seccomp C sources)" >&2
+    continue
+  fi
+
+  out="${pkg}/vendor/seccomp/${native_dir}"
+  mkdir -p "${out}"
+
+  gen="${out}/seccomp-unix-block"
+  gcc -O2 -Wall -Wextra -o "${gen}" "${src}/seccomp-unix-block.c" -lseccomp
+
+  tmp_bpf="${out}/${bpf_target}.bpf"
+  "${gen}" "${tmp_bpf}" "${bpf_target}"
+
+  header="${out}/unix-block-bpf.h"
+  if [[ "${machine}" == "x86_64" ]]; then
+    python3 - "${tmp_bpf}" "${header}" <<'PY'
+import pathlib, sys
+b = pathlib.Path(sys.argv[1]).read_bytes()
+hexes = [f"0x{b:02x}" for b in b]
+lines = [" " + ", ".join(hexes[i:i + 8]) + "," for i in range(0, len(hexes), 8)]
+body = "\n".join(lines)
+pathlib.Path(sys.argv[2]).write_text(
+    "#if defined(__x86_64__)\n"
+    "static const unsigned char unix_block_bpf[] = {\n"
+    f"{body}\n"
+    "};\n"
+    "#else\n"
+    '#error "unsupported architecture for unix-block BPF filter"\n'
+    "#endif\n"
+)
+PY
+  else
+    python3 - "${tmp_bpf}" "${header}" <<'PY'
+import pathlib, sys
+b = pathlib.Path(sys.argv[1]).read_bytes()
+hexes = [f"0x{b:02x}" for b in b]
+lines = [" " + ", ".join(hexes[i:i + 8]) + "," for i in range(0, len(hexes), 8)]
+body = "\n".join(lines)
+pathlib.Path(sys.argv[2]).write_text(
+    "#if defined(__aarch64__)\n"
+    "static const unsigned char unix_block_bpf[] = {\n"
+    f"{body}\n"
+    "};\n"
+    "#else\n"
+    '#error "unsupported architecture for unix-block BPF filter"\n'
+    "#endif\n"
+)
+PY
+  fi
+
+  dest="${out}/apply-seccomp"
+  gcc -O2 -Wall -Wextra -I "${out}" -o "${dest}" "${src}/apply-seccomp.c" -lseccomp
+  strip "${dest}"
+  chmod 0755 "${dest}"
+  rm -f "${gen}" "${tmp_bpf}" "${header}"
+
+  for other in x64 arm64; do
+    if [[ "${other}" != "${native_dir}" ]]; then
+      rm -f "${pkg}/vendor/seccomp/${other}/apply-seccomp"
+    fi
+  done
+
+  if command -v readelf >/dev/null 2>&1; then
+    if ! readelf -l "${dest}" | grep -q 'INTERP'; then
+      echo "ERROR: rebuilt apply-seccomp is still static: ${dest}" >&2
+      exit 1
+    fi
+    if ! readelf -d "${dest}" | grep -q 'libseccomp.so'; then
+      echo "ERROR: rebuilt apply-seccomp does not link libseccomp: ${dest}" >&2
+      exit 1
+    fi
+  fi
+
+  rebuilt=$((rebuilt + 1))
+  echo "Rebuilt dynamically linked apply-seccomp: ${dest}"
+done < <(find "${ROOT}" -type d -path '*/node_modules/@vscode/sandbox-runtime' -print0 2>/dev/null)
+
+if [[ "${rebuilt}" -eq 0 ]]; then
+  echo "WARNING: no @vscode/sandbox-runtime packages found under ${ROOT}" >&2
+else
+  echo "Rebuilt apply-seccomp in ${rebuilt} sandbox-runtime package(s) on ${machine}"
+fi

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/rebuild-apply-seccomp.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/rebuild-apply-seccomp.sh
@@ -118,7 +118,8 @@ PY
 
   for other in x64 arm64; do
     if [[ "${other}" != "${native_dir}" ]]; then
-      rm -f "${pkg}/vendor/seccomp/${other}/apply-seccomp"
+      stale_apply_seccomp="${pkg}/vendor/seccomp/${other}/apply-seccomp"
+      rm -f "${stale_apply_seccomp}"
     fi
   done
 

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml
@@ -110,6 +110,8 @@ packages:
   - mesa-libGL
 
   # Dev libraries
+  - libseccomp-devel
+  - libseccomp
   - openssl-devel
   - zlib-devel
   - boost-devel

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -18,13 +18,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.aarch64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54080966
-    checksum: sha256:aca8538e130743bdd3aeae1ec02732402ed7d71840d6ac7016bd27cd63c7540c
+    size: 54160127
+    checksum: sha256:51e8a599b800c1f8d1758030557aa28cf65e335d00b555e50b2f048ad0393444
     name: openshift-clients
-    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/annobin-12.98-2.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1120755
@@ -389,20 +389,20 @@ arches:
     name: cpp
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/c/criu-3.19-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/c/criu-3.19-4.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 555523
-    checksum: sha256:376aca78a8d78a052503fc4406ee84e4d0607c047e8486190b06ed3acd19a6c7
+    size: 552955
+    checksum: sha256:2f4934b17b8fb4bca5f418f383075c37ab3485f2db4e83d78bee808865e5bbd8
     name: criu
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/c/criu-libs-3.19-3.el9.aarch64.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/c/criu-libs-3.19-4.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 31064
-    checksum: sha256:34b7c037743e730a07117d9627725517d60ed356f945c9f42880573f552b7c4f
+    size: 36419
+    checksum: sha256:0c636b32a97822573321095b02d113735b93701d9ccbd3f12bd66dc7c0eee807
     name: criu-libs
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/c/crun-1.27-1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 251772
@@ -816,34 +816,34 @@ arches:
     name: harfbuzz-icu
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.5.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 55611
-    checksum: sha256:5701ef7b1253a4623c76f7be5efe7acd0f129c48fa5af5b6d7c1a2a18062dc30
+    size: 55513
+    checksum: sha256:80a02c3e3db8b46e2fb04bd57028ef06031e1c9e382d400de34b16efecdb931f
     name: httpd
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.5.aarch64.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 1574330
-    checksum: sha256:9f21eb03a61b268b756e7acb4f3768088f3c7faca655caccbf52e32f82da53d6
+    size: 1574019
+    checksum: sha256:787c01c123c8832742e7931efa126085a963a9a296b2d5bc92a7c64db42c264d
     name: httpd-core
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.5.noarch.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.6.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 19824
-    checksum: sha256:029e57575e4e29e1a0f447084f5f65f5e62a2b6fa88aaf332c5159326cc691b1
+    size: 19733
+    checksum: sha256:974f63bbff7d8b4f4106bd06b5204b57cf6b09a9a37d76053b65db9c72c48864
     name: httpd-filesystem
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.5.aarch64.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 89285
-    checksum: sha256:4370ea84d36cdecb0175ea6d6b7cce358ff14324e11763314d68e9908ea70aec
+    size: 89784
+    checksum: sha256:4ba931cca63d03e942ed7c0dbc2b4822b85f4f3124540cefe064bf3a6225499e
     name: httpd-tools
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/j/jbigkit-libs-2.1-23.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 57006
@@ -851,13 +851,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.41.1.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.42.1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2872021
-    checksum: sha256:badc73a635a0552aa4d86eeaba804ccbbe811065e4fbbf3531fe1f9cf646fcd9
+    size: 2874189
+    checksum: sha256:4eaed7563988ff556b2c52e8e90195f42dadeaae5c5c7e849af2d3f5a87afdd0
     name: kernel-headers
-    evr: 5.14.0-687.41.1.el9_8
-    sourcerpm: kernel-5.14.0-687.41.1.el9_8.src.rpm
+    evr: 5.14.0-687.42.1.el9_8
+    sourcerpm: kernel-5.14.0-687.42.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -1117,6 +1117,13 @@ arches:
     name: libpng-devel
     evr: 2:1.6.37-15.el9_8.2
     sourcerpm: libpng-1.6.37-15.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/l/libseccomp-devel-2.5.2-2.el9.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 64130
+    checksum: sha256:806a1580d5eea8ca6abc4f2f1384be58e9830501c0f627156cc9fb5961cfea34
+    name: libseccomp-devel
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/l/libselinux-devel-3.6-3.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 166975
@@ -1327,20 +1334,20 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.2.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 168309
-    checksum: sha256:a78593737889274f667272089a807c31b3f0371d6749567b60b3f7cb9e7069ee
+    size: 168506
+    checksum: sha256:18213307cd7f451d644a7da4401fbd6b9d091a5920cae61ffb670d402401aa55
     name: mod_http2
-    evr: 2.0.26-6.el9_8.1
-    sourcerpm: mod_http2-2.0.26-6.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.5.aarch64.rpm
+    evr: 2.0.26-6.el9_8.2
+    sourcerpm: mod_http2-2.0.26-6.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.6.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 65366
-    checksum: sha256:bb1e49df74808d22dfb49ce60392ee2aafcaea4114672ac2963c2e8872f0766e
+    size: 65275
+    checksum: sha256:5baa3c85c4a5a8f72cacdc337439c2a7ab32e98767c1447f7a4e45b3a4332473
     name: mod_lua
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 92062
@@ -1355,41 +1362,41 @@ arches:
     name: mpg123-libs
     evr: 1.32.9-1.el9_5
     sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.4.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 45660
-    checksum: sha256:4634581b662c747914e59aef230cb8fbfe37236a3ff9b01863baf1d38b125d67
+    size: 45861
+    checksum: sha256:a47070b2514ad0f834c14e1adb3f89811b09586030f17b3b3ee0405837443a26
     name: nginx
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.4.aarch64.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 594130
-    checksum: sha256:ffac90d1f29023be52212e392b31f75a7e09bebba12d661235312c0022dc71c9
+    size: 594186
+    checksum: sha256:614cf5806eaedf18058f63e98a54faa69d816cb5b056eb2250f83bcd1e52117e
     name: nginx-core
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.4.noarch.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.5.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 17343
-    checksum: sha256:51593c39d33d82ee7425e2c2ac17d58ca051fa1a2810f11d633d3b9b714d669a
+    size: 17539
+    checksum: sha256:dd719c68fb0a659400ba0a82f460ecc60bc287ee587776b548899d3a9f78b723
     name: nginx-filesystem
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.4.aarch64.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 38580
-    checksum: sha256:f8555eeff61e8d7004f5d39734c8b6f621065475a8adf26262264e348b5f0107
+    size: 38818
+    checksum: sha256:8c036779c65b1dd806858a7e59d840425dd85c40e150fde0c1dc539590767ace
     name: nginx-mod-http-perl
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.4.aarch64.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 86377
-    checksum: sha256:6230eb46c4d5c38cbe1b4761c024143386104db428f068ab26d74b28401a253b
+    size: 86581
+    checksum: sha256:464efc6b7537bc5bd630cb8ae03450111c396a0e31411044a70e3d2daf0bb2b8
     name: nginx-mod-stream
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/n/nodejs-22.23.1-3.module+el9.8.0+24637+e0b636e5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 2402851
@@ -3280,27 +3287,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8.3
     sourcerpm: python3.9-3.9.25-7.el9_8.3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 32747
-    checksum: sha256:f1878fee909c46fadc203680309dfe2f2cb5926796569dc71ef327f13e57f732
+    size: 32440
+    checksum: sha256:127b8467e15c3f233d87bdb85c57809332eefb2e7b483aca7a08790dd9b62b74
     name: python3.12
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.1.aarch64.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 338615
-    checksum: sha256:bc817f9ae2394672eb88bba84f40f6f9e1c26b5e0cee43469eaeb1b2b5475242
+    size: 338273
+    checksum: sha256:89b3da83c56d333c4e6b8f20e85d5df93560c82731a254b6e00ab91e011c61a8
     name: python3.12-devel
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.1.aarch64.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 10137763
-    checksum: sha256:95a5f3c22a8604ce4e5b4c770ec455cf7fcda812a1a0bb7de988f388adf28155
+    size: 10145691
+    checksum: sha256:cca9ebdb4242036911ccc7271de7cb9e3d621c152b402f781ae22b700ab02231
     name: python3.12-libs
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1527128
@@ -3308,13 +3315,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 434699
-    checksum: sha256:bb23aea3b50132127b987dfef99e77eea7a5bd1ddc910decb8548b6b7eec10ce
+    size: 433842
+    checksum: sha256:5aa96f8ae8b358c63ad7a818a63be88646742938ab5024be04f145fb78187cff
     name: python3.12-tkinter
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 9344
@@ -3959,13 +3966,13 @@ arches:
     name: libatomic
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/l/libattr-2.5.1-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/l/libattr-2.6.0-1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 20696
-    checksum: sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412
+    size: 23276
+    checksum: sha256:ec08036348dbe2ee41645bdb96eb485b9db5121ec0524258b0639426a22a49bc
     name: libattr
-    evr: 2.5.1-3.el9
-    sourcerpm: attr-2.5.1-3.el9.src.rpm
+    evr: 2.6.0-1.el9_8
+    sourcerpm: attr-2.6.0-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 113931
@@ -4687,13 +4694,13 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-16.el9
     sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 660260
-    checksum: sha256:dda4c59309d47d73d64291c53078cce330b8d5a9d95c903e133d9f37ec0e0a68
+    size: 660770
+    checksum: sha256:0fbb8043f9c02870c831da433f69b856a6674d02b60306d9cc01149ec89ed239
     name: sqlite-libs
-    evr: 3.34.1-10.el9_8
-    sourcerpm: sqlite-3.34.1-10.el9_8.src.rpm
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/s/systemd-252-67.el9_8.4.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 4156431
@@ -4899,10 +4906,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/8437cbdf89dc0e6a8f6d77806dd5958f9be729e420a08090cbe110125645ecdf-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/3aa4f72a11e21c1f727a54eb63be9a9b3e4cb457966192349f73f26f35a4b2ae-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 64616
-    checksum: sha256:8437cbdf89dc0e6a8f6d77806dd5958f9be729e420a08090cbe110125645ecdf
+    size: 65051
+    checksum: sha256:3aa4f72a11e21c1f727a54eb63be9a9b3e4cb457966192349f73f26f35a4b2ae
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -4919,13 +4926,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.ppc64le.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 51126038
-    checksum: sha256:eadbf175188502377555dc98a03d2359ba7c03ed14bc1b788bbfd3a83cddbab1
+    size: 51128429
+    checksum: sha256:ac85191b03d4889030e6e26e7d51b0fefc8a0b243bcc86a5e7fa6ca0ed7e7e84
     name: openshift-clients
-    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/annobin-12.98-2.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1126819
@@ -5290,20 +5297,20 @@ arches:
     name: cpp
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/c/criu-3.19-3.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/c/criu-3.19-4.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 603115
-    checksum: sha256:127155d8ccc2e3b1971631e251b6bcf788072302b36d85d0cd9b86e5488327a0
+    size: 608553
+    checksum: sha256:7f091d686c20f52a1f70a28c9ca7f3aed796202fb2ab4f9af8398d38fe683649
     name: criu
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/c/criu-libs-3.19-3.el9.ppc64le.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/c/criu-libs-3.19-4.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 33613
-    checksum: sha256:f004060055d65ee045db9f4a445d9de0ca824a7b41bb48458bb9ac449a558ce0
+    size: 38994
+    checksum: sha256:84c3af47dc5270662f91eab5b8457c2372186ed7c751ba89ac05771a0f3763c2
     name: criu-libs
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/c/crun-1.27-1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 292788
@@ -5731,34 +5738,34 @@ arches:
     name: harfbuzz-icu
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.5.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 56677
-    checksum: sha256:d13ad7fbb130e0a93d2e00c513739eae4905524afec9e3da6f3f5dd61726991b
+    size: 56573
+    checksum: sha256:5634216118664273092f672ff81e58773038401e8e6c8a81a5dbc547e888ab35
     name: httpd
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.5.ppc64le.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 1681104
-    checksum: sha256:fad915c2434fa740574f3449843440c2a9f8e3ca5ce6f40e8dd46402107d2db5
+    size: 1679526
+    checksum: sha256:d544e78de8f62f2a879af1f99ddcbcaf912b34c278c5392dea33285c308b9e2d
     name: httpd-core
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.5.noarch.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.6.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 19824
-    checksum: sha256:029e57575e4e29e1a0f447084f5f65f5e62a2b6fa88aaf332c5159326cc691b1
+    size: 19733
+    checksum: sha256:974f63bbff7d8b4f4106bd06b5204b57cf6b09a9a37d76053b65db9c72c48864
     name: httpd-filesystem
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.5.ppc64le.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 92167
-    checksum: sha256:2885090c232268e708a9de9afd271af0332bf92ab9d3537cbc993e1a89c4bb88
+    size: 92667
+    checksum: sha256:fd98777cc7dff72a14844883b1873a26c964a0439ccc1ee7ca57b19431465e6f
     name: httpd-tools
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/j/jbigkit-libs-2.1-23.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 61560
@@ -5766,13 +5773,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.41.1.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.42.1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2895853
-    checksum: sha256:77cd0483c762c111190ae1b006ec02cb176aba064c1846f733c7edf859eed410
+    size: 2898017
+    checksum: sha256:57297ffdb162abd9cd49914972a2d43bda711f9d4ead2a90cfc9331f93daf0cf
     name: kernel-headers
-    evr: 5.14.0-687.41.1.el9_8
-    sourcerpm: kernel-5.14.0-687.41.1.el9_8.src.rpm
+    evr: 5.14.0-687.42.1.el9_8
+    sourcerpm: kernel-5.14.0-687.42.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -6039,6 +6046,13 @@ arches:
     name: libquadmath-devel
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/l/libseccomp-devel-2.5.2-2.el9.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 64233
+    checksum: sha256:661bdc234f5a33e2d98eec86c3d5e651ebfd14a43449268137b694a60ac11cc6
+    name: libseccomp-devel
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/l/libselinux-devel-3.6-3.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 166992
@@ -6249,20 +6263,20 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.2.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 182621
-    checksum: sha256:4123bb7d92c8589a2a182fcd0c5bebdb01c1474872a1db5c6582abcc934e07fa
+    size: 182779
+    checksum: sha256:01e36ddd94e3cfd338e0d84a73d2a52d63dcc4503308d8c4c5db94e72a0016fb
     name: mod_http2
-    evr: 2.0.26-6.el9_8.1
-    sourcerpm: mod_http2-2.0.26-6.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.5.ppc64le.rpm
+    evr: 2.0.26-6.el9_8.2
+    sourcerpm: mod_http2-2.0.26-6.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 71146
-    checksum: sha256:a484bf740b4226af7febdeb2fb9f1185dcf993a6cadf23d7e4c6f4d7b03ec114
+    size: 71055
+    checksum: sha256:7325def588b0a4d8b8d11c142e30ca2c27ca6dfefd6417c2d92a218adc5bb7f2
     name: mod_lua
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 106314
@@ -6277,41 +6291,41 @@ arches:
     name: mpg123-libs
     evr: 1.32.9-1.el9_5
     sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.4.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 45684
-    checksum: sha256:2863d2de8bd4bf476dd70078fdd14936f56d5b5ee3d75d125549122648e620b8
+    size: 45889
+    checksum: sha256:24883437ac1dbce663bcf7110259521351c148c1091f52fc6514916d8b977c29
     name: nginx
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.4.ppc64le.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 674832
-    checksum: sha256:84fbbcdf35ced6de10b229df3f29b0bd20d083ea34bbb07f631e8f3a0fe991bd
+    size: 674823
+    checksum: sha256:9f3ade684828e01b653a0c692b04ca8bd45ff1bd3f46b341eb3930682d91c5d9
     name: nginx-core
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.4.noarch.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.5.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 17343
-    checksum: sha256:51593c39d33d82ee7425e2c2ac17d58ca051fa1a2810f11d633d3b9b714d669a
+    size: 17539
+    checksum: sha256:dd719c68fb0a659400ba0a82f460ecc60bc287ee587776b548899d3a9f78b723
     name: nginx-filesystem
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.4.ppc64le.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 40482
-    checksum: sha256:84adead5487129968fee7e91b9a88486d14b3e0521100cbe3059a6357a8352dd
+    size: 40692
+    checksum: sha256:9e921de3d4b7d2472dcb5533d2d10a9f974bfbb5a6371f2dcd55ea5e01b873d2
     name: nginx-mod-http-perl
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.4.ppc64le.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 98833
-    checksum: sha256:734a99d5a4a89694c8471842a8f6868f5fe7382bc78969a8db4925902a50055d
+    size: 99281
+    checksum: sha256:77d6f40e1b2a60bf4bf9adbcb87111336e3c083866db157f6733990da39f8ac4
     name: nginx-mod-stream
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/n/nodejs-22.23.1-3.module+el9.8.0+24637+e0b636e5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 2403611
@@ -8202,27 +8216,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8.3
     sourcerpm: python3.9-3.9.25-7.el9_8.3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 32808
-    checksum: sha256:18f196faebc9865f11e1ca27f82cc69b92e5354cc5580072793beabb70eeec91
+    size: 32494
+    checksum: sha256:8e3fcabf92bf5be325dbb114ab2921b92c3a3007c9bab8b24f93d3c2a5bb44c8
     name: python3.12
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.1.ppc64le.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 338710
-    checksum: sha256:814b238f29a6e865bab595c09b10813b795fc2d65bfd3dc7c2d2c84b1e27bd1a
+    size: 338324
+    checksum: sha256:2b8ca99850b8755bd9fbb5394b2522bd7b104600d102fd1b48f29adb4c8c37ff
     name: python3.12-devel
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.1.ppc64le.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 10087484
-    checksum: sha256:56acbc33e3d1bf7f5795fc53937a8e60e2d2f62e5eb668f017ecaa0255e42cd4
+    size: 10093244
+    checksum: sha256:32e4a045a4ce07f8db54811f223def1404fbabe4b7b521d48a56c7480f6b1057
     name: python3.12-libs
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1527128
@@ -8230,13 +8244,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 433082
-    checksum: sha256:8b6da968d92e6cfdb13ea8fd36ac1fec8ee4afd8551440c9162313ac50cbd9b8
+    size: 432811
+    checksum: sha256:5d377e670b37718a80213b4001ce0a2a913372b04f7b60e2209bfb8bae7af814
     name: python3.12-tkinter
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 9344
@@ -8881,13 +8895,13 @@ arches:
     name: libatomic
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/l/libattr-2.5.1-3.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/l/libattr-2.6.0-1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 21501
-    checksum: sha256:a2398158adad2016fca3d0d2c272e027b8279020992a349664caf6a2299ec50b
+    size: 24709
+    checksum: sha256:9931133a1f833d158bc8098815924c1b15cf6c024bc89e0f55571ef906ae8f43
     name: libattr
-    evr: 2.5.1-3.el9
-    sourcerpm: attr-2.5.1-3.el9.src.rpm
+    evr: 2.6.0-1.el9_8
+    sourcerpm: attr-2.6.0-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/l/libblkid-2.37.4-25.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 130845
@@ -9623,13 +9637,13 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-16.el9
     sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 758081
-    checksum: sha256:6eac353037fe537e4639455a4ce8595b6b8c345913f84868b2a3288c6b54000a
+    size: 758085
+    checksum: sha256:f51af80eda44e36b51b315a90e44a0bfd2c6c7d4ce4aadd40bac23af3fc43cb8
     name: sqlite-libs
-    evr: 3.34.1-10.el9_8
-    sourcerpm: sqlite-3.34.1-10.el9_8.src.rpm
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/s/systemd-252-67.el9_8.4.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 4435450
@@ -9835,10 +9849,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/e6f3935129b33909605eeb5c10bc08962001b42071fec05e12414c8b1cd6431d-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/0c8af2e47c2965928905dd4f2c1686b29e3fb39aa8095b1a4946ead367dbe85b-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 64714
-    checksum: sha256:e6f3935129b33909605eeb5c10bc08962001b42071fec05e12414c8b1cd6431d
+    size: 64968
+    checksum: sha256:0c8af2e47c2965928905dd4f2c1686b29e3fb39aa8095b1a4946ead367dbe85b
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -9855,13 +9869,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.s390x.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 52969532
-    checksum: sha256:f64c95c9dbb421beddef5dcaa741d2765c5303f872e9eb7d19c337a5cda3cd6b
+    size: 53235751
+    checksum: sha256:4db0881f22ab8b470ed49749e9ec27b7272bf6b993e12cf5106082efac395194
     name: openshift-clients
-    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/annobin-12.98-2.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1120442
@@ -10226,20 +10240,20 @@ arches:
     name: cpp
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/c/criu-3.19-3.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/c/criu-3.19-4.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 534901
-    checksum: sha256:4bda534498f502506bb2eff2fa9fdddefe37e3a20bfdeb70a401f3c662e6d037
+    size: 542784
+    checksum: sha256:c3bacbbbb008a63fd384b79c4575d9200db72175d5042de52f6fae3ae2a6d6e6
     name: criu
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/c/criu-libs-3.19-3.el9.s390x.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/c/criu-libs-3.19-4.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 31157
-    checksum: sha256:fad9de9210d49010e73da6b23544bb759ee8d314b0200ae095b5b2ba7a96d7bb
+    size: 36524
+    checksum: sha256:442e1b3384e4694977918354a81945528b6f2631fcb819696db9f52fc204ff9d
     name: criu-libs
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/c/crun-1.27-1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 249046
@@ -10695,34 +10709,34 @@ arches:
     name: harfbuzz-icu
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.5.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 55574
-    checksum: sha256:37b7865ce03b4ecd0973b8f0e5689fe806a6394d7a4b709f9d1842f57c8a0229
+    size: 55479
+    checksum: sha256:526aaee70deb968beb40814d442a98fdc5918f446c594d31f08bb3b46a1573a6
     name: httpd
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.5.s390x.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 1553677
-    checksum: sha256:b8bee7458cbef95314bdb3f3968ecd4dc75488113f030bc52ce2666c6105a2c8
+    size: 1551538
+    checksum: sha256:804077be33d45d99466eaab747727adefd24e15d95e22843000b9d7d446afe4c
     name: httpd-core
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.5.noarch.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.6.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 19824
-    checksum: sha256:029e57575e4e29e1a0f447084f5f65f5e62a2b6fa88aaf332c5159326cc691b1
+    size: 19733
+    checksum: sha256:974f63bbff7d8b4f4106bd06b5204b57cf6b09a9a37d76053b65db9c72c48864
     name: httpd-filesystem
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.5.s390x.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 90541
-    checksum: sha256:f2cbf78351608317ca8caeb46777bcbace0af80dd477e3d3c221fb408ecddefa
+    size: 90160
+    checksum: sha256:107c9fa081784451007a7b7cf3586f13f60228fa73d30cf7979e3a676c4a6aff
     name: httpd-tools
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/j/jbigkit-libs-2.1-23.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 57047
@@ -10730,13 +10744,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.41.1.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.42.1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2902017
-    checksum: sha256:5078b1c5b552c0f2f738e8aae65d87bac7d3060f4eaa028d3d6c31b69603b292
+    size: 2904169
+    checksum: sha256:1ea7397bda094b9a2848af9b91e46731863b4e7e820c9c1fffa9e7a4fa07672d
     name: kernel-headers
-    evr: 5.14.0-687.41.1.el9_8
-    sourcerpm: kernel-5.14.0-687.41.1.el9_8.src.rpm
+    evr: 5.14.0-687.42.1.el9_8
+    sourcerpm: kernel-5.14.0-687.42.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -11003,6 +11017,13 @@ arches:
     name: libpng-devel
     evr: 2:1.6.37-15.el9_8.2
     sourcerpm: libpng-1.6.37-15.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/l/libseccomp-devel-2.5.2-2.el9.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 64316
+    checksum: sha256:5961abe4682cddf3ec9b06aa868363361c57a3af92d77b5a2316b7a323a5ca65
+    name: libseccomp-devel
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/l/libselinux-devel-3.6-3.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 166973
@@ -11213,20 +11234,20 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.2.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 169971
-    checksum: sha256:6f8c2f6b7cf1484ea3ab4e6ac2b7c2bc4eda24435820737444fed15f41f44ca8
+    size: 170072
+    checksum: sha256:c5b8c9f589c9e260230f5e01ef5cff4213eaf55297303696a81ad2c400bad3d7
     name: mod_http2
-    evr: 2.0.26-6.el9_8.1
-    sourcerpm: mod_http2-2.0.26-6.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.5.s390x.rpm
+    evr: 2.0.26-6.el9_8.2
+    sourcerpm: mod_http2-2.0.26-6.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.6.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 65596
-    checksum: sha256:6abe8813b19c8b5b106631184ffc827023730db1a630f4105c4c386c9c35a3c5
+    size: 65541
+    checksum: sha256:cfb197167a2849a9a4996485ab7d37b66fbf6b39bb4ae7799a895d63f39a6e54
     name: mod_lua
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 94813
@@ -11241,41 +11262,41 @@ arches:
     name: mpg123-libs
     evr: 1.32.9-1.el9_5
     sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.4.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 45666
-    checksum: sha256:3178f83bcb48d0fef2610b5e7d749744871d97f0639ea9c756360abb43b92a82
+    size: 45853
+    checksum: sha256:8c8a4ec35fe8710d9b068e72b1f14defe2c5689b868a7d483a7d6482daad1864
     name: nginx
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.4.s390x.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 570177
-    checksum: sha256:ff6048049c1720e574647c4e39a79f0fbebfa75c8e775b7f2f0f2f30d05a28d2
+    size: 570369
+    checksum: sha256:79461e9583e61d5a0206678edf9ab59253826b2706916d0c7f1d00160204455a
     name: nginx-core
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.4.noarch.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.5.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 17343
-    checksum: sha256:51593c39d33d82ee7425e2c2ac17d58ca051fa1a2810f11d633d3b9b714d669a
+    size: 17539
+    checksum: sha256:dd719c68fb0a659400ba0a82f460ecc60bc287ee587776b548899d3a9f78b723
     name: nginx-filesystem
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.4.s390x.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 38262
-    checksum: sha256:31f8d52cab6317399ca540d9b215e3642fd4a33ea9e5fb3c415c723ae0039e37
+    size: 38462
+    checksum: sha256:3d2068f45d0f55975a5e9503a090505eb832899b006c98853f6b788b890a742f
     name: nginx-mod-http-perl
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.4.s390x.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 83806
-    checksum: sha256:22cb47af580f8db0889976c90979d19eed704163d9287ffcabb84629a4207ab4
+    size: 83973
+    checksum: sha256:e253f02b6ac1da64457294dab1a9f54dbc090ece5058c03370a0942e99f1f63d
     name: nginx-mod-stream
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/n/nodejs-22.23.1-3.module+el9.8.0+24637+e0b636e5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 2403355
@@ -13166,27 +13187,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8.3
     sourcerpm: python3.9-3.9.25-7.el9_8.3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 32622
-    checksum: sha256:1b8026822b4302d08915e55b692f2cf274ed1a537d797d962883a7e8b7fc386a
+    size: 32298
+    checksum: sha256:1d9c6400225666643a98052596e6a10a3e0f84c81daf0fef28867331749bf2f9
     name: python3.12
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.1.s390x.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 338622
-    checksum: sha256:d57803b33c39e6c79d96b709467fc2beeca205adc91720a0313bc620a4b994b8
+    size: 338253
+    checksum: sha256:3388967387eb568f8e59ef6bc06a0313794db4aa602c883fbb511f9eff70fcad
     name: python3.12-devel
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.1.s390x.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 9971141
-    checksum: sha256:20b2d5c7372f2f46c180d0e34806c99375326c1bb17afc2f4355715bfa28753d
+    size: 9974169
+    checksum: sha256:000bf9abc0a7627f453b50e1a94181a2f6729927d8d3324aa27ab8b251fb1ed1
     name: python3.12-libs
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1527128
@@ -13194,13 +13215,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 434730
-    checksum: sha256:fcc5409371f11510acafd6a71158ae3de54d9f7ea22cdc7c0bc58d4bca66e60b
+    size: 434493
+    checksum: sha256:a64656979e2a1228d14cac26ffb1be943df03bf37fcfd1bf548ed72fac1a3490
     name: python3.12-tkinter
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 9344
@@ -13810,13 +13831,13 @@ arches:
     name: libatomic
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/l/libattr-2.5.1-3.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/l/libattr-2.6.0-1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 20575
-    checksum: sha256:4013df08b49661a8592c2c57428f8040f8e2397379dfc02fa9a125cbf8de44c6
+    size: 23584
+    checksum: sha256:a0bb5b85dfc28983f2522c860fcde0792ec03398f1d39ef019d134b840f88165
     name: libattr
-    evr: 2.5.1-3.el9
-    sourcerpm: attr-2.5.1-3.el9.src.rpm
+    evr: 2.6.0-1.el9_8
+    sourcerpm: attr-2.6.0-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/l/libblkid-2.37.4-25.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 111331
@@ -14531,13 +14552,13 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-16.el9
     sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 652115
-    checksum: sha256:d773b3c1eac55a53efd669c87906804b31cf065a8f9885e6370b739c8f213f9d
+    size: 653093
+    checksum: sha256:5897571d31b7cc9d3e8ef0e7dc9dbf8230bea207c9e926d4fef9fb635ab16f64
     name: sqlite-libs
-    evr: 3.34.1-10.el9_8
-    sourcerpm: sqlite-3.34.1-10.el9_8.src.rpm
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/s/systemd-252-67.el9_8.4.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 4167506
@@ -14743,10 +14764,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/ab9c7d0d37a64206c44da239065d175c87c798e86003f960ebff2c27f2c4ce22-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/70b927f3ea851478ee4df4834ca3a8e7e3b2022dc5c983a583a0410a8ec6eb8d-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 62925
-    checksum: sha256:ab9c7d0d37a64206c44da239065d175c87c798e86003f960ebff2c27f2c4ce22
+    size: 63165
+    checksum: sha256:70b927f3ea851478ee4df4834ca3a8e7e3b2022dc5c983a583a0410a8ec6eb8d
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -14763,13 +14784,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.x86_64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54964214
-    checksum: sha256:ee71ce72f2b9a1804559527a18c68dd2430394425f9ad64e3fe6384fdb28e00b
+    size: 54962756
+    checksum: sha256:f54ee03ff8005b69bc15955e5ceb8b648cedd122fa39b391c33c44adde1bf291
     name: openshift-clients
-    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/annobin-12.98-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1121890
@@ -15134,20 +15155,20 @@ arches:
     name: cpp
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/c/criu-3.19-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/c/criu-3.19-4.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 569988
-    checksum: sha256:991367e0ca6f3b1672f98ffccc32d43c2b959bf8b82562b79e9f9ff5be23642b
+    size: 575825
+    checksum: sha256:8b5d9ead51b4543ed5368b969ad0764f463a5ab448f552610c44cd8e4cde3acf
     name: criu
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/c/criu-libs-3.19-3.el9.x86_64.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/c/criu-libs-3.19-4.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 31913
-    checksum: sha256:37144e6c13da6a622fb1f15d0ff3a36fc359477db916a157fefb5d1934881614
+    size: 37299
+    checksum: sha256:3a9f645c6d495fc465fd65bfe02170e93552567bb45745bc6b8bf1402cd35464
     name: criu-libs
-    evr: 3.19-3.el9
-    sourcerpm: criu-3.19-3.el9.src.rpm
+    evr: 3.19-4.el9_8
+    sourcerpm: criu-3.19-4.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 268116
@@ -15582,34 +15603,34 @@ arches:
     name: harfbuzz-icu
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.5.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-2.4.62-13.el9_8.6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 56062
-    checksum: sha256:5375adfa1a0a3675cf6bc7d9aa290ac133f52bf354dff8a75dd0af744212d38a
+    size: 55979
+    checksum: sha256:14873d78390188b5e7cd12aeb1b78e3e357ed4fc1c658937fadc379bd8424a3b
     name: httpd
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.5.x86_64.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-core-2.4.62-13.el9_8.6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 1594424
-    checksum: sha256:32a3d89904bae9662b5cd8ed6d4896f9886ec7df7567f701e5a96fae5d7b7176
+    size: 1596807
+    checksum: sha256:8571ac2a87eb7a793d939359bb69b88a5c79edda7746ac60801c927b156e1817
     name: httpd-core
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.5.noarch.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-filesystem-2.4.62-13.el9_8.6.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 19824
-    checksum: sha256:029e57575e4e29e1a0f447084f5f65f5e62a2b6fa88aaf332c5159326cc691b1
+    size: 19733
+    checksum: sha256:974f63bbff7d8b4f4106bd06b5204b57cf6b09a9a37d76053b65db9c72c48864
     name: httpd-filesystem
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.5.x86_64.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/h/httpd-tools-2.4.62-13.el9_8.6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 90469
-    checksum: sha256:05417ee4fbfeb194b86be51b6498b6c433e497700b6bf9611b4f772618afc54b
+    size: 90050
+    checksum: sha256:247f1cc9b0f4a792ff363197e7ca1f02b95a0f949dcea52e5ecad21558d476fd
     name: httpd-tools
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/j/jbigkit-libs-2.1-23.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 57187
@@ -15617,13 +15638,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.41.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.42.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2911313
-    checksum: sha256:7fab4963bb2f80e238051586a6df2b0ffea787daf7ef59659ba8d0fa3648f46e
+    size: 2913473
+    checksum: sha256:6a2a1bdb7d755358f35a283de880abb48b359aedd5fdfcd2da80bbe03541688c
     name: kernel-headers
-    evr: 5.14.0-687.41.1.el9_8
-    sourcerpm: kernel-5.14.0-687.41.1.el9_8.src.rpm
+    evr: 5.14.0-687.42.1.el9_8
+    sourcerpm: kernel-5.14.0-687.42.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -15890,6 +15911,13 @@ arches:
     name: libquadmath-devel
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/l/libseccomp-devel-2.5.2-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 64523
+    checksum: sha256:65024fd65e1b4b16f0e63d4122b0b1f3d02f41ac63ca3a56e8024454f875cd27
+    name: libseccomp-devel
+    evr: 2.5.2-2.el9
+    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/l/libselinux-devel-3.6-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 166987
@@ -16093,20 +16121,20 @@ arches:
     name: mesa-libgbm
     evr: 25.2.7-4.el9
     sourcerpm: mesa-25.2.7-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/m/mod_http2-2.0.26-6.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 173752
-    checksum: sha256:ee38b8dafc25b54e4298cc4efe524d846ddcb26cf4c22be69392befca5924881
+    size: 173889
+    checksum: sha256:624ddb8883a44786afe061d2c45170db0e78479523c3c8071943fb99709dcfd4
     name: mod_http2
-    evr: 2.0.26-6.el9_8.1
-    sourcerpm: mod_http2-2.0.26-6.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.5.x86_64.rpm
+    evr: 2.0.26-6.el9_8.2
+    sourcerpm: mod_http2-2.0.26-6.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/m/mod_lua-2.4.62-13.el9_8.6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 67642
-    checksum: sha256:4211aea26f82486e3f421b5401118827d8cd5528f5afb38a71a9d3e239b2a30b
+    size: 67584
+    checksum: sha256:20dfcea1f12db0dfc688b39a37c0020ad8f69ed3a6bb0e55768ec48130247169
     name: mod_lua
-    evr: 2.4.62-13.el9_8.5
-    sourcerpm: httpd-2.4.62-13.el9_8.5.src.rpm
+    evr: 2.4.62-13.el9_8.6
+    sourcerpm: httpd-2.4.62-13.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/m/mpdecimal-2.5.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 89670
@@ -16121,41 +16149,41 @@ arches:
     name: mpg123-libs
     evr: 1.32.9-1.el9_5
     sourcerpm: mpg123-1.32.9-1.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.4.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-1.20.1-28.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 45703
-    checksum: sha256:2633a8ed0524966c81538cf6857a765eaa13f4328c47b267cda77bb7de344901
+    size: 45914
+    checksum: sha256:4434134fe86e0bb445beaa624661cf3d25d14e30fe0c8b9af78a0d2c2a042777
     name: nginx
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.4.x86_64.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-core-1.20.1-28.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 593727
-    checksum: sha256:7f899b12477df91c4f819c3eede8e9e18300396ac0b65724a993e38ffe777d66
+    size: 593526
+    checksum: sha256:f3b57f41db3765603f2b195aed9b2410a3803e20a31d84bd4b22f820a38f9955
     name: nginx-core
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.4.noarch.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-filesystem-1.20.1-28.el9_8.5.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 17343
-    checksum: sha256:51593c39d33d82ee7425e2c2ac17d58ca051fa1a2810f11d633d3b9b714d669a
+    size: 17539
+    checksum: sha256:dd719c68fb0a659400ba0a82f460ecc60bc287ee587776b548899d3a9f78b723
     name: nginx-filesystem
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.4.x86_64.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-mod-http-perl-1.20.1-28.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 39396
-    checksum: sha256:0876fa4da215c70f78fba93b5a25f6ce43806b3857f2c62a7d842a4f6b6744bd
+    size: 39721
+    checksum: sha256:6574c89763680860ee9574d1a51da208fc9c32dc68abbf2711d2d38b9d76d118
     name: nginx-mod-http-perl
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.4.x86_64.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nginx-mod-stream-1.20.1-28.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 86669
-    checksum: sha256:8131bf9c7bfae4ef8521467840b597d413beabefc35891263e7e4573bd8c55b3
+    size: 86866
+    checksum: sha256:f9117e9beb9426d8653bf42c29e8411a02e34dcadc1bccdf51a83882339a4b48
     name: nginx-mod-stream
-    evr: 2:1.20.1-28.el9_8.4
-    sourcerpm: nginx-1.20.1-28.el9_8.4.src.rpm
+    evr: 2:1.20.1-28.el9_8.5
+    sourcerpm: nginx-1.20.1-28.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/n/nodejs-22.23.1-3.module+el9.8.0+24637+e0b636e5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 2403378
@@ -18046,27 +18074,27 @@ arches:
     name: python3-tkinter
     evr: 3.9.25-7.el9_8.3
     sourcerpm: python3.9-3.9.25-7.el9_8.3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-3.12.13-3.el9_8.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-3.12.14-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 32810
-    checksum: sha256:e3824eb610d0a5c444a9c49462dcd3c31e9ef2ce0b6f42f5b75e0d492a64deb6
+    size: 32484
+    checksum: sha256:10640d8db1555fb7ae4e63c62be4b8f341032fb3ee52cc7176047438ab893b1f
     name: python3.12
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.13-3.el9_8.1.x86_64.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.14-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 338768
-    checksum: sha256:d48f03d05360926a7fbeb37aec33c1593680cf719ad0c9e5354f87f9ab7d9609
+    size: 338289
+    checksum: sha256:3a7a0b4139eab58579f787f806083bd622b09346c4a72a4f282b833c39b2d6b3
     name: python3.12-devel
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.13-3.el9_8.1.x86_64.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.14-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 10207533
-    checksum: sha256:2135bca6d950ad5e8b3cc18e370fdeeedbe7bff413362247b28e0336d3bccb9d
+    size: 10211157
+    checksum: sha256:0eaade47a20924ba0fe3fb0a93898e053772248793069f40c1ba80c5115fddbb
     name: python3.12-libs
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1527128
@@ -18074,13 +18102,13 @@ arches:
     name: python3.12-pip-wheel
     evr: 23.2.1-5.el9
     sourcerpm: python3.12-pip-23.2.1-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-tkinter-3.12.13-3.el9_8.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/p/python3.12-tkinter-3.12.14-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 434307
-    checksum: sha256:14cb71956d3c792cc3fae8795728a0a7eb73680df92621a698d089f3defda8b8
+    size: 434117
+    checksum: sha256:a5a2e2d32fbe9c77f08f0f594fe9d4e117cb3ac01160e409831aad994e8210c9
     name: python3.12-tkinter
-    evr: 3.12.13-3.el9_8.1
-    sourcerpm: python3.12-3.12.13-3.el9_8.1.src.rpm
+    evr: 3.12.14-1.el9_8
+    sourcerpm: python3.12-3.12.14-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 9344
@@ -18732,13 +18760,13 @@ arches:
     name: libatomic
     evr: 11.5.0-14.el9
     sourcerpm: gcc-11.5.0-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/l/libattr-2.5.1-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/l/libattr-2.6.0-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 20786
-    checksum: sha256:6519f028915fbd7ee0474f0bf4e98e35f04b5d0cf7be9f66c0cb9eafac0b8c5a
+    size: 23752
+    checksum: sha256:9e37537f690c748f7f05faa80966072f118ec722e38ef332fe19cf22b087349f
     name: libattr
-    evr: 2.5.1-3.el9
-    sourcerpm: attr-2.5.1-3.el9.src.rpm
+    evr: 2.6.0-1.el9_8
+    sourcerpm: attr-2.6.0-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 114192
@@ -19474,13 +19502,13 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-16.el9
     sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-11.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 664960
-    checksum: sha256:7dc2202e08184890c851dcb2218a9abce14da150f12dfb8663ca306416e1d8d4
+    size: 665095
+    checksum: sha256:e5c20e933ec01f746a6c59a94cb99f46c6138dab3f387f0d02dab47f356e2e98
     name: sqlite-libs
-    evr: 3.34.1-10.el9_8
-    sourcerpm: sqlite-3.34.1-10.el9_8.src.rpm
+    evr: 3.34.1-11.el9_8
+    sourcerpm: sqlite-3.34.1-11.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/s/systemd-252-67.el9_8.4.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 4401138
@@ -19686,7 +19714,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/34039a43e315ae4a28d2cb5768fca0c7033ec1df735f0a8a35e8a7f04e5ed70f-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/584fd074da50f526a02444f8d92ea6f3b38a273f971bc687f4de1092311588b8-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 67285
-    checksum: sha256:34039a43e315ae4a28d2cb5768fca0c7033ec1df735f0a8a35e8a7f04e5ed70f
+    size: 67408
+    checksum: sha256:584fd074da50f526a02444f8d92ea6f3b38a273f971bc687f4de1092311588b8


### PR DESCRIPTION
## Summary

- Add `rebuild-apply-seccomp.sh` to rebuild `@vscode/sandbox-runtime` `apply-seccomp` from bundled C sources as a dynamically linked binary (fixes Konflux `fips-check` `ErrNotDynLinked` without a check-payload waiver).
- Wire the script into `Dockerfile.konflux.cpu` after `npm run release`; install `libseccomp-devel` in the build stage and `libseccomp` in the runtime image.
- On ppc64le/s390x, remove unused static `apply-seccomp` blobs (sandbox-runtime seccomp is x64/arm64 only).
- Prefetch `libseccomp` / `libseccomp-devel` in ODH and RHDS `rpms.in.yaml` lockfiles.

## Test plan

- [ ] Konflux codeserver build succeeds on x86_64 and aarch64
- [ ] `fips-check` passes for `odh-workbench-codeserver-datascience-cpu-py312-rhel9`
- [ ] code-server starts; Copilot Chat / agent sandbox smoke test on amd64


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added libseccomp support to code-server’s Python 3.12 images.
  * Seccomp helpers are rebuilt for supported architectures to improve runtime compatibility.
  * Unsupported architectures now safely omit unavailable seccomp components.

* **Chores**
  * Updated bundled RPM packages and metadata across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->