### PR TITLE
fix: NO-JIRA: check-params-env.sh fallback release-suffix regex i

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -695,7 +695,7 @@ function check_image_variable_matches_name_and_commitref_and_size() {
             # Rollout automation rewrites released workbench keys with numeric
             # release suffixes (for example '-3-5', '-3-6'). Keep this check
             # forward-compatible instead of hardcoding every new release key.
-            if [[ "${image_variable}" =~ ^(odh-workbench-[a-z0-9-]+-py312-ubi9)-[0-9]+-[0-9]+$ ]]; then
+            if [[ "${image_variable}" =~ ^(odh-workbench-[a-z0-9-]+-py312-ubi9)-[0-9]{1,2}-[0-9]+$ ]]; then
                 local image_base
                 image_base="${BASH_REMATCH[1]}"
 


### PR DESCRIPTION
Fixes #4236

Tightened the fallback `case *)` regex in `ci/check-params-env.sh` from `[0-9]+` to `[0-9]{1,2}` for the release-major group so year-style keys (e.g. `-2026-1`) no longer match the rollout-automation path and instead fall through to the clearer unimplemented-variable error.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for workbench image identifiers with release suffixes containing one- or two-digit numeric components.
  * Image names such as `-3-5` and `-10-2` are now recognized correctly for supported UBI9 and C9S images.
  * Prevents valid released workbench image identifiers from being incorrectly rejected during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->