### PR TITLE
NO-JIRA: docs: unindent code-server heading in workbenches.md (MD023)

### DIFF
--- a/docs/workbenches.md
+++ b/docs/workbenches.md
@@ -58,7 +58,7 @@ Use the TrustyAI notebook image to leverage your data science work with model ex
 
 [2023b Packages](https://github.com/opendatahub-io/notebooks/blob/2023b/jupyter/trustyai/ubi9-python-3.9/Pipfile) || [2023a Packages](https://github.com/opendatahub-io/notebooks/blob/2023a/jupyter/trustyai/ubi9-python-3.9/Pipfile)
 
- ## code-server
+## code-server
 
 code-server provides a browser-based integrated development environment (IDE) where you can write, edit, and debug code using the familiar interface and features of code-server. It is particularly useful for collaborating with team members, as everyone can access the same development environment from their own devices.
 


### PR DESCRIPTION
Closes #4041

## What
`docs/workbenches.md` line 61: the `## code-server` heading had a leading space, so CommonMark parsers (and markdownlint MD023, heading-start-left) did not recognize it as a heading — breaking the section's anchor/TOC entry.

```diff
- ## code-server
+## code-server
```

## Verification
- Repo-wide sweep for indented headings (`^\s+#{1,6}\s` over all `*.md` on current main): every other hit is a `#` shell comment inside a fenced code block (false positive) — this is the only real MD023 instance, matching the issue's audit.

## CI
Prior push of the same change passed CI: [Build Notebooks (push) #33036193599 — success](https://github.com/opendatahub-io/notebooks/actions/runs/33036193599) (on `634e63190`, pre-rebase).

Note: this PR and the MD039 PR for `docs/workbenches.md` touch different lines (61 vs 18) and can merge independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the heading formatting for `code-server` in the workbenches documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->