### PR TITLE
NO-JIRA: docs: fix malformed Markdown link spacing in docs/workbenches.md

### DIFF
--- a/docs/workbenches.md
+++ b/docs/workbenches.md
@@ -15,7 +15,7 @@ Open Data Hub contains the following workbench images with different variations:
 
 These notebooks are incorporated to be used in conjunction with Open Data Hub, specifically utilizing the ODH Notebook Controller as the launching platform. The table above provides insights into the characteristics of each notebook, including their availability in both ODH and OpenShift AI environments, GPU support, and whether they are offered as runtimes ie without the JupyterLab UI.
 
-All the notebooks are available on the[ Quay.io registry](https://quay.io/repository/opendatahub/workbench-images?tab=tags&tag=latest); please filter the results by using the tag "2023b" for the latest release and "2023a" for the n-1.
+All the notebooks are available on the [Quay.io registry](https://quay.io/repository/opendatahub/workbench-images?tab=tags&tag=latest); please filter the results by using the tag "2023b" for the latest release and "2023a" for the n-1.
 
 ## Jupyter Minimal
 Jupyter Minimal provides a browser-based integrated development environment where you can write, edit, and debug code using the familiar interface and features of JupyterLab.


### PR DESCRIPTION
Closes #4042

## What
`docs/workbenches.md` line 18: the link had extra leading whitespace inside the brackets and no space before the opening bracket, which renders oddly and fails markdownlint MD039 (no-space-in-links):

```diff
-All the notebooks are available on the[ Quay.io registry](https://quay.io/repository/opendatahub/workbench-images?tab=tags&tag=latest); …
+All the notebooks are available on the [Quay.io registry](https://quay.io/repository/opendatahub/workbench-images?tab=tags&tag=latest); …
```

## Verification
- Repo-wide sweep on current main (link text starting with a space; non-space char directly before `[`): this line is the only genuine MD039 instance — other `[` hits are shell test syntax (`[ -d … ]`) and task-list checkboxes, not malformed links, matching the issue's investigation.
- Link target URL unchanged; only spacing/link-text whitespace fixed.

## CI
No prior green run exists for this branch (an earlier `workflow_dispatch` run failed on an unrelated `cuda-jupyter-pytorch-ubi9-python-3.12 · odh` image build). New CI runs on the rebased head.

Note: this PR and the MD023 PR for `docs/workbenches.md` touch different lines (18 vs 61) and can merge independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected Markdown link spacing for the Quay.io registry reference in the workbenches documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->