### PR TITLE
NO-JIRA: docs(AGENTS.md): add instructions for overriding entrypoint in container images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,23 @@ Key CI files:
 - `ci/` - Custom CI scripts and configurations
 - `scripts/ci/renovate_run.py` - Self-hosted Renovate (Podman or Docker via `CONTAINER_ENGINE`, same detection order as the Makefile); see `.github/workflows/renovate-self-hosted.yaml` and ADR 0013
 
+### Running Container Images
+
+Notebook images have an entrypoint (`start-notebook.sh`) that launches
+Jupyter Lab.  When you need to inspect the image (check installed RPMs,
+list files, run a shell), **override the entrypoint**:
+
+```bash
+# Interactive shell — won't start Jupyter
+podman run --rm -it --entrypoint="" quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.12-latest bash
+
+# One-off command
+podman run --rm --entrypoint="" <image> rpm -qa | sort
+```
+
+Without `--entrypoint=""`, `podman run <image> rpm -qa` is passed as
+arguments to `start-notebook.sh`, which ignores them and starts Jupyter.
+
 ### Deployment
 
 1. **Local Development**:


### PR DESCRIPTION
- Document how to override `start-notebook.sh` entrypoint for Jupyter Lab images using `--entrypoint=""`.
- Provide examples for launching an interactive shell or running one-off commands.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for inspecting notebook container images by overriding the default entrypoint.
  * Included interactive shell and one-off command examples.
  * Clarified container behavior when the entrypoint is not overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->