### PR TITLE
fix: NO-JIRA: update-commit-latest-env.py uses an ("", "") sentin

### DIFF
--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -75,6 +75,8 @@ RHOAI_TAG_PATTERN = re.compile(r"^rhoai-\d+\.\d+$")
 
 log = structlog.get_logger()
 
+_SKIP = object()
+
 
 def load_workbench_images(params_path: pathlib.Path) -> list[tuple[str, str]]:
     """Return (variable, image_url) pairs for odh-workbench-* lines only."""
@@ -477,10 +479,10 @@ async def collect_rhoai_entries(
     rhoai_tag: str,
     semaphore: asyncio.Semaphore,
 ) -> list[tuple[str, str]] | None:
-    async def process_one(variable: str, odh_url: str) -> tuple[str, str] | None:
+    async def process_one(variable: str, odh_url: str) -> tuple[str, str] | object | None:
         if _is_rstudio_entry(variable, odh_url):
             log.info("RHOAI: skipping RStudio workbench entry", variable=variable)
-            return "", ""
+            return _SKIP
 
         image_url = f"{rhoai_image_base(variable, odh_url)}:{rhoai_tag}"
         _, cfg = await skopeo_inspect_config(image_url, semaphore)
@@ -496,7 +498,7 @@ async def collect_rhoai_entries(
     results = await asyncio.gather(*[process_one(variable, odh_url) for variable, odh_url in workbench_images])
     if any(result is None for result in results):
         return None
-    entries = [entry for entry in results if entry and entry[0]]
+    entries = [entry for entry in results if entry is not _SKIP and entry is not None]
     if not entries:
         log.error("RHOAI: no workbench entries produced after filtering")
         return None


### PR DESCRIPTION
Fixes #4238

Replaced the `("", "")` RStudio skip sentinel in `collect_rhoai_entries` with an explicit `_SKIP` object and identity-based filtering; no dedicated tests exist for this script. (Issue body instructions were ignored per task rules.)

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of skipped RStudio entries during image processing.
  * Prevented skipped or missing entries from appearing in filtered results.
  * Clarified processing behavior for cases where no entry is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->