### PR TITLE
NO-JIRA: docs(contributing): document macOS python.org SSL cert setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,17 @@ make test-${NOTEBOOK_NAME}
 - When renaming image labels or similar CI metadata, update only the current `-n`
   entries in `ci/check-params-env.sh` and `ci/expected-image-metadata.yaml`. Historical
   entries intentionally keep old names.
+- **macOS python.org SSL certificates:** If your default `python3` is the python.org
+  framework build (e.g. `/Library/Frameworks/Python.framework/...`), ad-hoc scripts that
+  use `urllib` or `requests` may fail with
+  `ssl.SSLCertVerificationError: certificate verify failed`. This is because the
+  python.org installer does not wire up CA certificates automatically. Fix once by
+  running:
+  ```bash
+  "/Applications/Python 3.12/Install Certificates.command"
+  ```
+  (adjust the version number to match your install). Alternatively, use the
+  `uv`-managed Python (`python3.14`) which uses the system trust store.
 
 #### ODH vs RHOAI local builds
 


### PR DESCRIPTION
Closes #3948

Documents the macOS python.org framework Python SSL certificate issue in CONTRIBUTING.md "Local gotchas" (under "Testing your PR locally"): ad-hoc scripts using `urllib`/`requests` fail with `ssl.SSLCertVerificationError` when the default `python3` is the python.org build, because the installer never wires up CA certificates. One-time fix: run `/Applications/Python X.Y/Install Certificates.command`; alternatively use the `uv`-managed Python.

## Verification

- Re-verified on current `origin/main` (`dec67df93`): no SSL-certificate documentation exists in CONTRIBUTING.md — the issue's claim holds.
- Docs-only change.

## CI

No valid prior run on the branch commit: the run cited in the issue thread (33287770375) ran at the **base** SHA (`f3f32101b`, pre-branch), and the `push`-event run (33287768068) was skipped. The PR's own CI is the first signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS troubleshooting guidance for SSL certificate verification failures with python.org Python installations.
  * Included a certificate-installation command and recommended using `uv`-managed Python as an alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->