### PR TITLE
RHOAIENG-88676 RHAIENG-6849: fix(codeserver): strip apply-seccomp from the image

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -218,6 +218,11 @@ COPY --from=rpm-base /tmp/control /dev/null
 
 # Install code-server from built tree (no RPM: avoids unsigned-package issues on Konflux/Conforma).
 COPY --from=rpm-base /root/codeserver-baseline/ubi9-python-3.12/code-server/release/. /usr/lib/code-server/
+# RHOAIENG-88676 / RHAIENG-6849: drop static apply-seccomp (FIPS ErrNotDynLinked).
+COPY codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh /tmp/strip-apply-seccomp.sh
+RUN chmod 755 /tmp/strip-apply-seccomp.sh && \
+    /tmp/strip-apply-seccomp.sh /usr/lib/code-server && \
+    rm -f /tmp/strip-apply-seccomp.sh
 # Wrapper script (from code-server ci/build) that execs /usr/lib/code-server/bin/code-server
 COPY ${CODESERVER_SOURCE_CODE}/code-server/ci/build/code-server-nfpm.sh /usr/bin/code-server
 RUN chmod 755 /usr/bin/code-server

--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -220,8 +220,7 @@ COPY --from=rpm-base /tmp/control /dev/null
 COPY --from=rpm-base /root/codeserver-baseline/ubi9-python-3.12/code-server/release/. /usr/lib/code-server/
 # RHOAIENG-88676 / RHAIENG-6849: drop static apply-seccomp (FIPS ErrNotDynLinked).
 COPY codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh /tmp/strip-apply-seccomp.sh
-RUN chmod 755 /tmp/strip-apply-seccomp.sh && \
-    /tmp/strip-apply-seccomp.sh /usr/lib/code-server && \
+RUN bash /tmp/strip-apply-seccomp.sh /usr/lib/code-server && \
     rm -f /tmp/strip-apply-seccomp.sh
 # Wrapper script (from code-server ci/build) that execs /usr/lib/code-server/bin/code-server
 COPY ${CODESERVER_SOURCE_CODE}/code-server/ci/build/code-server-nfpm.sh /usr/bin/code-server

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -231,8 +231,7 @@ COPY --from=rpm-base /tmp/control /dev/null
 COPY --from=rpm-base /root/codeserver/ubi9-python-3.12/prefetch-input/code-server/release/. /usr/lib/code-server/
 # RHOAIENG-88676 / RHAIENG-6849: drop static apply-seccomp (FIPS ErrNotDynLinked).
 COPY ${CODESERVER_SOURCE_CODE}/prefetch-input/patches/strip-apply-seccomp.sh /tmp/strip-apply-seccomp.sh
-RUN chmod 755 /tmp/strip-apply-seccomp.sh && \
-    /tmp/strip-apply-seccomp.sh /usr/lib/code-server && \
+RUN bash /tmp/strip-apply-seccomp.sh /usr/lib/code-server && \
     rm -f /tmp/strip-apply-seccomp.sh
 # Wrapper script (from code-server ci/build) that execs /usr/lib/code-server/bin/code-server
 COPY ${CODESERVER_SOURCE_CODE}/prefetch-input/code-server/ci/build/code-server-nfpm.sh /usr/bin/code-server

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -229,6 +229,11 @@ COPY --from=rpm-base /tmp/control /dev/null
 # Install code-server from built tree (no RPM: avoids unsigned-package issues on Konflux/Conforma).
 # Path in rpm-base: /root/codeserver/ubi9-python-3.12/prefetch-input/code-server/release
 COPY --from=rpm-base /root/codeserver/ubi9-python-3.12/prefetch-input/code-server/release/. /usr/lib/code-server/
+# RHOAIENG-88676 / RHAIENG-6849: drop static apply-seccomp (FIPS ErrNotDynLinked).
+COPY ${CODESERVER_SOURCE_CODE}/prefetch-input/patches/strip-apply-seccomp.sh /tmp/strip-apply-seccomp.sh
+RUN chmod 755 /tmp/strip-apply-seccomp.sh && \
+    /tmp/strip-apply-seccomp.sh /usr/lib/code-server && \
+    rm -f /tmp/strip-apply-seccomp.sh
 # Wrapper script (from code-server ci/build) that execs /usr/lib/code-server/bin/code-server
 COPY ${CODESERVER_SOURCE_CODE}/prefetch-input/code-server/ci/build/code-server-nfpm.sh /usr/bin/code-server
 RUN chmod 755 /usr/bin/code-server

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh
@@ -15,24 +15,39 @@ if [[ ! -d "${ROOT}" ]]; then
   exit 1
 fi
 
+# find in process substitution does not propagate its exit status; write
+# results to a temp file so a traversal failure fails the build.
+find_nul_list() {
+  local out="$1"
+  shift
+  find "$@" -print0 >"${out}"
+}
+
+tmp_files="$(mktemp)"
+tmp_dirs="$(mktemp)"
+trap 'rm -f "${tmp_files}" "${tmp_dirs}"' EXIT
+
+find_nul_list "${tmp_files}" "${ROOT}" -type f -name apply-seccomp
+find_nul_list "${tmp_dirs}" "${ROOT}" -type d \( \
+  -path '*/node_modules/@vscode/sandbox-runtime/vendor/seccomp' -o \
+  -path '*/node_modules/@vscode/sandbox-runtime/dist/vendor/seccomp' -o \
+  -path '*/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp' -o \
+  -path '*/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp' \
+\)
+
 deleted=0
 while IFS= read -r -d '' dest; do
   rm -f "${dest}"
   deleted=$((deleted + 1))
   echo "Removed apply-seccomp: ${dest}"
-done < <(find "${ROOT}" -type f -name apply-seccomp -print0 2>/dev/null)
+done <"${tmp_files}"
 
 removed_dirs=0
 while IFS= read -r -d '' dir; do
   rm -rf "${dir}"
   removed_dirs=$((removed_dirs + 1))
   echo "Removed seccomp vendor dir: ${dir}"
-done < <(find "${ROOT}" -type d \( \
-  -path '*/node_modules/@vscode/sandbox-runtime/vendor/seccomp' -o \
-  -path '*/node_modules/@vscode/sandbox-runtime/dist/vendor/seccomp' -o \
-  -path '*/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp' -o \
-  -path '*/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp' \
-\) -print0 2>/dev/null)
+done <"${tmp_dirs}"
 
 if [[ "${deleted}" -eq 0 && "${removed_dirs}" -eq 0 ]]; then
   echo "WARNING: no apply-seccomp files or seccomp vendor dirs under ${ROOT}" >&2
@@ -40,7 +55,7 @@ else
   echo "Removed ${deleted} apply-seccomp file(s) and ${removed_dirs} seccomp vendor dir(s)"
 fi
 
-remaining="$(find "${ROOT}" -type f -name apply-seccomp 2>/dev/null || true)"
+remaining="$(find "${ROOT}" -type f -name apply-seccomp)"
 if [[ -n "${remaining}" ]]; then
   echo "ERROR: apply-seccomp ELF still present after strip:" >&2
   echo "${remaining}" >&2

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Remove statically linked apply-seccomp helpers shipped with
+# @vscode/sandbox-runtime (and legacy @anthropic-ai/sandbox-runtime).
+#
+# Those musl/static ELFs fail Konflux fips-check (ErrNotDynLinked).
+# OpenShift workbenches cannot run the Linux agent sandbox anyway (no
+# bubblewrap/socat in the image; unshare is ENOSYS under nonroot-v2).
+#
+# RHOAIENG-88676 / RHAIENG-6849
+set -euo pipefail
+
+ROOT="${1:-/usr/lib/code-server}"
+if [[ ! -d "${ROOT}" ]]; then
+  echo "ERROR: usage: $0 <code-server-root> (directory not found: ${ROOT})" >&2
+  exit 1
+fi
+
+deleted=0
+while IFS= read -r -d '' dest; do
+  rm -f "${dest}"
+  deleted=$((deleted + 1))
+  echo "Removed apply-seccomp: ${dest}"
+done < <(find "${ROOT}" -type f -name apply-seccomp -print0 2>/dev/null)
+
+removed_dirs=0
+while IFS= read -r -d '' dir; do
+  rm -rf "${dir}"
+  removed_dirs=$((removed_dirs + 1))
+  echo "Removed seccomp vendor dir: ${dir}"
+done < <(find "${ROOT}" -type d \( \
+  -path '*/node_modules/@vscode/sandbox-runtime/vendor/seccomp' -o \
+  -path '*/node_modules/@vscode/sandbox-runtime/dist/vendor/seccomp' -o \
+  -path '*/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp' -o \
+  -path '*/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp' \
+\) -print0 2>/dev/null)
+
+if [[ "${deleted}" -eq 0 && "${removed_dirs}" -eq 0 ]]; then
+  echo "WARNING: no apply-seccomp files or seccomp vendor dirs under ${ROOT}" >&2
+else
+  echo "Removed ${deleted} apply-seccomp file(s) and ${removed_dirs} seccomp vendor dir(s)"
+fi
+
+remaining="$(find "${ROOT}" -type f -name apply-seccomp 2>/dev/null || true)"
+if [[ -n "${remaining}" ]]; then
+  echo "ERROR: apply-seccomp ELF still present after strip:" >&2
+  echo "${remaining}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Delete the statically linked `apply-seccomp` helpers from both code-server images after the release tree is copied, so Konflux `fips-check` no longer fails `ErrNotDynLinked`.
- Leave `scripts/check-payload/config.toml` and `docs/fips.md` unchanged; scanner-config cleanup is a follow-up PR.

## Test plan
- [x] Smoke-tested `strip-apply-seccomp.sh` on a fake code-server tree: `apply-seccomp` ELFs gone, `vendor/seccomp` dirs removed, `vendor/seccomp-src/*.c` kept.
- [x] `gmake test` run; failures were pre-existing (manifest vs pylock in a local worktree), not from these Dockerfiles.
- [ ] Konflux `fips-check` on `odh-workbench-codeserver-datascience-cpu-py312` after this lands.
- [ ] Built image: `find /usr/lib/code-server -type f -name apply-seccomp` is empty.

## Description
Konflux `fips-check` fails on `@vscode/sandbox-runtime/.../apply-seccomp` (`ErrNotDynLinked`). GitHub Actions already waives that path via `scan local`; Konflux uses payload-name matching and still lists stale `@anthropic-ai` paths. Removing the ELF from the image unblocks Konflux without waiting on check-payload.

See **Why `apply-seccomp` is unused on OpenShift workbenches** below.

Self checklist:
- [x] `gmake test` was run before review.
- [x] Konflux-specific `Dockerfile.konflux` changes only.

## Why `apply-seccomp` is unused on OpenShift workbenches

`apply-seccomp` is a vendored helper from `@vscode/sandbox-runtime` (0.0.1 on 3.6 EA1; older trees used `@anthropic-ai/sandbox-runtime`). It lives at `vendor/seccomp/<arch>/apply-seccomp`. Its job is to `unshare()` a new PID and mount namespace, load a seccomp-BPF filter, then `exec` the given command — the Linux half of Copilot’s agent sandbox.

The shipped ELF is statically linked (~832KB, musl). `check-payload` flags `ErrNotDynLinked`. It does no crypto. Static linking is so the helper can run on arbitrary Linux distros without a host libc, not because an OpenShift workbench lacks `ld-linux`.

### The sandbox is a stack; this image does not ship it

Copilot’s Linux agent sandbox needs more than this binary:

1. `bubblewrap` (`bwrap`) for namespaces and bind mounts
2. `socat` (listed as a sandbox dependency in the UI)
3. A kernel and container policy that allow `unshare` / `clone` with `CLONE_NEW*`
4. Optionally `apply-seccomp` inside that environment

The RHOAI/ODH code-server image installs neither `bubblewrap` nor `socat`. With `chat.agent.sandbox.enabled: "on"`, code-server shows **Missing Sandbox Dependencies**. Default terminals are ordinary shells. They are not wrapped with `apply-seccomp`.

### `unshare` is not available under the workbench SCC

Workbenches run as uid 1001 with `restricted-v2` / `nonroot-v2`. OpenShift’s seccomp profile does not allow unprivileged namespace creation. That is not the Debian `unprivileged_userns_clone` sysctl.

On `rhoai-3.6-ea.1` in a real workbench:

- `apply-seccomp bash` → `unshare(CLONE_NEWPID|CLONE_NEWNS): Function not implemented` (`ENOSYS`). The helper dies on its first syscall.
- Installing `bwrap` 0.6.3 and `socat` 1.7.4.1 into `~/.local/bin` (already on `PATH`) still fails: `bwrap --unshare-all` → no permission to create a namespace.
- uid 1001 cannot `mv` the root-owned ELF out of the way at runtime.

A dynamically linked rebuild would still call `unshare` and still get `ENOSYS`. Product `bwrap --ro-bind / /` would still expose the dynamic linker; static vs dynamic is irrelevant on this platform.

### What we are not removing

Interactive code-server, Python, notebooks, and user terminals do not go through this helper. Agent Linux sandbox was already non-functional (missing `bwrap`/`socat` **and** blocked `unshare`). Deleting the ELF does not disable a working product feature. `vendor/seccomp-src/*.c` stays (source only; not an executable).

This is not a plan to enable Copilot sandbox on OpenShift. That would need SCC/seccomp policy (and likely `bwrap`/`socat` in the image). That is a separate product decision.

## Merge criteria
- [x] Single focused commit.
- [x] Testing notes in this body.
- [ ] Developer has verified on a built Konflux/GHA image (CI).

## Plan

<details>
<summary>Plan</summary>

PR1 only: strip `apply-seccomp` at image build. Do not edit `config.toml` or `docs/fips.md`.

Add `codeserver/ubi9-python-3.12/prefetch-input/patches/strip-apply-seccomp.sh` (same style as `replace-aipcc-ripgrep.sh`):
- Root argument default `/usr/lib/code-server`
- Delete files named `apply-seccomp`
- Remove `vendor/seccomp` and `dist/vendor/seccomp` under `@vscode/sandbox-runtime` and `@anthropic-ai/sandbox-runtime`
- Fail the build if any `apply-seccomp` ELF remains
- Leave `vendor/seccomp-src/*.c`

Call it once as root in the `codeserver` stage immediately after copying the release tree:
- `codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu`
- `codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu`

Baseline COPY uses the codeserver patches path (repo-root build context). Cite [RHOAIENG-88676](https://redhat.atlassian.net/browse/RHOAIENG-88676) / [RHAIENG-6849](https://redhat.atlassian.net/browse/RHAIENG-6849).

No `.tekton/` edits.

Follow-up PR (not this change): GHA check-payload config vs upstream vs Konflux test image; then drop dead apply-seccomp waivers.

</details>

## Trajectory

<details>
<summary>Trajectory</summary>

Chronological session (27 Aug 2026), through PR open. Ticket keys only.

1. **Ask:** suggest a fix on `odh-main` for [RHOAIENG-88676](https://redhat.atlassian.net/browse/RHOAIENG-88676) (Konflux `fips-check` blocking `odh-workbench-codeserver-datascience-cpu-py312` on 3.6 EA1). Failing ELF: `/usr/lib/code-server/lib/vscode/node_modules/@vscode/sandbox-runtime/vendor/seccomp/x64/apply-seccomp` (`ErrNotDynLinked`, static, no crypto).
2. **Related tickets / Slack:** [RHAIENG-6849](https://redhat.atlassian.net/browse/RHAIENG-6849) (Vath spike: remove apply-seccomp), [RHAIENG-5898](https://redhat.atlassian.net/browse/RHAIENG-5898) (FIPS known/non-blocker). Thread in `#wg-3_6_ea1-openshift-ai-release`. Konflux had re-enabled `fips-check-blocking` (konflux-central PRs 3070–3072), so a known issue became a hard fail.
3. **Scanner mismatch:** GitHub CI runs `check-payload scan local --path` with this repo’s `scripts/check-payload/config.toml`. Global `[[ignore]]` already waives `@vscode/sandbox-runtime/**/seccomp`. Konflux uses payload-name matching; `[[payload.odh-workbench-codeserver-datascience-cpu-py312-rhel9.ignore]]` still lists only `@anthropic-ai/sandbox-runtime/.../apply-seccomp`. Live package is `@vscode/sandbox-runtime` 0.0.1. Upstream `openshift/check-payload` `config.toml` has the same stale `@anthropic-ai` payload paths. Deleting the ELF unblocks Konflux without waiting on check-payload or konflux-central.
4. **Rejected early options:** recompile apply-seccomp dynamically; memfd / `.incbin` scanner wrapper; add bubblewrap/socat to the **image**; CentOS GPG / Conforma work; treating Agent sandbox as working after the strip.
5. **Alternate path considered:** user pasted a “recompile from sources” write-up (static musl helper vs RHEL dynlink / FIPS). Explored on **msg-qe-11**: binary ~832KB static; sources at `vendor/seccomp-src/{apply-seccomp.c,seccomp-unix-block.c}`; no `unix-block-bpf.h` in the npm tree. A dynamic rebuild on that host worked (~18KB, `libc.so.6` only) but was left **out of scope**.
6. **Image facts (msg-qe-11 + OpenShift `ntbcudashrd` project `jdanek`):** tag `quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9:rhoai-3.6-ea.1`. Jira digest `sha256:45cce80…` is **ppc64le**; amd64 is `sha256:f221472cff6b90bce6f9ffd8b5f5c894b857aee5c7a3f40757ee83dc78035c85`. `git.commit` `bf956c0ad0342d3043f54110f65e205a73b26b35`, version `v3.6.0-ea.1`. No `bubblewrap` / `socat` RPMs in the image.
7. **Cluster:** imported Konflux image as ImageStream `codeserver-rhoai-36-ea1-fips:rhoai-3.6-ea.1`. Workbench `codeserver36ea1prerc1ish`. OpenShift probe / `nonroot-v2`: `unshare(CLONE_NEWPID|CLONE_NEWNS)` → `ENOSYS`. Debian `unprivileged_userns_clone` sysctl is the wrong advice for this platform.
8. **Product `bwrap` note:** product bubblewrap would `--ro-bind / /`, so a dynlinked helper would still see `ld-linux`. Static link is musl/glibc portability, not “missing linker in product bwrap.”
9. **FROM-build experiment:** user asked for a project-specific workbench with the static binary deleted. Built `codeserver-no-apply-seccomp:latest` (`sha256:bcf5b102…`) stripping apply-seccomp; patched the Notebook to that image. Binary gone except `seccomp-src/*.c`.
10. **Chrome / code-server UI:** Copilot `chat.agent.sandbox.enabled: "on"` → **Missing Sandbox Dependencies** (bwrap/socat). Copilot wrongly claimed “no sudo = sandbox” and that terminals start with `apply-seccomp bash` (user had run that by hand on the **old** image).
11. **Stock image as uid 1001:** `mv …/apply-seccomp …bck` → Permission denied (root-owned). Confirmed only a new image can drop the ELF.
12. **User-run on stock image:** `apply-seccomp bash` → `unshare(CLONE_NEWPID|CLONE_NEWNS): Function not implemented`.
13. **Copilot logs:** Git extension / Copilot token / BYOK providers; sandbox feature waiting on token; user offered to handle GitHub login if it appeared.
14. **User-space bwrap/socat (not for the product image):** user asked for pasteable install commands (`sudo apt` is not available in the workbench). Installed into `~/.local/bin` (already on PATH). `bwrap --version` 0.6.3, `socat` 1.7.4.1. `bwrap --unshare-all` then failed: **no permission to create namespace**. Agent sandbox still **not** running. Do not add bwrap/socat to the image as part of this FIPS PR.
15. **Plan request:** fix the two issues by deleting the seccomp binary during Docker build (Vath). First plan also cleaned `config.toml` / `docs/fips.md`.
16. **Config question:** can GHA use Konflux’s check-payload config? Konflux does **not** mount this repo’s TOML; it uses the default config baked into the Konflux test image (same family as `openshift/check-payload` `config.toml`, public). Releng `red-hat-data-services/fips-compliance` is for FBC/release scans, not notebooks GHA. This repo’s TOML is a fork plus footer because GHA is `scan local` (empty payload name → `[[payload.*]]` never matches). `quay.io/konflux-ci/konflux-test` is public; this repo already documented it as too large (~1.3 GB vs ~50 MB slim image).
17. **Split PRs:** (1) remove seccomp; (2) `config.toml` later, decide just-in-time: keep fork, use upstream TOML unchanged, or scan with the Konflux test image.
18. **PR body convention:** `## Plan` and `## Trajectory` in collapsed `<details>` (no `open` attribute). No full URLs in the PR text.
19. **Implementation:** `strip-apply-seccomp.sh`; RUN after release COPY in both Konflux CPU Dockerfiles; script removed from `/tmp` after run. Stashed off `chore/pylocks-header-exclude-newer`, branched from `origin/main` as `fix/RHOAIENG-88676-strip-apply-seccomp`.
20. **Verify:** fake-tree smoke test OK. `gmake test` (GNU Make 4.x): 33 failures from a local `.claude/worktrees/…` tree / imagestream vs pylock, not these Dockerfiles. Did not hermetic-build the full codeserver image locally.
21. **Land:** commit `RHOAIENG-88676 [RHAIENG-6849](https://redhat.atlassian.net/browse/RHAIENG-6849): fix(codeserver): strip apply-seccomp from the image` (3 files, +58). Pushed to `origin`. Opened as PR 4457. Follow-up PR for scanner config not in this change.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container image builds by reliably removing unnecessary security-related components and legacy vendor files.
  - Added validation to detect incomplete cleanup and report build issues clearly.
  - Improved handling of cleanup failures to prevent silently producing incomplete images.

- **Maintenance**
  - Standardized cleanup execution across supported Python-based code-server images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[RHOAIENG-88676]: https://redhat.atlassian.net/browse/RHOAIENG-88676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ