### PR TITLE
NO-JIRA: test(workbench_image_test): add assert failure message for exec exit_code

### DIFF
--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -279,7 +279,7 @@ class WorkbenchContainer(testcontainers.core.container.DockerContainer):
             script_path.write_text(script_content)
             docker_utils.container_cp(self.get_wrapped_container(), src=str(script_path), dst=dest)
         exit_code, output = self.exec([python, f"{dest}/{script_name}"])
-        assert exit_code is not None
+        assert exit_code is not None, f"exec() returned no exit code for script {script_name}"
         return exit_code, output.decode()
 
 


### PR DESCRIPTION
Closes #4030

Adds the missing failure message to the `exit_code` assertion in `WorkbenchContainer.exec_script`, per the CodeRabbit nitpick on PR #4025.

## Changes

- `tests/containers/workbenches/workbench_image_test.py`: `assert exit_code is not None, f"exec() returned no exit code for script {script_name}"` — the exact message proposed in the issue.
- No other changes to the script execution helper. Line 282 was the only occurrence of the bare `assert exit_code is not None` pattern under `tests/containers/workbenches/`.

## Verification

- Re-verified on current `origin/main` (`dec67df93`): the bare `assert exit_code is not None` is still present in `exec_script` — the issue's audit claim holds; no prior PR addressed it.
- `uv run pytest tests/containers/workbenches/workbench_image_test.py --collect-only -q` → 7 tests collected (env var `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` needed locally to bypass an unrelated podman-daemon preflight).
- `uvx prek run --files tests/containers/workbenches/workbench_image_test.py` — all checks passed (ruff check, ruff format, pyright, …).

## CI

- The prior run on this branch (pre-rebase SHA `e92ffac9e`): [run 33033556021](https://github.com/opendatahub-io/notebooks/actions/runs/33033556021) — **failure**, but only in unrelated image-build jobs: `jupyter-trustyai-ubi9-python-3.12 · linux/amd64 / rhoai`, `runtime-datascience-ubi9-python-3.12 · linux/s390x / rhoai`, `codeserver-ubi9-python-3.12 · linux/arm64 / odh` (no test job; the diff is a one-line assert-message change). No fully green prior run exists for this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved assertion failure messages to include the script name when no exit code is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->