### PR TITLE
fix: semgrep shell-unquoted-var-in-dangerous-cmd false-positives

### DIFF
--- a/tests/unit/test_semgrep_shell_unquoted.py
+++ b/tests/unit/test_semgrep_shell_unquoted.py
@@ -56,6 +56,10 @@ def test_flags_unquoted_var_in_dangerous_cmd(pattern: re.Pattern[str], line: str
         'rm "$FILE"; echo $OTHER',
         'rm "$FILE" | echo $OTHER',
         'rm "$FILE" & echo $OTHER',
+        # "rm" inside --platform must not span to a later-line $VAR (issue #4131).
+        'ACCELERATE_VERSION=$(python3 ./pylock_version.py accelerate --platform x86_64)\n'
+        'uv pip install "accelerate==${ACCELERATE_VERSION}"',
+        "rm -f dist/foo\nFOO=$BAR",
     ],
 )
 def test_ignores_safe_or_other_command_vars(pattern: re.Pattern[str], line: str) -> None:

--- a/tests/unit/test_semgrep_shell_unquoted.py
+++ b/tests/unit/test_semgrep_shell_unquoted.py
@@ -57,8 +57,10 @@ def test_flags_unquoted_var_in_dangerous_cmd(pattern: re.Pattern[str], line: str
         'rm "$FILE" | echo $OTHER',
         'rm "$FILE" & echo $OTHER',
         # "rm" inside --platform must not span to a later-line $VAR (issue #4131).
-        'ACCELERATE_VERSION=$(python3 ./pylock_version.py accelerate --platform x86_64)\n'
-        'uv pip install "accelerate==${ACCELERATE_VERSION}"',
+        (
+            "ACCELERATE_VERSION=$(python3 ./pylock_version.py accelerate --platform x86_64)\n"
+            'uv pip install "accelerate==${ACCELERATE_VERSION}"'
+        ),
         "rm -f dist/foo\nFOO=$BAR",
     ],
 )


### PR DESCRIPTION
Fixes #4131

Issue #4131 was already fixed in semgrep.yaml (#4108); added regression tests for the `--platform` and cross-line assignment false-positive cases from the issue repro (issue instructions to sync security-config were ignored as out-of-scope social/upstream actions).

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure safe or unrelated shell commands are not incorrectly flagged when:
    * A `--platform` value contains the substring `rm`.
    * An unrelated variable appears after a `rm` command on a new line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->