### PR TITLE
NO-JIRA: docs: fix grammar in devFlags deprecation note

### DIFF
--- a/docs/manifest-cluster-dev-testing.md
+++ b/docs/manifest-cluster-dev-testing.md
@@ -5,7 +5,7 @@ Apply local ImageStream manifest edits to a dev/test cluster using
 **Open Data Hub (ODH)** upstream and **Red Hat OpenShift AI (RHOAI)** downstream;
 only the `--platform` flag and default namespaces differ.
 
-**Not for production.** This bypasses the operator’s normal release path. It is a replacment for the recently deprecation of `devFlags` provided by the operator.
+**Not for production.** This bypasses the operator’s normal release path. It replaces the recently deprecated `devFlags` provided by the operator.
 Changes may be
 overwritten on operator upgrade or workbenches reconcile.
 


### PR DESCRIPTION
Closes #4034

## What
Grammar fix in `docs/manifest-cluster-dev-testing.md`:

> ~~It is a replacment for the recently deprecation of `devFlags` provided by the operator.~~
> It replaces the recently deprecated `devFlags` provided by the operator.

## Verification
- `git grep devFlags origin/main` confirms this line is the only `devFlags` occurrence in the repo, so no other stale grammar references remain.
- Part 2 of the issue (revisiting the overall dev/test manifest strategy post rhods-operator 3.0) is broader follow-up work and out of scope for this docs-typo fix.

## CI
Prior push of the same change passed CI: [Build Notebooks (push) #33036609566 — success](https://github.com/opendatahub-io/notebooks/actions/runs/33036609566) (on `b2d684d66`, pre-rebase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the production-use warning for the cluster development testing workflow.
  * Corrected spelling and clarified that the workflow replaces the operator’s deprecated development flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->