### PR TITLE
RHAIENG-7242: remove CentOS GPG key from RHDS prefetch artifacts

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
@@ -5,7 +5,4 @@
 # They are stored at /cachi2/output/deps/generic/<filename>. The corresponding lock file (artifacts.lock.yaml)
 # is auto-generated and contains integrity hashes for each URL.
 
-input:
-    # Temporary add it here, so it won't break the RHDS build, until we have enough time
-    # to update all .tekton files for all versions.
-    - url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+input: []

--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
@@ -1,7 +1,4 @@
 ---
 metadata:
   version: '1.0'
-artifacts:
-  - download_url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
-    checksum: sha256:146059788b214d7ba0dd70c1cf21111e594c6cfde201da8a9a88fe7101be8a78
-    filename: RPM-GPG-KEY-CentOS-Official
+artifacts: []

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
@@ -5,7 +5,4 @@
 # They are stored at /cachi2/output/deps/generic/<filename>. The corresponding lock file (artifacts.lock.yaml)
 # is auto-generated and contains integrity hashes for each URL.
 
-input:
-    # Temporary add it here, so it won't break the RHDS build, until we have enough time
-    # to update all .tekton files for all versions.
-    - url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+input: []

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
@@ -1,7 +1,4 @@
 ---
 metadata:
   version: '1.0'
-artifacts:
-  - download_url: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
-    checksum: sha256:146059788b214d7ba0dd70c1cf21111e594c6cfde201da8a9a88fe7101be8a78
-    filename: RPM-GPG-KEY-CentOS-Official
+artifacts: []

--- a/scripts/lockfile-generators/create-artifact-lockfile.py
+++ b/scripts/lockfile-generators/create-artifact-lockfile.py
@@ -173,8 +173,7 @@ def main():
             artifacts.append(result)
 
     if not artifacts:
-        print("Error: No artifacts were processed.", file=sys.stderr)
-        sys.exit(1)
+        print("No artifacts to process; writing empty lockfile.")
 
     # Write lockfile
     lock_data = {


### PR DESCRIPTION
## Summary

- Remove `RPM-GPG-KEY-CentOS-Official` from RHDS `prefetch-input/rhds/artifacts.in.yaml` (codeserver + codeserver-baseline)
- Regenerate empty `artifacts.lock.yaml` files for RHDS generic prefetch
- Allow `create-artifact-lockfile.py` to succeed when `input` is empty

Jira: https://redhat.atlassian.net/browse/RHAIENG-7242

## Test plan

- [x] `python3 scripts/lockfile-generators/create-artifact-lockfile.py --artifact-input codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml`
- [ ] RHDS codeserver Konflux build passes
- [ ] ODH prefetch unchanged (`prefetch-input/odh/artifacts.in.yaml` still has CentOS key)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prefetch configurations no longer download the CentOS RPM GPG key.
  * Empty artifact lists are now handled successfully, producing valid empty lockfiles instead of failing with an error.
* **Chores**
  * Updated artifact lockfiles to reflect the removal of the previously pinned key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->