### PR TITLE
NO-JIRA: test(kubernetes_utils): add assert message and rename pod_name to pod_list

### DIFF
--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -216,11 +216,11 @@ class ImageDeployment:
         )
 
         core_v1_api = kubernetes.client.api.core_v1_api.CoreV1Api(api_client=self.client.client)
-        pod_name: kubernetes.client.models.v1_pod_list.V1PodList = core_v1_api.list_namespaced_pod(
+        pod_list: kubernetes.client.models.v1_pod_list.V1PodList = core_v1_api.list_namespaced_pod(
             namespace=ns.name, label_selector=f"app={container_name}"
         )
-        assert len(pod_name.items) == 1
-        self.pod: kubernetes.client.models.v1_pod.V1Pod = pod_name.items[0]
+        assert len(pod_list.items) == 1, f"Expected exactly one pod for app={container_name}, got {len(pod_list.items)}"
+        self.pod: kubernetes.client.models.v1_pod.V1Pod = pod_list.items[0]
 
         if not is_runtime_image:
             p = socket_proxy.SocketProxy(lambda: exposing_contextmanager(core_v1_api, self.pod), "localhost", 0)  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Closes #4028

Fixes the CodeRabbit nitpick from PR #4025: the local variable `pod_name` misleadingly holds a `V1PodList`, and the count assertion had no failure message.

## Changes

- `tests/containers/kubernetes_utils.py`: renamed `pod_name` → `pod_list` (it holds a `V1PodList`).
- Assertion now: `assert len(pod_list.items) == 1, f"Expected exactly one pod for app={container_name}, got {len(pod_list.items)}"` — the exact message from the issue.
- No functional change to pod selection logic. This was the only occurrence of the bare `assert len(...items) == 1` idiom in the file.

## Verification

- Re-verified on current `origin/main` (`dec67df93`): lines 219–223 still use the bare `assert len(pod_name.items) == 1` with the misleading `pod_name` variable — the issue's audit claim holds; no prior PR addressed it.
- `git grep 'assert len(' origin/main -- tests/containers/` — only occurrence of the `.items` idiom is this one.
- `uvx prek run --files tests/containers/kubernetes_utils.py` — all hooks passed (ruff check, ruff format, pyright, secret scan, etc.).
- `pytest tests/containers --collect-only -q` fails in `conftest.py::pytest_sessionstart` with a podman `PodmanInfo` schema `ValidationError` — reproduced identically on a pristine `origin/main` worktree, pre-existing local environment issue.

## CI

- The prior run on this branch (pre-rebase SHA `e77772bbf`): [run 33033816928](https://github.com/opendatahub-io/notebooks/actions/runs/33033816928) — **failure**, but only in the unrelated `runtime-datascience-ubi9-python-3.12 · linux/s390x / rhoai` build job (no test job; the diff is a 3-line test-helper change). No fully green prior run exists for this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved deployment validation to confirm that exactly one matching pod is available.
  * Added clearer failure details when the expected pod is not found or multiple matches exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->