### PR TITLE
NO-JIRA: chore(test): remove unused pathlib import from minimal test notebook

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/test/test_notebook.ipynb
+++ b/jupyter/minimal/ubi9-python-3.12/test/test_notebook.ipynb
@@ -10,7 +10,6 @@
     "import re\n",
     "import json\n",
     "import unittest\n",
-    "from pathlib import Path\n",
     "from platform import python_version\n",
     "\n",
     "import jupyterlab as jp\n",


### PR DESCRIPTION
Closes #1688. Also resolves the duplicate #1687 (same file, same line).

Removes the unused `from pathlib import Path` import from `jupyter/minimal/ubi9-python-3.12/test/test_notebook.ipynb` (line 14), per static analysis review on PR #1686.

## Changes

- Single-line removal of the unused import. No other cell references `Path` or any `pathlib` functionality (verified in the branch notebook — the import line was the only occurrence).

## Verification

- Re-verified on current `origin/main` (`dec67df93`): the unused import is still present at line 13 of the notebook — the issue's claim holds.
- Notebook compiles after removal (`json.load` + `compile` on the source cell).
- `uvx prek run --files jupyter/minimal/ubi9-python-3.12/test/test_notebook.ipynb` — passed.

## CI

- The prior run on this branch (pre-rebase SHA `c8ee3583c`): [run 33109813767](https://github.com/opendatahub-io/notebooks/actions/runs/33109813767) — **failure**, but only in unrelated `jupyter-baseline-ubi9-python-3.12 · linux/amd64` (odh + rhoai) build jobs (no test job; the diff is a one-line notebook import removal). No fully green prior run exists for this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused import from notebook test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->