### PR TITLE
NO-JIRA: docs: make CLAUDE.md a symlink to AGENTS.md, migrate Cursor rules to Agent Skills

### DIFF
--- a/.agents/skills/jira-conventions/SKILL.md
+++ b/.agents/skills/jira-conventions/SKILL.md
@@ -68,7 +68,7 @@ RHOAIENG tickets are per-component vulnerability trackers created automatically 
 
 The sprint field ID differs between projects. Use `jira_add_issues_to_sprint` (from the project MCP server) which works for **both** projects regardless of field ID:
 
-```
+```text
 jira_add_issues_to_sprint(sprint_id="66724", issue_keys="RHOAIENG-12345,RHOAIENG-12346")
 ```
 
@@ -88,13 +88,13 @@ Standard workflow for resolving CVE tickets on `rhoai-2.25`:
 
 Use `jira_update_issue` with the `fields` parameter as a JSON string:
 
-```
+```text
 jira_update_issue(issue_key="RHOAIENG-12345", fields="{\"assignee\": \"user@redhat.com\"}")
 ```
 
 For transitions:
 
-```
+```text
 jira_transition_issue(issue_key="RHOAIENG-12345", transition_id="131")
 ```
 

--- a/.agents/skills/jira-conventions/SKILL.md
+++ b/.agents/skills/jira-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: Jira project IDs, custom fields, and conventions for creating issues in RHAIENG and related projects
-alwaysApply: false
+name: jira-conventions
+description: Jira project IDs, custom fields, and conventions for creating and updating issues in RHAIENG and related projects (RHOAIENG CVE trackers, RHAIRFE, RHAISTRAT) on redhat.atlassian.net — cloud ID, component/team IDs, key custom field IDs, issue hierarchy and parent linking, MCP create/update/transition call patterns, link types, sprint assignment, and the RHOAIENG CVE resolution workflow. Use whenever creating, updating, linking, assigning, or transitioning Jira tickets for this team; do not use for non-Jira task tracking.
 ---
 
 # Jira Conventions for Notebooks Team

--- a/.agents/skills/test-conventions/SKILL.md
+++ b/.agents/skills/test-conventions/SKILL.md
@@ -1,7 +1,11 @@
 ---
-description: Test creation conventions for the notebooks repository — pytest patterns, testcontainers, markers, fixtures, allure, and test organization.
-globs: "tests/**,ci/**/*.py,scripts/**/*.py,ntb/**/*.py"
-alwaysApply: false
+name: test-conventions
+description: Test creation conventions for the notebooks repository — pytest patterns, testcontainers, markers, fixtures, allure, assertion patterns, and test organization, with DO/DON'T lists and an implementation checklist. Apply when creating or modifying tests, fixtures, or conftest under tests/, ci/**.py, scripts/**.py, or ntb/**.py; docs/agents/testing.md holds the test catalog (types, commands, CI parity).
+paths:
+  - "tests/**"
+  - "ci/**/*.py"
+  - "scripts/**/*.py"
+  - "ntb/**/*.py"
 ---
 
 # Test Conventions for opendatahub-io/notebooks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ multi-stage Dockerfiles on Centos 9 Stream (ODH) and RHEL 9.8 EUS (RHOAI) with P
 This file is the short entry point for AI agents working in this repository. Keep it lean,
 and follow linked documents for topic-specific detail.
 
+`CLAUDE.md` at the repo root is a symlink to this file (alias for Claude Code
+discovery); `AGENTS.md` remains the single source of truth — edit only this file.
+
 ## Start here
 
 | Read this | When |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,1 @@
-## References
-
-- Jira conventions (project IDs, custom fields, MCP call patterns): see `.cursor/rules/jira-conventions.mdc`
-- Test conventions (pytest patterns, markers, testcontainers, allure, fixture chains): see `.cursor/rules/test-conventions.mdc`
+AGENTS.md

--- a/docs/ai-coding-assistant-project-config.md
+++ b/docs/ai-coding-assistant-project-config.md
@@ -89,14 +89,14 @@ OpenCode's fallback to `CLAUDE.md` and `.claude/skills/` means teams already usi
 
 The practical problem: your team has Jira conventions, coding standards, or workflow instructions that should be available regardless of which tool a developer uses. Here are the approaches we evaluated.
 
-### Approach 1: Pointers (what we use)
+### Approach 1: Pointers
 
 Each tool's instructions file contains a one-line pointer to the canonical source.
 
 ```markdown
 # CLAUDE.md
 ## References
-- Jira conventions: see `.cursor/rules/jira-conventions.mdc`
+- Jira conventions: see `.agents/skills/jira-conventions/SKILL.md`
 ```
 
 **Pros:** Simple, robust, no dependencies. Each tool loads only a few bytes of overhead.
@@ -137,9 +137,10 @@ npx skills list              # shows installed skills
 
 ## What We Did in This Repo
 
-- Created `CLAUDE.md` at the repo root with a pointer to `.cursor/rules/jira-conventions.mdc`
-- `.cursor/rules/jira-conventions.mdc` remains the single source of truth for Jira project IDs, custom fields, and MCP call patterns
-- Both Cursor and Claude Code can access the same knowledge without content duplication
+- `AGENTS.md` is the single source of truth for always-on project conventions
+- `CLAUDE.md` at the repo root is a symlink to `AGENTS.md`, so Claude Code (and other `CLAUDE.md`-based finders) load the same file — no pointer stub to keep in sync
+- Conditional knowledge lives in Agent Skills under `.agents/skills/` — e.g. `jira-conventions` (Jira project IDs, custom fields, MCP call patterns) and `test-conventions` (pytest, testcontainers, markers, fixtures)
+- `.claude/skills` and `.cursor/skills` are symlinks to `.agents/skills/`, so all clients scan one tree; tool-specific directories contain symlinks only, no unique content
 
 ## Recommendations
 


### PR DESCRIPTION
Closes #4403.

## What changed

Replaces the standalone `CLAUDE.md` (a 4-line `## References` stub) with a
relative symlink to `AGENTS.md`, so Claude Code picks up the full repo
conventions instead of a stub that only pointed at two `.cursor/rules/*.mdc`
files. Also adds a one-line note in `AGENTS.md` that `CLAUDE.md` is an
alias, not a second source of truth (the issue's optional follow-up).

**Cursor rules → Agent Skills** (added after review): the stub was the only
thing pointing non-Cursor agents at `.cursor/rules/*.mdc`, so with it gone
that knowledge would be Cursor-only. Both rules are migrated into the Agent
Skills layout the repo already uses for skills (#4533):

- `.cursor/rules/jira-conventions.mdc` → `.agents/skills/jira-conventions/SKILL.md`
  (description-triggered; body moved verbatim)
- `.cursor/rules/test-conventions.mdc` → `.agents/skills/test-conventions/SKILL.md`
  (path-scoped: `paths` frontmatter from the old globs, scope restated in the
  description for clients that ignore unknown frontmatter)
- `.cursor/rules/` deleted; Cursor keeps working via the existing
  `.cursor/skills` → `.agents/skills` symlink
- `docs/ai-coding-assistant-project-config.md` "What We Did in This Repo"
  updated to the current layout

The stub's two pointers are not lost: `docs/ai-coding-assistant-project-config.md`
(already linked from `AGENTS.md`'s "Start here" table) references the
jira-conventions skill and documents the cross-tool layout, and `AGENTS.md`
links `docs/agents/testing.md` for test conventions.

## Verification

Re-verified against current `origin/main` (`dec67df93`) before rebuilding:

- `git ls-tree origin/main CLAUDE.md` showed a regular file (mode `100644`,
  4-line stub) — the issue's gap was still live; no symlink existed.
- The pre-existing branch's commit (based on an Aug 27 snapshot) would have
  deleted the stub's References content with no replacement; since
  `origin/main` has since evolved, this branch was rebuilt from
  `origin/main` as a clean single commit instead of rebasing the stale one.
  The stale base is retained locally as
  `issue-4403-claude-md-symlink-stale` for review.
- Result: the PR diff is the symlink + note (`AGENTS.md` +3 lines,
  `CLAUDE.md` mode change `100644 => 120000`, now `AGENTS.md`) plus the
  rule migration (two renames with a frontmatter swap, one doc update).
- `readlink CLAUDE.md` -> `AGENTS.md`; content resolves correctly in the
  worktree.
- Both migrated skill bodies are verbatim copies of the old `.mdc` bodies,
  except three MCP-call code fences in `jira-conventions` gained a `text`
  language specifier required by markdownlint (MD040) — `.mdc` files were
  outside the linter's `**/*.md` scope.

## CI

No prior green run existed for this branch. The pre-rebase
`workflow_dispatch` run
[33123049013](https://github.com/opendatahub-io/notebooks/actions/runs/33123049013)
on commit `8a6b86519` failed only in unrelated container image build jobs
(`jupyter-baseline` and `codeserver-baseline`, `linux/amd64`, odh and
rhoai); all non-image-build jobs passed. The change here is doc/skill files
only (no Dockerfiles, no dependencies).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `AGENTS.md` is the authoritative source for project guidance and should be edited directly.
  - Removed the references section from the project guidance documentation, including links to Jira and testing convention materials.
  - Updated project configuration guidance to describe shared skills, documentation pointers, and linked guidance files.
  - Expanded Jira and testing convention descriptions with applicable areas, usage guidance, and supported project paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->