### PR TITLE
RHAIENG-7168 - CVE skill: add specific instructions for specific changes regarding code changes

### DIFF
--- a/.agents/plugins/cve-resolution/skills/fix-cve/SKILL.md
+++ b/.agents/plugins/cve-resolution/skills/fix-cve/SKILL.md
@@ -200,6 +200,16 @@ gh run list --workflow=check-image-availability.yaml --limit 1 --json status,con
 
 ## Guardrails
 
+### Packages and image references
+- When upgrading a package, update the manifests under `manifests/*/base/*.yaml` files with the respective version, following the version pattern of X.Y, i.e., numpy in lockfile is `2.5.2` and on manifest will be `2.5`
+- When changing a referenced image (e.g. mongocli-builder `FROM`):
+  - If the line sits in a `### BEGIN` / `### END` block, edit `scripts/dockerfile_fragments.py` then run `uv run scripts/dockerfile_fragments.py`. Do not hand-edit those blocks.
+  - If the line is unmarked (today: mongocli-builder `FROM` in Jupyter Dockerfiles), update every affected Dockerfile **and** the matching strings in `scripts/dockerfile_fragments.py`. Running the script will not rewrite unmarked `FROM` lines.
+  - Confirm the new tag appears in both places and the old tag is gone (e.g. `rg 'go-toolset:' jupyter/ scripts/dockerfile_fragments.py`).
+
+### Testing
+- Ensure that `make test` runs without issues after the proposed changes. `make test` does not check generator/Dockerfile sync; after fragment changes also run `uv run scripts/dockerfile_fragments.py` and review the resulting diff.
+
 ### Fully Autonomous Execution
 
 - NEVER ask "Would you like me to proceed?"


### PR DESCRIPTION
## Description
The /fix-cve command will work to fixing CVEs on different areas of the code base, either being package upgrade, image reference or even code, conditionals, etc. While it will work fine for the vast majority of cases and scenarios, for some cases, additional instructions might help both with the token consumption and the reliability of the output.

One example is about changing references to mongocli-builder references, when CVE Manager tried to fix directly the references, but this piece of code is autogenerated by a script called dockerfile_fragments.py under the scripts folder (this script is also used to validate builds and ensure nothing is missing), so proper instructions can guide the AI skill to properly change the code in the right places.

As an example, the following code is available in each Dockerfile (i.e., jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu):

```dockerfile
[...]

######################################################
# mongocli-builder (build stage only, not published) #
# Source: shared git submodule; Go modules from Cachi2 #
######################################################
FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 AS mongocli-builder

[...]
```

The image reference above should not be manually changed, as it is replaced by a script ([scripts/dockerfile_fragments.py](https://github.com/opendatahub-io/notebooks/blob/main/scripts/dockerfile_fragments.py#L127-L143)):

```python
"mongocli-builder stage": textwrap.dedent(r"""
  ######################################################
  # mongocli-builder (build stage only, not published) #
  ######################################################
  FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 AS mongocli-builder

  [...]
"""),
```

## Required fix

To properly change all image references using the CVE Manager skill, an instruction that explains this kind of change should be added, so not only the Dockerfile references will be changed, but also the dockerfile_fragments.py file as well.

## How Has This Been Tested?
- Executed locally the skill and checked that the proposed changes worked properly

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to update manifest versions when upgrading packages.
  * Added guidance to update image references in both build configuration and affected Dockerfiles.
  * Added a testing step to run the build-fragment generator and review the resulting changes for synchronization.
  * Clarified that the standard test suite does not verify generator and Dockerfile consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->