### PR TITLE
fix(ntb): insert a blank line after heredoc EOF before ### END

### DIFF
--- a/ntb/strings.py
+++ b/ntb/strings.py
@@ -130,6 +130,13 @@ def blockinfile(
     new_contents = contents.lstrip("\n").splitlines(keepends=True)
     if new_contents and new_contents[-1] == "\n":
         new_contents = new_contents[:-1]
+    # Hadolint fails with "unexpected '#' expecting a new line followed by the
+    # next instruction" when ### END sits immediately after a HEREDOC terminator.
+    # Fragments that close the string on the same line as EOF (`EOF"""`) have no
+    # trailing newline, so the `\n` before end_marker would otherwise only
+    # terminate the EOF line instead of inserting a blank line.
+    if new_contents and new_contents[-1].rstrip("\n") == "EOF":
+        new_contents[-1] = "EOF\n"
     if begin == end == -1:
         # no markers found
         return
@@ -164,3 +171,13 @@ class TestBlockinfile:
         blockinfile("/config.txt", "key=value\n\n")
 
         assert fs.get_object("/config.txt").contents == "hello\nworld\n### BEGIN\nkey=value\n\n### END\n"
+
+    def test_heredoc_eof_gets_blank_line_before_end(self, fs: FakeFilesystem):
+        """Hadolint requires a blank line after a Dockerfile HEREDOC terminator."""
+        fs.create_file("/Dockerfile", contents="FROM x\n### BEGIN frag\n### END frag\n")
+
+        blockinfile("/Dockerfile", "RUN <<'EOF'\necho hi\nEOF", prefix="frag")
+
+        assert fs.get_object("/Dockerfile").contents == (
+            "FROM x\n### BEGIN frag\nRUN <<'EOF'\necho hi\nEOF\n\n### END frag\n"
+        )


### PR DESCRIPTION
Hadolint rejects a comment immediately after a Dockerfile heredoc terminator. Normalize fragments that end on EOF so regen always emits the required blank line.

follow up for: https://github.com/opendatahub-io/notebooks/pull/4459

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured Dockerfile HEREDOC content includes the required trailing blank line before the closing marker.

* **Tests**
  * Added regression coverage for the HEREDOC formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->