### PR TITLE
NO-JIRA: docs: fix CONTRIBUTING.md push example to use upstream remote

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,12 @@ See [ADR 0008](docs/architecture/decisions/0008-harden-github-actions-pin-sha-di
 ### Contributing from branches vs forks
 
 **Recommended:** If you have write access to the repo, push your branch directly
-and create the PR from there:
+and create the PR from there. If you started from a fork, add the upstream remote
+first so the branch lands in `opendatahub-io/notebooks` (not your fork):
 
 ```bash
-git push origin HEAD:<your-initials>/branch-name
+git remote add upstream https://github.com/opendatahub-io/notebooks.git
+git push upstream HEAD:<your-initials>/branch-name
 ```
 
 This gives CI full access to build secrets (RHEL subscription, AIPCC registry) and


### PR DESCRIPTION
Closes #3284

The "Contributing from branches vs forks" section in `CONTRIBUTING.md` recommends pushing directly to `opendatahub-io/notebooks` to unlock same-repo CI, but its example used `git push origin HEAD:<your-initials>/branch-name`. For contributors following the fork-based workflow above it, `origin` points at their **fork** — the branch never lands in the main repo and the subscription (RHEL, AIPCC) CI the section promises is not enabled.

## Changes

- `CONTRIBUTING.md`: the example now adds the upstream remote and pushes to it:

```bash
git remote add upstream https://github.com/opendatahub-io/notebooks.git
git push upstream HEAD:<your-initials>/branch-name
```

plus one sentence explaining why fork-based contributors need the upstream remote.

## Verification

- Re-verified on current `origin/main` (`dec67df93`): the `git push origin HEAD:<your-initials>/branch-name` example is still present — the issue's claim holds.
- Docs-only change; `uvx prek run --files CONTRIBUTING.md` passes.

## CI

- The prior run on this branch (pre-rebase SHA `28896675c`): [run 33106811634](https://github.com/opendatahub-io/notebooks/actions/runs/33106811634) — **failure**, but only in unrelated `jupyter-baseline-ubi9-python-3.12 · linux/amd64` (odh + rhoai) build jobs (no test job; the diff is a docs-only change). No fully green prior run exists for this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution instructions for working from a fork, including how to configure the upstream repository and push branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->