### PR TITLE
NO-JIRA: fix(codeserver): enable GPG verification for openshift-clients repo

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo
@@ -3,5 +3,9 @@ name=OpenShift 4.12 Public - $basearch
 # Note: el8, because that is the only available option for ppc64le and s390x, but it is compatible with el9.
 baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/dependencies/rpms/4.12-el8-beta/
 enabled=1
-gpgcheck=0
+# RPMs are signed with the Red Hat release key 2 (567E347A...FD431D51, verified
+# against the RPM signatures for x86_64/aarch64/ppc64le/s390x), shipped as
+# RPM-GPG-KEY-redhat-release in UBI9 and the ODH base images.
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 skip_if_unavailable=True

--- a/codeserver/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo
+++ b/codeserver/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo
@@ -3,5 +3,9 @@ name=OpenShift 4.12 Public - $basearch
 # Note: el8, because that is the only available option for ppc64le and s390x, but it is compatible with el9.
 baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/dependencies/rpms/4.12-el8-beta/
 enabled=1
-gpgcheck=0
+# RPMs are signed with the Red Hat release key 2 (567E347A...FD431D51, verified
+# against the RPM signatures for x86_64/aarch64/ppc64le/s390x), shipped as
+# RPM-GPG-KEY-redhat-release in UBI9 and the ODH base images.
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 skip_if_unavailable=True

--- a/prefetch-input/repos/openshift-clients.repo
+++ b/prefetch-input/repos/openshift-clients.repo
@@ -3,5 +3,9 @@ name=OpenShift 4.12 Public - $basearch
 # Note: el8, because that is the only available option for ppc64le and s390x, but it is compatible with el9.
 baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/dependencies/rpms/4.12-el8-beta/
 enabled=1
-gpgcheck=0
+# RPMs are signed with the Red Hat release key 2 (567E347A...FD431D51, verified
+# against the RPM signatures for x86_64/aarch64/ppc64le/s390x), shipped as
+# RPM-GPG-KEY-redhat-release in UBI9 and the ODH base images.
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 skip_if_unavailable=True


### PR DESCRIPTION
## Summary

Enables RPM signature validation (`gpgcheck=1`) in the `openshift-clients` prefetch repo, replacing `gpgcheck=0`, and pins the verified Red Hat release signing key via `gpgkey`. This closes the `CWE-494` (signature validation not performed) finding raised against the hermetic enablement work in [#4441](https://github.com/opendatahub-io/notebooks/pull/4441).

**Fixes #4475**

### Why `gpgcheck=0` was a risk

`openshift-clients.repo` was the *only* prefetch repo with `gpgcheck=0`. When Cachi2/Hermeto prefetches the `openshift-clients` (and `compat-openssl11`) RPMs across x86_64/aarch64/ppc64le/s390x, it therefore did **not** verify RPM signatures — so an unsigned or substituted RPM could enter codeserver-baseline image builds. Every sibling repo (`ubi.repo`, `rhsm-pulp.repo`, `centos.repo`, `epel.repo`) already uses `gpgcheck=1`.

### The change

In **all three copies** of the repo file, replace `gpgcheck=0` with:

```ini
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
```

- `prefetch-input/repos/openshift-clients.repo`
- `codeserver-baseline/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo`
- `codeserver/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo`

with a comment documenting the signer. No new key artifact, Dockerfile, or lockfile change is required.

## Why signature validation actually works here

The OpenShift mirror serves **no** published GPG key file, so the key has to come from elsewhere. It does, and it is already present in every place that validates signatures:

- **Key identity — verified, not assumed.** I extracted the actual RPM signature from the mirror for **all four** target arches (x86_64, aarch64, ppc64le, s390x). Every `openshift-clients` RPM is signed with **Key ID `199E2F91FD431D51`** = *Red Hat, Inc. (release key 2)*, fingerprint `567E347A D0044ADE 55BA8A5F 199E2F91 FD431D51`.
- **That key == `RPM-GPG-KEY-redhat-release`**, which is shipped in UBI9 and in the ODH base image (`quay.io/opendatahub/odh-base-image-cpu-py312-c9s:latest`) — the *same* image the lockfile generator (`create-rpm-lockfile.sh` → `Dockerfile.rpm-lockfile`) runs in — so both prefetch/lock generation **and** the in-build offline `dnf install` have the key at `/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release`.
- The build already imports it: `Dockerfile.konflux.cpu:54` and `:147` run `RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release` before the offline `dnf install`.

So both the prefetch (rpm-lockfile container) and the in-build offline install will now reject unsigned/substituted RPMs from this repo, and the key is available in both contexts.

## CI

This branch was force-pushed onto current `main` (rebase from an older base), so the original CI run below is against the *pre-rebase* commit (`1dd95da51`) but the same change. The **current** run is triggered by this PR's push.

<details>
<summary>Initial CI run (pre-rebase) — <code>33101155543</code> — odh + rhoai matrix</summary>

**Run:** https://github.com/opendatahub-io/notebooks/actions/runs/33101155543

- **All `codeserver` and `codeserver-baseline` jobs `success`** (odh & rhoai; amd64 & arm64) — i.e. the images that actually consume the changed repo **built, prefetched hermetically, and passed the `check-payload` FIPS check** with `gpgcheck=1` enabled. This directly proves the signature-validation path works.
- The only failing jobs were **unrelated** to this change:
  - `jupyter-baseline` (amd64, odh + rhoai) and `rocm-jupyter-tensorflow` (rhoai)
  - These failed at the **`Run Testcontainers container tests (in PyTest)` / `Run image tests`** steps — *test* steps, not build. Their `Build` and `Prefetch hermetic build dependencies` steps were `success`.
  - `jupyter-baseline` **has no `prefetch-input/`** and does not consume the openshift-clients repo, so `gpgcheck` cannot affect it — consistent with the known-flaky container/K8s test steps rather than a regression from this change.

</details>

## Review notes / context

- **Not yet merged:** the change is not on `main` as of writing — all three repo copies still show `gpgcheck=0` there.
- **Issue was closed `wont-fix` / `not planned`** while still labelled `has-fix` with no explanatory comment. If that closure was intentional (e.g. a maintainer deemed the key approach unworkable in their environment), please say so and I will close this PR. The key-availability analysis above is included to make that decision easy.
- A sibling branch (`issue-4475-4476-codeserver-fixes`) bundled this change with a separate `patch`-manifest addition (#4476) and a large stale `rpms.lock.yaml` churn; it only edited the `codeserver/` copy. This PR is the cleaner, more complete version (all three copies, no lockfile churn).

## Files changed

```
 prefetch-input/repos/openshift-clients.repo                                     | 6 +++++-
 codeserver-baseline/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo | 6 +++++-
 codeserver/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo          | 6 +++++-
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled RPM signature verification for the OpenShift 4.12 package repository.
  * Configured validation using the Red Hat release signing key included with the base images.
  * Added documentation identifying the key and supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->