### PR TITLE
NO-JIRA: fix(tests/containers): make TestFrame.destroy() fault-tolerant

### DIFF
--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -360,9 +360,15 @@ def test_frame():
         def destroy(self):
             """Runs __exit__() on the registered resources as a cleanup."""
             for resource, cleanup_func in reversed(self.resources):
-                if cleanup_func is not None:
-                    cleanup_func(resource)
-                resource.__exit__(None, None, None)  # don't use named args, there are inconsistencies
+                try:
+                    if cleanup_func is not None:
+                        cleanup_func(resource)
+                    resource.__exit__(None, None, None)  # don't use named args, there are inconsistencies
+                except Exception:
+                    # Transient podman API failures (e.g. RemoteDisconnected during
+                    # IPv6 network removal) should not abort teardown of remaining
+                    # resources. The orphaned resource will be GC'd by podman.
+                    logging.exception("Cleanup failed for %r (continuing teardown)", resource)
 
     t = TestFrame()
     yield t

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -363,12 +363,15 @@ def test_frame():
                 try:
                     if cleanup_func is not None:
                         cleanup_func(resource)
+                except Exception:
+                    logging.exception("Cleanup callback failed for %r (continuing teardown)", resource)
+                try:
                     resource.__exit__(None, None, None)  # don't use named args, there are inconsistencies
                 except Exception:
                     # Transient podman API failures (e.g. RemoteDisconnected during
                     # IPv6 network removal) should not abort teardown of remaining
                     # resources. The orphaned resource will be GC'd by podman.
-                    logging.exception("Cleanup failed for %r (continuing teardown)", resource)
+                    logging.exception("Context exit failed for %r (continuing teardown)", resource)
 
     t = TestFrame()
     yield t

--- a/tests/containers/test_test_frame_cleanup.py
+++ b/tests/containers/test_test_frame_cleanup.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+class RecordingResource:
+    def __init__(self, name: str, events: list[str]):
+        self.name = name
+        self.events = events
+
+    def __enter__(self):
+        self.events.append(f"enter {self.name}")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.events.append(f"exit {self.name}")
+
+
+def test_frame_exits_resource_and_continues_after_cleanup_callback_failure(test_frame):
+    events: list[str] = []
+    expected_events = [
+        "enter later",
+        "enter failing",
+        "cleanup failing",
+        "exit failing",
+        "cleanup later",
+        "exit later",
+    ]
+    later_resource = RecordingResource("later", events)
+    failing_resource = RecordingResource("failing", events)
+
+    def clean_later_resource(resource):
+        resource.events.append("cleanup later")
+
+    def fail_to_clean_resource(resource):
+        resource.events.append("cleanup failing")
+        raise RuntimeError("cleanup failed")
+
+    test_frame.append(later_resource, clean_later_resource)
+    test_frame.append(failing_resource, fail_to_clean_resource)
+
+    try:
+        test_frame.destroy()
+        assert events == expected_events
+    finally:
+        test_frame.resources.clear()


### PR DESCRIPTION
Closes #3645

## Summary

`test_ipv6_only` intermittently failed in GHA with a pytest **ERROR** (not a test failure):

```
ERROR tests/containers/workbenches/workbench_image_test.py::TestWorkbenchImage::test_ipv6_only[...jupyter-trustyai...rhoai...]
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

The `ERROR` status points at fixture teardown, not the test body: the test itself passed, but `TestFrame.destroy()` propagated a transient podman API failure (`RemoteDisconnected` while tearing down the IPv6-only network) as an exception. Because `destroy()` iterates all registered resources with no error handling, one failing cleanup aborted the loop and skipped cleanup of the remaining resources, surfacing as a CI error.

## Changes

`tests/containers/conftest.py` — wrap each resource's cleanup (`cleanup_func(resource)` + `resource.__exit__(...)`) in `try/except`, log the failure via `logging.exception(...)`, and continue with the next resource. A transient failure to remove one resource (e.g. the IPv6 network) no longer aborts teardown of the others; the orphaned resource is garbage collected by podman. `logging` is already imported at module scope.

## Verification

- Re-verified against current `origin/main` (`dec67df93`): `tests/containers/conftest.py` was **unchanged** by the 24 commits since the branch point, so the fix applies cleanly and still matches the reported traceback (teardown `ERROR`, `RemoteDisconnected`).
- The change is a scoped teardown-fault-tolerance fix in the container test `conftest.py`; it does not alter any test assertion or image under test.
- Integration/container tests (`make test-integration`) require podman + a built image and are the appropriate gate for this change.

## CI

No prior green run exercised the container tests for this branch. The only prior run (pre-rebase SHA `77eba7226`, [run 33309457240](https://github.com/opendatahub-io/notebooks/actions/runs/33309457240)) was a `workflow_dispatch` marked success in ~12s but with **all matrix jobs skipped** — only "Generate job matrix" ran, so it provides no container-test evidence. This PR's own CI run is the first to actually exercise the container test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability by continuing to release remaining resources when an individual cleanup operation fails.
  * Cleanup errors are now logged without stopping the rest of the teardown process.
  * Resource contexts continue to exit even when cleanup callbacks raise errors.
  * Cleanup operations now follow the expected order, helping ensure all resources are released consistently.

* **Tests**
  * Added coverage for cleanup ordering and continued teardown after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->