### PR TITLE
NO-JIRA: docs: fix incorrect claim that 'npm init -y' creates package-lock.json

### DIFF
--- a/tests/browser/scripts/README.md
+++ b/tests/browser/scripts/README.md
@@ -29,7 +29,7 @@ Install **Node.js + npm**:
 
 ----------
 
-# 3️⃣ Initialize the project (creates package.json **and** package-lock.json)
+# 3️⃣ Initialize the project (creates package.json)
 
 From the repo root:
 
@@ -38,7 +38,8 @@ From the repo root:
 This generates:
 
 -   `package.json` — declares dependencies and scripts
--   `package-lock.json` — _locks_ exact dependency versions for reproducible installs
+
+Note: `package-lock.json` is **not** created by `npm init` — it is generated on the first `npm install` (see step 4 below).
 
 ----------
 
@@ -48,11 +49,11 @@ Playwright **must** be installed locally so the scripts can import it:
 
 `npm install playwright`
 
-This updates:
+This creates/updates:
 
 -   `node_modules/` with the dependency
 -   `package.json` with `"playwright": "..."`
--   `package-lock.json` with the exact resolved version
+-   `package-lock.json` with the exact resolved version (created on the first `npm install`)
 
 Then install browser binaries:
 


### PR DESCRIPTION
Closes #4043

## Summary

`tests/browser/scripts/README.md` incorrectly stated that `npm init -y` creates both `package.json` **and** `package-lock.json`. `npm init -y` only creates `package.json`; `package-lock.json` is generated on the first `npm install`.

## Changes

- Step 3 heading now reads "Initialize the project (creates package.json)" and the bullet list only claims `package.json`.
- Added a note that `package-lock.json` is **not** created by `npm init` — it is generated on the first `npm install` (step 4).
- Step 4 wording now says "This creates/updates:" and marks `package-lock.json` as created on the first `npm install`.

## Verification

- Re-verified against current `origin/main` (`dec67df93`): the inaccuracy was still present at `tests/browser/scripts/README.md:32` (and line 41 bullet).
- Searched the rest of the repo for similar claims: `npm init` appears only in `tests/browser/scripts/README.md` on `origin/main`, so no other instances exist to fix. All other `package-lock.json` mentions (cachi2/hermetic docs, lockfile-generators README) correctly describe it as generated by `npm install` or as an input file — no inaccuracy there.
- Docs-only change; no tests apply.

## CI

No prior green GitHub Actions run exists for this branch pre-rebase. The only prior run (pre-rebase SHA `1adc0de03`, run https://github.com/opendatahub-io/notebooks/actions/runs/33032291838) failed in `runtime-baseline-ubi9-python-3.12 · linux/amd64` — a container build job unrelated to this docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified setup instructions for initializing the project.
  - Documented when `package-lock.json` is created.
  - Expanded Playwright installation guidance to describe the files and dependencies generated or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->