### PR TITLE
ci(.github/): add actionlint gate to code-static-analysis

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -28,6 +28,21 @@ GITHUB_TOKEN=$(gh auth token) pinact run --check --verify
 Install pinact: `brew install pinact` (macOS/Linux) or
 `go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0`.
 
+## Workflow linting (actionlint)
+
+The `code-static-analysis` job lints every file in `.github/workflows/` with
+actionlint (binary version pinned in the workflow, same pattern as hadolint).
+Run it locally:
+
+```bash
+actionlint .github/workflows/*.yaml .github/workflows/*.yml
+```
+
+Install actionlint: `brew install actionlint`; shellcheck must be on PATH for
+the shell-script checks. Baseline exceptions live in `.github/actionlint.yaml`
+(picked up automatically) - every entry is commented with why it exists and
+when to drop it. Do not add new ignores for new code; fix the workflow instead.
+
 ## Comment spacing
 
 Use **two spaces** before `#` in version comments (yamllint `comments` rule):

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,27 @@
 ---
-# actionlint 1.7.12 (used by CodeRabbit) does not yet list ubuntu-26.04 hosted
-# runners; register them here until upstream adds GA preview labels.
+# actionlint configuration, shared by the code-static-analysis CI job and
+# CodeRabbit's actionlint review. See
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# The ignores below are baseline exceptions for historical code and
+# actionlint false positives. Every entry is commented with why it exists
+# and when it can be dropped; do not add new ignores for new code - fix the
+# workflow instead.
+
+# actionlint 1.7.12 does not yet list ubuntu-26.04 hosted runners; register
+# them here until upstream adds GA preview labels.
 self-hosted-runner:
   labels:
     - ubuntu-26.04
     - ubuntu-26.04-arm
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # Info/style-level shellcheck noise in historical scripts (e.g. SC2086,
+      # SC2129); the gate still fails on warning/error-level findings.
+      - 'shellcheck reported issue in this script: SC\d+:(info|style):.+'
+      # 'code-quality' is a valid GitHub token scope (required by
+      # actions/upload-code-coverage) that actionlint's known-scope list has
+      # not caught up with; drop once a newer actionlint recognizes it.
+      - 'unknown permission scope "code-quality"'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,10 +19,10 @@ paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
       # Baseline shellcheck findings in historical scripts, enumerated per
-      # code (count): SC2059 info "Don't use variables in the printf format
-      # string. Use printf '..%s..' "$foo"" (1), SC2086 info "Double quote to
-      # prevent globbing and word splitting" (49), SC2129 style "Consider
-      # using { cmd1; cmd2; } >> file instead of individual redirects" (2).
+      # code (count):
+      # - SC2059 info "Don't use variables in the printf format string. Use printf '..%s..' "$foo"" (1),
+      # - SC2086 info "Double quote to prevent globbing and word splitting" (49),
+      # - SC2129 style "Consider using { cmd1; cmd2; } >> file instead of individual redirects" (2).
       # The gate still fails on any other code and on warning/error-level
       # findings; fix new scripts instead of extending this list.
       - 'shellcheck reported issue in this script: SC(2059|2086|2129):(info|style):.+'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -18,9 +18,14 @@ self-hosted-runner:
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
-      # Info/style-level shellcheck noise in historical scripts (e.g. SC2086,
-      # SC2129); the gate still fails on warning/error-level findings.
-      - 'shellcheck reported issue in this script: SC\d+:(info|style):.+'
+      # Baseline shellcheck findings in historical scripts, enumerated per
+      # code (count): SC2059 info "Don't use variables in the printf format
+      # string. Use printf '..%s..' "$foo"" (1), SC2086 info "Double quote to
+      # prevent globbing and word splitting" (49), SC2129 style "Consider
+      # using { cmd1; cmd2; } >> file instead of individual redirects" (2).
+      # The gate still fails on any other code and on warning/error-level
+      # findings; fix new scripts instead of extending this list.
+      - 'shellcheck reported issue in this script: SC(2059|2086|2129):(info|style):.+'
       # 'code-quality' is a valid GitHub token scope (required by
       # actions/upload-code-coverage) that actionlint's known-scope list has
       # not caught up with; drop once a newer actionlint recognizes it.

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -270,6 +270,17 @@ jobs:
           find . -name "*.yaml" | grep -v "./.tekton/" | grep -v "./.github/workflows/insta-merge.yaml" | grep -v "\.lock\.yaml$" | xargs yamllint --strict --config-file ./ci/yamllint-config.yaml
           find . -name "*.yml" | grep -v "./.tekton/" | xargs yamllint --strict --config-file ./ci/yamllint-config.yaml
 
+      # The version is pinned in the URL (same pattern as hadolint above). The
+      # config at .github/actionlint.yaml is picked up automatically.
+      - name: Validate GitHub workflows (actionlint)
+        if: ${{ !cancelled() }}
+        id: validate-github-workflows
+        run: |
+          wget --output-document=actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          tar -xzf actionlint.tar.gz actionlint
+          chmod a+x actionlint
+          ./actionlint .github/workflows/*.yaml .github/workflows/*.yml
+
       # In some YAML files we use JSON strings, let's check these
       - name: Validate JSON strings in YAML files (just syntax)
         if: ${{ !cancelled() }}
@@ -289,7 +300,7 @@ jobs:
           wget --output-document=hadolint https://github.com/hadolint/hadolint/releases/download/v2.15.0/hadolint-Linux-x86_64
           chmod a+x hadolint
           echo "Starting Hadolint"
-          find . -name "Dockerfile*" | xargs ./hadolint --config ./ci/hadolint-config.yaml
+          find . -name "Dockerfile*" -print0 | xargs -0 ./hadolint --config ./ci/hadolint-config.yaml
           echo "Hadolint done"
 
       # This simply checks that the manifests and respective kustomization.yaml finishes without an error.


### PR DESCRIPTION
## Summary

Adds an **actionlint** gate to the `code-static-analysis` job in `code-quality.yaml` — previously only yamllint covered workflows, so broken expressions, invalid permissions, and bad shell in run-steps were only caught if they happened to fail at runtime.

## Changes

- **`code-quality.yaml`**: new "Validate GitHub workflows (actionlint)" step — binary version pinned in the URL (same pattern as the existing hadolint step), lints all of `.github/workflows/*.yaml` and *.yml`; the config at `.github/actionlint.yaml` is picked up automatically.
- **`.github/actionlint.yaml`** (already shared with CodeRabbit's actionlint review; existing `self-hosted-runner` ubuntu-26.04 workaround kept as-is): per-path baseline ignores, each commented with why it exists and when to drop it:
  - the three baseline shellcheck codes, enumerated per code with message and count in the comment (SC2059, SC2086, SC2129) — the gate still fails on any other code and on warning/error-level findings
  - the `code-quality` permission-scope false positive: it **is** a valid GitHub token scope (required by `actions/upload-code-coverage`, whose README mandates it), but actionlint 1.7.12's known-scope list predates it
- **`code-quality.yaml`** hadolint step: fixed the one warning-level shellcheck finding the gate would trip on (`find | xargs` → `find -print0 | xargs -0`).
- **`.github/AGENTS.md`**: short section documenting the gate, local run command, and the "no new ignores for new code" rule.

## Baseline measured before wiring

`actionlint` v1.7.12 over all 60 workflow files: 57 ubuntu-26.04 runner-label false positives (handled by the pre-existing config block), 52 info/style shellcheck across the three enumerated codes (SC2059 x1, SC2086 x49, SC2129 x2), 2 `code-quality` scope false positives (ignored per above), and **1 real warning** (SC2038, fixed in code). No expression/permissions/action-call errors in existing code.

## Verification

- `actionlint` exits 0 on every workflow file with the new config (config auto-discovered from `.github/actionlint.yaml`)
- **Negative tests**: a deliberately broken workflow was reported both for an unknown permission scope and for an SC1072 shell syntax error, proving the ignores are selective (the three baseline codes only) and the gate actually bites
- `yamllint --strict` clean on all touched files
- no new third-party action references → no `pinact` changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated linting for GitHub Actions workflow files using a pinned actionlint version.
  * Added shared workflow-linting configuration and documented installation and baseline guidance.

* **Bug Fixes**
  * Improved Dockerfile validation for file paths containing spaces or other whitespace.
  * Retained support for Ubuntu 26.04 runner labels while limiting workflow-lint exceptions to documented historical findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->