### PR TITLE
ci: migrate local action/workflow references from ./ to $/ self-repository syntax

### DIFF
--- a/.github/actions/provision-k8s/action.yml
+++ b/.github/actions/provision-k8s/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install prerequisites
-      uses: ./.github/actions/apt-install
+      uses: $/.github/actions/apt-install
       with:
         packages: software-properties-common curl
 

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -110,7 +110,7 @@ jobs:
       # do this early because it's fast and why not
       - name: Install git-crypt
         if: ${{ inputs.subscription }}
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: git-crypt
 
@@ -413,7 +413,7 @@ jobs:
       # Single place we install from uv.lock (dev deps include structlog for scripts/sandbox.py).
       # Make and later pytest steps all use this venv.
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install from uv.lock (project + dev deps)
         run: uv sync --group dev --locked
@@ -465,7 +465,7 @@ jobs:
 
       - name: Run Playwright tests
         if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' && steps.browser-tests-image.outcome == 'success' }}
-        uses: ./.github/actions/playwright-test
+        uses: $/.github/actions/playwright-test
         with:
           test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
           playwright-image: ${{ steps.browser-tests-image.outputs.image }}
@@ -539,7 +539,7 @@ jobs:
       - name: Provision K8s cluster
         id: provision-k8s
         if: ${{ !cancelled() && steps.make-target.outcome == 'success' && steps.have-tests.outputs.tests == 'true' }}
-        uses: ./.github/actions/provision-k8s
+        uses: $/.github/actions/provision-k8s
 
       - name: "Run image tests"
         id: makefile-tests
@@ -632,7 +632,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: ${{ !cancelled() && steps.resolve-target.outputs.target }}
-        uses: ./.github/actions/trivy-scan-action
+        uses: $/.github/actions/trivy-scan-action
         with:
           scan-type: ${{ steps.resolve-target.outputs.type }}
           scan-target: ${{ steps.resolve-target.outputs.target }}
@@ -669,6 +669,6 @@ jobs:
 
       - name: Capture kernel logs on failure
         if: "${{ failure() }}"
-        uses: ./.github/actions/capture-kernel-logs
+        uses: $/.github/actions/capture-kernel-logs
         with:
           log-prefix: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}"

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: "${{ fromJson(needs.gen.outputs.matrix) }}"
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     if: ${{ fromJson(needs.gen.outputs.has_jobs) }}
     with:
       target: "${{ matrix.target }}"

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: "${{ fromJson(needs.gen.outputs.matrix) }}"
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     if: ${{ fromJson(needs.gen.outputs.has_jobs) }}
     with:
       target: "${{ matrix.target }}"

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: "${{ fromJson(needs.gen.outputs.matrix) }}"
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     if: ${{ fromJson(needs.gen.outputs.has_jobs) && github.repository != 'red-hat-data-services/notebooks' }}
     with:
       target: "${{ matrix.target }}"
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: "${{ fromJson(needs.gen.outputs.matrix) }}"
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     if: ${{ fromJson(needs.gen.outputs.has_jobs) && needs.gen.outputs.is_fork == 'false' }}
     with:
       target: "${{ matrix.target }}"

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: "${{ fromJson(needs.gen.outputs.matrix) }}"
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     if: ${{ (inputs.odh || (github.event_name != 'workflow_dispatch' && github.repository != 'red-hat-data-services/notebooks')) && fromJson(needs.gen.outputs.has_jobs) }}
     with:
       target: "${{ matrix.target }}"
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: "${{ fromJson(needs.gen.outputs.matrix) }}"
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     if: ${{ (inputs.rhds || (github.event_name != 'workflow_dispatch' && github.repository == 'red-hat-data-services/notebooks')) && fromJson(needs.gen.outputs.has_jobs) }}
     with:
       target: "${{ matrix.target }}"

--- a/.github/workflows/check-image-availability.yaml
+++ b/.github/workflows/check-image-availability.yaml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install skopeo
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
           update: 'false'
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Check ODH image availability
         id: check

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -32,10 +32,10 @@ jobs:
           git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install skopeo
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
 
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Check uv is installed correctly
         run: uv version
@@ -257,7 +257,7 @@ jobs:
         run: rm -rf ./ci/secrets
 
       - name: Install linting tools
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: yamllint yajl-tools wget
 
@@ -307,7 +307,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-uv
+      - uses: $/.github/actions/setup-uv
       - name: "Install workspace packages for prek"
         run: uv sync --locked --all-packages
       - name: "Cache prek"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Run the release notes script
         run: |

--- a/.github/workflows/lock-renewal.yaml
+++ b/.github/workflows/lock-renewal.yaml
@@ -76,10 +76,10 @@ jobs:
           echo "RENEWAL_BRANCH=$BRANCH_NAME" >> "${GITHUB_ENV}"
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install skopeo
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
 
@@ -150,7 +150,7 @@ jobs:
       # install-podman-action runs `sudo podman system reset`, which can leave
       # root-owned files under $HOME/.config/containers and break a later cp.
       - name: Install git-crypt
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: git-crypt
 
@@ -196,7 +196,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Podman
-        uses: ./.github/actions/install-podman-action
+        uses: $/.github/actions/install-podman-action
         with:
           platform: linux/amd64
 

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install dependencies
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: ${{ matrix.packages }}
           update: 'false'

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -69,10 +69,10 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install skopeo
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
 

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Install skopeo
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
       - name: Get Pull Request Number

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -68,10 +68,10 @@ jobs:
           echo "KICKOFF_BRANCH=$BRANCH_NAME" >> "${GITHUB_ENV}"
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install skopeo and git-crypt
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo git-crypt
 
@@ -271,7 +271,7 @@ jobs:
           fi
 
       - name: Install Podman
-        uses: ./.github/actions/install-podman-action
+        uses: $/.github/actions/install-podman-action
         with:
           platform: linux/amd64
 

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -76,10 +76,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install git-crypt
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: git-crypt
           update: "false"

--- a/.github/workflows/rpms-lock-renewal.yaml
+++ b/.github/workflows/rpms-lock-renewal.yaml
@@ -70,7 +70,7 @@ jobs:
       # root-owned files under $HOME/.config/containers and break a later cp.
       - name: Install git-crypt
         if: env.VARIANT == 'rhds'
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: git-crypt
 
@@ -114,7 +114,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Podman
-        uses: ./.github/actions/install-podman-action
+        uses: $/.github/actions/install-podman-action
         with:
           platform: linux/amd64
 

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: true
 
       - name: Install Skopeo CLI
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
 

--- a/.github/workflows/software-versions.yaml
+++ b/.github/workflows/software-versions.yaml
@@ -33,13 +33,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install dependencies
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo git-crypt
           update: 'false'
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Unlock encrypted secrets with git-crypt
         run: |

--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test-template-minimal:
     name: Test Template with Minimal Notebook
-    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    uses: $/.github/workflows/build-notebooks-TEMPLATE.yaml
     with:
       target: jupyter-minimal-ubi9-python-3.12
       python: "3.12"

--- a/.github/workflows/test-capture-kernel-logs.yaml
+++ b/.github/workflows/test-capture-kernel-logs.yaml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Capture kernel logs
         # condition this if: ${{ failure() }}
-        uses: ./.github/actions/capture-kernel-logs
+        uses: $/.github/actions/capture-kernel-logs
         with:
           log-prefix: test-capture

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install deps
         run: uv sync --locked
@@ -173,7 +173,7 @@ jobs:
 
       - name: Capture kernel logs on failure
         if: ${{ failure() }}
-        uses: ./.github/actions/capture-kernel-logs
+        uses: $/.github/actions/capture-kernel-logs
         with:
           log-prefix: ${{ matrix.name }}
 
@@ -190,7 +190,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Install deps
         run: uv sync --locked
@@ -203,7 +203,7 @@ jobs:
           platform: linux/amd64
 
       - name: Provision K8s cluster
-        uses: ./.github/actions/provision-k8s
+        uses: $/.github/actions/provision-k8s
 
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0

--- a/.github/workflows/test-playwright-action.yaml
+++ b/.github/workflows/test-playwright-action.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install missing dependencies
         if: steps.detect-packages.outputs.packages != ''
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: ${{ steps.detect-packages.outputs.packages }}
 
@@ -132,7 +132,7 @@ jobs:
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Run Playwright tests
-        uses: ./.github/actions/playwright-test
+        uses: $/.github/actions/playwright-test
         with:
           test-target: ${{ steps.get-image.outputs.image }}
           playwright-image: ${{ steps.browser-tests-image.outputs.image }}

--- a/.github/workflows/test-provision-k8s.yaml
+++ b/.github/workflows/test-provision-k8s.yaml
@@ -24,4 +24,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Provision K8s cluster
-        uses: ./.github/actions/provision-k8s
+        uses: $/.github/actions/provision-k8s

--- a/.github/workflows/test-setup-uv.yaml
+++ b/.github/workflows/test-setup-uv.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Verify uv version matches pyproject.toml
         run: uv version

--- a/.github/workflows/test-trivy-scan-action.yaml
+++ b/.github/workflows/test-trivy-scan-action.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install missing dependencies
         if: steps.detect-packages.outputs.packages != ''
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: ${{ steps.detect-packages.outputs.packages }}
 
@@ -67,7 +67,7 @@ jobs:
           sudo podman images
 
       - name: Test Trivy scan on container image (full scan)
-        uses: ./.github/actions/trivy-scan-action
+        uses: $/.github/actions/trivy-scan-action
         with:
           scan-type: image
           scan-target: ${{ env.TEST_IMAGE }}
@@ -77,7 +77,7 @@ jobs:
       # This is used for CentOS Stream images which are not supported by Trivy
       # See: https://github.com/opendatahub-io/notebooks/issues/2848
       - name: Test Trivy scan on container image (library only, skip OS packages)
-        uses: ./.github/actions/trivy-scan-action
+        uses: $/.github/actions/trivy-scan-action
         with:
           scan-type: image
           scan-target: ${{ env.TEST_IMAGE }}
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Test Trivy scan on filesystem
-        uses: ./.github/actions/trivy-scan-action
+        uses: $/.github/actions/trivy-scan-action
         with:
           scan-type: fs
           scan-target: './'

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -68,13 +68,13 @@ jobs:
           echo "update_branch=${update_branch}" >> "${GITHUB_OUTPUT}"
 
       - name: Install skopeo
-        uses: ./.github/actions/apt-install
+        uses: $/.github/actions/apt-install
         with:
           packages: skopeo
           update: 'false'
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Configure Quay.io pull auth for RHOAI namespace
         if: env.RHOAI_QUAY_BOT_USERNAME != ''

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+        uses: $/.github/actions/setup-uv
 
       - name: Validate renovate.json5 semantics
         run: ./uv run python scripts/ci/validate_renovate_config.py


### PR DESCRIPTION
## Summary

Migrates `uses: ./...` references to the new GitHub Actions `$/` self-repository syntax across 27 workflow/action files (62 references: 54 composite actions + 8 reusable workflows).

## Why

The `uses: ./...` syntax has two drawbacks `$/` fixes (per [GitHub changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)):
1. It requires an `actions/checkout` step to have already run (reads whatever is on disk rather than resolving via git ref)
2. For reusable workflows called from another repo with a pinned SHA, `./` resolves to whatever ref the caller's checkout used — not necessarily the pinned SHA, quietly defeating SHA pinning. `$/` resolves to the exact commit the running workflow was invoked at.

## Changes

Mechanical find-and-replace across 27 files:
- `uses: ./.github/actions/...` → `uses: $/.github/actions/...`
- `uses: ./.github/workflows/...` → `uses: $/.github/workflows/...`

No behavior change on `github.com`-hosted runs. GitHub-hosted runners meet the 2.336.0+ requirement; the repo's only self-hosted-labeled workflow (`renovate-self-hosted.yaml`) has no local `uses: ./` references that block this.

## Verification

- All 27 affected files updated successfully (0 failures)
- Replacement is literal `uses: ./` → `uses: $/` only