### PR TITLE
test: add conftest.py autouse fixture to clear Jira env vars in CVE tests

### DIFF
--- a/tests/unit/scripts/cve/conftest.py
+++ b/tests/unit/scripts/cve/conftest.py
@@ -1,0 +1,25 @@
+"""Shared test fixtures for the CVE scripts unit tests.
+
+Clears all Jira-related environment variables before every test so that a
+developer's local environment cannot leak into assertions. Each test then only
+needs to ``monkeypatch.setenv`` the variables it explicitly requires.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_jira_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove Jira env vars that would otherwise leak from a developer shell."""
+    for var in (
+        "JIRA_EMAIL",
+        "JIRA_API_TOKEN",
+        "JIRA_TOKEN",
+        "JIRA_OAUTH_CLIENT_SECRET",
+        "JIRA_RHAIENG_TEAM_OPTION_ID",
+        "JIRA_RHAIENG_EXTRA_CONTRIBUTORS",
+        "JIRA_RUNNER_ACCOUNT_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
## Summary

Adds `tests/unit/scripts/cve/conftest.py` with an `autouse=True` fixture that clears all Jira-related environment variables before each test, so:

- Tests no longer need to remember which env vars to clear (currently ~16 `monkeypatch.delenv` calls in `test_jira_auth.py` alone, plus repeated cleanup in `test_create_cve_trackers.py` and `test_create_cve_trackers_fields.py`)
- Missing one var no longer causes flaky failures when a developer has it set locally
- Adding a new env var to production code only requires updating one conftest instead of every test

The fixture uses `monkeypatch.delenv(var, raising=False)`, so it is a no-op when the var is unset. Each test still `setenv`s only the vars it explicitly requires.

## Changes

- New file: `tests/unit/scripts/cve/conftest.py`

## Acceptance criteria

- [x] All Jira env vars listed in the issue are cleared before each test
- [x] Autouse fixture applies to every test in the directory
- [x] `monkeypatch.delenv(..., raising=False)` — safe when var is unset
- [x] No changes to existing test logic (cleanup is now centralized)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing Jira-related environment settings before each test.
  * Tests must now explicitly define any environment values they require.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->