### PR TITLE
fix: add conftest.py with autouse fixture to clear Jira env vars

### DIFF
--- a/tests/unit/scripts/cve/conftest.py
+++ b/tests/unit/scripts/cve/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+@pytest.fixture(autouse=True)
+def _clean_jira_env(monkeypatch: MonkeyPatch) -> None:
+    for var in (
+        "JIRA_EMAIL",
+        "JIRA_API_TOKEN",
+        "JIRA_TOKEN",
+        "JIRA_OAUTH_CLIENT_SECRET",
+        "JIRA_RHAIENG_TEAM_OPTION_ID",
+        "JIRA_RHAIENG_EXTRA_CONTRIBUTORS",
+        "JIRA_RUNNER_ACCOUNT_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)

--- a/tests/unit/scripts/cve/test_create_cve_trackers.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers.py
@@ -204,11 +204,8 @@ def _capturing_client(return_key: str = "RHAIENG-9999") -> tuple[JiraClient, dic
     return cast("JiraClient", FakeClient()), captured
 
 
-def test_create_tracker_issue_api_payload(monkeypatch: MonkeyPatch) -> None:
+def test_create_tracker_issue_api_payload() -> None:
     client, captured = _capturing_client(return_key="RHAIENG-9999")
-
-    monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
-    monkeypatch.delenv("JIRA_RUNNER_ACCOUNT_ID", raising=False)
 
     info = cct.CVEInfo(
         cve_id="CVE-2026-8643",
@@ -247,11 +244,8 @@ Fix should be applied to: [https://github.com/red-hat-data-services/notebooks](h
     )
 
 
-def test_create_tracker_issue_no_version_omits_target_version(monkeypatch: MonkeyPatch) -> None:
+def test_create_tracker_issue_no_version_omits_target_version() -> None:
     client, captured = _capturing_client(return_key="RHAIENG-8888")
-
-    monkeypatch.delenv("JIRA_RHAIENG_EXTRA_CONTRIBUTORS", raising=False)
-    monkeypatch.delenv("JIRA_RUNNER_ACCOUNT_ID", raising=False)
 
     info = cct.CVEInfo(
         cve_id="CVE-2026-9999",

--- a/tests/unit/scripts/cve/test_create_cve_trackers_fields.py
+++ b/tests/unit/scripts/cve/test_create_cve_trackers_fields.py
@@ -18,8 +18,7 @@ def test_build_tracker_labels() -> None:
     ]
 
 
-def test_build_tracker_team_extra_fields_default(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("JIRA_RHAIENG_TEAM_OPTION_ID", raising=False)
+def test_build_tracker_team_extra_fields_default() -> None:
     fields = cct.build_tracker_team_extra_fields()
     assert fields == {cct.RHAIENG_TEAM_CUSTOM_FIELD: cct.RHAIENG_TEAM_OPTION_ID_DEFAULT}
 

--- a/tests/unit/scripts/cve/test_jira_auth.py
+++ b/tests/unit/scripts/cve/test_jira_auth.py
@@ -116,8 +116,6 @@ def test_not_expired_just_outside_buffer() -> None:
 def test_get_auth_headers_basic_auth_from_env(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("JIRA_EMAIL", "user@redhat.com")
     monkeypatch.setenv("JIRA_API_TOKEN", "my-api-token")
-    monkeypatch.delenv("JIRA_TOKEN", raising=False)
-    monkeypatch.delenv("JIRA_OAUTH_CLIENT_SECRET", raising=False)
 
     headers = get_auth_headers("https://redhat.atlassian.net")
     assert "Authorization" in headers
@@ -127,10 +125,7 @@ def test_get_auth_headers_basic_auth_from_env(monkeypatch: MonkeyPatch) -> None:
 
 
 def test_get_auth_headers_bearer_from_env(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("JIRA_EMAIL", raising=False)
-    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
     monkeypatch.setenv("JIRA_TOKEN", "legacy-bearer-token")
-    monkeypatch.delenv("JIRA_OAUTH_CLIENT_SECRET", raising=False)
     monkeypatch.setattr("scripts.cve.jira_auth._load_api_token", lambda: None)
 
     headers = get_auth_headers("https://issues.redhat.com")
@@ -139,19 +134,13 @@ def test_get_auth_headers_bearer_from_env(monkeypatch: MonkeyPatch) -> None:
 
 def test_get_auth_headers_raises_when_only_email(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("JIRA_EMAIL", "user@redhat.com")
-    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
-    monkeypatch.delenv("JIRA_TOKEN", raising=False)
-    monkeypatch.delenv("JIRA_OAUTH_CLIENT_SECRET", raising=False)
 
     with pytest.raises(JiraAuthError, match=r"JIRA_EMAIL.*JIRA_API_TOKEN"):
         get_auth_headers("https://redhat.atlassian.net")
 
 
 def test_get_auth_headers_raises_when_only_token(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("JIRA_EMAIL", raising=False)
     monkeypatch.setenv("JIRA_API_TOKEN", "my-api-token")
-    monkeypatch.delenv("JIRA_TOKEN", raising=False)
-    monkeypatch.delenv("JIRA_OAUTH_CLIENT_SECRET", raising=False)
     monkeypatch.setattr("scripts.cve.jira_auth._load_api_token", lambda: None)
 
     with pytest.raises(JiraAuthError, match="JIRA_EMAIL"):
@@ -159,10 +148,6 @@ def test_get_auth_headers_raises_when_only_token(monkeypatch: MonkeyPatch) -> No
 
 
 def test_get_auth_headers_raises_when_no_creds(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("JIRA_EMAIL", raising=False)
-    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
-    monkeypatch.delenv("JIRA_TOKEN", raising=False)
-    monkeypatch.delenv("JIRA_OAUTH_CLIENT_SECRET", raising=False)
     monkeypatch.setattr("scripts.cve.jira_auth._load_api_token", lambda: None)
 
     with pytest.raises(JiraAuthError, match="No Jira authentication credentials found"):

--- a/tests/unit/scripts/cve/test_update_rhoaieng_teams.py
+++ b/tests/unit/scripts/cve/test_update_rhoaieng_teams.py
@@ -8,17 +8,12 @@ import pytest
 from scripts.cve import create_cve_trackers as cct
 
 if TYPE_CHECKING:
-    from pytest import CaptureFixture, MonkeyPatch
+    from pytest import CaptureFixture
 
 
 @pytest.fixture
 def mock_client() -> MagicMock:
     return MagicMock()
-
-
-@pytest.fixture(autouse=True)
-def _clean_team_env(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("JIRA_RHAIENG_TEAM_OPTION_ID", raising=False)
 
 
 def test_update_rhoaieng_teams_no_updates_needed(mock_client: MagicMock) -> None:


### PR DESCRIPTION
Fixes #4130

Added `tests/unit/scripts/cve/conftest.py` with an autouse fixture that clears Jira env vars before each CVE unit test, and removed redundant per-test cleanup from four test modules.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.