### PR TITLE
NO-JIRA: ci: stop prefetch-all.sh from re-locking pip dependencies

### DIFF
--- a/scripts/lockfile-generators/README.md
+++ b/scripts/lockfile-generators/README.md
@@ -91,13 +91,13 @@ and a full walkthrough (including jupyter datascience).
 ### What it does
 
 
-| Step                 | Condition                                                   | Script called                                                                         |
-| -------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| 1. Generic artifacts | `prefetch-input/<variant>/artifacts.in.yaml` exists         | `create-artifact-lockfile.py`                                                         |
-| 2. Pip wheels        | `pyproject.toml` exists in component dir                    | `create-requirements-lockfile.sh --download`                                          |
-| 3. NPM packages      | Tekton PipelineRun found for component (see below)          | `download-npm.sh --tekton-file`                                                       |
-| 4. RPMs              | `prefetch-input/<variant>/rpms.in.yaml` exists              | `hermeto-fetch-rpm.sh` (if lockfile committed) or `create-rpm-lockfile.sh --download` |
-| 5. Go modules        | Tekton file has `prefetch-input` entries with `type: gomod` | `create-go-lockfile.sh --tekton-file`                                                 |
+| Step                 | Condition                                                   | Script called                                                                                  |
+| -------------------- | ----------------------------------------------------------- |------------------------------------------------------------------------------------------------|
+| 1. Generic artifacts | `prefetch-input/<variant>/artifacts.in.yaml` exists         | `create-artifact-lockfile.py`                                                                  |
+| 2. Pip wheels        | `pyproject.toml` exists in component dir                    | `download-pip-packages.py` from committed `requirements.<flavor>.txt` (no lockfile generation) |
+| 3. NPM packages      | Tekton PipelineRun found for component (see below)          | `download-npm.sh --tekton-file`                                                                |
+| 4. RPMs              | `prefetch-input/<variant>/rpms.in.yaml` exists              | `hermeto-fetch-rpm.sh` (if lockfile committed) or `create-rpm-lockfile.sh --download`          |
+| 5. Go modules        | Tekton file has `prefetch-input` entries with `type: gomod` | `create-go-lockfile.sh --tekton-file`                                                          |
 
 
 **Variant directory:** Lockfiles live under `prefetch-input/odh/` (upstream) or

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -219,38 +219,42 @@ else
 fi
 
 # =========================================================================
-# Step 2: Pip wheels (create-requirements-lockfile.sh --download)
+# Step 2: Pip wheels (download from committed requirements.<flavor>.txt)
 #
-# Resolves Python dependencies from pyproject.toml using uv, generates
-# pylock.<flavor>.toml + requirements.<flavor>.txt, then downloads all
-# wheels.  The --flavor flag selects which optional dependency groups
-# to include (e.g. cpu vs cuda have different torch/triton packages).
+# Download-only, like the RPM step (step 4): this script never generates
+# pip lockfiles.  GHA and Konflux (Hermeto/cachi2) must consume the same
+# committed pylock/requirements files; regenerating them here would let
+# GHA pass while Konflux fails on the stale committed locks (and vice
+# versa).  When pyproject.toml changes, regenerate with
+# `make refresh-lock-files` (or create-requirements-lockfile.sh) and
+# commit the result — prefetch only downloads.
+#
+# The --flavor flag selects which lockfile flavor to use (cpu, cuda,
+# rocm have different optional dependency groups, e.g. torch/triton).
 # Output: cachi2/output/deps/pip/
 # =========================================================================
 PYPROJECT="$COMPONENT_DIR/pyproject.toml"
 if [[ -f "$PYPROJECT" ]]; then
   echo "=== [2/5] Pip wheels ==="
-  # Generate lockfile + requirements.txt (no download)
-  "$SCRIPTS_PATH/create-requirements-lockfile.sh" \
-      --pyproject-toml "$PYPROJECT" --flavor "$FLAVOR"
-
   REQUIREMENTS_FILE="$COMPONENT_DIR/requirements.${FLAVOR}.txt"
-  if [[ -f "$REQUIREMENTS_FILE" ]]; then
-    # Derive target arch from BUILD_ARCH (GHA cross-build via QEMU) or host
-    if [[ -n "${BUILD_ARCH:-}" ]]; then
-      case "${BUILD_ARCH##*/}" in
-        amd64) ARCH="x86_64" ;;
-        arm64) ARCH="aarch64" ;;
-        *) ARCH="${BUILD_ARCH##*/}" ;;
-      esac
-    else
-      ARCH=$(uname -m)
-    fi
-
-    # Download wheels (parallel, arch-filtered)
-    python3 "$SCRIPTS_PATH/helpers/download-pip-packages.py" \
-        --arch "$ARCH" "$REQUIREMENTS_FILE"
+  if [[ ! -f "$REQUIREMENTS_FILE" ]]; then
+    error_exit "requirements.${FLAVOR}.txt not found in $COMPONENT_DIR. prefetch-all.sh does not generate pip lockfiles — run 'make refresh-lock-files DIR=$COMPONENT_DIR' (or scripts/lockfile-generators/create-requirements-lockfile.sh), commit the result, then re-run prefetch."
   fi
+
+  # Derive target arch from BUILD_ARCH (GHA cross-build via QEMU) or host
+  if [[ -n "${BUILD_ARCH:-}" ]]; then
+    case "${BUILD_ARCH##*/}" in
+      amd64) ARCH="x86_64" ;;
+      arm64) ARCH="aarch64" ;;
+      *) ARCH="${BUILD_ARCH##*/}" ;;
+    esac
+  else
+    ARCH=$(uname -m)
+  fi
+
+  # Download wheels (parallel, arch-filtered)
+  python3 "$SCRIPTS_PATH/helpers/download-pip-packages.py" \
+      --arch "$ARCH" "$REQUIREMENTS_FILE"
   STEPS_RUN=$((STEPS_RUN + 1))
   echo ""
 else


### PR DESCRIPTION
## Context

The GHA "Prefetch hermetic build dependencies" step ran `create-requirements-lockfile.sh` on every hermetic build, regenerating `pylock.*.toml` / `requirements.*.txt` from `pyproject.toml` with fresh index hashes. Konflux's `prefetch-dependencies` (Hermeto/cachi2) consumes only the **committed** lockfiles — so a stale or broken committed pip lock could pass GHA while failing Konflux, and the two pipelines were not building from the same inputs.

## Change

- `scripts/lockfile-generators/prefetch-all.sh`: the pip step is now **download-only**, mirroring the existing RPM step. It downloads wheels from the committed `requirements.<flavor>.txt` (sha256-verified via `download-pip-packages.py`) and never generates lockfiles. A missing requirements file fails the step with a pointer to `make refresh-lock-files DIR=<component>` / `create-requirements-lockfile.sh` instead of silently regenerating.
- `scripts/lockfile-generators/README.md`: one "What it does" table row (the script called actually changed).

Lockfile regeneration stays where it belongs: `make refresh-lock-files` and the lock-renewal GHA workflows; PR lock drift is caught by `check-generated-code` (`ci/generate_code.sh`).

## Verification

- `bash -n` + `shellcheck` on `prefetch-all.sh` (actionlint/yamllint on the unchanged workflow: no new findings).
- Functional test with a scratch component: committed `requirements.cpu.txt` -> wheel downloaded + sha256-verified, lockfiles byte-identical after the run; missing file -> exit 1 with the regeneration instructions, nothing generated.
- Every hermetic image component commits `requirements.<flavor>.txt`, so no CI path hits the new error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package prefetching to use committed requirement files directly.
  * Added a clear failure message when the required requirements file is missing.
  * Package architecture detection and wheel downloading remain unchanged.

* **Documentation**
  * Clarified the updated prefetch workflow and separate lockfile regeneration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->