### PR TITLE
updated the 3.5 images with the official once RHAIENG-6691

### DIFF
--- a/manifests/rhoai/base/params.env
+++ b/manifests/rhoai/base/params.env
@@ -1,17 +1,14 @@
-# TODO: Update the hashes after 3.5 official release, these values fetched from
-# https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/rhoai-3.5/bundle/manifests/rhods-operator.clusterserviceversion.yaml
-odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:fcc88f6ac8cd95529fa628f099ad2e8efafc1b86a9cc75231e884dd228bb7551
-odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:6665b7535f585e3cea5b82d21f1f31af3e6c71010cea3a93f6761bdcd2bb8681
-odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:86b6aa368b8bdafb2a635c9baabae90ce86a6d706c4bf766a8ad2b0e3d4512da
-odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:cb2ada31cbac556ecc0a36b0769fd2fcd9271734338bb2a9f4edbbf45053f30d
-odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:b88d771fc5659eed82eaca29d3e26ed962fdb4fee426d333001031431d17b260
-odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:ee52b460479e67e2f73618c451f57d8216104d37f2c730c1a88a0da0d593e613
-odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:f6ecb02b9f8fcf11d0f2297be61031414aff96f4c3bc3af265d8781143164da5
-odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:b11e3331470879c2c1c3b0366a4cecabdffc789fe4c2d4e6550d00dae24ca0dc
-odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:3e428f81eaa9f81ac75c6b1c970cbe54458c438b3a87707de4636db374f7abe2
-odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:b889cf7107d1bfe5ebad71738b5d936b05c3783f213aa9eb886ec44b56fb9680
-odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:aab713109d63674d3a726b30a6fe2bd6b611c13f183a65d3feeac238f7107db3
-
+odh-workbench-codeserver-datascience-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:96a22d9697b6b57d639c9801c6d834f48b3a42316b9c508f3a2cd55ed497085c
+odh-workbench-jupyter-datascience-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:bc8502bebfc7b07b54960545aa60377a1c67008418c8a5b11dcd4595dae85076
+odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:4e0c3457dc3d9fd552a367f0d17f838e7021f0b479a0a1f4bfeacb7fda6375e0
+odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:2bb6a58b9455f1ca48793955a0ab4b9f4429fbbf3b6d99a5eee102f0c29a7bcd
+odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:f0e01346fd678d592b5d021a82aee96ec83bf29201602dfc544dd5921519c9f9
+odh-workbench-jupyter-pytorch-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:32ad6f55c054f32b4345c12597fccbaac8bee2304dd3c051a20464d02892d9e7
+odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:c3135b6ba4e9c6d6475856c18340492ce9e42d03e73401e30389f62a2cba3a15
+odh-workbench-jupyter-pytorch-rocm-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:6a448ea7cb25ad8b29d06931addb7f866b719b47976f39782b2d1e21cfcd1b67
+odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:ccaa644e04ee7272154f39f266ecc9fee44e8026686dcf828afb98227afad146
+odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:e3b932219250e7db8a060cd439013b40cce7298bc51433b7bbf8eb293a51b9e0
+odh-workbench-jupyter-trustyai-cpu-py312-ubi9-3-5=registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:949cf48e74f6c54d95627a3cd85832ff85cb469e4943c879a8e03d8ef1d2ee4e
 odh-workbench-jupyter-minimal-cpu-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
 odh-workbench-jupyter-minimal-cuda-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9
 odh-workbench-jupyter-minimal-rocm-py312-ubi9-3-4=registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:496b9ff80594d486f594bba69652c3ae4445265b94a44995b25f5ebd1e5767b3


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-95419

Related to: https://redhat.atlassian.net/browse/RHAIENG-6691

PR for disconnected helper: https://github.com/red-hat-data-services/rhoai-additional-images/pull/96
## Description
<!--- Describe your changes in detail -->
This PR updates the 3.5 images with the official 3.5 release 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated RHOAI 3.5 Python 3.12 workbench image references across CPU, CUDA, and ROCm variants.
  * Improved image consistency by using updated verified image versions.
  * Ensured workbench environments use the latest available image revisions for improved reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->