### PR TITLE
NO-JIRA: fix(ci): match variable name up to first '=' in check-params-env

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -58,7 +58,7 @@ function check_variables_uniq() {
     echo "Checking that all variables in the file '${env_file_path_1}' & '${env_file_path_2}' are unique and expected"
 
     local content
-    content=$(sed '/^$/d;/^[[:space:]]*#/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#\(.*\)=.*#\1#' | sort)
+    content=$(sed '/^$/d;/^[[:space:]]*#/d' "${env_file_path_1}" "${env_file_path_2}" | sed 's#^\([^=]*\)=.*#\1#' | sort)
 
     local num_records
     num_records=$(echo "${content}" | wc -l)


### PR DESCRIPTION
Closes #1785

The variable-name extraction in `check_variables_uniq` (`ci/check-params-env.sh`) used the greedy pattern `s#\(.*\)=.*#\1#`, which matches up to the **last** `=`. A value containing `=` (e.g. `KEY2=abc=def`) leaked `KEY2=abc` into the extracted name.

## Changes

- `ci/check-params-env.sh`: `s#\(.*\)=.*#\1#` → `s#^\([^=]*\)=.*#\1#` — anchored, matches only up to the first `=` (the exact pattern proposed in the issue).
- The sibling value-uniqueness check quoted in the issue was already fixed upstream (it is now an `awk -F'='` block), so only the one line changes.

## Verification

- Re-verified on current `origin/main` (`dec67df93`): the greedy pattern is still present in `check_variables_uniq` — the issue's claim holds.
- Side-by-side on sample lines: old pattern turns `KEY2=abc=def` → `KEY2=abc`; new pattern → `KEY2`. Identical output for normal `KEY=value` lines (`KEY1=value1` → `KEY1`, `EMPTY_VAL=` → `EMPTY_VAL` in both).
- `bash -n` (syntax) and `shellcheck -S warning` clean.

## CI

- The prior run on this branch (pre-rebase SHA `8b8ef8be8`): [run 33116155078](https://github.com/opendatahub-io/notebooks/actions/runs/33116155078) — **failure**, but only in unrelated image-build jobs: `jupyter-baseline-ubi9-python-3.12 · linux/amd64` (odh + rhoai) and `jupyter-minimal-ubi9-python-3.12 · linux/s390x / odh` (no test job; the diff is a one-line sed-pattern change). No fully green prior run exists for this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable validation for values containing additional equals signs.
  * Variable names are now identified correctly when configuration values include `=` characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->