### PR TITLE
(chore:fragments)add UV version logic update on the fragments script

### DIFF
--- a/.github/workflows/lock-renewal.yaml
+++ b/.github/workflows/lock-renewal.yaml
@@ -120,15 +120,18 @@ jobs:
 
           git commit -m "Update pylock lock files"
 
-      - name: Commit manifest annotation updates
+      - name: Regenerate Dockerfile fragments
         run: |
           set -euo pipefail
-
-          # Regenerate Dockerfiles after lockfile changes.
           # Lockfiles may bump package versions (e.g. uv) that dockerfile_fragments.py
           # derives and embeds in Dockerfiles. Without this step, Dockerfiles drift
           # out of sync and check-generated-code fails.
           uv run scripts/dockerfile_fragments.py
+
+      - name: Commit manifest annotation updates
+        run: |
+          set -euo pipefail
+
           uv run manifests/tools/generate_kustomization.py
 
           uv run python manifests/tools/update_imagestream_annotations_from_pylock.py --variant odh

--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -361,8 +361,11 @@ COPY ${CODESERVER_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.
 # The raw RHEL Python base does not bootstrap uv the way AIPCC notebook bases
 # do. Install uv from the hermeto/cachi2 pip cache (offline) before the main
 # package install. Online `pip install uv` would break hermetic Konflux builds.
-# UV_VERSION is derived from this image's pylock by scripts/dockerfile_fragments.py.
+# UV_VERSION is derived from this image's requirements.cpu.txt by scripts/dockerfile_fragments.py.
+### BEGIN UV version
 ARG UV_VERSION=0.12.5
+
+### END UV version
 RUN python3 -m pip install --no-cache-dir --no-index \
     --find-links /cachi2/output/deps/pip \
     "uv==${UV_VERSION}"

--- a/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -152,8 +152,11 @@ COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-package
 # The raw RHEL Python base does not bootstrap uv the way AIPCC notebook bases
 # do. Install uv from the hermeto/cachi2 pip cache (offline) before the main
 # package install. Online `pip install uv` would break hermetic Konflux builds.
-# UV_VERSION is derived from this image's pylock by scripts/dockerfile_fragments.py.
+# UV_VERSION is derived from this image's requirements.cpu.txt by scripts/dockerfile_fragments.py.
+### BEGIN UV version
 ARG UV_VERSION=0.12.5
+
+### END UV version
 RUN python3 -m pip install --no-cache-dir --no-index \
     --find-links /cachi2/output/deps/pip \
     "uv==${UV_VERSION}"

--- a/runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -102,6 +102,18 @@ COPY --chown=1001:0 ${BASELINE_SOURCE_CODE}/utils ./utils/
 COPY --chown=1001:0 prefetch-input/elyra-v4.3.1/elyra/kfp/bootstrapper.py /opt/app-root/bin/utils/bootstrapper.py
 COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
+# The raw RHEL Python base does not bootstrap uv the way AIPCC notebook bases
+# do. Install uv from the hermeto/cachi2 pip cache (offline) before the main
+# package install. Online `pip install uv` would break hermetic Konflux builds.
+# UV_VERSION is derived from this image's requirements.cpu.txt by scripts/dockerfile_fragments.py.
+### BEGIN UV version
+ARG UV_VERSION=0.12.5
+
+### END UV version
+RUN python3 -m pip install --no-cache-dir --no-index \
+    --find-links /cachi2/output/deps/pip \
+    "uv==${UV_VERSION}"
+
 USER 1001:0
 
 ENV ELYRA_INSTALL_PACKAGES="false"
@@ -111,11 +123,6 @@ set -Eeuxo pipefail
 umask 0002
 
 echo "Installing software and packages"
-# rhel9/python-312 does not ship uv (ODH/AIPCC bases do). Bootstrap it from
-# the Cachi2 pip cache, then install the rest of the lockfile with uv.
-python3 -m pip install --no-index --no-cache-dir --no-deps \
-    --find-links /cachi2/output/deps/pip \
-    uv
 UV_NO_CACHE=true UV_LINK_MODE=copy UV_PREVIEW_FEATURES=pylock uv pip install --no-index \
     --strict --no-deps --no-config --no-progress \
     --compile-bytecode --index-strategy=unsafe-best-match \

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -14,6 +14,7 @@ We could also support files, or maybe even `### BEGIN funcname("param1", "param2
 
 from __future__ import annotations
 
+import re
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,10 @@ if TYPE_CHECKING:
 
     from pyfakefs.fake_filesystem import FakeFilesystem
 
+UV_VERSION_PREFIX = "UV version"
+UV_REQUIREMENT_RE = re.compile(r"^uv==([^\\\s;]+)")
+REQUIREMENTS_CPU = "requirements.cpu.txt"
+
 # restricting to the relevant directories significantly speeds up the processing
 docker_directories = (
     ntb.ROOT_DIR / "base-images",
@@ -32,6 +37,35 @@ docker_directories = (
     ntb.ROOT_DIR / "codeserver-baseline",
     ntb.ROOT_DIR / "runtimes",
 )
+
+
+def uv_version_from_requirements(requirements: pathlib.Path) -> str:
+    """Return the pinned ``uv`` version from a hashed requirements file."""
+    versions: set[str] = set()
+    with open(requirements, "rt") as fp:
+        for line in fp:
+            match = UV_REQUIREMENT_RE.match(line.strip())
+            if match:
+                versions.add(match.group(1))
+    if not versions:
+        raise ValueError(f"No uv== pin found in {requirements}")
+    if len(versions) > 1:
+        raise ValueError(f"Conflicting uv pins in {requirements}: {sorted(versions)}")
+    return next(iter(versions))
+
+
+def uv_version_replacement(dockerfile: pathlib.Path) -> dict[str, str]:
+    """Fill ``ARG UV_VERSION`` from the Dockerfile's sibling ``requirements.cpu.txt``."""
+    begin = f"### BEGIN {UV_VERSION_PREFIX}"
+    with open(dockerfile, "rt") as fp:
+        has_marker = any(line.rstrip() == begin for line in fp)
+    if not has_marker:
+        return {}
+    requirements = dockerfile.parent / REQUIREMENTS_CPU
+    if not requirements.is_file():
+        raise ValueError(f"{dockerfile} has '{begin}' but {requirements} is missing")
+    version = uv_version_from_requirements(requirements)
+    return {UV_VERSION_PREFIX: f"ARG UV_VERSION={version}\n"}
 
 
 def sanity_check(dockerfile: pathlib.Path, replacements: dict[str, str]):
@@ -192,9 +226,10 @@ def main():
             if dockerfile.is_relative_to(ntb.ROOT_DIR / "examples"):
                 continue
 
-            sanity_check(dockerfile, replacements)
+            replacements_for_file = {**replacements, **uv_version_replacement(dockerfile)}
+            sanity_check(dockerfile, replacements_for_file)
 
-            for prefix, contents in replacements.items():
+            for prefix, contents in replacements_for_file.items():
                 ntb.blockinfile(
                     filename=dockerfile,
                     contents=contents,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix for:  https://github.com/opendatahub-io/notebooks/actions/runs/33671773360/job/100386978151?pr=4510#step:20:2889

https://redhat.atlassian.net/browse/RHAIENG-6393
## Description
<!--- Describe your changes in detail -->
Add UV version logic update on the fragments script, if not happen this https://github.com/opendatahub-io/notebooks/actions/runs/33671773360/job/100386978151?pr=4510#step:20:2889 the reason is that the pylocks get updated but the dockerfile varsion remains obsolete. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container build consistency by deriving the `uv` version from pinned CPU requirements.
  * Added validation for missing or conflicting `uv` version pins during image generation.
  * Updated build automation to regenerate Dockerfile fragments and manifest annotations in separate steps.
  * Improved container builds with offline, prefetched package installation.
  * Updated Jupyter images to apply post-install configuration only on supported architectures.
  * Clarified generated Dockerfile metadata showing the source of the `uv` version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->