### PR TITLE
NO-JIRA: test(conftest): add assert failure message for --image option

### DIFF
--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -102,7 +102,7 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
         # overrides the fixture scope (https://github.com/pytest-dev/pytest/issues/634),
         # causing ScopeMismatch for any session-scoped fixture that depends on `image`.
         image_option = metafunc.config.getoption("--image")
-        assert image_option is not None
+        assert image_option is not None, "--image option must be provided"
         metafunc.parametrize(image.__name__, image_option, scope="session")
 
 
@@ -118,7 +118,7 @@ def get_image_metadata(image: str) -> Image:
             return Image(id=None, name=image, labels=image_info.labels, env=image_info.env or {})
         # pull & docker inspect
         image_metadata = client.client.images.pull(image)
-        assert isinstance(image_metadata, docker.models.images.Image)
+        assert isinstance(image_metadata, docker.models.images.Image), "docker images.pull() did not return an Image"
 
     return Image.from_docker(image_metadata, name=image)
 


### PR DESCRIPTION
Closes #4027

Adds the missing failure message to the `--image` assertion in `pytest_generate_tests`, per the CodeRabbit nitpick on PR #4025 and `.cursor/rules/test-conventions.mdc`.

## Changes

- `tests/containers/conftest.py`: `assert image_option is not None, "--image option must be provided"` — the exact message proposed in the issue.
- Same bare-assert idiom in `get_image_metadata` extended with `"docker images.pull() did not return an Image"`.
- No other behavior changes.

## Verification

- Re-verified on current `origin/main` (`dec67df93`): the bare `assert image_option is not None` is still present in `pytest_generate_tests` — the issue's audit claim holds; no prior PR addressed it.
- `py_compile` + `ast.parse` on the edited file (all asserts in the file now carry messages, 0 bare).
- `uvx prek run --files tests/containers/conftest.py` — ruff check, ruff format, pyright all passed.
- `pytest tests/containers --collect-only` fails locally with a pre-existing podman `PodmanInfo` schema `ValidationError` (`host.slirp4netns` / `store.configFile` missing) — reproduced identically on a pristine `origin/main` checkout, so it is unrelated to this change.

## CI

- Prior green run on this branch (pre-rebase SHA `a30286965`): [build-notebooks-push, run 33037826944](https://github.com/opendatahub-io/notebooks/actions/runs/33037826944) — `success` (odh=true, rhds=true).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved failure messages for Docker image option and image pull type assertions, making test failures easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->