### PR TITLE
fix condition for CodeReady Builder for RHEL Konflux builds

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -44,6 +44,7 @@ ENV CODESERVER_SOURCE_PREFETCH=${CODESERVER_SOURCE_CODE}/prefetch-input/code-ser
 
 ARG BASE_IMAGE
 ARG GHA_BUILD=false
+ARG PRODUCT=odh
 
 ARG NODE_VERSION=22.22.0
 ARG CODESERVER_VERSION=v4.122.1
@@ -54,23 +55,22 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # Enable CodeReady Builder before installing -devel packages from CRB.
-# ODH/UBI: cachi2 ubi.repo already enables codeready-builder-for-ubi-9-*.
-# ODH/CentOS: enable the crb stream (same pattern as base-images/utils/aipcc.sh).
-# RHOAI/RHEL: RHSM does not enable CRB by default.
-RUN /bin/bash <<'EOF'
+# PRODUCT=rhoai (konflux.cpu.conf): RHEL via RHSM — CRB is not enabled by default.
+# PRODUCT=odh (cpu.conf): skip — hermeto ubi.repo/centos.repo already enable CRB.
+# Do not key off subscription-manager identity alone: GHA mounts RHSM certs on ODH too.
+RUN /bin/bash <<EOF
 set -Eeuxo pipefail
-basearch="$(rpm --eval '%{_arch}')"
-if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then
-    for repo in \
-        "codeready-builder-for-rhel-9-${basearch}-eus-rpms" \
-        "codeready-builder-for-rhel-9-${basearch}-rpms"; do
-        if subscription-manager repos --enable="${repo}"; then
-            break
-        fi
-    done
-elif grep -qE '^ID="?centos"?$' /etc/os-release 2>/dev/null; then
-    dnf install -y dnf-plugins-core
-    dnf config-manager --set-enabled crb
+if [[ "${PRODUCT}" == "rhoai" ]]; then
+    basearch="\$(rpm --eval '%{_arch}')"
+    if command -v subscription-manager &>/dev/null; then
+        for repo in \
+            "codeready-builder-for-rhel-9-\${basearch}-eus-rpms" \
+            "codeready-builder-for-rhel-9-\${basearch}-rpms"; do
+            if subscription-manager repos --enable="\${repo}" 2>/dev/null; then
+                break
+            fi
+        done
+    fi
 fi
 EOF
 
@@ -157,6 +157,8 @@ RUN echo "done" > /tmp/control
 ############################################################################################
 FROM ${BASE_IMAGE} AS cpu-base
 
+ARG PRODUCT=odh
+
 WORKDIR /opt/app-root/bin
 
 # OS Packages needs to be installed as root
@@ -168,20 +170,19 @@ RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
 # Enable CodeReady Builder (see rpm-base comment).
-RUN /bin/bash <<'EOF'
+RUN /bin/bash <<EOF
 set -Eeuxo pipefail
-basearch="$(rpm --eval '%{_arch}')"
-if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then
-    for repo in \
-        "codeready-builder-for-rhel-9-${basearch}-eus-rpms" \
-        "codeready-builder-for-rhel-9-${basearch}-rpms"; do
-        if subscription-manager repos --enable="${repo}"; then
-            break
-        fi
-    done
-elif grep -qE '^ID="?centos"?$' /etc/os-release 2>/dev/null; then
-    dnf install -y dnf-plugins-core
-    dnf config-manager --set-enabled crb
+if [[ "${PRODUCT}" == "rhoai" ]]; then
+    basearch="\$(rpm --eval '%{_arch}')"
+    if command -v subscription-manager &>/dev/null; then
+        for repo in \
+            "codeready-builder-for-rhel-9-\${basearch}-eus-rpms" \
+            "codeready-builder-for-rhel-9-\${basearch}-rpms"; do
+            if subscription-manager repos --enable="\${repo}" 2>/dev/null; then
+                break
+            fi
+        done
+    fi
 fi
 EOF
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image builds for different product configurations.
  * Ensured CodeReady Builder repositories are enabled only when required, while allowing other configurations to use their preconfigured repositories.
  * Removed an unnecessary subscription identity requirement during repository setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->