### PR TITLE
NO-JIRA: docs: replace generic 'here' link text (MD059)

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -85,7 +85,7 @@ spec:
 
 ### **ImageStream definitions for the supported out-of-the-box images in ODH**
 
-The ImageStream definitions of the out-of-the-box workbench images for ODH can be found [here](https://github.com/opendatahub-io/notebooks/tree/main/manifests).
+The ImageStream definitions of the out-of-the-box workbench images for ODH can be found in the [notebooks manifests](https://github.com/opendatahub-io/notebooks/tree/main/manifests).
 
 ### **Example ImageStream object definition**
 

--- a/docs/workbench-imagestreams.md
+++ b/docs/workbench-imagestreams.md
@@ -46,7 +46,7 @@ spec:
 
 ### **ImageStream definitions for the supported out-of-the-box images in ODH**
 
-The ImageStream definitions of the out-of-the-box workbench images for ODH can be found [here](https://github.com/opendatahub-io/notebooks/tree/main/manifests).
+The ImageStream definitions of the out-of-the-box workbench images for ODH can be found in the [notebooks manifests](https://github.com/opendatahub-io/notebooks/tree/main/manifests).
 
 ### **Example ImageStream object definition**
 

--- a/tests/manual/runtime_elyra/README.md
+++ b/tests/manual/runtime_elyra/README.md
@@ -89,7 +89,7 @@ To run Elyra pipelines, you need to create a data science cluster workbench in R
 
       ![Create workbench button][image9]
 
-3. On the workbench creation form, you can put any name you want, but it needs to be, at least, the data science image (you can choose the TensorFlow, PyTorch, among other images \- click [here](https://github.com/search?q=repo%3Aopendatahub-io%2Fnotebooks+COPY+%2F%24%7BDATASCIENCE_SOURCE_CODE%7D%5C%2Fsetup-elyra.sh%2F&type=code) for a full list of images with Elyra):
+3. On the workbench creation form, you can put any name you want, but it needs to be, at least, the data science image (you can choose the TensorFlow, PyTorch, among other images \- click [the repository search for images with Elyra](https://github.com/search?q=repo%3Aopendatahub-io%2Fnotebooks+COPY+%2F%24%7BDATASCIENCE_SOURCE_CODE%7D%5C%2Fsetup-elyra.sh%2F&type=code) for a full list):
 
    	**Name:** elyra-wb
    	**Image Selection:** Jupyter | Data Science | CPU | Python 3.12


### PR DESCRIPTION
Closes #4038

## What
Replaces the three generic `here` / `click here` link texts flagged by markdownlint MD059 (descriptive-link-text); only visible link text changes, no URLs touched:

- `docs/developer-guide.md` — "…can be found [here](…/manifests)" → "…can be found in the [notebooks manifests](…/manifests)"
- `docs/workbench-imagestreams.md` — same sentence, same fix
- `tests/manual/runtime_elyra/README.md` — "…click [here](…search…) for a full list of images with Elyra" → "…click [the repository search for images with Elyra](…search…) for a full list"

## Verification
- `git grep '\[here\](' origin/main -- '*.md'` confirms these three are the only MD059 "here" link instances in the repo — no other occurrences remain to fix.

## CI
No prior green run exists for this branch (an earlier `workflow_dispatch` run failed on an unrelated `codeserver-ubi9-python-3.12 · rhoai` image build). New CI runs on the rebased head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved link text for ImageStream definitions and notebooks manifests references.
  - Updated workbench setup instructions with a direct link to relevant Elyra images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->