### PR TITLE
NO-JIRA: docs: fix duplicate 'Available annotations' heading (MD024)

### DIFF
--- a/docs/workbench-imagestreams.md
+++ b/docs/workbench-imagestreams.md
@@ -36,7 +36,7 @@ spec:
         name: image-repository/tag
       name: tag-name
 ```
-### **Available annotations**
+### **Available per-tag annotations**
   - **`opendatahub.io/notebook-software:`** - a string that represents the technology stack included within the workbench image. Each technology in the list is described by its name and the version used (e.g. `'[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]`')
   - **`opendatahub.io/notebook-python-dependencies:`** -  a string that represents the list of Python libraries included within the workbench image. Each library is described by its name and currently used version (e.g. `'[{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"}]'`)
   - **`openshift.io/imported-from:`** - a reference to the image repository where the workbench image was obtained (e.g. `quay.io/repository/opendatahub/workbench-images`)


### PR DESCRIPTION
Closes #4036

## What
`docs/workbench-imagestreams.md` had two identical `### **Available annotations**` headings (ImageStream-level at line 20 and tag-specific at line 39), which trips markdownlint MD024 (no-duplicate-heading) and produces an ambiguous `#available-annotations` anchor.

Renames the tag-specific heading to `### **Available per-tag annotations**`, aligning with the wording already used by `docs/developer-guide.md` for the equivalent section.

## Verification
- Only the heading text changed; both sections' content is preserved and the headings are now distinct.
- Repo-wide scan found no other files with duplicate heading text (per the issue's investigation; re-confirmed on current main — the two headings in this file were the only identical pair).

## CI
Prior push of the same change passed CI: [Build Notebooks (push) #33033982697 — success](https://github.com/opendatahub-io/notebooks/actions/runs/33033982697) (on `675c7deea`, pre-rebase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the annotation subsection to clarify that the listed annotations are available per tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->