### PR TITLE
RHOAIENG-89794: Add ODH Kale to Runtime Images Dependencies

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/pylock.toml
+++ b/codeserver-baseline/ubi9-python-3.12/pylock.toml
@@ -6,11 +6,11 @@ requires-python = "==3.12.*"
 
 [[packages]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", upload-time = 2026-07-12T20:29:07Z, size = 260176, hashes = { sha256 = "cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", upload-time = 2026-07-12T20:29:05Z, size = 125813, hashes = { sha256 = "9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", upload-time = 2026-09-02T21:46:36Z, size = 276504, hashes = { sha256 = "b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", upload-time = 2026-09-02T21:46:35Z, size = 131908, hashes = { sha256 = "7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99" } }]
 
 [[packages]]
 name = "argon2-cffi"

--- a/codeserver-baseline/ubi9-python-3.12/requirements.cpu.txt
+++ b/codeserver-baseline/ubi9-python-3.12/requirements.cpu.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.org/simple
-anyio==4.14.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
-    --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494
+anyio==4.15.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99
 argon2-cffi==25.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741
 argon2-cffi-bindings==26.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \

--- a/codeserver/ubi9-python-3.12/requirements.cpu.txt
+++ b/codeserver/ubi9-python-3.12/requirements.cpu.txt
@@ -370,7 +370,11 @@ pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:448cb61682a3e28102675a13569439021a4cd9ef78d93f1d7d7c9a2a7938952a \
     --hash=sha256:47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c \
     --hash=sha256:592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693 \
-    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e
+    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e \
+    --hash=sha256:5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35 \
+    --hash=sha256:24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006 \
+    --hash=sha256:ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e \
+    --hash=sha256:68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a4b4cb2c5bf334d29c8288652669cffc0809ea7e7c30f6344204493be297df3f
 paramiko==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \

--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -1040,6 +1040,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 12941471, hashes = { sha256 = "47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 16095328, hashes = { sha256 = "592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 12761080, hashes = { sha256 = "4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:45:03Z, size = 12053826, hashes = { sha256 = "5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-28T01:52:37Z, size = 12925504, hashes = { sha256 = "24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-28T01:10:19Z, size = 16064649, hashes = { sha256 = "ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:39:05Z, size = 12742532, hashes = { sha256 = "68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7" } },
 ]
 
 [[packages]]

--- a/dependencies/odh-notebooks-meta-runtime-kale-deps/pyproject.toml
+++ b/dependencies/odh-notebooks-meta-runtime-kale-deps/pyproject.toml
@@ -5,21 +5,7 @@ requires-python = "==3.12.*"
 
 # This is a comprehensive list of python dependencies that Kale requires to execute Jupyter notebooks.
 dependencies = [
-    "ipykernel",
-    "ipython",
-    "jupyter-client",
-    "jupyter-core",
-    "nbclient",
-    "nbconvert",
-    "nbformat",
-    "jinja2",
-    "dill",
-    "networkx",
-    "autopep8",
-    "pyflakes",
-    "astor",
-    "packaging",
-    "progress",
+    "odh_kale"
 ]
 
 [tool.uv]

--- a/jupyter/baseline/ubi9-python-3.12/pylock.toml
+++ b/jupyter/baseline/ubi9-python-3.12/pylock.toml
@@ -35,11 +35,11 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/fb/76/641ae3715086764
 
 [[packages]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", upload-time = 2026-07-12T20:29:07Z, size = 260176, hashes = { sha256 = "cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", upload-time = 2026-07-12T20:29:05Z, size = 125813, hashes = { sha256 = "9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", upload-time = 2026-09-02T21:46:36Z, size = 276504, hashes = { sha256 = "b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", upload-time = 2026-09-02T21:46:35Z, size = 131908, hashes = { sha256 = "7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99" } }]
 
 [[packages]]
 name = "argon2-cffi"

--- a/jupyter/baseline/ubi9-python-3.12/requirements.cpu.txt
+++ b/jupyter/baseline/ubi9-python-3.12/requirements.cpu.txt
@@ -8,8 +8,8 @@ aiohttp==3.14.3 ; (implementation_name == 'cpython' and platform_machine == 'aar
     --hash=sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19
 aiosignal==1.4.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e
-anyio==4.14.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
-    --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494
+anyio==4.15.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99
 argon2-cffi==25.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741
 argon2-cffi-bindings==26.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \

--- a/jupyter/datascience/ubi9-python-3.12/requirements.cpu.txt
+++ b/jupyter/datascience/ubi9-python-3.12/requirements.cpu.txt
@@ -425,7 +425,11 @@ pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:448cb61682a3e28102675a13569439021a4cd9ef78d93f1d7d7c9a2a7938952a \
     --hash=sha256:47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c \
     --hash=sha256:592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693 \
-    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e
+    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e \
+    --hash=sha256:5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35 \
+    --hash=sha256:24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006 \
+    --hash=sha256:ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e \
+    --hash=sha256:68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5d462b652bf0beb76435dc6e07dbb6583efbdfba15e8491a4071687ca18f5570 \
     --hash=sha256:52099276f67227cc89734c4aa296bbbba4c1e3cd48640845499a65933552635b \

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -1201,6 +1201,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 12941471, hashes = { sha256 = "47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 16095328, hashes = { sha256 = "592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 12761080, hashes = { sha256 = "4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:45:03Z, size = 12053826, hashes = { sha256 = "5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-28T01:52:37Z, size = 12925504, hashes = { sha256 = "24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-28T01:10:19Z, size = 16064649, hashes = { sha256 = "ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:39:05Z, size = 12742532, hashes = { sha256 = "68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
@@ -445,7 +445,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:82db81c4684f6adbccf842766e8331afc357f894224290991bc631d290f05fbe \
     --hash=sha256:eabba6cc75f2f13e312d06a722ee95fe8f7e523201d8865cd349d299bdfc6201
@@ -712,7 +714,9 @@ transformers==5.14.1 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:890155bed35a8ec2767ea95a8125cd66d35809474b0b756da8659592e7804e2a
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828 \
-    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504
+    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504 \
+    --hash=sha256:f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b \
+    --hash=sha256:455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae
 truststore==0.10.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d2528385e0ee7dd5def63f527675b242bb2ad6dfbe13561388b9d8d1be793cab
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1343,6 +1343,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]
@@ -2132,6 +2134,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 118614827, hashes = { sha256 = "74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 119953430, hashes = { sha256 = "b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-27T00:39:10Z, size = 118614910, hashes = { sha256 = "f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T00:38:43Z, size = 119953513, hashes = { sha256 = "455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch/ubi9-python-3.12/requirements.cuda.txt
+++ b/jupyter/pytorch/ubi9-python-3.12/requirements.cuda.txt
@@ -394,7 +394,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:82db81c4684f6adbccf842766e8331afc357f894224290991bc631d290f05fbe \
     --hash=sha256:eabba6cc75f2f13e312d06a722ee95fe8f7e523201d8865cd349d299bdfc6201
@@ -619,7 +621,9 @@ traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:6227f237db51451f31357bb6e6715fdabef00a3a16f475845856cf0a20ce3529
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828 \
-    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504
+    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504 \
+    --hash=sha256:f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b \
+    --hash=sha256:455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4d72791c38455c3365e3125938ae90692878f20be81bdb4295f8b5e633b35a0c
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1190,6 +1190,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]
@@ -1857,6 +1859,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 118614827, hashes = { sha256 = "74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 119953430, hashes = { sha256 = "b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-27T00:39:10Z, size = 118614910, hashes = { sha256 = "f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T00:38:43Z, size = 119953513, hashes = { sha256 = "455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae" } },
 ]
 
 [[packages]]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.rocm.txt
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.rocm.txt
@@ -370,7 +370,8 @@ opentelemetry-semantic-conventions==0.65b0 ; python_full_version == '3.12.*' and
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:799bf47192d30b1f8abdebe52e7159d4e061e73f1cca84db3766eeb70af0df22
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -570,7 +571,8 @@ tqdm==4.70.0 ; python_full_version == '3.12.*' and implementation_name == 'cpyth
 traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d522f22796a09555cfc57c6529951e7f369481ae7ab53f95da559a918032110d
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc
+    --hash=sha256:bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc \
+    --hash=sha256:c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9301f862d28e9220bbe54557d13cf05fcd86d0914b1dcff530892ae533320d17
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1118,7 +1118,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandoc-rhai"
@@ -1718,7 +1721,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "triton"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 119953429, hashes = { sha256 = "bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 119953429, hashes = { sha256 = "bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T02:12:20Z, size = 119953509, hashes = { sha256 = "c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c" } },
+]
 
 [[packages]]
 name = "typeguard"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/requirements.rocm.txt
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/requirements.rocm.txt
@@ -384,7 +384,8 @@ optree==0.19.1 ; python_full_version == '3.12.*' and implementation_name == 'cpy
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:799bf47192d30b1f8abdebe52e7159d4e061e73f1cca84db3766eeb70af0df22
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1160,7 +1160,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandoc-rhai"

--- a/jupyter/tensorflow/ubi9-python-3.12/requirements.cuda.txt
+++ b/jupyter/tensorflow/ubi9-python-3.12/requirements.cuda.txt
@@ -410,7 +410,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:4ff10c33baae07c17d38d7bf83d734762ae7e42000bb5957eaa2a7ecaa79cfaa
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2 \
-    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0
+    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0 \
+    --hash=sha256:610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99 \
+    --hash=sha256:e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:38003fe8745508e83684f99424598b2901fb4ab7ba74889379003f33831cb8a0 \
     --hash=sha256:a5fa43cad0d6756207706577ba37f93aa2ec258976aa16118532508609cdeb61

--- a/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1238,6 +1238,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-15T05:36:58Z, size = 12065020, hashes = { sha256 = "1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T05:23:21Z, size = 12761081, hashes = { sha256 = "0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:54:15Z, size = 12053826, hashes = { sha256 = "610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:49:38Z, size = 12742529, hashes = { sha256 = "e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698" } },
 ]
 
 [[packages]]

--- a/jupyter/trustyai/ubi9-python-3.12/requirements.cpu.txt
+++ b/jupyter/trustyai/ubi9-python-3.12/requirements.cpu.txt
@@ -714,7 +714,9 @@ transformers==5.15.0 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:56932914aed366fef56e3929535ce6b2af9f6b784d79179f3a17c0d8180ce972
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:4faa64744bb3259b03481b1898f3094adb9e06d9a995401602fbe54d3c51b41c \
-    --hash=sha256:10a4312290e8aa8ebd51fb7d609cdff7b5de87ea533554adbafc8209350b45f8
+    --hash=sha256:10a4312290e8aa8ebd51fb7d609cdff7b5de87ea533554adbafc8209350b45f8 \
+    --hash=sha256:3bb6255461bc028df69d457907a2b00b49b12427788f63107badad314f288735 \
+    --hash=sha256:2cfbdb91cdb02bfc9c2f9e512bc4d56e0d228323ca5690bc8320077a291acec2
 trustyai==0.6.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d88bef3fbbb9c83cb527ccf6245ff1416afa6f952ddb585a1387e7385344d202
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -1972,6 +1972,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/triton-3.6.0-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T01:08:08Z, size = 118614828, hashes = { sha256 = "4faa64744bb3259b03481b1898f3094adb9e06d9a995401602fbe54d3c51b41c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:51:06Z, size = 119953429, hashes = { sha256 = "10a4312290e8aa8ebd51fb7d609cdff7b5de87ea533554adbafc8209350b45f8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/triton-3.6.0-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-27T00:36:28Z, size = 118614911, hashes = { sha256 = "3bb6255461bc028df69d457907a2b00b49b12427788f63107badad314f288735" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T00:39:17Z, size = 119953507, hashes = { sha256 = "2cfbdb91cdb02bfc9c2f9e512bc4d56e0d228323ca5690bc8320077a291acec2" } },
 ]
 
 [[packages]]

--- a/runtimes/baseline/ubi9-python-3.12/pylock.toml
+++ b/runtimes/baseline/ubi9-python-3.12/pylock.toml
@@ -34,6 +34,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b57915636024
 wheels = [{ url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", upload-time = 2025-07-03T22:54:42Z, size = 7490, hashes = { sha256 = "053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e" } }]
 
 [[packages]]
+name = "anyio"
+version = "4.15.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", upload-time = 2026-09-02T21:46:36Z, size = 276504, hashes = { sha256 = "b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", upload-time = 2026-09-02T21:46:35Z, size = 131908, hashes = { sha256 = "7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99" } }]
+
+[[packages]]
 name = "argon2-cffi"
 version = "25.1.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -55,6 +63,14 @@ wheels = [
 ]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", upload-time = 2025-10-18T17:46:46Z, size = 152931, hashes = { sha256 = "ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", upload-time = 2025-10-18T17:46:45Z, size = 68797, hashes = { sha256 = "749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205" } }]
+
+[[packages]]
 name = "astor"
 version = "0.8.1"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -71,6 +87,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98
 wheels = [{ url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", upload-time = 2026-07-12T03:31:47Z, size = 28702, hashes = { sha256 = "9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", upload-time = 2026-03-19T01:04:32Z, size = 16332, hashes = { sha256 = "89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", upload-time = 2026-03-19T01:04:30Z, size = 8403, hashes = { sha256 = "eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -85,6 +109,14 @@ marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' an
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", upload-time = 2025-01-14T14:46:18Z, size = 92210, hashes = { sha256 = "89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", upload-time = 2025-01-14T14:46:15Z, size = 45807, hashes = { sha256 = "ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", upload-time = 2026-02-01T12:30:56Z, size = 9959554, hashes = { sha256 = "b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", upload-time = 2026-02-01T12:30:53Z, size = 10196845, hashes = { sha256 = "e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35" } }]
 
 [[packages]]
 name = "beautifulsoup4"
@@ -150,12 +182,45 @@ sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090
 wheels = [{ url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", upload-time = 2026-08-26T13:33:12Z, size = 125251, hashes = { sha256 = "255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360" } }]
 
 [[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/b9/9f/1f917934da4e07ae7715a982347e3c2179556d8a58d1108c5da3e8f09c76/click_option_group-0.5.7.tar.gz", upload-time = 2025-03-24T13:24:55Z, size = 22110, hashes = { sha256 = "8dc780be038712fc12c9fecb3db4fe49e0d0723f9c171d7cda85c20369be693c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3b14dbcdb93740defd7b8c58dae3736be8d264f2a643fb/click_option_group-0.5.7-py3-none-any.whl", upload-time = 2025-03-24T13:24:54Z, size = 11483, hashes = { sha256 = "96b9f52f397ef4d916f81929bd6c1f85e89046c7a401a64e72a61ae74ad35c24" } }]
+
+[[packages]]
 name = "comm"
 version = "0.2.3"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", upload-time = 2025-07-25T14:02:04Z, size = 6319, hashes = { sha256 = "2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", upload-time = 2025-07-25T14:02:02Z, size = 7294, hashes = { sha256 = "c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417" } }]
+
+[[packages]]
+name = "cryptography"
+version = "50.0.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", upload-time = 2026-08-25T19:45:45Z, size = 880381, hashes = { sha256 = "5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20" } }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2026-08-25T19:44:05Z, size = 4723133, hashes = { sha256 = "53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f" } },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-08-25T19:44:07Z, size = 4712478, hashes = { sha256 = "ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef" } },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", upload-time = 2026-08-25T19:44:09Z, size = 4730726, hashes = { sha256 = "e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8" } },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", upload-time = 2026-08-25T19:44:14Z, size = 4746720, hashes = { sha256 = "51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad" } },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", upload-time = 2026-08-25T19:44:18Z, size = 4730028, hashes = { sha256 = "e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f" } },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", upload-time = 2026-08-25T19:44:22Z, size = 4746230, hashes = { sha256 = "51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a" } },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", upload-time = 2026-08-25T19:44:24Z, size = 4862596, hashes = { sha256 = "be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959" } },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", upload-time = 2026-08-25T19:44:26Z, size = 5014082, hashes = { sha256 = "9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b" } },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2026-08-25T19:45:00Z, size = 4751900, hashes = { sha256 = "05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23" } },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-08-25T19:45:02Z, size = 4738357, hashes = { sha256 = "e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733" } },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", upload-time = 2026-08-25T19:45:04Z, size = 4758474, hashes = { sha256 = "4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88" } },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", upload-time = 2026-08-25T19:45:09Z, size = 4772942, hashes = { sha256 = "407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5" } },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", upload-time = 2026-08-25T19:45:13Z, size = 4758050, hashes = { sha256 = "01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71" } },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", upload-time = 2026-08-25T19:45:18Z, size = 4772694, hashes = { sha256 = "9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239" } },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", upload-time = 2026-08-25T19:45:20Z, size = 4888413, hashes = { sha256 = "fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558" } },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", upload-time = 2026-08-25T19:45:22Z, size = 5044355, hashes = { sha256 = "2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e" } },
+]
 
 [[packages]]
 name = "debugpy"
@@ -185,6 +250,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc
 wheels = [{ url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", upload-time = 2026-01-19T02:36:55Z, size = 120019, hashes = { sha256 = "1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", upload-time = 2026-04-14T04:09:19Z, size = 29341, hashes = { sha256 = "292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", upload-time = 2026-04-14T04:09:18Z, size = 22484, hashes = { sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b" } }]
+
+[[packages]]
 name = "entrypoints"
 version = "0.4"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -209,6 +282,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/33/a4/9473c7c3b87009d9c
 wheels = [{ url = "https://files.pythonhosted.org/packages/49/82/2755c7c982086f00d4dab85bc120ec35045a9fc2191893a6ce79afe94443/fastjsonschema-2.22.2-py3-none-any.whl", upload-time = 2026-08-15T19:47:04Z, size = 27413, hashes = { sha256 = "0fb3915616adac85ccfdd737d26be1089845d2019819505b42d39888458f74d4" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", upload-time = 2021-03-11T07:16:29Z, size = 6015, hashes = { sha256 = "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", upload-time = 2021-03-11T07:16:28Z, size = 9121, hashes = { sha256 = "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -221,6 +302,89 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2025-10-06T05:36:22Z, size = 239096, hashes = { sha256 = "776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa" } },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", upload-time = 2025-10-06T05:38:16Z, size = 13409, hashes = { sha256 = "0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d" } },
 ]
+
+[[packages]]
+name = "google-api-core"
+version = "2.34.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7c/9be3903e3d45415e8ca493c75f8990a0f6f579d168015d44c379350d0ab0/google_api_core-2.34.0.tar.gz", upload-time = 2026-08-06T06:23:58Z, size = 187953, hashes = { sha256 = "98a779fe72de956eb1c9c2f47ff4c4432a668ece1a002ec38bed07ec2698ae59" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/bc/c1/a8a92ae1bc4b1a8f804c776d7d3f0c771b78a62c3ad4df1be41b3fd8c767/google_api_core-2.34.0-py3-none-any.whl", upload-time = 2026-08-06T06:22:47Z, size = 180545, hashes = { sha256 = "cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de" } }]
+
+[[packages]]
+name = "google-auth"
+version = "2.57.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", upload-time = 2026-08-25T19:18:26Z, size = 370794, hashes = { sha256 = "9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", upload-time = 2026-08-24T21:55:08Z, size = 259728, hashes = { sha256 = "180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59" } }]
+
+[[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/f9/54/790548b190cff9cf07225c811d2668eacd8f2cbf04114475cbe3e5738752/google_cloud_core-2.7.0.tar.gz", upload-time = 2026-08-25T19:18:43Z, size = 36603, hashes = { sha256 = "874aaf89765db87a9b911b7a2ca7c5068554868eed9e75c7766affe342a2913d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/cb/64/904dbc9bee128e7b87eeb60da67c8fa4d1a8acdc9a45dd2fedca67ef184d/google_cloud_core-2.7.0-py3-none-any.whl", upload-time = 2026-08-24T21:55:28Z, size = 31046, hashes = { sha256 = "c18a250904cfdda021eb3ae8b8238c9f9ca272a4cbbfb5cba946b3fe3022eed1" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/ce/7e/73bb7512df1d1aad6ce3f9aed847cd40e0cd400ba4a85d86ab8eb412e9cc/google_cloud_storage-3.13.1.tar.gz", upload-time = 2026-08-06T06:24:42Z, size = 17341051, hashes = { sha256 = "a80bf8cac2794808aa61c50c5f769ecbbe2d10331bacd0d69d30e59b14b346b2" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/06/6f/d69f0e185e08ddb58c323a0a935af2b492907b5de362bc08933b0a3b5644/google_cloud_storage-3.13.1-py3-none-any.whl", upload-time = 2026-08-06T06:23:36Z, size = 341486, hashes = { sha256 = "98208de6c21e85cecd3eb44551894efff33d98365500e178867d4305854a770a" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", upload-time = 2025-12-16T00:35:25Z, size = 14192, hashes = { sha256 = "a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79" } }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", upload-time = 2025-12-16T00:40:22Z, size = 33364, hashes = { sha256 = "14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411" } },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", upload-time = 2025-12-16T00:40:23Z, size = 33740, hashes = { sha256 = "cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454" } },
+]
+
+[[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/17/4b/44e128cd7b0e72cd26da4a3052cd8a9ef1b5a890be7c611558067ea0b354/google_resumable_media-2.10.2.tar.gz", upload-time = 2026-08-25T19:19:11Z, size = 2164918, hashes = { sha256 = "1de441703cd298d75a419bfdc0066e9fc7b0a1de630df96eea8ce8f5c759358c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/55/30/3e976681b5319715ab022363f58f6f8e10f546a1777756fe3ebd918857e4/google_resumable_media-2.10.2-py3-none-any.whl", upload-time = 2026-08-25T19:18:07Z, size = 81531, hashes = { sha256 = "e3cedc827a4ea41e216582d74346f1fb9fceb625a8c3c53912f2ca1d663334d7" } }]
+
+[[packages]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", upload-time = 2026-08-25T19:19:13Z, size = 154083, hashes = { sha256 = "8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", upload-time = 2026-08-25T19:18:08Z, size = 307002, hashes = { sha256 = "6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e" } }]
+
+[[packages]]
+name = "h11"
+version = "0.16.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", upload-time = 2025-04-24T03:35:25Z, size = 101250, hashes = { sha256 = "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", upload-time = 2025-04-24T03:35:24Z, size = 37515, hashes = { sha256 = "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86" } }]
+
+[[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", upload-time = 2025-04-24T22:06:22Z, size = 85484, hashes = { sha256 = "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", upload-time = 2025-04-24T22:06:20Z, size = 78784, hashes = { sha256 = "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55" } }]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", upload-time = 2024-12-06T15:37:23Z, size = 141406, hashes = { sha256 = "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", upload-time = 2024-12-06T15:37:21Z, size = 73517, hashes = { sha256 = "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad" } }]
 
 [[packages]]
 name = "idna"
@@ -263,6 +427,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c
 wheels = [{ url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", upload-time = 2025-01-17T11:24:33Z, size = 8074, hashes = { sha256 = "a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", upload-time = 2020-11-01T11:00:00Z, size = 11649, hashes = { sha256 = "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", upload-time = 2020-11-01T10:59:58Z, size = 11321, hashes = { sha256 = "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042" } }]
+
+[[packages]]
 name = "jedi"
 version = "0.20.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -277,6 +449,22 @@ marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' an
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", upload-time = 2025-03-05T20:05:02Z, size = 245115, hashes = { sha256 = "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", upload-time = 2025-03-05T20:05:00Z, size = 134899, hashes = { sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67" } }]
+
+[[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", upload-time = 2026-06-19T20:08:27Z, size = 53278, hashes = { sha256 = "7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", upload-time = 2026-06-19T20:08:26Z, size = 36570, hashes = { sha256 = "56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", upload-time = 2026-03-23T22:32:32Z, size = 9068, hashes = { sha256 = "0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", upload-time = 2026-03-23T22:32:31Z, size = 7659, hashes = { sha256 = "8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca" } }]
 
 [[packages]]
 name = "jsonschema"
@@ -295,6 +483,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa
 wheels = [{ url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", upload-time = 2025-09-08T01:34:57Z, size = 18437, hashes = { sha256 = "98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe" } }]
 
 [[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e1/e4ef07e2be228271b59e011a746d97feef69577af1f465b1cff0f1d7c760/jupyter_builder-1.2.2.tar.gz", upload-time = 2026-08-07T06:47:18Z, size = 981074, hashes = { sha256 = "b6cea88f58e44b2c5eba96f28d2e0d16fd453d3ca6dc9c4492ff8a1f2e97f601" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/c4/3b/920bc7f3c2ad25abc0071ae7ae55789f4b85ecf3e4467f0602a88dc668cb/jupyter_builder-1.2.2-py3-none-any.whl", upload-time = 2026-08-07T06:47:16Z, size = 915266, hashes = { sha256 = "6ebcd4c49daf5df6a18068a74a48010406700ed90a76c189fac43eaf85c60c63" } }]
+
+[[packages]]
 name = "jupyter-client"
 version = "8.10.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -311,12 +507,107 @@ sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c75
 wheels = [{ url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", upload-time = 2025-10-16T19:19:16Z, size = 29032, hashes = { sha256 = "ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", upload-time = 2026-04-20T23:17:50Z, size = 62854, hashes = { sha256 = "faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", upload-time = 2026-04-20T23:17:48Z, size = 19512, hashes = { sha256 = "c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", upload-time = 2026-04-02T08:10:06Z, size = 55677, hashes = { sha256 = "fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", upload-time = 2026-04-02T08:10:01Z, size = 77513, hashes = { sha256 = "71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/cf/e0/63b481d5b21f81fe23173dfc9eb25629fa1bc174fdc4a2c19d09c1ff8124/jupyter_server-2.21.0.tar.gz", upload-time = 2026-08-27T16:06:34Z, size = 760357, hashes = { sha256 = "70d9a1883f57d3576ea17f4ce061ec1a7aad7ef388d00428cfb7f5e4f0022271" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/cb/8a/cb97c2b353cb46cced413be8f742fa8fcd3cb1659524f27314494aa94968/jupyter_server-2.21.0-py3-none-any.whl", upload-time = 2026-08-27T16:06:31Z, size = 393961, hashes = { sha256 = "2ae2e5ce5e97268553e25aebe040197455673d925b5fc7995477153318160cf7" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", upload-time = 2026-01-14T16:53:20Z, size = 31770, hashes = { sha256 = "bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", upload-time = 2026-01-14T16:53:18Z, size = 13704, hashes = { sha256 = "55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.6.3"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/00/c0/45934229995d4c6e38192ca118d93185f60808f64157e3df3c5c28f8c5fd/jupyterlab-4.6.3.tar.gz", upload-time = 2026-08-10T18:50:57Z, size = 28319771, hashes = { sha256 = "2e3db6e3a12495ebd188276e985bf5ac502fbde3d1e8628819920210008de498" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e9/47/242f46de028074651c9bd6d8000fc340ed0d3cdd1a0eae4387826123413a/jupyterlab-4.6.3-py3-none-any.whl", upload-time = 2026-08-10T18:50:53Z, size = 17168312, hashes = { sha256 = "0a1ebc6567186f1eabd99536e94df7ed9e96d1e7c5ddf3e4406ae16e88abacb7" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", upload-time = 2023-11-23T09:26:37Z, size = 512900, hashes = { sha256 = "721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", upload-time = 2023-11-23T09:26:34Z, size = 15884, hashes = { sha256 = "841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", upload-time = 2025-10-22T13:59:18Z, size = 76996, hashes = { sha256 = "35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", upload-time = 2025-10-22T13:59:16Z, size = 59830, hashes = { sha256 = "e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968" } }]
+
+[[packages]]
+name = "kfp"
+version = "2.16.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/24/d8/4b72f7ffaf8918f629873766db81d444c7dd65a2c7342829b7b9df3d0cc3/kfp-2.16.1.tar.gz", upload-time = 2026-05-05T13:47:52Z, size = 317570, hashes = { sha256 = "67fffff19960bb4624836d1ee0a4449e6e326092646883f7d57e9d1cc402bce2" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/b7/64/c2393ab7410017cefd5fd5693811a77d7d55d5b02faf09a9e6402c4d187c/kfp-2.16.1-py3-none-any.whl", upload-time = 2026-05-05T13:47:50Z, size = 421579, hashes = { sha256 = "d90742de35d1fee871240ddf619b29f5c25103f522eddaf97d2b24cb2483d3ba" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.16.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/fe/bf/ec1d0b97220b779fe373a2e52b217e70ac391cbcdbe184d5d4a128aecb3d/kfp_kubernetes-2.16.1.tar.gz", upload-time = 2026-05-05T13:48:28Z, size = 19754, hashes = { sha256 = "31267b58d04ad97165fb640ab8fe99c2ac58b9f46077a046bd34d281e9491d54" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/38/be/f6022a3c453318b867d2ba9ec9d07f52ecb01ff0bfccd3567b2d3280d0d7/kfp_kubernetes-2.16.1-py3-none-any.whl", upload-time = 2026-05-05T13:48:27Z, size = 27306, hashes = { sha256 = "d6bb854d93a6bc6893f70e9e4f4978d6133760ae62d8626be8a4360993cc9375" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/83/ba/61c1986a0724e146b745cac3006e4123dad6077084c5eeca43f5351d77ec/kfp_pipeline_spec-2.17.0.tar.gz", upload-time = 2026-07-09T13:46:39Z, size = 10621, hashes = { sha256 = "9ffe0a9a881d52ae867fd274d6b458a92d980bb368c15793d9f5e536c7f24521" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/b1/b3/15c2bf2a0063b1fe595cba12ce88e858a90861a166e966fc3d656a3ebbac/kfp_pipeline_spec-2.17.0-py3-none-any.whl", upload-time = 2026-07-09T13:46:38Z, size = 9920, hashes = { sha256 = "a2ae9f287ce69d72f2fc10a5dca30a5e32ab3b6975ad6ce9d4b54e0e02c54371" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/4c/66/96e957346130828d5b8eaf9d3bea89fea5008680289c54f03be70cb745a3/kfp_server_api-2.17.0.tar.gz", upload-time = 2026-07-09T13:46:09Z, size = 69867, hashes = { sha256 = "12adfe269ca4758f01c687898f4471e786183e720fe5fa5aa4ad4fb0f3737d4f" } }
+
+[[packages]]
+name = "kubernetes"
+version = "30.1.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/82/3c/9f29f6cab7f35df8e54f019e5719465fa97b877be2454e99f989270b4f34/kubernetes-30.1.0.tar.gz", upload-time = 2024-06-06T15:58:30Z, size = 887810, hashes = { sha256 = "41e4c77af9f28e7a6c314e3bd06a8c6229ddd787cad684e0ab9f69b498e98ebc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/62/a1/2027ddede72d33be2effc087580aeba07e733a7360780ae87226f1f91bd8/kubernetes-30.1.0-py2.py3-none-any.whl", upload-time = 2024-06-06T15:58:27Z, size = 1706042, hashes = { sha256 = "e212e8b7579031dd2e512168b617373bc1e03888d41ac4e04039240a292d478d" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", upload-time = 2025-10-27T18:25:56Z, size = 382732, hashes = { sha256 = "b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", upload-time = 2025-10-27T18:25:54Z, size = 113151, hashes = { sha256 = "c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12" } }]
 
 [[packages]]
 name = "markupsafe"
@@ -418,6 +709,38 @@ sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be
 wheels = [{ url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", upload-time = 2025-12-08T17:02:38Z, size = 2068504, hashes = { sha256 = "d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/31/d9/5c76de84e96e1cf8aae3fce930875e0615e14f3557bbcdb634aab52da9d3/notebook-7.6.2.tar.gz", upload-time = 2026-08-11T13:21:16Z, size = 5500147, hashes = { sha256 = "cc02b5f0bb972160cccfe44ad8a1a202036206ba3439469c514f03aefa9ae807" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5c/fd/3e552ff5b24dd305c6e9a10e8645e29c03091c317429f326ae10dbae1ac6/notebook-7.6.2-py3-none-any.whl", upload-time = 2026-08-11T13:21:13Z, size = 5547102, hashes = { sha256 = "5fe9e09c335cb4b7de21627b860f77210e70e54b1fb1276ad942a4a7e1d858d3" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", upload-time = 2024-02-14T23:35:18Z, size = 13167, hashes = { sha256 = "b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", upload-time = 2024-02-14T23:35:16Z, size = 13307, hashes = { sha256 = "411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef" } }]
+
+[[packages]]
+name = "oauthlib"
+version = "3.3.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", upload-time = 2025-06-19T22:48:08Z, size = 185918, hashes = { sha256 = "0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", upload-time = 2025-06-19T22:48:06Z, size = 160065, hashes = { sha256 = "88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/66/96/0a16e089701d7503f0b6604b9976ae5f5595712208d2d430377066377d6f/odh_kale-2.2.0.tar.gz", upload-time = 2026-08-08T01:16:22Z, size = 12344249, hashes = { sha256 = "b5615c184fc10915b16612b4a7e06b2c0934f9f463f49edd41be9554b9e155f3" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/b8/cd/1623c87c45a18b3a0aae65d924ae14d9a43ebe02a0fd77f1883e561d5a86/odh_kale-2.2.0-py3-none-any.whl", upload-time = 2026-08-08T01:16:21Z, size = 376135, hashes = { sha256 = "21d51ce32e4641a6c8e490cacdeac4820e61e1c1b6b4e590b67c4336de9a70f7" } }]
+
+[[packages]]
 name = "packaging"
 version = "26.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -482,6 +805,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/ac/26/3b086f0c5d6c1c18c
 wheels = [{ url = "https://files.pythonhosted.org/packages/42/59/123aee44a039b212cfb8d90be1adf06496a99b313ee1683aadf90b3d9799/progress-1.6.1-py3-none-any.whl", upload-time = 2025-07-01T05:50:40Z, size = 9761, hashes = { sha256 = "5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b" } }]
 
 [[packages]]
+name = "prometheus-client"
+version = "0.26.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", upload-time = 2026-07-24T19:36:41Z, size = 92910, hashes = { sha256 = "04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", upload-time = 2026-07-24T19:36:40Z, size = 64494, hashes = { sha256 = "fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6" } }]
+
+[[packages]]
 name = "prompt-toolkit"
 version = "3.0.53"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -501,6 +832,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-05-08T21:00:22Z, size = 60029, hashes = { sha256 = "80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a" } },
     { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-05-08T21:00:30Z, size = 62514, hashes = { sha256 = "c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a" } },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", upload-time = 2026-05-08T21:02:10Z, size = 14036, hashes = { sha256 = "be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe" } },
+]
+
+[[packages]]
+name = "proto-plus"
+version = "1.28.4"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/40/a6/4fbadcc2044034449b3f8f0ce82dcf3005d53f37c136642103fd4836a31c/proto_plus-1.28.4.tar.gz", upload-time = 2026-08-25T19:19:15Z, size = 58679, hashes = { sha256 = "5ff7ecad828e032a491fcb86947801768e32237f99dd049b649965b892ae9a63" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/41/5d/0f04b85dafdc3250ced7f2592efc17dce7f40712e941e9632202481e600d/proto_plus-1.28.4-py3-none-any.whl", upload-time = 2026-08-25T19:18:12Z, size = 50797, hashes = { sha256 = "4b01341272f8a348db3f003b6143109f83ab43091019d5181b3fcdf500ab32aa" } }]
+
+[[packages]]
+name = "protobuf"
+version = "6.33.6"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", upload-time = 2026-03-18T19:05:00Z, size = 444531, hashes = { sha256 = "a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135" } }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", upload-time = 2026-03-18T19:04:53Z, size = 324610, hashes = { sha256 = "e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2" } },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", upload-time = 2026-03-18T19:04:55Z, size = 323436, hashes = { sha256 = "e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593" } },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", upload-time = 2026-03-18T19:04:59Z, size = 170656, hashes = { sha256 = "77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901" } },
 ]
 
 [[packages]]
@@ -531,6 +882,22 @@ marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' an
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", upload-time = 2024-07-21T12:58:21Z, size = 19752, hashes = { sha256 = "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", upload-time = 2024-07-21T12:58:20Z, size = 11842, hashes = { sha256 = "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0" } }]
+
+[[packages]]
+name = "pyasn1"
+version = "0.6.4"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", upload-time = 2026-07-09T01:12:33Z, size = 151262, hashes = { sha256 = "9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", upload-time = 2026-07-09T01:12:32Z, size = 84410, hashes = { sha256 = "deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b" } }]
+
+[[packages]]
+name = "pyasn1-modules"
+version = "0.4.2"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", upload-time = 2025-03-28T02:41:22Z, size = 307892, hashes = { sha256 = "677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", upload-time = 2025-03-28T02:41:19Z, size = 181259, hashes = { sha256 = "29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a" } }]
 
 [[packages]]
 name = "pycodestyle"
@@ -586,6 +953,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee
 wheels = [{ url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", upload-time = 2024-03-01T18:36:18Z, size = 229892, hashes = { sha256 = "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/21/25/5473e46b179f8e8b4ad3aeeb36773d1701b7770eaf5e5bc2025c7303b598/python_json_logger-4.2.0.tar.gz", upload-time = 2026-08-15T11:36:38Z, size = 18211, hashes = { sha256 = "e371ebe22ec01e289850102091a2b1f6fc9e655c7f1f5f29073936756c290afa" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/55/6467fde553886cb293e41538f3a8b4e4fd4688c6df242cf982162d8367fb/python_json_logger-4.2.0-py3-none-any.whl", upload-time = 2026-08-15T11:36:36Z, size = 14988, hashes = { sha256 = "158a52126fcd6869e09574d2b66272666f3dc8f468c62637ef9a1fa883719cb9" } }]
+
+[[packages]]
 name = "pyyaml"
 version = "6.0.3"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -628,6 +1003,46 @@ sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179a
 wheels = [{ url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", upload-time = 2026-05-14T19:25:26Z, size = 73075, hashes = { sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0" } }]
 
 [[packages]]
+name = "requests-oauthlib"
+version = "2.0.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", upload-time = 2024-03-22T20:32:29Z, size = 55650, hashes = { sha256 = "b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", upload-time = 2024-03-22T20:32:28Z, size = 24179, hashes = { sha256 = "7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", upload-time = 2023-05-01T04:11:33Z, size = 206888, hashes = { sha256 = "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", upload-time = 2023-05-01T04:11:28Z, size = 54481, hashes = { sha256 = "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", upload-time = 2021-05-12T16:37:54Z, size = 5513, hashes = { sha256 = "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", upload-time = 2021-05-12T16:37:52Z, size = 3490, hashes = { sha256 = "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", upload-time = 2019-10-28T16:00:19Z, size = 6760, hashes = { sha256 = "3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", upload-time = 2019-10-28T16:00:13Z, size = 4242, hashes = { sha256 = "2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", upload-time = 2025-07-18T01:05:05Z, size = 14239, hashes = { sha256 = "717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", upload-time = 2025-07-18T01:05:03Z, size = 8046, hashes = { sha256 = "6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f" } }]
+
+[[packages]]
 name = "rpds-py"
 version = "2026.6.3"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -639,6 +1054,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-06-30T07:15:27Z, size = 543807, hashes = { sha256 = "2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa" } },
     { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-06-30T07:15:30Z, size = 573030, hashes = { sha256 = "a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822" } },
 ]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", upload-time = 2026-01-14T06:27:36Z, size = 17255, hashes = { sha256 = "1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", upload-time = 2026-01-14T06:27:35Z, size = 17610, hashes = { sha256 = "0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c" } }]
 
 [[packages]]
 name = "setuptools"
@@ -673,12 +1096,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29
 wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", upload-time = 2023-09-30T13:58:03Z, size = 24521, hashes = { sha256 = "d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695" } }]
 
 [[packages]]
+name = "tabulate"
+version = "0.10.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", upload-time = 2026-03-04T18:55:34Z, size = 91754, hashes = { sha256 = "e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", upload-time = 2026-03-04T18:55:31Z, size = 39814, hashes = { sha256 = "f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3" } }]
+
+[[packages]]
 name = "tenacity"
 version = "9.1.4"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", upload-time = 2026-02-07T10:45:33Z, size = 49413, hashes = { sha256 = "adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", upload-time = 2026-02-07T10:45:32Z, size = 28926, hashes = { sha256 = "6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55" } }]
+
+[[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", upload-time = 2024-03-12T14:34:39Z, size = 32701, hashes = { sha256 = "de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", upload-time = 2024-03-12T14:34:36Z, size = 14154, hashes = { sha256 = "a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0" } }]
 
 [[packages]]
 name = "tinycss2"
@@ -726,6 +1165,22 @@ sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3
 wheels = [{ url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", upload-time = 2026-07-02T08:40:04Z, size = 45571, hashes = { sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8" } }]
 
 [[packages]]
+name = "tzdata"
+version = "2026.3"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", upload-time = 2026-07-10T08:50:37Z, size = 198674, hashes = { sha256 = "4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", upload-time = 2026-07-10T08:50:36Z, size = 348168, hashes = { sha256 = "dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931" } }]
+
+[[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", upload-time = 2023-06-21T01:49:05Z, size = 21678, hashes = { sha256 = "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", upload-time = 2023-06-21T01:49:03Z, size = 11140, hashes = { sha256 = "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363" } }]
+
+[[packages]]
 name = "urllib3"
 version = "2.7.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
@@ -764,12 +1219,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a
 wheels = [{ url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", upload-time = 2026-08-28T18:10:04Z, size = 331669, hashes = { sha256 = "d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", upload-time = 2025-10-31T07:51:03Z, size = 53491, hashes = { sha256 = "62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", upload-time = 2025-10-31T07:51:01Z, size = 14905, hashes = { sha256 = "032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/d5/a0/8fd707bcb776a7be556bad06a2ea5fb9bd519df78ef8e26f70ccf0f38bff/webencodings-0.6.1.tar.gz", upload-time = 2026-08-15T14:22:57Z, size = 15001, hashes = { sha256 = "565f9ad031c702dae404e27a099e3e09186a3ab1b9520f06d215502b651fd910" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/77/c6/040cbc72480d789a5f40d63fb484d3106554c4dfa2d2b70ad5022057750f/webencodings-0.6.1-py3-none-any.whl", upload-time = 2026-08-15T14:22:56Z, size = 8745, hashes = { sha256 = "7fab6269c8bf237c657876b52058ccb182e861518d1c695c1a9aaa8c1c105d5b" } }]
+
+[[packages]]
+name = "websocket-client"
+version = "1.9.2"
+marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", upload-time = 2026-08-31T14:08:40Z, size = 84110, hashes = { sha256 = "0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", upload-time = 2026-08-31T14:08:39Z, size = 95786, hashes = { sha256 = "e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce" } }]
 
 [[packages]]
 name = "wheel"

--- a/runtimes/baseline/ubi9-python-3.12/requirements.cpu.txt
+++ b/runtimes/baseline/ubi9-python-3.12/requirements.cpu.txt
@@ -8,6 +8,8 @@ aiohttp==3.14.3 ; (implementation_name == 'cpython' and platform_machine == 'aar
     --hash=sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19
 aiosignal==1.4.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e
+anyio==4.15.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99
 argon2-cffi==25.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741
 argon2-cffi-bindings==26.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -15,14 +17,20 @@ argon2-cffi-bindings==26.1.0 ; (implementation_name == 'cpython' and platform_ma
     --hash=sha256:27f1821903e2ceadcb88ec2b45ef190897b7682449c772f4d9b53e42c520cf29 \
     --hash=sha256:34b7d9c24a4165a2c61cc8ae11d44d48c9ce2830fb536cb7914e11fdd9962728 \
     --hash=sha256:ffff613aaa9ce6236766e2fc6dc560bb5abde7a2e2416e3db1f9ae395a2b4dd4
+arrow==1.4.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205
 astor==0.8.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5
 asttokens==3.0.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933
+async-lru==2.3.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315
 attrs==26.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
 autopep8==2.3.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128
+babel==2.18.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35
 beautifulsoup4==4.15.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9
 bleach==6.4.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -46,8 +54,27 @@ charset-normalizer==3.5.1 ; (implementation_name == 'cpython' and platform_machi
     --hash=sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6
 click==8.5.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360
+click-option-group==0.5.7 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:96b9f52f397ef4d916f81929bd6c1f85e89046c7a401a64e72a61ae74ad35c24
 comm==0.2.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417
+cryptography==50.0.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f \
+    --hash=sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef \
+    --hash=sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8 \
+    --hash=sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad \
+    --hash=sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f \
+    --hash=sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a \
+    --hash=sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959 \
+    --hash=sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b \
+    --hash=sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23 \
+    --hash=sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733 \
+    --hash=sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88 \
+    --hash=sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5 \
+    --hash=sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71 \
+    --hash=sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239 \
+    --hash=sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558 \
+    --hash=sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e
 debugpy==1.8.21 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176 \
     --hash=sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92
@@ -55,18 +82,43 @@ defusedxml==0.7.1 ; (implementation_name == 'cpython' and platform_machine == 'a
     --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
 dill==0.4.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d
+docstring-parser==0.18.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b
 entrypoints==0.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f
 executing==2.2.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017
 fastjsonschema==2.22.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:0fb3915616adac85ccfdd737d26be1089845d2019819505b42d39888458f74d4
+fqdn==1.5.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014
 frozenlist==1.8.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383 \
     --hash=sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4 \
     --hash=sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29 \
     --hash=sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa \
     --hash=sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d
+google-api-core==2.34.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de
+google-auth==2.57.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59
+google-cloud-core==2.7.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:c18a250904cfdda021eb3ae8b8238c9f9ca272a4cbbfb5cba946b3fe3022eed1
+google-cloud-storage==3.13.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:98208de6c21e85cecd3eb44551894efff33d98365500e178867d4305854a770a
+google-crc32c==1.8.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411 \
+    --hash=sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454
+google-resumable-media==2.10.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:e3cedc827a4ea41e216582d74346f1fb9fceb625a8c3c53912f2ca1d663334d7
+googleapis-common-protos==1.75.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e
+h11==0.16.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+httpcore==1.0.9 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55
+httpx==0.28.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
 idna==3.19 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4
 ipykernel==7.3.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -77,20 +129,52 @@ ipython-genutils==0.2.0 ; (implementation_name == 'cpython' and platform_machine
     --hash=sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8
 ipython-pygments-lexers==1.1.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c
+isoduration==20.11.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042
 jedi==0.20.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67
 jinja2==3.1.6 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+json5==0.15.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618
+jsonpointer==3.1.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca
 jsonschema==4.26.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
 jsonschema-specifications==2025.9.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+jupyter-builder==1.2.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:6ebcd4c49daf5df6a18068a74a48010406700ed90a76c189fac43eaf85c60c63
 jupyter-client==8.10.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:5f73f24f22fa25192cfff6b23c051932a2473a797b05734aff495b392103e14e
 jupyter-core==5.9.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407
+jupyter-events==0.12.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf
+jupyter-lsp==2.3.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81
+jupyter-server==2.21.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:2ae2e5ce5e97268553e25aebe040197455673d925b5fc7995477153318160cf7
+jupyter-server-terminals==0.5.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14
+jupyterlab==4.6.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:0a1ebc6567186f1eabd99536e94df7ed9e96d1e7c5ddf3e4406ae16e88abacb7
 jupyterlab-pygments==0.3.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780
+jupyterlab-server==2.28.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968
+kfp==2.16.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:d90742de35d1fee871240ddf619b29f5c25103f522eddaf97d2b24cb2483d3ba
+kfp-kubernetes==2.16.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:d6bb854d93a6bc6893f70e9e4f4978d6133760ae62d8626be8a4360993cc9375
+kfp-pipeline-spec==2.17.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:a2ae9f287ce69d72f2fc10a5dca30a5e32ab3b6975ad6ce9d4b54e0e02c54371
+kfp-server-api==2.17.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:12adfe269ca4758f01c687898f4471e786183e720fe5fa5aa4ad4fb0f3737d4f
+kubernetes==30.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:e212e8b7579031dd2e512168b617373bc1e03888d41ac4e04039240a292d478d
+lark==1.3.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12
 markupsafe==3.0.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d \
     --hash=sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d \
@@ -120,6 +204,14 @@ nest-asyncio2==1.7.2 ; (implementation_name == 'cpython' and platform_machine ==
     --hash=sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01
 networkx==3.6.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762
+notebook==7.6.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:5fe9e09c335cb4b7de21627b860f77210e70e54b1fb1276ad942a4a7e1d858d3
+notebook-shim==0.2.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef
+oauthlib==3.3.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+odh-kale==2.2.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:21d51ce32e4641a6c8e490cacdeac4820e61e1c1b6b4e590b67c4336de9a70f7
 packaging==26.3 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
 pandocfilters==1.5.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -136,6 +228,8 @@ platformdirs==4.11.7 ; (implementation_name == 'cpython' and platform_machine ==
     --hash=sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6
 progress==1.6.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b
+prometheus-client==0.26.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6
 prompt-toolkit==3.0.53 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2
 propcache==0.5.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -144,6 +238,12 @@ propcache==0.5.2 ; (implementation_name == 'cpython' and platform_machine == 'aa
     --hash=sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a \
     --hash=sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a \
     --hash=sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe
+proto-plus==1.28.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:4b01341272f8a348db3f003b6143109f83ab43091019d5181b3fcdf500ab32aa
+protobuf==6.33.6 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2 \
+    --hash=sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593 \
+    --hash=sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901
 psutil==7.2.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9 \
     --hash=sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e \
@@ -153,6 +253,10 @@ ptyprocess==0.7.0 ; (implementation_name == 'cpython' and platform_machine == 'a
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35
 pure-eval==0.2.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
+pyasn1==0.6.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
+pyasn1-modules==0.4.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a
 pycodestyle==2.14.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d
 pycparser==3.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -168,6 +272,8 @@ pygments==2.21.0 ; (implementation_name == 'cpython' and platform_machine == 'aa
     --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
 python-dateutil==2.9.0.post0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+python-json-logger==4.2.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:158a52126fcd6869e09574d2b66272666f3dc8f468c62637ef9a1fa883719cb9
 pyyaml==6.0.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28 \
     --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc \
@@ -182,11 +288,23 @@ referencing==0.37.0 ; (implementation_name == 'cpython' and platform_machine == 
     --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
 requests==2.34.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+requests-oauthlib==2.0.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36
+requests-toolbelt==1.0.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06
+rfc3339-validator==0.1.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
+rfc3986-validator==0.1.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9
+rfc3987-syntax==1.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f
 rpds-py==2026.6.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24 \
     --hash=sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6 \
     --hash=sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa \
     --hash=sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822
+send2trash==2.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c
 setuptools==84.0.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670
 six==1.17.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -195,8 +313,12 @@ soupsieve==2.9.2 ; (implementation_name == 'cpython' and platform_machine == 'aa
     --hash=sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823
 stack-data==0.6.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
+tabulate==0.10.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
 tenacity==9.1.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55
+terminado==0.18.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0
 tinycss2==1.5.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661
 tornado==6.5.8 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -210,6 +332,10 @@ traitlets==5.16.1 ; (implementation_name == 'cpython' and platform_machine == 'a
     --hash=sha256:f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b
 typing-extensions==4.16.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+tzdata==2026.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
+uri-template==1.3.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363
 urllib3==2.7.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
 uv==0.12.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -228,8 +354,12 @@ uv==0.12.5 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dc14e4f81a99b585a891350c60d1ff4557d54cb3c3c81fa45fd4e0dd512ba752
 wcwidth==0.8.3 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4
+webcolors==25.10.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d
 webencodings==0.6.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:7fab6269c8bf237c657876b52058ccb182e861518d1c695c1a9aaa8c1c105d5b
+websocket-client==1.9.2 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce
 wheel==0.48.0 ; implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab
 yarl==1.24.5 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \

--- a/runtimes/datascience/ubi9-python-3.12/requirements.cpu.txt
+++ b/runtimes/datascience/ubi9-python-3.12/requirements.cpu.txt
@@ -25,6 +25,8 @@ argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementatio
     --hash=sha256:2e335e8b236ef704a19967005b0b85c8feed7f60fb377421f1f46c718bbe0eff \
     --hash=sha256:7dda6e7a1d127fd865c3b16e537855e55f8c40914ed4ce14c3466cbd055af8a5 \
     --hash=sha256:85679d0aa734c50fde4a9f2df33192860f1fc0332512497f2ec768a73c8cccdd
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fd6661e8bebee4e62a704e5d59854e82870743fb261633ac45fab5b2f0e67241
 ast-serialize==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e66a24f9e8df2f04aa29d58e99d8d589fe56b640f0d187024dd612633e7300de \
     --hash=sha256:6388e848f210ba089b10ddba7ff58ebaba26b6dad0295b7bd3428fbbd5c5f83f \
@@ -34,10 +36,14 @@ astor==0.8.1 ; python_full_version == '3.12.*' and implementation_name == 'cpyth
     --hash=sha256:cf7da720e6337a9fbc1e3fec53339f463b6968f880926d0e11777792c2ee87d4
 asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c56de98b4bbcd9b28697fedb1381679afa3c9a237071cbd7e50a343840ff1e4e
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b36060caf6ef63db88f23b53aab4c7ccb8fe471cf4b75da5e6bd2ef04429efa3
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2743bc4ee570bfbff0689b6e320523c87c2adfe205306cb14142155d11569fab
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:712cee22ee81cd31e5bfbee2a66da356f714ce4aee97c774de64f9b8e64d323b
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:53f2e369782200a613927eff62c18fefedd66d9ac113cbb5dee4115ff94b936a
 bcrypt==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:0f4190da1810679994e8d9e04b3361d1131a36ebfa2a69ba6772e1195733cabc \
     --hash=sha256:2ef57281bbc3824e32d59d70df87e8b3a1e03aa25648afbab2e3696aee848e7e
@@ -66,6 +72,8 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:aeac1eeb950a89b952cf6a9e60411e92a706e116c76ba6182a1834daf9ae2f32
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6e18eed0a727a8a903729a024b94912fb3636fadae097ea79ddcf2697d233a2f
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b48288d7abe1ab1f28dcea6e84597743e09b8a43345c1f30e04e772bbfaad24a
 cloudpickle==3.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a796d78b6c6ee2fec31ec4a44e74a44565cd914b373f28c382d5de60f6da232f
 codeflare-sdk==0.38.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
@@ -107,7 +115,9 @@ dnspython==2.8.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:d6cbbd509f94409e79083728c0184bdf732973836ddbcee49869c678ebf226bc
 docker==7.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5335477705c54ee1ca95ea9108b753a05b293a570211c50ff589d0be5c02372b
-durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9c5320c27124b926c7c44ed569788bed1efc1c74b3cf544f710c2fe384404694
+durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e1fd85941f19ba774b3eb47d96b151a137b29adc561b5cbf6aa948fb5957a2aa
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1faee7b15d168647a1e9b08fd77e502f9b818b5670eb7cff2859e27912e14477
@@ -127,6 +137,8 @@ flask-cors==6.0.5 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:a401a140421dd8cbc30de6909a8f559dafb3c79cd2993ad07e6b7ad7960890c9
 fonttools==4.63.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ccdb40c8a6197fd1b451be171c5ee3a7d7bd6fdac7758d05fae8c39f0a6883f2
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:209fed349f2c3d9499d3b1d199ebb10bea342b9db106b66718c864ba315e5f12
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:25cc97274d43add7842ecf7279a64f4567dc362f250e6074971fbfbf6f251005 \
     --hash=sha256:94833878f626544d8ed7d24a4ca76f1fec8d626b4bcde06f82a260fe5c3d098a \
@@ -138,11 +150,19 @@ gitdb==4.0.12 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:97816c19dbacbf51644b6580d22b1494476b305a5d066b023c2438100cc444ce
 gitpython==3.1.59 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:cb2ee699a68920968557a0dd41a27e83afce5604728236e96d5ff62820492c0b
-google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f05f245bf71918de2f5bfee3ccdfcf38522fc87af32b8296f2af1aae3af399fe
 google-auth==2.56.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5422babfa3231e432df2081e02a59be73a7288ec3ca7fe186821ef265b758d9d
-googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:189a300f2de463e563649860d4c131f26db251c15ead1b65f37c27eedd30f379
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e2d41e879f0cf1b0fbb3de5a222965911dc7badb0b2132c07bc92e1c7445b359
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6f62c011e01848fcbd0f4e51b45fe8680d40880b8f3b1245dca4df175bfff48b
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:626c12dd7db75040a738d5153657a8717ff632234f0baaf008a8b71981818e78
+googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6791549561a145e59419ad9b65206995aa190e15e0a7b3ad964f869e8e979955
 graphene==3.4.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5985ea550c7653175dc1b7098ed818294c1a8cda07d7baa532ad15aaaa3dfe4a
@@ -161,11 +181,15 @@ gunicorn==26.0.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:353bf0ccd9498011cb54eef4bef47f6f16f60b173936ce4f949a481bc4e4efc8
 h11==0.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e44ad99adcda4c6141fdf245e22a6b506959df7fcb89d1f8f08e675e60eaf782
+httpcore==1.0.9 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c5597b774a5e1061731601fe2a5e84ec2336af935a2aa964943efcdb8ef85a2f
 httptools==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:78e1feca4e73791f6a874d7c2e3f8da8df83fa8466a84d5c28204b3f1eafeddc \
     --hash=sha256:36065a8403a2d462ac86d47fe6ca1de18c5b3bbbbca2a1e898e1804a77111e1d \
     --hash=sha256:bb825e3282b17b93e9a53f7a550e5b7f48fb27a2a451813c7f95f9b3a32d598f \
     --hash=sha256:3665ed73a1cae3ba2024cb991405e225a9b08095695ff92bc9064a6c49477c53
+httpx==0.28.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:efca1a86438747d4ba695232764a5b3b0d134ddcd64e09abe946dc4295319547
 huey==3.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:16e2e8cce65adc9738014a134a1d7c6ae12104ea6221764891da9aaebc3771b8
 idna==3.18 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -184,6 +208,8 @@ ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementat
     --hash=sha256:53735aa64313d30e3daa300e467a120b02ff61006db6ca2c3d3dca5fe165be2a
 ipywidgets==8.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:4d202ba95dfd26b36cde48dcd74685b3e66f283d7b606916d69993625daf7f9d
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7ae1d18f8ce0713d7a9857d2c9c3d6d95eb11114000c924bb018019a6b91bd74
 itsdangerous==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b0f9b950d2f935a11c3873e5aa2f21aba06f3411f036b97731c11931224b4bca
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -194,20 +220,46 @@ jmespath==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:8a55aa455b5517b3cb109f789c956a95875eac4b5d9986dac69f8093447cd123
 joblib==1.5.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a92f544d14316a579117d71c0f4ee6f63b21d07c370fa1f3e23397fa38a0bc43
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1699d884ff6e97b4f0fce0823fb118e29660751af61fd9a0a47e4f88210b8f85
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:57c05b6c42f8fbb4c98cd735cc995eea3f19a31ec126c94f58e1ddad6765761b
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:362ef10db9ed85b707ede08e25f8336016df3f9a758568760439350bf20e6ed0
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:15b04b8b340156cde62f352b33a1605a9eae565708e6fc475f90d3a53dd8f6e4
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:294548f7c4515523860fe7a71b50c4aed4706b48f1771f1a16922720670339c4
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:09b8eff468e8fce72b7cc59ca036ed4af960c5a80958d7cade944840978d04d1
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e4efe9399594a9e46fb2bd049ff793faf2e41eaf570635786b7e56ab3ac72f6
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:de3352fb77bcdbfc44e84051ec8317d26211f741c5045add18081730892aacc5
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e9c41f8064a058c7d26c742ef54267084c5b3f5e0a428b1cf63c3c1709928e1f
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b45a13be8e75c4aae53e9747fefcd7f478b168d91ee2256fa07165c3cb68cf56
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ee8694a34f33dbb831166dc6da227621e7e8e02684decd4ff20684942ac3bf2a
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:63f69199cfdba005a0a3a577cf7bc326f91950141c0b51a7c612d5f23e369419
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a7838ddba7ef759672d6f06d3a657db1f1b222df2ea30cc8fa12238cf2152c48
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3e1d8eb8bc3030df7be780a53f2e4f051b163e1e5652cc561340dc69340d7530
 jupyterlab-widgets==3.0.16 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:7439813c7e05f6cdd67839614afb2d886e136b2ab626f7ae09dbdc43394cacf1
 kafka-python-ng==2.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1eaac7def1189da234eb5c443f2bc43ab690b65e9674227e62143f079bbfc649
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a6bb17423aaae00d05b22505ba663d91d39aac192619989e17ed44d65c905030
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6326f072af17863960beb38a5f14b4b59c02763fbea804011f5a2c43d0146094
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:742a3cbb2a9e4aabf5505bb0f07ff90ebe394930244724d98d0df4de7647bac8
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e99f4d87407cba00d47ccd582d4416766643b53719e5415c46aaa75368e56ed5
 kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:13dd9933ad502f5cdc9352c33854ca592f915717a13089f4a0e7e62e583fdd91 \
     --hash=sha256:a3b72745f5e4b70c78308fb901ef20e2c7a6cd70a86078a05b484f086127a16d \
@@ -215,8 +267,10 @@ kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:5e36c85a1605d16eb2bf00d9734cf5609171dbb72fb5be3bcde56a1bfb34f8b8
 kube-authkit==0.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:f2a9496d44a9817c3f77d523090918ba432a720fa1a7443cb11edf52ba5d189b
-kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5abef75f6749b0a1d75b0a886a490d2502ed1754ed8e95e4dd99082161571656
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2e1f9a6f017474e27772b4fdd733aab241fe73a9d546e74f7e8db7b4d3ef288b
 librt==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
     --hash=sha256:ed03cc2a75cd0d3fec357ec99d7604dd7dfe0cda01bcd5f7cee439723384068c \
     --hash=sha256:1bc187a151092a75b6e2f085f0db198ff2a139919fec0a6742fbded5856e5d1a \
@@ -293,13 +347,19 @@ nest-asyncio2==1.7.2 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:a2af2111265a271e2a646150862402411f10f0348856e8dcc95764657192dafb
 networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:cf13e752b157f3b94b6bdef4be9c98f01901a8ba80084f7e3a87bc9778905f5f
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:48e9115bfe69cccf3462e3eebed5fab1d0b2e64130b2e6844c5bae7cf88e003a
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dff20201f6677c0f7f31517898d5073da70e51d8039a1ff98da4ffc2e7827ae3
 numpy==2.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:afaa711680b33da727d91bcfd75b131fee66f392bea5acd140df9e7907ed02b6 \
     --hash=sha256:92b58e25cab7bc6e7ebc69952a84acdf7563af8b68ffc3296a6ae35fd347c6ed \
     --hash=sha256:68df8564f43607eefa4460cb5f2ed2253edb9ad9bd40c84aa8d874ab75ec66d4 \
     --hash=sha256:0044665c94ad26cb4ba49db1b50e3634de4f7773859c90c612da981ab08fbd2f
-oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f370abab1b1c2a6c4cee58209d430d26d73807b4e30980e78e9801788f534cf3
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1b4b0c5a2f035a5421854275d0565b813b2f02efbfc7320056fecd3f0344fd2e
 onnx==1.22.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b45193d0e48f1354ad6602647fc40e5b08f25348d342903faf6af4193e263acb \
     --hash=sha256:83c41cd31dd61a3ae8987ad153a036dc6b603ac4aab22233dae7fee2c276a26a \
@@ -329,7 +389,11 @@ pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:448cb61682a3e28102675a13569439021a4cd9ef78d93f1d7d7c9a2a7938952a \
     --hash=sha256:47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c \
     --hash=sha256:592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693 \
-    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e
+    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e \
+    --hash=sha256:5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35 \
+    --hash=sha256:24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006 \
+    --hash=sha256:ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e \
+    --hash=sha256:68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a4b4cb2c5bf334d29c8288652669cffc0809ea7e7c30f6344204493be297df3f
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -368,7 +432,7 @@ propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:a1b9679c2435bec7edbfcf75d9e31b1c7984fe54c4e09eaaa2856c76dfbdc7f9 \
     --hash=sha256:9ff1c5c4caae00455aae23300862b8cf4df09e75efc13596c1b3b68c23c6d4cb \
     --hash=sha256:4b5ae20932f4cb043164642b2303ef86297f7a93ee4336d153fdfac9f711796f
-proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a5be36fe0739093bfb1b3476a50cfa3a99faecb513aee153646c2adac66236e4
 protobuf==6.31.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1771712c0394d38ac7ce8d3029bd93e5be6cc00f45e7bb6c2ab7825ad97b6bb8 \
@@ -438,6 +502,8 @@ python-discovery==1.5.2 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:ff6c7414e70198ec59e57c63185de143173a75ffd5ea6e7604951348d16c6cf8
 python-dotenv==1.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:562d2a70286b8cf2972d12caf587992a5ccf5e1d9ec1ea90dfd2640bdc8d1590
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:705b66a54544867ebcdffc48e61b6adbc66f8410b4b77e56e4ae293864582247
 pytz==2026.3.post1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5a879209aecbc1a499171ae1e0eb1fd9a4b8ba587a2a27dcdc99cae51f082cd8
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -455,10 +521,18 @@ ray==2.55.1 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
     --hash=sha256:dd279d8502ee79a41f46424a8367696fb3b7419310be921bc7a2c53895d47c5c
 referencing==0.37.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3cb7ea100b68d42b173d034a42b99c8036052271aba2f5ebeff318f82d05f1e2
-requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:a9af2e58bdfc2ce308285230ae028e85344a322a84aad258bffecc98ba875bb8
-requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+requests==2.33.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5a9b26a054cec98d10da567b6e8783b556032f96ebc075665e9ba7144b30a8e2
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:634963f9a16cff466939af3b006af734a67df64b31a92dd9d1f37d11ec1b9771
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4a6f146dea9f38b77300d27d183664bdf6f92d7324a48eda3f2093b9a1288e25
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dc3664e5d7c536ec4af21122247b1c2b719ef18412ecea83913eb74a4d93b7ff
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3e9b53655518c0d6254ef6a33d7af198e9b32b927fda5cac6941e2dc209d10dc
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1e2842aef14b9ffa974bb57cbf3dd14eea37d54f569a01debd6965ce3d8c1835
 rich==14.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:8689e335c608f877fa5aaeab19d5972f202d61226beffa684616a0d6bfb2d226
 rpds-py==2026.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -478,6 +552,8 @@ scipy==1.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:17a1edd502aafd593b3ec19ab5bcb2cd293609510f3df6743d5ff7f2d60244e9 \
     --hash=sha256:b550c9f4f748917ee645804432ab4c2e81830ccebc2d2fb1788c8c9684045372 \
     --hash=sha256:c4902b58295199b9e6891606caaf7c1d1fdefc2d1d15ee4e8c89873eff253307
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bcce65332cb56b574fdbd76779291d5c3635da813bf719c8ade92887094af294
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d3a096864c3017b2b537f98876fb7c795958f7bb4e2fb1204ec98cf1850c0db2
 six==1.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -507,6 +583,8 @@ tabulate==0.10.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:437f1c5d5e558c8178f88d2fdca451d82fe12172a4fadfd91e4c774a6755300f
 tenacity==8.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fc611ec9ec5413788b51c7f806f71c3c81262159e3478fc51e034c02a9641d46
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:720c7eddf2ba20c7fa279dbeb4636f0621344066656855d23603b0944d95e9e4
 threadpoolctl==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:51f76e816fd4b37af2529f48627f1fa3c3240424f0b1047f4d1af7d009a79ddb
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -532,6 +610,8 @@ typing-inspection==0.4.4 ; python_full_version == '3.12.*' and implementation_na
     --hash=sha256:e2c58302efc64caa542402f36e28d8150b3d6bd85865ebae1331109e63579cee
 tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0d183bc3f56f7cdc6a69745b4b3f744c839da134df1b032153b4b93fa97bc324
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:52a35f31b19eb1eb9190a92112770348cf2d2f9144a93ca5f90ace45f0a20dd3
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3109b1affa53baae9cc52a6702f0560ff8999d994e82b5f19138e6e044979f54
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -557,9 +637,11 @@ watchfiles==1.2.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:40167c27c90bffc569fb25b8895ae152e30c55e820c89576e5c3152c76de6549
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5880f454b3b69f0479eafbec007169d262ddd33c2d7e66432c819283b0d54eab
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:709970f37b58749eaf278c77ed1836df39e58bff8847d645cd7b89df849c59fe
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4bae5fba959dd841b2ca2748b08abdb67b02ad08a2cbb101337d750adc8a25f6
-websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f99e4267f2ed84d6fc26ef1348245ef1d371c69898da692995163fbbd7554f9a
 websockets==17.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:67212f58a785e0fc28e4549af502c6458eaa7cb368859afdde32a6ca9c8d081c \

--- a/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -75,6 +75,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 70409, hashes = { sha256 = "fd6661e8bebee4e62a704e5d59854e82870743fb261633ac45fab5b2f0e67241" } }]
+
+[[packages]]
 name = "ast-serialize"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -98,6 +104,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/asttokens-3.0.2-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 29413, hashes = { sha256 = "c56de98b4bbcd9b28697fedb1381679afa3c9a237071cbd7e50a343840ff1e4e" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 10054, hashes = { sha256 = "b36060caf6ef63db88f23b53aab4c7ccb8fe471cf4b75da5e6bd2ef04429efa3" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -108,6 +120,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 47527, hashes = { sha256 = "712cee22ee81cd31e5bfbee2a66da356f714ce4aee97c774de64f9b8e64d323b" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 10198502, hashes = { sha256 = "53f2e369782200a613927eff62c18fefedd66d9ac113cbb5dee4115ff94b936a" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -188,6 +206,12 @@ name = "click"
 version = "8.4.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 120858, hashes = { sha256 = "6e18eed0a727a8a903729a024b94912fb3636fadae097ea79ddcf2697d233a2f" } }]
+
+[[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 13199, hashes = { sha256 = "b48288d7abe1ab1f28dcea6e84597743e09b8a43345c1f30e04e772bbfaad24a" } }]
 
 [[packages]]
 name = "cloudpickle"
@@ -301,9 +325,15 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/docker-7.2.0-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 150398, hashes = { sha256 = "5335477705c54ee1ca95ea9108b753a05b293a570211c50ff589d0be5c02372b" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 24249, hashes = { sha256 = "9c5320c27124b926c7c44ed569788bed1efc1c74b3cf544f710c2fe384404694" } }]
+
+[[packages]]
 name = "durationpy"
 version = "0.10"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/durationpy-0.10-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 5634, hashes = { sha256 = "e1fd85941f19ba774b3eb47d96b151a137b29adc561b5cbf6aa948fb5957a2aa" } }]
 
 [[packages]]
@@ -361,6 +391,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/fonttools-4.63.0-1-py3-none-any.whl", upload-time = 2026-08-14T01:08:08Z, size = 1166224, hashes = { sha256 = "ccdb40c8a6197fd1b451be171c5ee3a7d7bd6fdac7758d05fae8c39f0a6883f2" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 5292, hashes = { sha256 = "209fed349f2c3d9499d3b1d199ebb10bea342b9db106b66718c864ba315e5f12" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -392,7 +428,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "google-api-core"
 version = "2.34.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 182296, hashes = { sha256 = "f05f245bf71918de2f5bfee3ccdfcf38522fc87af32b8296f2af1aae3af399fe" } }]
 
 [[packages]]
@@ -402,9 +438,33 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_auth-2.56.3-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 260806, hashes = { sha256 = "5422babfa3231e432df2081e02a59be73a7288ec3ca7fe186821ef265b758d9d" } }]
 
 [[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 32812, hashes = { sha256 = "189a300f2de463e563649860d4c131f26db251c15ead1b65f37c27eedd30f379" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 343298, hashes = { sha256 = "e2d41e879f0cf1b0fbb3de5a222965911dc7badb0b2132c07bc92e1c7445b359" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 15529, hashes = { sha256 = "6f62c011e01848fcbd0f4e51b45fe8680d40880b8f3b1245dca4df175bfff48b" } }]
+
+[[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 83369, hashes = { sha256 = "626c12dd7db75040a738d5153657a8717ff632234f0baaf008a8b71981818e78" } }]
+
+[[packages]]
 name = "googleapis-common-protos"
 version = "1.75.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/googleapis_common_protos-1.75.1-1-py3-none-any.whl", upload-time = 2026-08-14T01:04:01Z, size = 302478, hashes = { sha256 = "6791549561a145e59419ad9b65206995aa190e15e0a7b3ad964f869e8e979955" } }]
 
 [[packages]]
@@ -457,6 +517,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/h11-0.16.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 39148, hashes = { sha256 = "e44ad99adcda4c6141fdf245e22a6b506959df7fcb89d1f8f08e675e60eaf782" } }]
 
 [[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/httpcore-1.0.9-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 80434, hashes = { sha256 = "c5597b774a5e1061731601fe2a5e84ec2336af935a2aa964943efcdb8ef85a2f" } }]
+
+[[packages]]
 name = "httptools"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -466,6 +532,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/httptools-0.8.0-1-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T02:14:48Z, size = 600567, hashes = { sha256 = "bb825e3282b17b93e9a53f7a550e5b7f48fb27a2a451813c7f95f9b3a32d598f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/httptools-0.8.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:51:06Z, size = 514720, hashes = { sha256 = "3665ed73a1cae3ba2024cb991405e225a9b08095695ff92bc9064a6c49477c53" } },
 ]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/httpx-0.28.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 75162, hashes = { sha256 = "efca1a86438747d4ba695232764a5b3b0d134ddcd64e09abe946dc4295319547" } }]
 
 [[packages]]
 name = "huey"
@@ -522,6 +594,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/ipywidgets-8.1.2-1-py3-none-any.whl", upload-time = 2026-08-15T08:39:02Z, size = 141123, hashes = { sha256 = "4d202ba95dfd26b36cde48dcd74685b3e66f283d7b606916d69993625daf7f9d" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 13136, hashes = { sha256 = "7ae1d18f8ce0713d7a9857d2c9c3d6d95eb11114000c924bb018019a6b91bd74" } }]
+
+[[packages]]
 name = "itsdangerous"
 version = "2.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -552,6 +630,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/joblib-1.5.3-1-py3-none-any.whl", upload-time = 2026-08-14T01:08:08Z, size = 310691, hashes = { sha256 = "a92f544d14316a579117d71c0f4ee6f63b21d07c370fa1f3e23397fa38a0bc43" } }]
 
 [[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 38187, hashes = { sha256 = "1699d884ff6e97b4f0fce0823fb118e29660751af61fd9a0a47e4f88210b8f85" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 9358, hashes = { sha256 = "57c05b6c42f8fbb4c98cd735cc995eea3f19a31ec126c94f58e1ddad6765761b" } }]
+
+[[packages]]
 name = "jsonschema"
 version = "4.26.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -562,6 +652,12 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T01:04:01Z, size = 20295, hashes = { sha256 = "15b04b8b340156cde62f352b33a1605a9eae565708e6fc475f90d3a53dd8f6e4" } }]
+
+[[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 917003, hashes = { sha256 = "294548f7c4515523860fe7a71b50c4aed4706b48f1771f1a16922720670339c4" } }]
 
 [[packages]]
 name = "jupyter-client"
@@ -576,10 +672,46 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 30714, hashes = { sha256 = "8e4efe9399594a9e46fb2bd049ff793faf2e41eaf570635786b7e56ab3ac72f6" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 21225, hashes = { sha256 = "de3352fb77bcdbfc44e84051ec8317d26211f741c5045add18081730892aacc5" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 79187, hashes = { sha256 = "e9c41f8064a058c7d26c742ef54267084c5b3f5e0a428b1cf63c3c1709928e1f" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 395767, hashes = { sha256 = "b45a13be8e75c4aae53e9747fefcd7f478b168d91ee2256fa07165c3cb68cf56" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 15514, hashes = { sha256 = "ee8694a34f33dbb831166dc6da227621e7e8e02684decd4ff20684942ac3bf2a" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 12454274, hashes = { sha256 = "63f69199cfdba005a0a3a577cf7bc326f91950141c0b51a7c612d5f23e369419" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 17964, hashes = { sha256 = "a7838ddba7ef759672d6f06d3a657db1f1b222df2ea30cc8fa12238cf2152c48" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 61571, hashes = { sha256 = "3e1d8eb8bc3030df7be780a53f2e4f051b163e1e5652cc561340dc69340d7530" } }]
 
 [[packages]]
 name = "jupyterlab-widgets"
@@ -592,6 +724,30 @@ name = "kafka-python-ng"
 version = "2.2.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kafka_python_ng-2.2.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 234707, hashes = { sha256 = "1eaac7def1189da234eb5c443f2bc43ab690b65e9674227e62143f079bbfc649" } }]
+
+[[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 479782, hashes = { sha256 = "a6bb17423aaae00d05b22505ba663d91d39aac192619989e17ed44d65c905030" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 29466, hashes = { sha256 = "6326f072af17863960beb38a5f14b4b59c02763fbea804011f5a2c43d0146094" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 11704, hashes = { sha256 = "742a3cbb2a9e4aabf5505bb0f07ff90ebe394930244724d98d0df4de7647bac8" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 130411, hashes = { sha256 = "e99f4d87407cba00d47ccd582d4416766643b53719e5415c46aaa75368e56ed5" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -613,8 +769,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "kubernetes"
 version = "36.0.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 4619742, hashes = { sha256 = "5abef75f6749b0a1d75b0a886a490d2502ed1754ed8e95e4dd99082161571656" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 114762, hashes = { sha256 = "2e1f9a6f017474e27772b4fdd733aab241fe73a9d546e74f7e8db7b4d3ef288b" } }]
 
 [[packages]]
 name = "librt"
@@ -817,6 +979,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/networkx-3.6.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 2070144, hashes = { sha256 = "cf13e752b157f3b94b6bdef4be9c98f01901a8ba80084f7e3a87bc9778905f5f" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 5548932, hashes = { sha256 = "48e9115bfe69cccf3462e3eebed5fab1d0b2e64130b2e6844c5bae7cf88e003a" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 15000, hashes = { sha256 = "dff20201f6677c0f7f31517898d5073da70e51d8039a1ff98da4ffc2e7827ae3" } }]
+
+[[packages]]
 name = "numpy"
 version = "2.5.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -830,8 +1004,14 @@ wheels = [
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 161707, hashes = { sha256 = "f370abab1b1c2a6c4cee58209d430d26d73807b4e30980e78e9801788f534cf3" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T00:56:21Z, size = 377926, hashes = { sha256 = "1b4b0c5a2f035a5421854275d0565b813b2f02efbfc7320056fecd3f0344fd2e" } }]
 
 [[packages]]
 name = "onnx"
@@ -913,6 +1093,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 12941471, hashes = { sha256 = "47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 16095328, hashes = { sha256 = "592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 12761080, hashes = { sha256 = "4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:45:03Z, size = 12053826, hashes = { sha256 = "5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-28T01:52:37Z, size = 12925504, hashes = { sha256 = "24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-28T01:10:19Z, size = 16064649, hashes = { sha256 = "ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:39:05Z, size = 12742532, hashes = { sha256 = "68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7" } },
 ]
 
 [[packages]]
@@ -1024,7 +1208,7 @@ wheels = [
 [[packages]]
 name = "proto-plus"
 version = "1.28.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/proto_plus-1.28.3-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 52498, hashes = { sha256 = "a5be36fe0739093bfb1b3476a50cfa3a99faecb513aee153646c2adac66236e4" } }]
 
 [[packages]]
@@ -1204,6 +1388,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/python_dotenv-1.2.3-1-py3-none-any.whl", upload-time = 2026-08-20T00:46:11Z, size = 24505, hashes = { sha256 = "562d2a70286b8cf2972d12caf587992a5ccf5e1d9ec1ea90dfd2640bdc8d1590" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T00:37:34Z, size = 16754, hashes = { sha256 = "705b66a54544867ebcdffc48e61b6adbc66f8410b4b77e56e4ae293864582247" } }]
+
+[[packages]]
 name = "pytz"
 version = "2026.3.post1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1248,15 +1438,39 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "requests"
-version = "2.34.2"
+version = "2.33.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests-2.34.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 74727, hashes = { sha256 = "a9af2e58bdfc2ce308285230ae028e85344a322a84aad258bffecc98ba875bb8" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests-2.33.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 66704, hashes = { sha256 = "5a9b26a054cec98d10da567b6e8783b556032f96ebc075665e9ba7144b30a8e2" } }]
 
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 26050, hashes = { sha256 = "634963f9a16cff466939af3b006af734a67df64b31a92dd9d1f37d11ec1b9771" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 53484, hashes = { sha256 = "4a6f146dea9f38b77300d27d183664bdf6f92d7324a48eda3f2093b9a1288e25" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 5385, hashes = { sha256 = "dc3664e5d7c536ec4af21122247b1c2b719ef18412ecea83913eb74a4d93b7ff" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 6205, hashes = { sha256 = "3e9b53655518c0d6254ef6a33d7af198e9b32b927fda5cac6941e2dc209d10dc" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 9778, hashes = { sha256 = "1e2842aef14b9ffa974bb57cbf3dd14eea37d54f569a01debd6965ce3d8c1835" } }]
 
 [[packages]]
 name = "rich"
@@ -1302,6 +1516,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/scipy-1.18.0-1-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T02:14:48Z, size = 33670680, hashes = { sha256 = "b550c9f4f748917ee645804432ab4c2e81830ccebc2d2fb1788c8c9684045372" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/scipy-1.18.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:51:06Z, size = 25301248, hashes = { sha256 = "c4902b58295199b9e6891606caaf7c1d1fdefc2d1d15ee4e8c89873eff253307" } },
 ]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 19287, hashes = { sha256 = "bcce65332cb56b574fdbd76779291d5c3635da813bf719c8ade92887094af294" } }]
 
 [[packages]]
 name = "setuptools"
@@ -1387,6 +1607,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/tenacity-8.5.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 29976, hashes = { sha256 = "fc611ec9ec5413788b51c7f806f71c3c81262159e3478fc51e034c02a9641d46" } }]
 
 [[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 15815, hashes = { sha256 = "720c7eddf2ba20c7fa279dbeb4636f0621344066656855d23603b0944d95e9e4" } }]
+
+[[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1458,6 +1684,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 349806, hashes = { sha256 = "0d183bc3f56f7cdc6a69745b4b3f744c839da134df1b032153b4b93fa97bc324" } }]
 
 [[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 12895, hashes = { sha256 = "52a35f31b19eb1eb9190a92112770348cf2d2f9144a93ca5f90ace45f0a20dd3" } }]
+
+[[packages]]
 name = "urllib3"
 version = "2.7.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1521,6 +1753,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 324792, hashes = { sha256 = "5880f454b3b69f0479eafbec007169d262ddd33c2d7e66432c819283b0d54eab" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 16605, hashes = { sha256 = "709970f37b58749eaf278c77ed1836df39e58bff8847d645cd7b89df849c59fe" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1529,7 +1767,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 84341, hashes = { sha256 = "f99e4267f2ed84d6fc26ef1348245ef1d371c69898da692995163fbbd7554f9a" } }]
 
 [[packages]]

--- a/runtimes/minimal/ubi9-python-3.12/requirements.cpu.txt
+++ b/runtimes/minimal/ubi9-python-3.12/requirements.cpu.txt
@@ -8,6 +8,8 @@ aiohttp==3.14.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:0a6d245422f2bb3d8caf05b7d1d63bd3a06bc434bcb89523b5bd4e2d1bc5a460
 aiosignal==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1c7350f826518aee08b77722670980ad426cac6772f574c9d66a4ad4c634867d
+anyio==4.14.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:982d481dc430ecf619d63c5dd77b534442795acdd713344c5f405a69c20aadaa
 argon2-cffi==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b22a8ecbb711c25a81822423979eb21884f406394838f64250ea29b1cbafffaf
 argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -15,14 +17,20 @@ argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementatio
     --hash=sha256:2e335e8b236ef704a19967005b0b85c8feed7f60fb377421f1f46c718bbe0eff \
     --hash=sha256:7dda6e7a1d127fd865c3b16e537855e55f8c40914ed4ce14c3466cbd055af8a5 \
     --hash=sha256:85679d0aa734c50fde4a9f2df33192860f1fc0332512497f2ec768a73c8cccdd
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fd6661e8bebee4e62a704e5d59854e82870743fb261633ac45fab5b2f0e67241
 astor==0.8.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:cf7da720e6337a9fbc1e3fec53339f463b6968f880926d0e11777792c2ee87d4
 asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c56de98b4bbcd9b28697fedb1381679afa3c9a237071cbd7e50a343840ff1e4e
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b36060caf6ef63db88f23b53aab4c7ccb8fe471cf4b75da5e6bd2ef04429efa3
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2743bc4ee570bfbff0689b6e320523c87c2adfe205306cb14142155d11569fab
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:712cee22ee81cd31e5bfbee2a66da356f714ce4aee97c774de64f9b8e64d323b
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:53f2e369782200a613927eff62c18fefedd66d9ac113cbb5dee4115ff94b936a
 beautifulsoup4==4.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:093525ef67b60a99bc418b266eb9af9f096b422f73ccd397d5b7df8ef020a670
 bleach==6.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -38,8 +46,15 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:aeac1eeb950a89b952cf6a9e60411e92a706e116c76ba6182a1834daf9ae2f32
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6e18eed0a727a8a903729a024b94912fb3636fadae097ea79ddcf2697d233a2f
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b48288d7abe1ab1f28dcea6e84597743e09b8a43345c1f30e04e772bbfaad24a
 comm==0.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9ccd14add1c584c4e22566362e7719d7160255468e660d98ca2a3a8080bb5ec7
+cryptography==50.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:558f64d5e321422716e83f573ffda0539aee4df2eef2c1442bcf62aa8957d204 \
+    --hash=sha256:cbfd8106711fa3284a3ee7b0beba311125a3e32678b47db019921ad95050a0ff \
+    --hash=sha256:4892f6455f7aed026606fc7b1af3d9603ee193f62d1955f189d4cd62ce1488f1 \
+    --hash=sha256:cbab34813a87e21ef5fc14a049859984e8b0bb6da890d4fedd2cd941c316f05d
 debugpy==1.8.21 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:db6caaeec8a4934fcb6557d14625a56916b6027628b94d1d327d379b724192b0 \
     --hash=sha256:98fb4ffb94905c3965facb8e5e5687f646c32b7be3b0d7737d793d8ee99fb057 \
@@ -49,17 +64,43 @@ defusedxml==0.7.1 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:c96c75b7ba586f81a0b001eb2e5c47a77ef61fffb5b40145e5734666981e6989
 dill==0.4.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dfabac0123f51ca3bdd613902a9580eb086a1448ddb4d3d7b42af753f633853b
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9c5320c27124b926c7c44ed569788bed1efc1c74b3cf544f710c2fe384404694
+durationpy==0.11 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c5d7083e29197532d32ba19f669461b1934721390a5f75bbcf2abaac1b2cc225
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1faee7b15d168647a1e9b08fd77e502f9b818b5670eb7cff2859e27912e14477
 executing==2.2.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:cbab989fdeb35d0ab5dbdc86273b6f9310c71f605662cb864f20f3840492142a
 fastjsonschema==2.22.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:811a7f325cea611d1666a2d7b87671a5ca4fc99737017c0326cf18fd5ae32799
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:209fed349f2c3d9499d3b1d199ebb10bea342b9db106b66718c864ba315e5f12
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:25cc97274d43add7842ecf7279a64f4567dc362f250e6074971fbfbf6f251005 \
     --hash=sha256:94833878f626544d8ed7d24a4ca76f1fec8d626b4bcde06f82a260fe5c3d098a \
     --hash=sha256:f8c8c62f91d0eea7fccfa913b0ca2dbd46aa314cd290a57f642366f94e80dc0e \
     --hash=sha256:28cd1e39bf5a8cbe5fe4d7279a97ca15ab3aa0f90e792aa4986ab56c042d011e
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f05f245bf71918de2f5bfee3ccdfcf38522fc87af32b8296f2af1aae3af399fe
+google-auth==2.57.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b429f39024a115c261d1f7d72cfaeb4fbd34a7644a7587f3ff11565dd8022ffa
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:189a300f2de463e563649860d4c131f26db251c15ead1b65f37c27eedd30f379
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e2d41e879f0cf1b0fbb3de5a222965911dc7badb0b2132c07bc92e1c7445b359
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6f62c011e01848fcbd0f4e51b45fe8680d40880b8f3b1245dca4df175bfff48b
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:626c12dd7db75040a738d5153657a8717ff632234f0baaf008a8b71981818e78
+googleapis-common-protos==1.75.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6b909664310afcd123e982e200925e686ba1998a94eeac24371675a62218d56b
+h11==0.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e44ad99adcda4c6141fdf245e22a6b506959df7fcb89d1f8f08e675e60eaf782
+httpcore==1.0.9 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c5597b774a5e1061731601fe2a5e84ec2336af935a2aa964943efcdb8ef85a2f
+httpx==0.28.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:efca1a86438747d4ba695232764a5b3b0d134ddcd64e09abe946dc4295319547
 idna==3.18 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c76ba5aae0af6a24aa766648cbf0274e10352184fa03cf262371160fd26d5b26
 ipykernel==7.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -70,20 +111,52 @@ ipython-genutils==0.2.0 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:1fe76b0bebe1fcea9a69f30d62e50753f292f2bc7859bcbc32d90fc651c7f51f
 ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:53735aa64313d30e3daa300e467a120b02ff61006db6ca2c3d3dca5fe165be2a
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7ae1d18f8ce0713d7a9857d2c9c3d6d95eb11114000c924bb018019a6b91bd74
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:54e49ba04597ee4416eff7d94cea47c7e7b0918d078bd241461c22b8246f37ff
 jinja2==3.1.6 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fba973f3495c14a0ddfa2f1bbae1195a65ff3d8fe43147111779f9fd2d6710c1
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1699d884ff6e97b4f0fce0823fb118e29660751af61fd9a0a47e4f88210b8f85
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:57c05b6c42f8fbb4c98cd735cc995eea3f19a31ec126c94f58e1ddad6765761b
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:362ef10db9ed85b707ede08e25f8336016df3f9a758568760439350bf20e6ed0
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:15b04b8b340156cde62f352b33a1605a9eae565708e6fc475f90d3a53dd8f6e4
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:294548f7c4515523860fe7a71b50c4aed4706b48f1771f1a16922720670339c4
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:09b8eff468e8fce72b7cc59ca036ed4af960c5a80958d7cade944840978d04d1
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e4efe9399594a9e46fb2bd049ff793faf2e41eaf570635786b7e56ab3ac72f6
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:de3352fb77bcdbfc44e84051ec8317d26211f741c5045add18081730892aacc5
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e9c41f8064a058c7d26c742ef54267084c5b3f5e0a428b1cf63c3c1709928e1f
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b45a13be8e75c4aae53e9747fefcd7f478b168d91ee2256fa07165c3cb68cf56
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ee8694a34f33dbb831166dc6da227621e7e8e02684decd4ff20684942ac3bf2a
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:63f69199cfdba005a0a3a577cf7bc326f91950141c0b51a7c612d5f23e369419
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a7838ddba7ef759672d6f06d3a657db1f1b222df2ea30cc8fa12238cf2152c48
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3e1d8eb8bc3030df7be780a53f2e4f051b163e1e5652cc561340dc69340d7530
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a6bb17423aaae00d05b22505ba663d91d39aac192619989e17ed44d65c905030
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6326f072af17863960beb38a5f14b4b59c02763fbea804011f5a2c43d0146094
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:742a3cbb2a9e4aabf5505bb0f07ff90ebe394930244724d98d0df4de7647bac8
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e99f4d87407cba00d47ccd582d4416766643b53719e5415c46aaa75368e56ed5
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5abef75f6749b0a1d75b0a886a490d2502ed1754ed8e95e4dd99082161571656
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2e1f9a6f017474e27772b4fdd733aab241fe73a9d546e74f7e8db7b4d3ef288b
 markupsafe==3.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f2190f6edad3c6cd70c86f6242f418d403f2549e7fcd7de5bcfa8644ded7cf69 \
     --hash=sha256:13f8495038330fbd6905b18abd15c3d90c4da56fe26262ef8a3f48dcbaab3d8c \
@@ -112,6 +185,14 @@ nest-asyncio2==1.7.2 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:a2af2111265a271e2a646150862402411f10f0348856e8dcc95764657192dafb
 networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:cf13e752b157f3b94b6bdef4be9c98f01901a8ba80084f7e3a87bc9778905f5f
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:48e9115bfe69cccf3462e3eebed5fab1d0b2e64130b2e6844c5bae7cf88e003a
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dff20201f6677c0f7f31517898d5073da70e51d8039a1ff98da4ffc2e7827ae3
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f370abab1b1c2a6c4cee58209d430d26d73807b4e30980e78e9801788f534cf3
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1b4b0c5a2f035a5421854275d0565b813b2f02efbfc7320056fecd3f0344fd2e
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:deb834ee2fe51e528b40cca13dd998c438ba0f0ba890d86c7ef1918afe4a9dbb
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -128,6 +209,8 @@ platformdirs==4.11.3 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:601f4e43a01e9e85e759da05e1d17afa142ef7f57014ed039ed4582e6151a9b1
 progress==1.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d3c5f68db84e11599ea79ca58d5c1f94dc0fe49fad3b7c13aaea0a21a73a34c3
+prometheus-client==0.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5e8baf7c797d92256e9e56cab17b15eed22d5f2d560a28de918a8ee7bb692613
 prompt-toolkit==3.0.53 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dd1f6003f30d03b2ea8d3d9a8ec635c068a4e5c0d35e3a0248e5a58c9892465f
 propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -135,6 +218,13 @@ propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:a1b9679c2435bec7edbfcf75d9e31b1c7984fe54c4e09eaaa2856c76dfbdc7f9 \
     --hash=sha256:9ff1c5c4caae00455aae23300862b8cf4df09e75efc13596c1b3b68c23c6d4cb \
     --hash=sha256:4b5ae20932f4cb043164642b2303ef86297f7a93ee4336d153fdfac9f711796f
+proto-plus==1.28.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fa3e50ba9b63f27129c860706ab554ed6fd3051de4b53faace1cf39189155ab9
+protobuf==6.33.6 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:63006ec5d99aa11f0d6571167fc78fedd2b8a97aebae717fda728c6f3de8b34b \
+    --hash=sha256:1f43f5d94d298f15dad99c259923c59fcd2254dac6bbb853c3f46f9144c47a20 \
+    --hash=sha256:37ad32066dbe00d3cf4e3692072de09703f49abfd424518a77827ec48c8baa59 \
+    --hash=sha256:9190332c2a7cc9e740df778f87dab7a07c48afa04bcd9c242d6321a8d8648934
 psutil==7.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:45359f0fec42eec801362f3077a020a10db119789995f25fe384d9bd7ba9e160 \
     --hash=sha256:003d61fca1b74b27394838aa22c55ae2ec9a7e599ff72fa4a887df0fd61fb6b1 \
@@ -144,6 +234,10 @@ ptyprocess==0.7.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:b2b1de7faaedf7449240d9e03721540adf51c638cb971d8be989ce4fe45cb908
 pure-eval==0.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3c9c0cd14dd91e7a2934b33e74cb0eb0353b1461325f06b41c9ff8350c380993
+pyasn1==0.6.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a1c6555370d74ccf3ca076e09c2b77a823bd9f19943cbf1527cc83cf2205b12f
+pyasn1-modules==0.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6ee3464546d8f7daf5ca504390d3c525806ed7fcc972998866f7fd07b3d8cf2b
 pycodestyle==2.14.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8043c5fa81c2325f6b670174a256ad2d3f778e3c84c13fa767b0ee77725096a1
 pycparser==3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -159,6 +253,8 @@ pygments==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:7132f8bc907a2491cc1e51a85e06f4b163aff46dafdcf23b54eac8cacff3c16d
 python-dateutil==2.9.0.post0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e3d7c7c7054ebe488f9bb1e1f14a22955c9c5e4b1ac4f0cefefa25c2e3a30f4c
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:705b66a54544867ebcdffc48e61b6adbc66f8410b4b77e56e4ae293864582247
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:eb3fc043c3b2844d501c7cc7a115e904c0f2c0ff4401ed0b9856aea4eb22dafc \
     --hash=sha256:301a160656813f221026e4fd2c85d4111d0b5192c1a80f8db79e1dffbabc6529 \
@@ -171,13 +267,25 @@ pyzmq==27.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:6a8c0c2abbcf9a9ba883dfdc1392793169cc91583a9855c25adc408716c9f086
 referencing==0.37.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3cb7ea100b68d42b173d034a42b99c8036052271aba2f5ebeff318f82d05f1e2
-requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:a9af2e58bdfc2ce308285230ae028e85344a322a84aad258bffecc98ba875bb8
+requests==2.33.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5a9b26a054cec98d10da567b6e8783b556032f96ebc075665e9ba7144b30a8e2
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:634963f9a16cff466939af3b006af734a67df64b31a92dd9d1f37d11ec1b9771
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4a6f146dea9f38b77300d27d183664bdf6f92d7324a48eda3f2093b9a1288e25
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dc3664e5d7c536ec4af21122247b1c2b719ef18412ecea83913eb74a4d93b7ff
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3e9b53655518c0d6254ef6a33d7af198e9b32b927fda5cac6941e2dc209d10dc
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1e2842aef14b9ffa974bb57cbf3dd14eea37d54f569a01debd6965ce3d8c1835
 rpds-py==2026.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f04f2eaabfe1ee788586e46a02fc85efe9987e28a7a18d7b59d2138c7ca15f26 \
     --hash=sha256:3d62b7af0ede668f67d11365058ea9862d47723ea4d54d44932c172f8b0a2faa \
     --hash=sha256:1f443cf494e7e314c44add89c4b244245ad0d27755dd9a026e69ea481db75bd9 \
     --hash=sha256:313a1c60e1972845e396e6781a52d20ab612518f22db5cb19d202fcb4f818421
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bcce65332cb56b574fdbd76779291d5c3635da813bf719c8ade92887094af294
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d3a096864c3017b2b537f98876fb7c795958f7bb4e2fb1204ec98cf1850c0db2
 six==1.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -186,8 +294,12 @@ soupsieve==2.9.2 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:b81a181d6c9cd38ad7601c45fd1ffd7c689239e2a2c95632c41c97d2f5cea6e2
 stack-data==0.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:cbcec9a4322ebcb786dcc5372241e8f70d9fd4b47f2dc13e2fa96cab10a7475e
+tabulate==0.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:437f1c5d5e558c8178f88d2fdca451d82fe12172a4fadfd91e4c774a6755300f
 tenacity==9.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d3c296fa4c831ba6a65c62bad73f635a9637772d43ff29394123514b59f6d118
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:720c7eddf2ba20c7fa279dbeb4636f0621344066656855d23603b0944d95e9e4
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0bc09774a3a228376376bc90ac9247bd36934b15c9d23505bd45f86ad768c389
 tornado==6.5.8 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -201,6 +313,10 @@ traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:ca8a41124e5ab9f620611b7115b39cfd3b32f4a94afd67e58b1a7d0cc71ce990
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:19ed460723b936cd45de80f01d92192bec0e9a9264bfbd1e1cf82945bc38983c
+tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0d183bc3f56f7cdc6a69745b4b3f744c839da134df1b032153b4b93fa97bc324
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:52a35f31b19eb1eb9190a92112770348cf2d2f9144a93ca5f90ace45f0a20dd3
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3109b1affa53baae9cc52a6702f0560ff8999d994e82b5f19138e6e044979f54
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -210,8 +326,12 @@ uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython
     --hash=sha256:e93a47051a479c83af303d0f3919e9a8d8e3da200660ef6e08f62b364ed66147
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5880f454b3b69f0479eafbec007169d262ddd33c2d7e66432c819283b0d54eab
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:709970f37b58749eaf278c77ed1836df39e58bff8847d645cd7b89df849c59fe
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4bae5fba959dd841b2ca2748b08abdb67b02ad08a2cbb101337d750adc8a25f6
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f99e4267f2ed84d6fc26ef1348245ef1d371c69898da692995163fbbd7554f9a
 wheel==0.48.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e1ee97885839daa5e0923360ed6be076d3483e655ec4dee79b1e49cc41eddbc
 yarl==1.24.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -28,6 +28,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/aiosignal-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 9140, hashes = { sha256 = "1c7350f826518aee08b77722670980ad426cac6772f574c9d66a4ad4c634867d" } }]
 
 [[packages]]
+name = "anyio"
+version = "4.14.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/anyio-4.14.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 126078, hashes = { sha256 = "982d481dc430ecf619d63c5dd77b534442795acdd713344c5f405a69c20aadaa" } }]
+
+[[packages]]
 name = "argon2-cffi"
 version = "25.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -45,6 +51,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 70409, hashes = { sha256 = "fd6661e8bebee4e62a704e5d59854e82870743fb261633ac45fab5b2f0e67241" } }]
+
+[[packages]]
 name = "astor"
 version = "0.8.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -57,6 +69,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/asttokens-3.0.2-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 29413, hashes = { sha256 = "c56de98b4bbcd9b28697fedb1381679afa3c9a237071cbd7e50a343840ff1e4e" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 10054, hashes = { sha256 = "b36060caf6ef63db88f23b53aab4c7ccb8fe471cf4b75da5e6bd2ef04429efa3" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -67,6 +85,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 47527, hashes = { sha256 = "712cee22ee81cd31e5bfbee2a66da356f714ce4aee97c774de64f9b8e64d323b" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 10198502, hashes = { sha256 = "53f2e369782200a613927eff62c18fefedd66d9ac113cbb5dee4115ff94b936a" } }]
 
 [[packages]]
 name = "beautifulsoup4"
@@ -110,10 +134,27 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 120858, hashes = { sha256 = "6e18eed0a727a8a903729a024b94912fb3636fadae097ea79ddcf2697d233a2f" } }]
 
 [[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 13199, hashes = { sha256 = "b48288d7abe1ab1f28dcea6e84597743e09b8a43345c1f30e04e772bbfaad24a" } }]
+
+[[packages]]
 name = "comm"
 version = "0.2.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/comm-0.2.3-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 8887, hashes = { sha256 = "9ccd14add1c584c4e22566362e7719d7160255468e660d98ca2a3a8080bb5ec7" } }]
+
+[[packages]]
+name = "cryptography"
+version = "50.0.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/cryptography-50.0.1-1-cp312-abi3-linux_aarch64.whl", upload-time = 2026-08-29T00:38:33Z, size = 2150271, hashes = { sha256 = "558f64d5e321422716e83f573ffda0539aee4df2eef2c1442bcf62aa8957d204" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/cryptography-50.0.1-1-cp312-abi3-linux_ppc64le.whl", upload-time = 2026-08-31T16:36:28Z, size = 2254742, hashes = { sha256 = "cbfd8106711fa3284a3ee7b0beba311125a3e32678b47db019921ad95050a0ff" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/cryptography-50.0.1-1-cp312-abi3-linux_s390x.whl", upload-time = 2026-08-29T01:21:57Z, size = 2623821, hashes = { sha256 = "4892f6455f7aed026606fc7b1af3d9603ee193f62d1955f189d4cd62ce1488f1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/cryptography-50.0.1-1-cp312-abi3-linux_x86_64.whl", upload-time = 2026-08-29T00:34:31Z, size = 2114770, hashes = { sha256 = "cbab34813a87e21ef5fc14a049859984e8b0bb6da890d4fedd2cd941c316f05d" } },
+]
 
 [[packages]]
 name = "debugpy"
@@ -139,6 +180,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/dill-0.4.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 121747, hashes = { sha256 = "dfabac0123f51ca3bdd613902a9580eb086a1448ddb4d3d7b42af753f633853b" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 24249, hashes = { sha256 = "9c5320c27124b926c7c44ed569788bed1efc1c74b3cf544f710c2fe384404694" } }]
+
+[[packages]]
+name = "durationpy"
+version = "0.11"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/durationpy-0.11-1-py3-none-any.whl", upload-time = 2026-08-31T18:55:37Z, size = 5782, hashes = { sha256 = "c5d7083e29197532d32ba19f669461b1934721390a5f75bbcf2abaac1b2cc225" } }]
+
+[[packages]]
 name = "entrypoints"
 version = "0.4"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -157,6 +210,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/fastjsonschema-2.22.2-1-py3-none-any.whl", upload-time = 2026-08-19T01:10:11Z, size = 29162, hashes = { sha256 = "811a7f325cea611d1666a2d7b87671a5ca4fc99737017c0326cf18fd5ae32799" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 5292, hashes = { sha256 = "209fed349f2c3d9499d3b1d199ebb10bea342b9db106b66718c864ba315e5f12" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -166,6 +225,66 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/frozenlist-1.8.0-1-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T02:14:48Z, size = 243497, hashes = { sha256 = "f8c8c62f91d0eea7fccfa913b0ca2dbd46aa314cd290a57f642366f94e80dc0e" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/frozenlist-1.8.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:51:06Z, size = 212275, hashes = { sha256 = "28cd1e39bf5a8cbe5fe4d7279a97ca15ab3aa0f90e792aa4986ab56c042d011e" } },
 ]
+
+[[packages]]
+name = "google-api-core"
+version = "2.34.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 182296, hashes = { sha256 = "f05f245bf71918de2f5bfee3ccdfcf38522fc87af32b8296f2af1aae3af399fe" } }]
+
+[[packages]]
+name = "google-auth"
+version = "2.57.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_auth-2.57.0-1-py3-none-any.whl", upload-time = 2026-08-29T00:34:31Z, size = 261421, hashes = { sha256 = "b429f39024a115c261d1f7d72cfaeb4fbd34a7644a7587f3ff11565dd8022ffa" } }]
+
+[[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 32812, hashes = { sha256 = "189a300f2de463e563649860d4c131f26db251c15ead1b65f37c27eedd30f379" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 343298, hashes = { sha256 = "e2d41e879f0cf1b0fbb3de5a222965911dc7badb0b2132c07bc92e1c7445b359" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-15T00:43:23Z, size = 15529, hashes = { sha256 = "6f62c011e01848fcbd0f4e51b45fe8680d40880b8f3b1245dca4df175bfff48b" } }]
+
+[[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 83369, hashes = { sha256 = "626c12dd7db75040a738d5153657a8717ff632234f0baaf008a8b71981818e78" } }]
+
+[[packages]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/googleapis_common_protos-1.75.2-1-py3-none-any.whl", upload-time = 2026-08-29T00:34:31Z, size = 308856, hashes = { sha256 = "6b909664310afcd123e982e200925e686ba1998a94eeac24371675a62218d56b" } }]
+
+[[packages]]
+name = "h11"
+version = "0.16.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/h11-0.16.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 39148, hashes = { sha256 = "e44ad99adcda4c6141fdf245e22a6b506959df7fcb89d1f8f08e675e60eaf782" } }]
+
+[[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/httpcore-1.0.9-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 80434, hashes = { sha256 = "c5597b774a5e1061731601fe2a5e84ec2336af935a2aa964943efcdb8ef85a2f" } }]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/httpx-0.28.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 75162, hashes = { sha256 = "efca1a86438747d4ba695232764a5b3b0d134ddcd64e09abe946dc4295319547" } }]
 
 [[packages]]
 name = "idna"
@@ -198,6 +317,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/ipython_pygments_lexers-1.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 9951, hashes = { sha256 = "53735aa64313d30e3daa300e467a120b02ff61006db6ca2c3d3dca5fe165be2a" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 13136, hashes = { sha256 = "7ae1d18f8ce0713d7a9857d2c9c3d6d95eb11114000c924bb018019a6b91bd74" } }]
+
+[[packages]]
 name = "jedi"
 version = "0.20.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -208,6 +333,18 @@ name = "jinja2"
 version = "3.1.6"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jinja2-3.1.6-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 136515, hashes = { sha256 = "fba973f3495c14a0ddfa2f1bbae1195a65ff3d8fe43147111779f9fd2d6710c1" } }]
+
+[[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 38187, hashes = { sha256 = "1699d884ff6e97b4f0fce0823fb118e29660751af61fd9a0a47e4f88210b8f85" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 9358, hashes = { sha256 = "57c05b6c42f8fbb4c98cd735cc995eea3f19a31ec126c94f58e1ddad6765761b" } }]
 
 [[packages]]
 name = "jsonschema"
@@ -222,6 +359,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T01:04:01Z, size = 20295, hashes = { sha256 = "15b04b8b340156cde62f352b33a1605a9eae565708e6fc475f90d3a53dd8f6e4" } }]
 
 [[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 917003, hashes = { sha256 = "294548f7c4515523860fe7a71b50c4aed4706b48f1771f1a16922720670339c4" } }]
+
+[[packages]]
 name = "jupyter-client"
 version = "8.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -234,10 +377,82 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 30714, hashes = { sha256 = "8e4efe9399594a9e46fb2bd049ff793faf2e41eaf570635786b7e56ab3ac72f6" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 21225, hashes = { sha256 = "de3352fb77bcdbfc44e84051ec8317d26211f741c5045add18081730892aacc5" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 79187, hashes = { sha256 = "e9c41f8064a058c7d26c742ef54267084c5b3f5e0a428b1cf63c3c1709928e1f" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 395767, hashes = { sha256 = "b45a13be8e75c4aae53e9747fefcd7f478b168d91ee2256fa07165c3cb68cf56" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 15514, hashes = { sha256 = "ee8694a34f33dbb831166dc6da227621e7e8e02684decd4ff20684942ac3bf2a" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 12454274, hashes = { sha256 = "63f69199cfdba005a0a3a577cf7bc326f91950141c0b51a7c612d5f23e369419" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 17964, hashes = { sha256 = "a7838ddba7ef759672d6f06d3a657db1f1b222df2ea30cc8fa12238cf2152c48" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 61571, hashes = { sha256 = "3e1d8eb8bc3030df7be780a53f2e4f051b163e1e5652cc561340dc69340d7530" } }]
+
+[[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 479782, hashes = { sha256 = "a6bb17423aaae00d05b22505ba663d91d39aac192619989e17ed44d65c905030" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 29466, hashes = { sha256 = "6326f072af17863960beb38a5f14b4b59c02763fbea804011f5a2c43d0146094" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 11704, hashes = { sha256 = "742a3cbb2a9e4aabf5505bb0f07ff90ebe394930244724d98d0df4de7647bac8" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 130411, hashes = { sha256 = "e99f4d87407cba00d47ccd582d4416766643b53719e5415c46aaa75368e56ed5" } }]
+
+[[packages]]
+name = "kubernetes"
+version = "36.0.3"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 4619742, hashes = { sha256 = "5abef75f6749b0a1d75b0a886a490d2502ed1754ed8e95e4dd99082161571656" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 114762, hashes = { sha256 = "2e1f9a6f017474e27772b4fdd733aab241fe73a9d546e74f7e8db7b4d3ef288b" } }]
 
 [[packages]]
 name = "markupsafe"
@@ -316,6 +531,30 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/networkx-3.6.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 2070144, hashes = { sha256 = "cf13e752b157f3b94b6bdef4be9c98f01901a8ba80084f7e3a87bc9778905f5f" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 5548932, hashes = { sha256 = "48e9115bfe69cccf3462e3eebed5fab1d0b2e64130b2e6844c5bae7cf88e003a" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 15000, hashes = { sha256 = "dff20201f6677c0f7f31517898d5073da70e51d8039a1ff98da4ffc2e7827ae3" } }]
+
+[[packages]]
+name = "oauthlib"
+version = "3.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 161707, hashes = { sha256 = "f370abab1b1c2a6c4cee58209d430d26d73807b4e30980e78e9801788f534cf3" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T00:56:21Z, size = 377926, hashes = { sha256 = "1b4b0c5a2f035a5421854275d0565b813b2f02efbfc7320056fecd3f0344fd2e" } }]
+
+[[packages]]
 name = "packaging"
 version = "26.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -364,6 +603,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/progress-1.6.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 11434, hashes = { sha256 = "d3c5f68db84e11599ea79ca58d5c1f94dc0fe49fad3b7c13aaea0a21a73a34c3" } }]
 
 [[packages]]
+name = "prometheus-client"
+version = "0.26.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/prometheus_client-0.26.0-1-py3-none-any.whl", upload-time = 2026-08-14T01:04:01Z, size = 66246, hashes = { sha256 = "5e8baf7c797d92256e9e56cab17b15eed22d5f2d560a28de918a8ee7bb692613" } }]
+
+[[packages]]
 name = "prompt-toolkit"
 version = "3.0.53"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -378,6 +623,23 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/propcache-0.5.2-1-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T00:49:42Z, size = 66146, hashes = { sha256 = "a1b9679c2435bec7edbfcf75d9e31b1c7984fe54c4e09eaaa2856c76dfbdc7f9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/propcache-0.5.2-1-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T02:14:48Z, size = 81210, hashes = { sha256 = "9ff1c5c4caae00455aae23300862b8cf4df09e75efc13596c1b3b68c23c6d4cb" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/propcache-0.5.2-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:51:06Z, size = 64197, hashes = { sha256 = "4b5ae20932f4cb043164642b2303ef86297f7a93ee4336d153fdfac9f711796f" } },
+]
+
+[[packages]]
+name = "proto-plus"
+version = "1.28.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/proto_plus-1.28.4-1-py3-none-any.whl", upload-time = 2026-08-31T16:58:41Z, size = 52499, hashes = { sha256 = "fa3e50ba9b63f27129c860706ab554ed6fd3051de4b53faace1cf39189155ab9" } }]
+
+[[packages]]
+name = "protobuf"
+version = "6.33.6"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/protobuf-6.33.6-1-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T03:41:10Z, size = 1201942, hashes = { sha256 = "63006ec5d99aa11f0d6571167fc78fedd2b8a97aebae717fda728c6f3de8b34b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/protobuf-6.33.6-1-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 1258496, hashes = { sha256 = "1f43f5d94d298f15dad99c259923c59fcd2254dac6bbb853c3f46f9144c47a20" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/protobuf-6.33.6-1-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 1505206, hashes = { sha256 = "37ad32066dbe00d3cf4e3692072de09703f49abfd424518a77827ec48c8baa59" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/protobuf-6.33.6-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 1218785, hashes = { sha256 = "9190332c2a7cc9e740df778f87dab7a07c48afa04bcd9c242d6321a8d8648934" } },
 ]
 
 [[packages]]
@@ -402,6 +664,18 @@ name = "pure-eval"
 version = "0.2.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pure_eval-0.2.3-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 13695, hashes = { sha256 = "3c9c0cd14dd91e7a2934b33e74cb0eb0353b1461325f06b41c9ff8350c380993" } }]
+
+[[packages]]
+name = "pyasn1"
+version = "0.6.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pyasn1-0.6.4-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 86054, hashes = { sha256 = "a1c6555370d74ccf3ca076e09c2b77a823bd9f19943cbf1527cc83cf2205b12f" } }]
+
+[[packages]]
+name = "pyasn1-modules"
+version = "0.4.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pyasn1_modules-0.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 183021, hashes = { sha256 = "6ee3464546d8f7daf5ca504390d3c525806ed7fcc972998866f7fd07b3d8cf2b" } }]
 
 [[packages]]
 name = "pycodestyle"
@@ -445,6 +719,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/python_dateutil-2.9.0.post0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 231850, hashes = { sha256 = "e3d7c7c7054ebe488f9bb1e1f14a22955c9c5e4b1ac4f0cefefa25c2e3a30f4c" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T00:37:34Z, size = 16754, hashes = { sha256 = "705b66a54544867ebcdffc48e61b6adbc66f8410b4b77e56e4ae293864582247" } }]
+
+[[packages]]
 name = "pyyaml"
 version = "6.0.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -474,9 +754,39 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "requests"
-version = "2.34.2"
+version = "2.33.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests-2.34.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 74727, hashes = { sha256 = "a9af2e58bdfc2ce308285230ae028e85344a322a84aad258bffecc98ba875bb8" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests-2.33.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 66704, hashes = { sha256 = "5a9b26a054cec98d10da567b6e8783b556032f96ebc075665e9ba7144b30a8e2" } }]
+
+[[packages]]
+name = "requests-oauthlib"
+version = "2.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 26050, hashes = { sha256 = "634963f9a16cff466939af3b006af734a67df64b31a92dd9d1f37d11ec1b9771" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 53484, hashes = { sha256 = "4a6f146dea9f38b77300d27d183664bdf6f92d7324a48eda3f2093b9a1288e25" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 5385, hashes = { sha256 = "dc3664e5d7c536ec4af21122247b1c2b719ef18412ecea83913eb74a4d93b7ff" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 6205, hashes = { sha256 = "3e9b53655518c0d6254ef6a33d7af198e9b32b927fda5cac6941e2dc209d10dc" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:17Z, size = 9778, hashes = { sha256 = "1e2842aef14b9ffa974bb57cbf3dd14eea37d54f569a01debd6965ce3d8c1835" } }]
 
 [[packages]]
 name = "rpds-py"
@@ -488,6 +798,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rpds_py-2026.6.3-1-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T02:14:48Z, size = 436980, hashes = { sha256 = "1f443cf494e7e314c44add89c4b244245ad0d27755dd9a026e69ea481db75bd9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/rpds_py-2026.6.3-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T01:46:27Z, size = 354375, hashes = { sha256 = "313a1c60e1972845e396e6781a52d20ab612518f22db5cb19d202fcb4f818421" } },
 ]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 19287, hashes = { sha256 = "bcce65332cb56b574fdbd76779291d5c3635da813bf719c8ade92887094af294" } }]
 
 [[packages]]
 name = "setuptools"
@@ -514,10 +830,22 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/stack_data-0.6.3-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 26384, hashes = { sha256 = "cbcec9a4322ebcb786dcc5372241e8f70d9fd4b47f2dc13e2fa96cab10a7475e" } }]
 
 [[packages]]
+name = "tabulate"
+version = "0.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/tabulate-0.10.0-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 41335, hashes = { sha256 = "437f1c5d5e558c8178f88d2fdca451d82fe12172a4fadfd91e4c774a6755300f" } }]
+
+[[packages]]
 name = "tenacity"
 version = "9.1.4"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/tenacity-9.1.4-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 30701, hashes = { sha256 = "d3c296fa4c831ba6a65c62bad73f635a9637772d43ff29394123514b59f6d118" } }]
+
+[[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 15815, hashes = { sha256 = "720c7eddf2ba20c7fa279dbeb4636f0621344066656855d23603b0944d95e9e4" } }]
 
 [[packages]]
 name = "tinycss2"
@@ -555,6 +883,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/typing_extensions-4.16.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:51:06Z, size = 47352, hashes = { sha256 = "19ed460723b936cd45de80f01d92192bec0e9a9264bfbd1e1cf82945bc38983c" } }]
 
 [[packages]]
+name = "tzdata"
+version = "2026.3"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 349806, hashes = { sha256 = "0d183bc3f56f7cdc6a69745b4b3f744c839da134df1b032153b4b93fa97bc324" } }]
+
+[[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 12895, hashes = { sha256 = "52a35f31b19eb1eb9190a92112770348cf2d2f9144a93ca5f90ace45f0a20dd3" } }]
+
+[[packages]]
 name = "urllib3"
 version = "2.7.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -578,10 +918,22 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 324792, hashes = { sha256 = "5880f454b3b69f0479eafbec007169d262ddd33c2d7e66432c819283b0d54eab" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T08:17:18Z, size = 16605, hashes = { sha256 = "709970f37b58749eaf278c77ed1836df39e58bff8847d645cd7b89df849c59fe" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/webencodings-0.6.1-1-py3-none-any.whl", upload-time = 2026-08-19T01:10:11Z, size = 10456, hashes = { sha256 = "4bae5fba959dd841b2ca2748b08abdb67b02ad08a2cbb101337d750adc8a25f6" } }]
+
+[[packages]]
+name = "websocket-client"
+version = "1.9.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-14T02:08:43Z, size = 84341, hashes = { sha256 = "f99e4267f2ed84d6fc26ef1348245ef1d371c69898da692995163fbbd7554f9a" } }]
 
 [[packages]]
 name = "wheel"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
@@ -25,6 +25,8 @@ argon2-cffi==25.1.0 ; python_full_version == '3.12.*' and implementation_name ==
 argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6b85e8f20ed628ff64f5c7ee06cec4161c33a9edbe79ee38cae24967cfbd90e6 \
     --hash=sha256:fbb9c953378afb816cb6a090c04005c2e2566b3355d2fbc73660f38b73da2613
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cd2b374b02201cb1a54dda30c31a3187b14f6a16fbec1c3162e343c7f6b32f83
 ast-serialize==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9a21624872c99a76f720e09ce4f2e978f3e49d0dd7cfae490306500bceaa7948 \
     --hash=sha256:eec05d3174f62cc102595380d577d921f85bbb2aca69f32efa433e666e817d5e
@@ -32,12 +34,16 @@ astor==0.8.1 ; python_full_version == '3.12.*' and implementation_name == 'cpyth
     --hash=sha256:c25250ea8d58b37a98632c56d68fc5f516ee4bc5270dc92b2095cd39505e3b01
 asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a0f70d22738459e6b462858b5c1556dc8e6b58c48923232276a8b7843bf2dda4
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:09cf67bd95791dd5c66a642d43fecb5d3f4d59f2cde0f4320ae06bb1f74d29f1
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2a329bafdb8a44c84f1949b23266caca598dad251f0b1d586f5b96d5d6fe69c0
 auto-round==0.14.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fde93cd52baf89cdb5934eb8cad2521bfb34eafb9ed7575f860cce4a9abebffa
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a2d19b14cbd0d750e8961443b092f5c65ac22f8661214b4290958a0db2690089
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:564565f6bc2b4cd98b166297b16840f362dacad5979d81b1cc3addabe5395306
 bcrypt==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:7ba3abf6fefcd2e8d066e3b8aa3947735c924c5ad48235f2f0058131803e463f \
     --hash=sha256:57f842b9edfd6d11c3e54375ea6675a6c7884567224178b8e376ddb6168bac8b
@@ -66,6 +72,8 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:d9c52b6daac930ba203ec4d4e2221fabb3dac87af4b1750f8d9d3855786d57ed
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4e90c67eff90cf0ae6dfea593cba6e9b8e8a64ddbbc983a3cd4ba0b4ae442914
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fb59fa3994e8b3b3eb94fe646780e08cc892ddc60b57aa8f557b6824daf55f46
 cloudpickle==3.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:abd95dc72b055ed19c47580bd546a87266e06aa61dc0abd3b9229da6f8ac463d
 codeflare-sdk==0.38.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
@@ -109,7 +117,9 @@ dnspython==2.8.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:42e12a03a1c83bae74818976361c977cf207b266f230081eee9c0769844b46fd
 docker==7.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9a26839a6f03681dd526e64383d960b8049bde54a86f3c62761173b0b43793b3
-durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:229c7cc98c6bedac75168c530c89db7b1a2e59738aa085d91b87c4d5121271f7
+durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0226bf76c182b6cf7f7b51f5dfe8727c9b7a92d2b0ec267a6b568cbeeb54a7a7
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:94959bb08d397915f41eeb3058bcf817e0bb50902b4df9f3ff2947c81b2d3e0e
@@ -131,6 +141,8 @@ flask-cors==6.0.5 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:a7a46c78a88db4aac2735152d29dc81569cea19699a511e7e48487d6707ed90d
 fonttools==4.63.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1d00dc952282971a8e054d6fe6a29b40dd0a42efce5e9a49fb300c48862039ff
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cd3f9598f4b63233df6a480b870ac9345ba918829d77d51388fd0fe17eac91a1
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:59f589f10c530dd2bcaf2c06e505487f21b36f306ee917c0724c40c39cecce77 \
     --hash=sha256:987a668ace14a860cc983ef6452c0f55dcaf75f9003dcc71cc87f5f031a4335c
@@ -140,11 +152,19 @@ gitdb==4.0.12 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:0b0bab215043ba322520b36d31a4b87dfe28d70f51841dfbb7399b8131b2aabc
 gitpython==3.1.59 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e3eb5873a0fa94da73c93fe1741931eba33501ab69cf72c087814c8e0fe8fc64
-google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d1458beb91a7e091a6bfa763971f13d83aed63346559a8d65ba31f6c040eddcd
 google-auth==2.56.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fb67e1edb56ca2c5df625b3b78fedf88f25eda3f7d4953a373684500e12ea8f5
-googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:59969cdfa9665281e26f4493ab42a0a6d8df72ab126a3f0e83f0df079845f736
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0f4087354eb54aded4155625d765df15255ef6f997a4950fe0f181a23ff3bdcd
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7b22b18c6d1d6317ea20511f6937ea2f24f2ca257cb4b46286bff3e5bb26390c
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dff3d15dfe5bccfc3aa7a3c56de7e0c287481ae6c4189cee7b2b6390bcc89a5f
+googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:bb8b588c499dc8e35dc76e85883f2424951748489e907b4c38025f92b8ec8c29
 graphene==3.4.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e632ab2584398e04f90963d7c23606fc18887104cdc5ca19e82274152a6ec56a
@@ -196,6 +216,8 @@ ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementat
     --hash=sha256:27e8b810135cdfbbc7b160fe5ec0cb8eec46944038126fb2b3d3a07a523e0560
 ipywidgets==8.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:3939b6befa6a3bebebc125a8c052fe0be0e3942fa3f0d8fbe0afed38aee0d213
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:000b7fe2770bd660c95c7481124fb970c1c77a84fee93d6655787afb2db7d83d
 itsdangerous==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d859aa9dbedb0dcbb6d9f12d9ecdeb70ff18dec29d15d8a1e1a7f65621ec4eb7
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -209,29 +231,57 @@ jmespath==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:8141c2bbb5a7b2137e36ec58984e5490e07062206b74d69b2e0b4de79dec6819
 joblib==1.5.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4099cde1fb51e46c612eff40973fccec60d0155660ffa534bcc01be91c0e1986
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:64ceca8013df57f5827ab332876a1731a819e2e2423e5ee849ae846c9543e6bb
 jsonlines==4.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7d0c2ad472718395561b34df01221e910aa7d0b59d3862ad7fd112fa458f3cb0
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7d47f0f9fe37f27e94d3d8ba7cd41da3d4a26f879328a5e150ed0ab768ec5519
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e2d06847dd14978a1ee072ccd8fec1e78abe4fdd6aa6f5aad835fa26c9a21b17
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0825040626d673255335af996e39ab3f1501f123e87ce616333f514b42db76d0
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1c9d1549c9c5e6fc373c9ea94527b43d7fba5c8639503f5234cc4ae4508bcc25
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:12ef4b1a53a6f9ac71cab820149cf04046a744c42443fb20f42f525f60126870
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:caebbfee5a19c1742e864419a40bc70dd4480912d3982076ebf27019f487ee6e
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:88a888ea0519b21d331cf732bd4319af9bcc9832a9f74da0e7f7e51cebeea84b
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8581f6c716f7567615713ded4c6e4984ba44045e5d28358427dc5171c4929aa4
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:62339041ecbf2778c8670f0e0fd752d3fa47c34d1b70611835838eaf573c856a
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7b63316024a2b60cb0d7703359ab6b84aefac9f195bd86b3afc158838d45bf2f
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6bd336d31aa9279713f2244f340c06c3ebb8a45357a4ebc2199bea2c8d079d5b
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3a9d865aed077c176452d5d2017da8c197e808c341c2cb8b57498eb256c59fb7
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ed75da7d76d1c7aa6818a5bfc15c82d0c369d41a3695caf4f6df2f8c475410ba
 jupyterlab-widgets==3.0.16 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:c039b2f4432f9d3139d5f1358c16750e4baec12c92b2ed36e2c8002f73e16550
 kafka-python-ng==2.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b7d57a5008f27b4ac0fbab0b97a767f666b833d973ac1009c93f56ee2a3f4cf7
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e051d6c0d9d0b7c8bda966b50f37ad2560c65507ec0063615d4ed69b5a485909
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a1d0fe95292300f9c23392bb5baf42fd251a227522fcd4e295be4e6c94ec121a
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ed37ef5670c6fff0169abe35191d384e55ef41666be167edcb751685090fb9ab
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6544bfb15cda3ebbc62def0edb37c41cdf8a74eb6a9026582b2330303db9a55b
 kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:773b9c47c97476fc1f85649c27e36f311006b9433b6b8575fc805fe3d30d0eaf \
     --hash=sha256:867dc3801289b7c99c31911f60cc832a09756cbccd459881c27c2c1511f018cd
 kube-authkit==0.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:c6398d8bc3723f1e93275c0999a78cff092a763878540d5a2cfbf6aba1becde0
-kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:52c576354d3f11e08870e4ae625e9498803cfb22e37bb5fa47d45e2db153e11a
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:540c228ba09623b784e922e209ec435c855eec909dbb6b7c3bf54374df045f0e
 librt==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
     --hash=sha256:06f75fbe3afe50730a4358d0559f54052a979e0f08d713a0a3670eccf8b47d5d \
     --hash=sha256:7869f768d179d9b26cd41157cb087a820c4a7937dca914bd9fda6d52ab3623e8
@@ -315,13 +365,19 @@ networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:71b26e57d5db6c1c7ba583420a7f7939c88a2a763f728d610790b1f05775cd92
 nltk==3.10.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7184a00a3761d610bc2ebe23142e42b3f2b2591de0b8ccae6d4ab0665fca3d28
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4883fd37c9577075ea36e2a81147112e7b0378ea3a5cc9ccbfbfc274064c58e1
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:72363e68aa1e21920403d437b9aa1f8fc6648221030da319c5e03e678862f065
 numpy==2.4.6 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:06cbdce3431f7f14ce950bc61548a5394e6515205394faf7c0082d7b31a0746c \
     --hash=sha256:48ea2107d0a48cfc8e957e60d0974ab046fa844a917aeb05edce3101fa60eea2
 nvidia-ml-py==13.610.43 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9cd08d10e3b5ee1ffa3011022de0cd53a43052d881287b07e627987f12d9e72b
-oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8ad6576fa403738412bb92587b6bbce4be8562f514c59c090327eeace803cb63
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4ad155f9beb3344bb3cd01cb48b0527f90435836649238a2c5195f364a34284e
 onnx==1.22.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ceff6a479c550c541638a379a88b8415a5419ac6b602aa225553406725a61f2b \
     --hash=sha256:09974c9c269b1fa662118c23f69ec2bd8d0dc784745c36ae98325c06acc29d3a
@@ -349,7 +405,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e910fdfb5465e33f4007a3f9e90a56a79f78a62a150ad24d6ebe7d846dedb95e
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -388,7 +446,7 @@ prompt-toolkit==3.0.53 ; python_full_version == '3.12.*' and implementation_name
 propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:41840717b46f0ce958d620688f07287fcc8f1c264a390be784ca80243f13c3ca \
     --hash=sha256:4c9c9dd6c28062556e10794e5388ede7025d4e7afc3f05665d156c7c93f556d1
-proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b99371be85a60317df94bdc274e9612026edcfe3126f3ce1fb44d2694019e06c
 protobuf==6.31.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:daa678e7a41a1c6abc124cc0a2c849e2d8382d2b30b03cf3197ebd896e546fb5 \
@@ -450,6 +508,8 @@ python-discovery==1.5.2 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:4f2e312fcc39064122587c8f83c4fe110375b51ecb5da40688ab99b2999353dc
 python-dotenv==1.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b0b0b19f7172643f1c79654d28615ce3d1b112be0eee4af88194bfa570c29d60
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bfc9fe1dd95b4b74f59573acb8ca4e118ff9e90b28c4876a59c3ca558906b107
 pytz==2026.3.post1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d5c1cdf3039a80b19ea642ad56c2782e291272c623da9f737bcaa59190cf396a
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -468,8 +528,16 @@ regex==2026.7.19 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:2c1f745b271e5fe8c71a63082210bd21450df7f5425cb1929ef3e76bfbd5b743
 requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:349a37be55c2f555fb3fe0b8b8dc7e24909f3b656473dd98c2a48c0de3cdc6a1
-requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dc0ef52c153db66aa5cc0e43b1895bebd6c4e5bf79c75e4b7f2e5aefbec8bc56
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0514d2a703b130d36592d043fdb076939c165c654c2d70dd27bf25e312f20c06
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b76ef37df7e558436092e4e87ad94534fd0e4f9ae876226f147aa4218bb68b86
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bea6feda7f80885268d94f67a316645e55da0d5dd97467ee854ea73a80220cab
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3daaccda58257b5684c5d4ba3363f5769b9013f729b9f60fa46a9a14e689d60e
 rich==14.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4281322642d3a1037a427ee8011bf723ad886fd4cf40fea7f8330f24693b3963
 rouge-score==0.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -490,6 +558,8 @@ scikit-learn==1.9.0 ; python_full_version == '3.12.*' and implementation_name ==
 scipy==1.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a0af5949e43841df1d3a1681bc7835376e550b9941d54d1e2afff7117849a12f \
     --hash=sha256:95faa4b9656b76335900f02314b9a3bfaba11e3e46c477e74ca01b1dda607973
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:caa206291a7461855a50ef98e5cc077dbfa4fb555b37c9db7875cae78a6f29f6
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:59c60deb1babb73f9e704ce8ab110f8f8eb9ed93f33c8e0847f3fc90fd58b974
 shellingham==1.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -535,6 +605,8 @@ tensorboard==2.20.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:c779236b278e7922d1b9f3b9de06ca217a4d3d8877036fad6dd32e8a3160ca78
 tensorboard-data-server==0.7.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a54bb525122e83cbd26b0d342a2cff5bc205de5660d2a080aa75d150110b6103
 threadpoolctl==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e890376b4d1c58b30d76cb1458693e81ee91e77eda05d5cfe7325b1db0203e4c
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -572,7 +644,9 @@ transformers==5.14.1 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:890155bed35a8ec2767ea95a8125cd66d35809474b0b756da8659592e7804e2a
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828 \
-    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504
+    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504 \
+    --hash=sha256:f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b \
+    --hash=sha256:455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae
 truststore==0.10.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d2528385e0ee7dd5def63f527675b242bb2ad6dfbe13561388b9d8d1be793cab
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -587,6 +661,8 @@ typing-inspection==0.4.4 ; python_full_version == '3.12.*' and implementation_na
     --hash=sha256:14d0fb26d04391bca8117008a9090c41f4ad3fec3a96440d112fad8ae005f430
 tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d982eaebb436a8e9915840f6b01aec8cd597dc48806128e2845e32c0e64ca57d
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9a63b6b78c8a9c1cc34907b952c8fd15efc42a893022025115688a3fdf035a56
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6822d128181a5283a1a6e16a4c728ccaaa04ade8043b6b0145dd172af1a16e56
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -606,9 +682,11 @@ watchfiles==1.2.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:0e40edeea11dd432bff30c5984bfecff1e7396a1347a1d5cf519a207e19369de
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:76222e89b10969948f0175d5e12e8e69910ba5d2d7717ff6cca58a93f8d85470
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:93d54e04b343628bfa1c42059820d442b2736a36dfc1bc8bfa5e7d3308b96ed6
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f334a0eae8c5c6b1f23faf69a3af099af5a6306d254fac7a8cad640a4f9a3747
-websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:95bd0077d98d01f06bfd2d2f180d365df6f5b32ad83f0daacc023a5b5a785b24
 websockets==17.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1c4119039c17b26e4c99226b05da4231da0b6c6b9bcec4235f2d839653483380 \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -83,6 +83,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 70409, hashes = { sha256 = "cd2b374b02201cb1a54dda30c31a3187b14f6a16fbec1c3162e343c7f6b32f83" } }]
+
+[[packages]]
 name = "ast-serialize"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -104,6 +110,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/asttokens-3.0.2-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 29415, hashes = { sha256 = "a0f70d22738459e6b462858b5c1556dc8e6b58c48923232276a8b7843bf2dda4" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 10055, hashes = { sha256 = "09cf67bd95791dd5c66a642d43fecb5d3f4d59f2cde0f4320ae06bb1f74d29f1" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -120,6 +132,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 47528, hashes = { sha256 = "a2d19b14cbd0d750e8961443b092f5c65ac22f8661214b4290958a0db2690089" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 10198502, hashes = { sha256 = "564565f6bc2b4cd98b166297b16840f362dacad5979d81b1cc3addabe5395306" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -204,6 +222,12 @@ name = "click"
 version = "8.4.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 120858, hashes = { sha256 = "4e90c67eff90cf0ae6dfea593cba6e9b8e8a64ddbbc983a3cd4ba0b4ae442914" } }]
+
+[[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 13201, hashes = { sha256 = "fb59fa3994e8b3b3eb94fe646780e08cc892ddc60b57aa8f557b6824daf55f46" } }]
 
 [[packages]]
 name = "cloudpickle"
@@ -335,9 +359,15 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/docker-7.2.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 150399, hashes = { sha256 = "9a26839a6f03681dd526e64383d960b8049bde54a86f3c62761173b0b43793b3" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 24248, hashes = { sha256 = "229c7cc98c6bedac75168c530c89db7b1a2e59738aa085d91b87c4d5121271f7" } }]
+
+[[packages]]
 name = "durationpy"
 version = "0.10"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/durationpy-0.10-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 5634, hashes = { sha256 = "0226bf76c182b6cf7f7b51f5dfe8727c9b7a92d2b0ec267a6b568cbeeb54a7a7" } }]
 
 [[packages]]
@@ -401,6 +431,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/fonttools-4.63.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:23Z, size = 1166224, hashes = { sha256 = "1d00dc952282971a8e054d6fe6a29b40dd0a42efce5e9a49fb300c48862039ff" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 5292, hashes = { sha256 = "cd3f9598f4b63233df6a480b870ac9345ba918829d77d51388fd0fe17eac91a1" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -430,7 +466,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "google-api-core"
 version = "2.34.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 182295, hashes = { sha256 = "d1458beb91a7e091a6bfa763971f13d83aed63346559a8d65ba31f6c040eddcd" } }]
 
 [[packages]]
@@ -440,9 +476,33 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_auth-2.56.3-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 260808, hashes = { sha256 = "fb67e1edb56ca2c5df625b3b78fedf88f25eda3f7d4953a373684500e12ea8f5" } }]
 
 [[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:26:52Z, size = 32811, hashes = { sha256 = "59969cdfa9665281e26f4493ab42a0a6d8df72ab126a3f0e83f0df079845f736" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 343297, hashes = { sha256 = "0f4087354eb54aded4155625d765df15255ef6f997a4950fe0f181a23ff3bdcd" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 15528, hashes = { sha256 = "7b22b18c6d1d6317ea20511f6937ea2f24f2ca257cb4b46286bff3e5bb26390c" } }]
+
+[[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T17:26:52Z, size = 83371, hashes = { sha256 = "dff3d15dfe5bccfc3aa7a3c56de7e0c287481ae6c4189cee7b2b6390bcc89a5f" } }]
+
+[[packages]]
 name = "googleapis-common-protos"
 version = "1.75.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/googleapis_common_protos-1.75.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 302478, hashes = { sha256 = "bb8b588c499dc8e35dc76e85883f2424951748489e907b4c38025f92b8ec8c29" } }]
 
 [[packages]]
@@ -596,6 +656,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/ipywidgets-8.1.2-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 141124, hashes = { sha256 = "3939b6befa6a3bebebc125a8c052fe0be0e3942fa3f0d8fbe0afed38aee0d213" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 13135, hashes = { sha256 = "000b7fe2770bd660c95c7481124fb970c1c77a84fee93d6655787afb2db7d83d" } }]
+
+[[packages]]
 name = "itsdangerous"
 version = "2.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -635,10 +701,22 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/joblib-1.5.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 310691, hashes = { sha256 = "4099cde1fb51e46c612eff40973fccec60d0155660ffa534bcc01be91c0e1986" } }]
 
 [[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 38186, hashes = { sha256 = "64ceca8013df57f5827ab332876a1731a819e2e2423e5ee849ae846c9543e6bb" } }]
+
+[[packages]]
 name = "jsonlines"
 version = "4.0.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jsonlines-4.0.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 10389, hashes = { sha256 = "7d0c2ad472718395561b34df01221e910aa7d0b59d3862ad7fd112fa458f3cb0" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 9356, hashes = { sha256 = "7d47f0f9fe37f27e94d3d8ba7cd41da3d4a26f879328a5e150ed0ab768ec5519" } }]
 
 [[packages]]
 name = "jsonschema"
@@ -653,6 +731,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 20293, hashes = { sha256 = "0825040626d673255335af996e39ab3f1501f123e87ce616333f514b42db76d0" } }]
 
 [[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 917005, hashes = { sha256 = "1c9d1549c9c5e6fc373c9ea94527b43d7fba5c8639503f5234cc4ae4508bcc25" } }]
+
+[[packages]]
 name = "jupyter-client"
 version = "8.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -665,10 +749,46 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 30712, hashes = { sha256 = "caebbfee5a19c1742e864419a40bc70dd4480912d3982076ebf27019f487ee6e" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 21227, hashes = { sha256 = "88a888ea0519b21d331cf732bd4319af9bcc9832a9f74da0e7f7e51cebeea84b" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 79185, hashes = { sha256 = "8581f6c716f7567615713ded4c6e4984ba44045e5d28358427dc5171c4929aa4" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:26:52Z, size = 395766, hashes = { sha256 = "62339041ecbf2778c8670f0e0fd752d3fa47c34d1b70611835838eaf573c856a" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 15516, hashes = { sha256 = "7b63316024a2b60cb0d7703359ab6b84aefac9f195bd86b3afc158838d45bf2f" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 12454273, hashes = { sha256 = "6bd336d31aa9279713f2244f340c06c3ebb8a45357a4ebc2199bea2c8d079d5b" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 17967, hashes = { sha256 = "3a9d865aed077c176452d5d2017da8c197e808c341c2cb8b57498eb256c59fb7" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 61572, hashes = { sha256 = "ed75da7d76d1c7aa6818a5bfc15c82d0c369d41a3695caf4f6df2f8c475410ba" } }]
 
 [[packages]]
 name = "jupyterlab-widgets"
@@ -681,6 +801,30 @@ name = "kafka-python-ng"
 version = "2.2.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kafka_python_ng-2.2.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 234707, hashes = { sha256 = "b7d57a5008f27b4ac0fbab0b97a767f666b833d973ac1009c93f56ee2a3f4cf7" } }]
+
+[[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 479782, hashes = { sha256 = "e051d6c0d9d0b7c8bda966b50f37ad2560c65507ec0063615d4ed69b5a485909" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 29466, hashes = { sha256 = "a1d0fe95292300f9c23392bb5baf42fd251a227522fcd4e295be4e6c94ec121a" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 11704, hashes = { sha256 = "ed37ef5670c6fff0169abe35191d384e55ef41666be167edcb751685090fb9ab" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 130412, hashes = { sha256 = "6544bfb15cda3ebbc62def0edb37c41cdf8a74eb6a9026582b2330303db9a55b" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -700,8 +844,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "kubernetes"
 version = "36.0.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 4619744, hashes = { sha256 = "52c576354d3f11e08870e4ae625e9498803cfb22e37bb5fa47d45e2db153e11a" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 114760, hashes = { sha256 = "540c228ba09623b784e922e209ec435c855eec909dbb6b7c3bf54374df045f0e" } }]
 
 [[packages]]
 name = "librt"
@@ -953,6 +1103,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/nltk-3.10.3-1-py3-none-any.whl", upload-time = 2026-08-16T00:51:33Z, size = 1800253, hashes = { sha256 = "7184a00a3761d610bc2ebe23142e42b3f2b2591de0b8ccae6d4ab0665fca3d28" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 5548934, hashes = { sha256 = "4883fd37c9577075ea36e2a81147112e7b0378ea3a5cc9ccbfbfc274064c58e1" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 14999, hashes = { sha256 = "72363e68aa1e21920403d437b9aa1f8fc6648221030da319c5e03e678862f065" } }]
+
+[[packages]]
 name = "numpy"
 version = "2.4.6"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -970,8 +1132,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 161706, hashes = { sha256 = "8ad6576fa403738412bb92587b6bbce4be8562f514c59c090327eeace803cb63" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T12:51:55Z, size = 377926, hashes = { sha256 = "4ad155f9beb3344bb3cd01cb48b0527f90435836649238a2c5195f364a34284e" } }]
 
 [[packages]]
 name = "onnx"
@@ -1055,6 +1223,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]
@@ -1174,7 +1344,7 @@ wheels = [
 [[packages]]
 name = "proto-plus"
 version = "1.28.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/proto_plus-1.28.3-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 52498, hashes = { sha256 = "b99371be85a60317df94bdc274e9612026edcfe3126f3ce1fb44d2694019e06c" } }]
 
 [[packages]]
@@ -1358,6 +1528,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/python_dotenv-1.2.3-1-py3-none-any.whl", upload-time = 2026-08-20T00:50:04Z, size = 24504, hashes = { sha256 = "b0b0b19f7172643f1c79654d28615ce3d1b112be0eee4af88194bfa570c29d60" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T00:49:08Z, size = 16754, hashes = { sha256 = "bfc9fe1dd95b4b74f59573acb8ca4e118ff9e90b28c4876a59c3ca558906b107" } }]
+
+[[packages]]
 name = "pytz"
 version = "2026.3.post1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1414,8 +1590,32 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 26049, hashes = { sha256 = "dc0ef52c153db66aa5cc0e43b1895bebd6c4e5bf79c75e4b7f2e5aefbec8bc56" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 53486, hashes = { sha256 = "0514d2a703b130d36592d043fdb076939c165c654c2d70dd27bf25e312f20c06" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 5388, hashes = { sha256 = "b76ef37df7e558436092e4e87ad94534fd0e4f9ae876226f147aa4218bb68b86" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 6206, hashes = { sha256 = "bea6feda7f80885268d94f67a316645e55da0d5dd97467ee854ea73a80220cab" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 9777, hashes = { sha256 = "3daaccda58257b5684c5d4ba3363f5769b9013f729b9f60fa46a9a14e689d60e" } }]
 
 [[packages]]
 name = "rich"
@@ -1476,6 +1676,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/scipy-1.18.0-1-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 23993810, hashes = { sha256 = "a0af5949e43841df1d3a1681bc7835376e550b9941d54d1e2afff7117849a12f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/scipy-1.18.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 25301248, hashes = { sha256 = "95faa4b9656b76335900f02314b9a3bfaba11e3e46c477e74ca01b1dda607973" } },
 ]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 19286, hashes = { sha256 = "caa206291a7461855a50ef98e5cc077dbfa4fb555b37c9db7875cae78a6f29f6" } }]
 
 [[packages]]
 name = "setuptools"
@@ -1613,6 +1819,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/tensorboard_data_server-0.7.2-py3-none-any.whl", upload-time = 2026-08-16T00:51:33Z, size = 2356, hashes = { sha256 = "7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb" } }]
 
 [[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 15815, hashes = { sha256 = "a54bb525122e83cbd26b0d342a2cff5bc205de5660d2a080aa75d150110b6103" } }]
+
+[[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1712,6 +1924,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 118614827, hashes = { sha256 = "74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 119953430, hashes = { sha256 = "b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-27T00:39:10Z, size = 118614910, hashes = { sha256 = "f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T00:38:43Z, size = 119953513, hashes = { sha256 = "455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae" } },
 ]
 
 [[packages]]
@@ -1755,6 +1969,12 @@ name = "tzdata"
 version = "2026.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 349805, hashes = { sha256 = "d982eaebb436a8e9915840f6b01aec8cd597dc48806128e2845e32c0e64ca57d" } }]
+
+[[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 12897, hashes = { sha256 = "9a63b6b78c8a9c1cc34907b952c8fd15efc42a893022025115688a3fdf035a56" } }]
 
 [[packages]]
 name = "urllib3"
@@ -1814,6 +2034,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 324791, hashes = { sha256 = "76222e89b10969948f0175d5e12e8e69910ba5d2d7717ff6cca58a93f8d85470" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 16603, hashes = { sha256 = "93d54e04b343628bfa1c42059820d442b2736a36dfc1bc8bfa5e7d3308b96ed6" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1822,7 +2048,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 84342, hashes = { sha256 = "95bd0077d98d01f06bfd2d2f180d365df6f5b32ad83f0daacc023a5b5a785b24" } }]
 
 [[packages]]

--- a/runtimes/pytorch/ubi9-python-3.12/requirements.cuda.txt
+++ b/runtimes/pytorch/ubi9-python-3.12/requirements.cuda.txt
@@ -23,6 +23,8 @@ argon2-cffi==25.1.0 ; python_full_version == '3.12.*' and implementation_name ==
 argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6b85e8f20ed628ff64f5c7ee06cec4161c33a9edbe79ee38cae24967cfbd90e6 \
     --hash=sha256:fbb9c953378afb816cb6a090c04005c2e2566b3355d2fbc73660f38b73da2613
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cd2b374b02201cb1a54dda30c31a3187b14f6a16fbec1c3162e343c7f6b32f83
 ast-serialize==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9a21624872c99a76f720e09ce4f2e978f3e49d0dd7cfae490306500bceaa7948 \
     --hash=sha256:eec05d3174f62cc102595380d577d921f85bbb2aca69f32efa433e666e817d5e
@@ -30,10 +32,14 @@ astor==0.8.1 ; python_full_version == '3.12.*' and implementation_name == 'cpyth
     --hash=sha256:c25250ea8d58b37a98632c56d68fc5f516ee4bc5270dc92b2095cd39505e3b01
 asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a0f70d22738459e6b462858b5c1556dc8e6b58c48923232276a8b7843bf2dda4
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:09cf67bd95791dd5c66a642d43fecb5d3f4d59f2cde0f4320ae06bb1f74d29f1
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2a329bafdb8a44c84f1949b23266caca598dad251f0b1d586f5b96d5d6fe69c0
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a2d19b14cbd0d750e8961443b092f5c65ac22f8661214b4290958a0db2690089
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:564565f6bc2b4cd98b166297b16840f362dacad5979d81b1cc3addabe5395306
 bcrypt==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:7ba3abf6fefcd2e8d066e3b8aa3947735c924c5ad48235f2f0058131803e463f \
     --hash=sha256:57f842b9edfd6d11c3e54375ea6675a6c7884567224178b8e376ddb6168bac8b
@@ -60,6 +66,8 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:d9c52b6daac930ba203ec4d4e2221fabb3dac87af4b1750f8d9d3855786d57ed
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4e90c67eff90cf0ae6dfea593cba6e9b8e8a64ddbbc983a3cd4ba0b4ae442914
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fb59fa3994e8b3b3eb94fe646780e08cc892ddc60b57aa8f557b6824daf55f46
 cloudpickle==3.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:abd95dc72b055ed19c47580bd546a87266e06aa61dc0abd3b9229da6f8ac463d
 codeflare-sdk==0.38.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
@@ -95,7 +103,9 @@ dnspython==2.8.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:42e12a03a1c83bae74818976361c977cf207b266f230081eee9c0769844b46fd
 docker==7.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9a26839a6f03681dd526e64383d960b8049bde54a86f3c62761173b0b43793b3
-durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:229c7cc98c6bedac75168c530c89db7b1a2e59738aa085d91b87c4d5121271f7
+durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0226bf76c182b6cf7f7b51f5dfe8727c9b7a92d2b0ec267a6b568cbeeb54a7a7
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:94959bb08d397915f41eeb3058bcf817e0bb50902b4df9f3ff2947c81b2d3e0e
@@ -115,6 +125,8 @@ flask-cors==6.0.5 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:a7a46c78a88db4aac2735152d29dc81569cea19699a511e7e48487d6707ed90d
 fonttools==4.63.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1d00dc952282971a8e054d6fe6a29b40dd0a42efce5e9a49fb300c48862039ff
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:cd3f9598f4b63233df6a480b870ac9345ba918829d77d51388fd0fe17eac91a1
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:59f589f10c530dd2bcaf2c06e505487f21b36f306ee917c0724c40c39cecce77 \
     --hash=sha256:987a668ace14a860cc983ef6452c0f55dcaf75f9003dcc71cc87f5f031a4335c
@@ -124,11 +136,19 @@ gitdb==4.0.12 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:0b0bab215043ba322520b36d31a4b87dfe28d70f51841dfbb7399b8131b2aabc
 gitpython==3.1.59 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e3eb5873a0fa94da73c93fe1741931eba33501ab69cf72c087814c8e0fe8fc64
-google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d1458beb91a7e091a6bfa763971f13d83aed63346559a8d65ba31f6c040eddcd
 google-auth==2.56.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fb67e1edb56ca2c5df625b3b78fedf88f25eda3f7d4953a373684500e12ea8f5
-googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:59969cdfa9665281e26f4493ab42a0a6d8df72ab126a3f0e83f0df079845f736
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0f4087354eb54aded4155625d765df15255ef6f997a4950fe0f181a23ff3bdcd
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7b22b18c6d1d6317ea20511f6937ea2f24f2ca257cb4b46286bff3e5bb26390c
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:dff3d15dfe5bccfc3aa7a3c56de7e0c287481ae6c4189cee7b2b6390bcc89a5f
+googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:bb8b588c499dc8e35dc76e85883f2424951748489e907b4c38025f92b8ec8c29
 graphene==3.4.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e632ab2584398e04f90963d7c23606fc18887104cdc5ca19e82274152a6ec56a
@@ -146,9 +166,13 @@ gunicorn==26.0.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:d0ee22c01ef73911b13877a46df72014b846828cc3562151bde9660a3649ad8a
 h11==0.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a2578bb46c2409e7be5599f93d70659478b79d382a4a82338188719da8d388ce
+httpcore==1.0.9 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:484350707982342ac862fea73f03dda7044c3fde20725bd723048c0c40d33c70
 httptools==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3ca710db27f80abcf6558651e3330ff610bd94112f6f9292bb1638395ffac69b \
     --hash=sha256:e9234a8cd7b8562479e3dd627910f8776b1e33e8611482551efd6325393abd9f
+httpx==0.28.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:751903c7c4617d974f82c5935bee6b8214b11af0d9a451f20122e09dfde1572c
 huey==3.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a8711a91498cc501a99f24505359bdb9ed72a68bd864d54f739062ab4855d83e
 idna==3.18 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -167,6 +191,8 @@ ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementat
     --hash=sha256:27e8b810135cdfbbc7b160fe5ec0cb8eec46944038126fb2b3d3a07a523e0560
 ipywidgets==8.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:3939b6befa6a3bebebc125a8c052fe0be0e3942fa3f0d8fbe0afed38aee0d213
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:000b7fe2770bd660c95c7481124fb970c1c77a84fee93d6655787afb2db7d83d
 itsdangerous==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d859aa9dbedb0dcbb6d9f12d9ecdeb70ff18dec29d15d8a1e1a7f65621ec4eb7
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -177,27 +203,55 @@ jmespath==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:8141c2bbb5a7b2137e36ec58984e5490e07062206b74d69b2e0b4de79dec6819
 joblib==1.5.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4099cde1fb51e46c612eff40973fccec60d0155660ffa534bcc01be91c0e1986
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:64ceca8013df57f5827ab332876a1731a819e2e2423e5ee849ae846c9543e6bb
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7d47f0f9fe37f27e94d3d8ba7cd41da3d4a26f879328a5e150ed0ab768ec5519
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e2d06847dd14978a1ee072ccd8fec1e78abe4fdd6aa6f5aad835fa26c9a21b17
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0825040626d673255335af996e39ab3f1501f123e87ce616333f514b42db76d0
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1c9d1549c9c5e6fc373c9ea94527b43d7fba5c8639503f5234cc4ae4508bcc25
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:12ef4b1a53a6f9ac71cab820149cf04046a744c42443fb20f42f525f60126870
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:caebbfee5a19c1742e864419a40bc70dd4480912d3982076ebf27019f487ee6e
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:88a888ea0519b21d331cf732bd4319af9bcc9832a9f74da0e7f7e51cebeea84b
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:8581f6c716f7567615713ded4c6e4984ba44045e5d28358427dc5171c4929aa4
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:62339041ecbf2778c8670f0e0fd752d3fa47c34d1b70611835838eaf573c856a
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7b63316024a2b60cb0d7703359ab6b84aefac9f195bd86b3afc158838d45bf2f
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6bd336d31aa9279713f2244f340c06c3ebb8a45357a4ebc2199bea2c8d079d5b
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3a9d865aed077c176452d5d2017da8c197e808c341c2cb8b57498eb256c59fb7
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ed75da7d76d1c7aa6818a5bfc15c82d0c369d41a3695caf4f6df2f8c475410ba
 jupyterlab-widgets==3.0.16 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:c039b2f4432f9d3139d5f1358c16750e4baec12c92b2ed36e2c8002f73e16550
 kafka-python-ng==2.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b7d57a5008f27b4ac0fbab0b97a767f666b833d973ac1009c93f56ee2a3f4cf7
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e051d6c0d9d0b7c8bda966b50f37ad2560c65507ec0063615d4ed69b5a485909
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a1d0fe95292300f9c23392bb5baf42fd251a227522fcd4e295be4e6c94ec121a
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ed37ef5670c6fff0169abe35191d384e55ef41666be167edcb751685090fb9ab
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6544bfb15cda3ebbc62def0edb37c41cdf8a74eb6a9026582b2330303db9a55b
 kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:773b9c47c97476fc1f85649c27e36f311006b9433b6b8575fc805fe3d30d0eaf \
     --hash=sha256:867dc3801289b7c99c31911f60cc832a09756cbccd459881c27c2c1511f018cd
 kube-authkit==0.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:c6398d8bc3723f1e93275c0999a78cff092a763878540d5a2cfbf6aba1becde0
-kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:52c576354d3f11e08870e4ae625e9498803cfb22e37bb5fa47d45e2db153e11a
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:540c228ba09623b784e922e209ec435c855eec909dbb6b7c3bf54374df045f0e
 librt==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
     --hash=sha256:06f75fbe3afe50730a4358d0559f54052a979e0f08d713a0a3670eccf8b47d5d \
     --hash=sha256:7869f768d179d9b26cd41157cb087a820c4a7937dca914bd9fda6d52ab3623e8
@@ -264,11 +318,17 @@ nest-asyncio2==1.7.2 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:eaba9b42b1eadba6525f5fe6d69787d7c76738342262f88bced1d6b324cd9a70
 networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:71b26e57d5db6c1c7ba583420a7f7939c88a2a763f728d610790b1f05775cd92
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4883fd37c9577075ea36e2a81147112e7b0378ea3a5cc9ccbfbfc274064c58e1
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:72363e68aa1e21920403d437b9aa1f8fc6648221030da319c5e03e678862f065
 numpy==2.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7281df6d751161c86ac5a2b6cbb8c12e40c4eace3b2bfa8426f21b2afa1c82b8 \
     --hash=sha256:269144afedbebca70c04b79eb286df93f4593f1a67f37271311c5ff81f9a2f68
-oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8ad6576fa403738412bb92587b6bbce4be8562f514c59c090327eeace803cb63
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4ad155f9beb3344bb3cd01cb48b0527f90435836649238a2c5195f364a34284e
 onnx==1.22.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ceff6a479c550c541638a379a88b8415a5419ac6b602aa225553406725a61f2b \
     --hash=sha256:09974c9c269b1fa662118c23f69ec2bd8d0dc784745c36ae98325c06acc29d3a
@@ -294,7 +354,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e910fdfb5465e33f4007a3f9e90a56a79f78a62a150ad24d6ebe7d846dedb95e
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -329,7 +391,7 @@ prompt-toolkit==3.0.53 ; python_full_version == '3.12.*' and implementation_name
 propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:41840717b46f0ce958d620688f07287fcc8f1c264a390be784ca80243f13c3ca \
     --hash=sha256:4c9c9dd6c28062556e10794e5388ede7025d4e7afc3f05665d156c7c93f556d1
-proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b99371be85a60317df94bdc274e9612026edcfe3126f3ce1fb44d2694019e06c
 protobuf==6.31.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:daa678e7a41a1c6abc124cc0a2c849e2d8382d2b30b03cf3197ebd896e546fb5 \
@@ -385,6 +447,8 @@ python-discovery==1.5.2 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:4f2e312fcc39064122587c8f83c4fe110375b51ecb5da40688ab99b2999353dc
 python-dotenv==1.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b0b0b19f7172643f1c79654d28615ce3d1b112be0eee4af88194bfa570c29d60
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bfc9fe1dd95b4b74f59573acb8ca4e118ff9e90b28c4876a59c3ca558906b107
 pytz==2026.3.post1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d5c1cdf3039a80b19ea642ad56c2782e291272c623da9f737bcaa59190cf396a
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -398,10 +462,18 @@ ray==2.55.1 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
     --hash=sha256:23a099c23df74632d81b7005e5cb5e22dfcf13f218796cb15a0cfd62a781701e
 referencing==0.37.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7a1007da1b01c26788065ca042f3657fd902f4096e7e1e6284017f26f86faabf
-requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:349a37be55c2f555fb3fe0b8b8dc7e24909f3b656473dd98c2a48c0de3cdc6a1
-requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+requests==2.33.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6b8e0a1995ce82558869bae98aa785606a64fff5e34cc3bc0d4a2d16ce254d65
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dc0ef52c153db66aa5cc0e43b1895bebd6c4e5bf79c75e4b7f2e5aefbec8bc56
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0514d2a703b130d36592d043fdb076939c165c654c2d70dd27bf25e312f20c06
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b76ef37df7e558436092e4e87ad94534fd0e4f9ae876226f147aa4218bb68b86
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bea6feda7f80885268d94f67a316645e55da0d5dd97467ee854ea73a80220cab
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3daaccda58257b5684c5d4ba3363f5769b9013f729b9f60fa46a9a14e689d60e
 rich==14.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:4281322642d3a1037a427ee8011bf723ad886fd4cf40fea7f8330f24693b3963
 rpds-py==2026.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -415,6 +487,8 @@ scikit-learn==1.9.0 ; python_full_version == '3.12.*' and implementation_name ==
 scipy==1.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a0af5949e43841df1d3a1681bc7835376e550b9941d54d1e2afff7117849a12f \
     --hash=sha256:95faa4b9656b76335900f02314b9a3bfaba11e3e46c477e74ca01b1dda607973
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:caa206291a7461855a50ef98e5cc077dbfa4fb555b37c9db7875cae78a6f29f6
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:59c60deb1babb73f9e704ce8ab110f8f8eb9ed93f33c8e0847f3fc90fd58b974
 six==1.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -448,6 +522,8 @@ tensorboard==2.20.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:c779236b278e7922d1b9f3b9de06ca217a4d3d8877036fad6dd32e8a3160ca78
 tensorboard-data-server==0.7.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:a54bb525122e83cbd26b0d342a2cff5bc205de5660d2a080aa75d150110b6103
 threadpoolctl==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e890376b4d1c58b30d76cb1458693e81ee91e77eda05d5cfe7325b1db0203e4c
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -475,7 +551,9 @@ traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:6227f237db51451f31357bb6e6715fdabef00a3a16f475845856cf0a20ce3529
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828 \
-    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504
+    --hash=sha256:b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504 \
+    --hash=sha256:f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b \
+    --hash=sha256:455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4d72791c38455c3365e3125938ae90692878f20be81bdb4295f8b5e633b35a0c
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -484,6 +562,8 @@ typing-inspection==0.4.4 ; python_full_version == '3.12.*' and implementation_na
     --hash=sha256:14d0fb26d04391bca8117008a9090c41f4ad3fec3a96440d112fad8ae005f430
 tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d982eaebb436a8e9915840f6b01aec8cd597dc48806128e2845e32c0e64ca57d
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9a63b6b78c8a9c1cc34907b952c8fd15efc42a893022025115688a3fdf035a56
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6822d128181a5283a1a6e16a4c728ccaaa04ade8043b6b0145dd172af1a16e56
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -503,9 +583,11 @@ watchfiles==1.2.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:0e40edeea11dd432bff30c5984bfecff1e7396a1347a1d5cf519a207e19369de
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:76222e89b10969948f0175d5e12e8e69910ba5d2d7717ff6cca58a93f8d85470
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:93d54e04b343628bfa1c42059820d442b2736a36dfc1bc8bfa5e7d3308b96ed6
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f334a0eae8c5c6b1f23faf69a3af099af5a6306d254fac7a8cad640a4f9a3747
-websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:95bd0077d98d01f06bfd2d2f180d365df6f5b32ad83f0daacc023a5b5a785b24
 websockets==17.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1c4119039c17b26e4c99226b05da4231da0b6c6b9bcec4235f2d839653483380 \

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -77,6 +77,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 70409, hashes = { sha256 = "cd2b374b02201cb1a54dda30c31a3187b14f6a16fbec1c3162e343c7f6b32f83" } }]
+
+[[packages]]
 name = "ast-serialize"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -98,6 +104,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/asttokens-3.0.2-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 29415, hashes = { sha256 = "a0f70d22738459e6b462858b5c1556dc8e6b58c48923232276a8b7843bf2dda4" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 10055, hashes = { sha256 = "09cf67bd95791dd5c66a642d43fecb5d3f4d59f2cde0f4320ae06bb1f74d29f1" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -108,6 +120,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 47528, hashes = { sha256 = "a2d19b14cbd0d750e8961443b092f5c65ac22f8661214b4290958a0db2690089" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 10198502, hashes = { sha256 = "564565f6bc2b4cd98b166297b16840f362dacad5979d81b1cc3addabe5395306" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -186,6 +204,12 @@ name = "click"
 version = "8.4.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 120858, hashes = { sha256 = "4e90c67eff90cf0ae6dfea593cba6e9b8e8a64ddbbc983a3cd4ba0b4ae442914" } }]
+
+[[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 13201, hashes = { sha256 = "fb59fa3994e8b3b3eb94fe646780e08cc892ddc60b57aa8f557b6824daf55f46" } }]
 
 [[packages]]
 name = "cloudpickle"
@@ -293,9 +317,15 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/docker-7.2.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 150399, hashes = { sha256 = "9a26839a6f03681dd526e64383d960b8049bde54a86f3c62761173b0b43793b3" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 24248, hashes = { sha256 = "229c7cc98c6bedac75168c530c89db7b1a2e59738aa085d91b87c4d5121271f7" } }]
+
+[[packages]]
 name = "durationpy"
 version = "0.10"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/durationpy-0.10-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 5634, hashes = { sha256 = "0226bf76c182b6cf7f7b51f5dfe8727c9b7a92d2b0ec267a6b568cbeeb54a7a7" } }]
 
 [[packages]]
@@ -353,6 +383,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/fonttools-4.63.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:23Z, size = 1166224, hashes = { sha256 = "1d00dc952282971a8e054d6fe6a29b40dd0a42efce5e9a49fb300c48862039ff" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 5292, hashes = { sha256 = "cd3f9598f4b63233df6a480b870ac9345ba918829d77d51388fd0fe17eac91a1" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -382,7 +418,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "google-api-core"
 version = "2.34.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 182295, hashes = { sha256 = "d1458beb91a7e091a6bfa763971f13d83aed63346559a8d65ba31f6c040eddcd" } }]
 
 [[packages]]
@@ -392,9 +428,33 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_auth-2.56.3-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 260808, hashes = { sha256 = "fb67e1edb56ca2c5df625b3b78fedf88f25eda3f7d4953a373684500e12ea8f5" } }]
 
 [[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:26:52Z, size = 32811, hashes = { sha256 = "59969cdfa9665281e26f4493ab42a0a6d8df72ab126a3f0e83f0df079845f736" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 343297, hashes = { sha256 = "0f4087354eb54aded4155625d765df15255ef6f997a4950fe0f181a23ff3bdcd" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 15528, hashes = { sha256 = "7b22b18c6d1d6317ea20511f6937ea2f24f2ca257cb4b46286bff3e5bb26390c" } }]
+
+[[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T17:26:52Z, size = 83371, hashes = { sha256 = "dff3d15dfe5bccfc3aa7a3c56de7e0c287481ae6c4189cee7b2b6390bcc89a5f" } }]
+
+[[packages]]
 name = "googleapis-common-protos"
 version = "1.75.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/googleapis_common_protos-1.75.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 302478, hashes = { sha256 = "bb8b588c499dc8e35dc76e85883f2424951748489e907b4c38025f92b8ec8c29" } }]
 
 [[packages]]
@@ -446,6 +506,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/h11-0.16.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 39145, hashes = { sha256 = "a2578bb46c2409e7be5599f93d70659478b79d382a4a82338188719da8d388ce" } }]
 
 [[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/httpcore-1.0.9-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 80436, hashes = { sha256 = "484350707982342ac862fea73f03dda7044c3fde20725bd723048c0c40d33c70" } }]
+
+[[packages]]
 name = "httptools"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -453,6 +519,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/httptools-0.8.0-1-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 506285, hashes = { sha256 = "3ca710db27f80abcf6558651e3330ff610bd94112f6f9292bb1638395ffac69b" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/httptools-0.8.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 514721, hashes = { sha256 = "e9234a8cd7b8562479e3dd627910f8776b1e33e8611482551efd6325393abd9f" } },
 ]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/httpx-0.28.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 75162, hashes = { sha256 = "751903c7c4617d974f82c5935bee6b8214b11af0d9a451f20122e09dfde1572c" } }]
 
 [[packages]]
 name = "huey"
@@ -509,6 +581,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/ipywidgets-8.1.2-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 141124, hashes = { sha256 = "3939b6befa6a3bebebc125a8c052fe0be0e3942fa3f0d8fbe0afed38aee0d213" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 13135, hashes = { sha256 = "000b7fe2770bd660c95c7481124fb970c1c77a84fee93d6655787afb2db7d83d" } }]
+
+[[packages]]
 name = "itsdangerous"
 version = "2.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -539,6 +617,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/joblib-1.5.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 310691, hashes = { sha256 = "4099cde1fb51e46c612eff40973fccec60d0155660ffa534bcc01be91c0e1986" } }]
 
 [[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 38186, hashes = { sha256 = "64ceca8013df57f5827ab332876a1731a819e2e2423e5ee849ae846c9543e6bb" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 9356, hashes = { sha256 = "7d47f0f9fe37f27e94d3d8ba7cd41da3d4a26f879328a5e150ed0ab768ec5519" } }]
+
+[[packages]]
 name = "jsonschema"
 version = "4.26.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -549,6 +639,12 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 20293, hashes = { sha256 = "0825040626d673255335af996e39ab3f1501f123e87ce616333f514b42db76d0" } }]
+
+[[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 917005, hashes = { sha256 = "1c9d1549c9c5e6fc373c9ea94527b43d7fba5c8639503f5234cc4ae4508bcc25" } }]
 
 [[packages]]
 name = "jupyter-client"
@@ -563,10 +659,46 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 30712, hashes = { sha256 = "caebbfee5a19c1742e864419a40bc70dd4480912d3982076ebf27019f487ee6e" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 21227, hashes = { sha256 = "88a888ea0519b21d331cf732bd4319af9bcc9832a9f74da0e7f7e51cebeea84b" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 79185, hashes = { sha256 = "8581f6c716f7567615713ded4c6e4984ba44045e5d28358427dc5171c4929aa4" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:26:52Z, size = 395766, hashes = { sha256 = "62339041ecbf2778c8670f0e0fd752d3fa47c34d1b70611835838eaf573c856a" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 15516, hashes = { sha256 = "7b63316024a2b60cb0d7703359ab6b84aefac9f195bd86b3afc158838d45bf2f" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 12454273, hashes = { sha256 = "6bd336d31aa9279713f2244f340c06c3ebb8a45357a4ebc2199bea2c8d079d5b" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 17967, hashes = { sha256 = "3a9d865aed077c176452d5d2017da8c197e808c341c2cb8b57498eb256c59fb7" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 61572, hashes = { sha256 = "ed75da7d76d1c7aa6818a5bfc15c82d0c369d41a3695caf4f6df2f8c475410ba" } }]
 
 [[packages]]
 name = "jupyterlab-widgets"
@@ -579,6 +711,30 @@ name = "kafka-python-ng"
 version = "2.2.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kafka_python_ng-2.2.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 234707, hashes = { sha256 = "b7d57a5008f27b4ac0fbab0b97a767f666b833d973ac1009c93f56ee2a3f4cf7" } }]
+
+[[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 479782, hashes = { sha256 = "e051d6c0d9d0b7c8bda966b50f37ad2560c65507ec0063615d4ed69b5a485909" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 29466, hashes = { sha256 = "a1d0fe95292300f9c23392bb5baf42fd251a227522fcd4e295be4e6c94ec121a" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 11704, hashes = { sha256 = "ed37ef5670c6fff0169abe35191d384e55ef41666be167edcb751685090fb9ab" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 130412, hashes = { sha256 = "6544bfb15cda3ebbc62def0edb37c41cdf8a74eb6a9026582b2330303db9a55b" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -598,8 +754,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "kubernetes"
 version = "36.0.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 4619744, hashes = { sha256 = "52c576354d3f11e08870e4ae625e9498803cfb22e37bb5fa47d45e2db153e11a" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 114760, hashes = { sha256 = "540c228ba09623b784e922e209ec435c855eec909dbb6b7c3bf54374df045f0e" } }]
 
 [[packages]]
 name = "librt"
@@ -800,6 +962,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/networkx-3.6.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 2070145, hashes = { sha256 = "71b26e57d5db6c1c7ba583420a7f7939c88a2a763f728d610790b1f05775cd92" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 5548934, hashes = { sha256 = "4883fd37c9577075ea36e2a81147112e7b0378ea3a5cc9ccbfbfc274064c58e1" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 14999, hashes = { sha256 = "72363e68aa1e21920403d437b9aa1f8fc6648221030da319c5e03e678862f065" } }]
+
+[[packages]]
 name = "numpy"
 version = "2.5.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -811,8 +985,14 @@ wheels = [
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 161706, hashes = { sha256 = "8ad6576fa403738412bb92587b6bbce4be8562f514c59c090327eeace803cb63" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T12:51:55Z, size = 377926, hashes = { sha256 = "4ad155f9beb3344bb3cd01cb48b0527f90435836649238a2c5195f364a34284e" } }]
 
 [[packages]]
 name = "onnx"
@@ -890,6 +1070,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]
@@ -997,7 +1179,7 @@ wheels = [
 [[packages]]
 name = "proto-plus"
 version = "1.28.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/proto_plus-1.28.3-1-py3-none-any.whl", upload-time = 2026-08-15T00:55:57Z, size = 52498, hashes = { sha256 = "b99371be85a60317df94bdc274e9612026edcfe3126f3ce1fb44d2694019e06c" } }]
 
 [[packages]]
@@ -1163,6 +1345,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/python_dotenv-1.2.3-1-py3-none-any.whl", upload-time = 2026-08-20T00:50:04Z, size = 24504, hashes = { sha256 = "b0b0b19f7172643f1c79654d28615ce3d1b112be0eee4af88194bfa570c29d60" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T00:49:08Z, size = 16754, hashes = { sha256 = "bfc9fe1dd95b4b74f59573acb8ca4e118ff9e90b28c4876a59c3ca558906b107" } }]
+
+[[packages]]
 name = "pytz"
 version = "2026.3.post1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1203,15 +1391,39 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "requests"
-version = "2.34.2"
+version = "2.33.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/requests-2.34.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 74726, hashes = { sha256 = "349a37be55c2f555fb3fe0b8b8dc7e24909f3b656473dd98c2a48c0de3cdc6a1" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/requests-2.33.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 66703, hashes = { sha256 = "6b8e0a1995ce82558869bae98aa785606a64fff5e34cc3bc0d4a2d16ce254d65" } }]
 
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 26049, hashes = { sha256 = "dc0ef52c153db66aa5cc0e43b1895bebd6c4e5bf79c75e4b7f2e5aefbec8bc56" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T00:49:59Z, size = 53486, hashes = { sha256 = "0514d2a703b130d36592d043fdb076939c165c654c2d70dd27bf25e312f20c06" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 5388, hashes = { sha256 = "b76ef37df7e558436092e4e87ad94534fd0e4f9ae876226f147aa4218bb68b86" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 6206, hashes = { sha256 = "bea6feda7f80885268d94f67a316645e55da0d5dd97467ee854ea73a80220cab" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 9777, hashes = { sha256 = "3daaccda58257b5684c5d4ba3363f5769b9013f729b9f60fa46a9a14e689d60e" } }]
 
 [[packages]]
 name = "rich"
@@ -1251,6 +1463,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/scipy-1.18.0-1-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 23993810, hashes = { sha256 = "a0af5949e43841df1d3a1681bc7835376e550b9941d54d1e2afff7117849a12f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/scipy-1.18.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 25301248, hashes = { sha256 = "95faa4b9656b76335900f02314b9a3bfaba11e3e46c477e74ca01b1dda607973" } },
 ]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 19286, hashes = { sha256 = "caa206291a7461855a50ef98e5cc077dbfa4fb555b37c9db7875cae78a6f29f6" } }]
 
 [[packages]]
 name = "setuptools"
@@ -1352,6 +1570,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/tensorboard_data_server-0.7.2-py3-none-any.whl", upload-time = 2026-08-16T00:51:33Z, size = 2356, hashes = { sha256 = "7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb" } }]
 
 [[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 15815, hashes = { sha256 = "a54bb525122e83cbd26b0d342a2cff5bc205de5660d2a080aa75d150110b6103" } }]
+
+[[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1425,6 +1649,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T00:56:09Z, size = 118614827, hashes = { sha256 = "74f2cfa9f3de14cf8758d7a8675074b9bc06826a7ab5da40f8c90c562f924828" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:49:59Z, size = 119953430, hashes = { sha256 = "b139cb99c49efdb25efe6985e40760c9a5146ac9a839229b28245392b7ce2504" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-27T00:39:10Z, size = 118614910, hashes = { sha256 = "f5a8b414b4a9717fe512891befc5f89a4d2d1d176d695f268a1521718cd7271b" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T00:38:43Z, size = 119953513, hashes = { sha256 = "455800fee571b329fbc98c34e8019b617ca823b6f29a771ae4dbdc848a2115ae" } },
 ]
 
 [[packages]]
@@ -1450,6 +1676,12 @@ name = "tzdata"
 version = "2026.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:19:22Z, size = 349805, hashes = { sha256 = "d982eaebb436a8e9915840f6b01aec8cd597dc48806128e2845e32c0e64ca57d" } }]
+
+[[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 12897, hashes = { sha256 = "9a63b6b78c8a9c1cc34907b952c8fd15efc42a893022025115688a3fdf035a56" } }]
 
 [[packages]]
 name = "urllib3"
@@ -1509,6 +1741,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 324791, hashes = { sha256 = "76222e89b10969948f0175d5e12e8e69910ba5d2d7717ff6cca58a93f8d85470" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T11:14:34Z, size = 16603, hashes = { sha256 = "93d54e04b343628bfa1c42059820d442b2736a36dfc1bc8bfa5e7d3308b96ed6" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1517,7 +1755,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:37:35Z, size = 84342, hashes = { sha256 = "95bd0077d98d01f06bfd2d2f180d365df6f5b32ad83f0daacc023a5b5a785b24" } }]
 
 [[packages]]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.rocm.txt
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.rocm.txt
@@ -21,16 +21,22 @@ argon2-cffi==25.1.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:0aa4852a4218d1719f97422214b85b01a4548cfa36f39d4bfd5542fc329b2d88
 argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4161ed2757def3b4923beba006f82493ece15900119a993e014e04048784269b
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ee5c9a6d206547ea0fd2086a55504aeef9b2e11962277d0bf5f010309f47e9a3
 ast-serialize==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3323d989785ac9b2e49becbeb3f1a309532b0e76074f5422dddf9b90c713a9ed
 astor==0.8.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:23201f1a982425ddf91570d2e143bb3dd3991bdf33468c6a1d2a4c7a0bc955c9
 asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ca4520ea7a874796fc8627d1a3b44b32c8b7661735a44b52e73a2c224df7d7f6
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1b42c7e9cb96060faf4a5c879fd4e44bc6f3fabda6fb5dd638324330a868e989
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:729c41aeef6209abb1a76f2d1b26ea09a6cd347debef6d9fbc8a509f434fff85
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:10975975ed9b1e8741aeceeae6f9d64f51df560ac5c0cd3297e74147b948655c
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:49d903d13c404e2de727709733f295a77f61660fb8c35b303f6a4f482c6d7035
 bcrypt==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:fc33be01668e12a02f2e0377e8dd6a5137fb481669f1c23a8f7370b6c054c147
 beautifulsoup4==4.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -55,6 +61,8 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:fd4ae4becfaa995378bf66e7a8f5558fb1d18a019dc7581ab91b812aa34a523b
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3706183f30a8d73eefcbd8cdf71d36c333aed206b087d7a02998d9b0655a4d51
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:875dff328231c0a7e7ca38b22018c8116e9ea94144753081f444e3ed45bb8783
 cloudpickle==3.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8ca7ce3c39b51c0ed1c1602f2da024399966d43991d3b14832d965620d7fab6e
 codeflare-sdk==0.38.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
@@ -87,7 +95,9 @@ dnspython==2.8.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:2d2f16c964ebf8943fb294cb53c4865e85c1a22f3a0d89588980f7d1e8b0bc21
 docker==7.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5a5a1445a21611e0dbce3bbb5dd5e88475e8b94b6ff6c11a4c8f3a472178dc33
-durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e30292d160f7435654ad3d0238dec21a081ac51c3f38b8f2626a39a00d49175a
+durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3d8381d7b51204661cfd5adf2d6d15f0062c6c1008e9e2044a7f15dc2efae0dd
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ef28e3b55915294e3a2cb625770754bfbefeec5c972a506c4a1aa19ad71312ea
@@ -107,6 +117,8 @@ flask-cors==6.0.5 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:7c1c907efcf81c12672a3b0e328bfdc30cce3ceb760bdf1d2d8e9256ceadfd1c
 fonttools==4.63.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e1f61230cb61c92bdf281ce20c60a71d78eb5962033921e31b26b76f783dc42a
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:269f79952da891c129457defa26977163ee9f9eb1ed3d3e7ed7d16ab39dcc20f
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:71547ca469b6c231ae7df34476f2dd5224ac3205d0d41fba5a7cfec76b2bf57c
 fsspec==2026.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -115,11 +127,19 @@ gitdb==4.0.12 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:ce9cd07eaafcba526d03aebd325b726311bf148b2bd49eb20e398d1c8cd818e6
 gitpython==3.1.59 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4dba1c94c0a491994de3a7c104afc5d458a6e5c17a9bda388e214781f018c661
-google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e4df772c66becdc49e364d528393d2461cb40d71f98adb0917a544dc9daea23
 google-auth==2.56.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b2816991ea9f32c72df04324ad1663b3a5a0c5c068fceb8a6a01c12d18b05294
-googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:90547e6d27939bc56fdae458b35a508ec36b868c0aa9c548be1d1988bc8f17ff
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9eca513a3d0e4af5d7d4c2ae845ae4a08681cb6581cc7d8d347591bdde5ce834
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:52fe7115ec85f30545bf974db9521fe2e0d15dac16c935cc79a4fc62abbafa7d
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f8dd30133a89307b04d861ff3bcca60606acb1328b570a2f6b441886585e2f06
+googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c863217e8061a385cb798121d9f1249f0ad397c11511805a260fe096029464c2
 graphene==3.4.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9f859e5c0c10e49dd833b971e7a53ba49d4035d046eafb7bd7b399b09d90d913
@@ -135,8 +155,12 @@ gunicorn==26.0.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:a999c83604ede7831caf70a58066ed338e67210bf87b9f017d9a8c277ee00671
 h11==0.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e481ac9aefe4a935351ee32b96fcca637222b7f5e48384bd52b838cd5f8af24b
+httpcore==1.0.9 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:082036e28a6d861254e132836874c52102488aa67de4400e3f4db02cf42522d1
 httptools==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7942ab61641871103eb228e9d220556df9e140093efd2755526012553d4f3c98
+httpx==0.28.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5d7138bea54ef31da9db5abd95b585f1a2812a98293dd2ff3634cd75d14fb41d
 huey==3.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9fed18c61ba53fde549dfd34bce1d7e16ef276e66f6e2a6c35ac987e0285b7c5
 idna==3.18 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -155,6 +179,8 @@ ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementat
     --hash=sha256:321d3caba426531f67b938f0f5bc9c01733567e38ce583bfc8a0bb4e65872f09
 ipywidgets==8.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:64be0e8a800f90b1ab2d356342c2d6aadd9cede8e8dab385614cc53360f7603c
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:81519bd3cda71507afa100e36e918d3cc5f0a2f1f0d54f8ab6e18c4aecf06180
 itsdangerous==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5ebd7b919a261d510a697e29c795acd3654d3620a44127426e8d0ada3c023b44
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -165,26 +191,54 @@ jmespath==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:0762a3bfd6559779d81338573657955bf7153e908b786bb64c894d492610f82d
 joblib==1.5.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:713e822a83cc588a62150403f15a34aa1e9a7b6dd1144a658910515abdd731cf
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d99630fef264966c9e1761550a0ae3b537064151a9f8a2a3b548560457a3e578
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ff9ed8cbe1f40fe316b1c1ab6bf7cf87ccabc6a022c944582b7c400f325376ee
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:00681fb9164e36b953da202164b2e214945cacd2a3ff94e748d6f5cd94b4da5d
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6cb9666251bcde94d436986b9fa7ed70195446be6eebba32680779d32184310c
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0dff35581c6a4768fbdb87e5a303af9cb25c535aaa11540c4b39d9ccba5e53c0
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f02ca8e58195c21ca643f2c59604f385ca8eba8f814a741f9319f9804bf47e70
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5d366ffd69eaad79f3e3b7f58f32d2323f31cbba2ec48f2a8fd5029e9955e924
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5dfa1698cf538cd1e2938c5b67a6b9f493e9176595552f452fdcf292322f1658
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:aee61b425d2f881fedfa9e74b5848aadd6aff299babfbc099c70c9f03aa8c533
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:18ec103d82dfb02ca5999274cf6f3edbd829fe29ed69483c0f7547c93b797787
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bf309d5b2c8d7d3eb0e9bec9770472a9ac8faa3a79d42f5f0c2f333fa90eb424
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:117dd2f50e68fe7dce2822528776707263e704a82b0d3ae3dea5796611e22674
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e252c24c3b5645842eb9b20db35666a53b26c753f21af9da99c1c3af0267ef7a
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d09c831d4672f8229ffe3a63155dcfc645f8138464902f5d7880d80810134982
 jupyterlab-widgets==3.0.16 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:2f2551f7b9e77fda7cef9c2dfbcdb89384b71ca6103e46c7c6a8b0a369cca045
 kafka-python-ng==2.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:028b202b1298051c6ca771d3042f2b04e97ba19e5143d4bf2e7a7249b42300ba
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c190196f31ca1f0bc9fa6f2e346e437ce72b5bd6d599546f59f98f641bf96c59
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5649dcecf8ec7137b7698bf7ee0095ceca7de87b03e9bc7ce634c78b389566d6
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e3a9611956f8b9d5ec9875c0e32adf3a685dd8732cebfa17f2a503b595e9f4c1
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:903e9a9852d599a666a6c8b7da7ba74834c08d6914a105607fd1d46f7630d6f1
 kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b2387e67540cd108b49cec537cecd2206f1dd6eb0e1839cf2199316cbfa10d1e
 kube-authkit==0.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:ae1724f8b23bd934ff1ccbf093e81cc8728373f51ed71f0cfc9878cf593dbe98
-kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4e23a8e68bc6d3e4bf7aab8d3840bb7cea244107d2496551c5eb5fbca9018c04
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:aa6fe9b26b947a05e846f6a12bdf1d0e2ea036d26ff0ec5aad2201ab5d7f2d1e
 librt==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
     --hash=sha256:879ad20691d9c649fa29811ac7fde1e8c26e20b9fb2a62c9e06bb776961d08a9
 locket==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -243,10 +297,16 @@ nest-asyncio2==1.7.2 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:b7509468fde4540006f4bfed9d97117e2bd5bab098d0f1b0b423ab607b93e4cf
 networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ccfd56d2553cf0797cd25fec22365f038d6918904becd1cde74e5a4ead72e237
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4898612847f29cdb6d9562421f7dd21ad0a731a13161cf0f04557f7c97152746
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:807ab07e2114489d90bbbd714759286920df7096ed42ef24aa027c4f43071ab7
 numpy==2.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9a30e094e70991e30b7342105b6c3a8cde23b004358ac92f0fe4654e98327843
-oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:85911787c86f5316402be0c046e4f8bc63eb276e43a89c678de724fd9bb919f1
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b81fe384fd3cd12112b5ac319da4689b65ca9c26c805a809d79778a54e742e2e
 onnx==1.22.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:930f864313343cbce034a47191717372a57e8da6de5e3a5b17baf05927676a79
 onnxconverter-common==1.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -270,7 +330,8 @@ opentelemetry-semantic-conventions==0.65b0 ; python_full_version == '3.12.*' and
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b81a13ee5e71ca470cf7650a70ef61fbd72ea6970526ce49feef1494557df834
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -303,7 +364,7 @@ prompt-toolkit==3.0.53 ; python_full_version == '3.12.*' and implementation_name
     --hash=sha256:54b3eae5de96a48958f735b3679c5ae1f86ae592d5721a90d12aa6271fc89bf0
 propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ea045cc044fefa85445d843bfb166d98c603bd1ff67387ef043a2a102c4268fa
-proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:03ccc3478943fa426138d02f6d9544d01fcd0c3b861e8fadbcb1cb1378c6f5a8
 protobuf==6.31.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:15c7601022dd83a16fa25b84b7e267d69b1b20b60afd8321cd26e832c6dba1c0
@@ -351,6 +412,8 @@ python-discovery==1.5.2 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:f13ab5694577172a974cc1818e9e2e9aa097d93099fe9b5031e620aea0bbedf0
 python-dotenv==1.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1119caaceafe3c3de340f1c81ff0bef768ac54cbe4e515c2bf13a107c428460c
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:675fbb87e2962894b0312ac0c71a09869f5ada530a9df6f17e4876e10e8963a0
 pytz==2026.3.post1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fc63086d3e3345d9181498328411bfc2a71b517045715cdb578f78d00fbe1760
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -361,10 +424,18 @@ ray==2.55.1 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
     --hash=sha256:2339e7e8a9079cfcac4faed47d2e637c6188caa7e2f81d58138daf81f16f8b1f
 referencing==0.37.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:60aec986b2ee0ad2093b55dfa1ab9bb04b75c7d25cf4ece320a7282aa5c76936
-requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:0170d9a4f1d63b2d17dc1765630ef4280c32edb64dfbf106429b1a9f6b3d8981
-requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+requests==2.33.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d8747770242c156929970f27c048c1e5f562ceaee3e5720dd4a6967f456613e1
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5747d7378989925f749b61baca7ca74291f58139a72c6a7d9da5cc3216c335ae
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fbb6f2df6e9a54c7507da09a60b5de158a1da49529783524ed3f47abb0ed6ae3
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:94366cf35067f911c75bec56f790a912cf97b3baefdfd2d7da19c3e8e554673a
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bb2e0ae3e7b060b72caad8e7194311086164637ed91a9c6916df5ee67073e7f5
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:367f0cc2b8c7a1f5ce74bc34d2c5c00d98bdfbb04ee37e1ce314e1df618d96ef
 rich==14.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:4d186b5042571765bf00dd57aff1b603fe4439a15f28ab7854d02aeea319bcf9
 rpds-py==2026.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -375,6 +446,8 @@ scikit-learn==1.9.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:714c352a5354e3d718f46a9ec8d92cb25018964c0dbcc26579710fa031c148c2
 scipy==1.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2f1e38ec86a3a1e98f10b082cac234f3d4b26b7c47141d345aa0a10cda5605e5
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:78f6a71068173712207c35296d0319c27afa8a0a4beb55aa0cf0644f1c1f5c43
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5bfbca783a7269470cd847f0f71862dbd6008a09d2ea2a5dc6142e24575aef26
 six==1.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -407,6 +480,8 @@ tensorboard==2.20.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:52136181d519e2ccd2317ef1ceec5c646bcf820f54f75bcb5c95a20c2aed8286
 tensorboard-data-server==0.7.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:157ecd9fc68d1025e2b7d989621abb570c544401d9ddcde255ade0b9066eef05
 threadpoolctl==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d6fa366ebb859a065d722f5ba4cca0df47067a1c92891182b08550c9917d6075
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -428,7 +503,8 @@ tqdm==4.70.0 ; python_full_version == '3.12.*' and implementation_name == 'cpyth
 traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d522f22796a09555cfc57c6529951e7f369481ae7ab53f95da559a918032110d
 triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc
+    --hash=sha256:bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc \
+    --hash=sha256:c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9301f862d28e9220bbe54557d13cf05fcd86d0914b1dcff530892ae533320d17
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -437,6 +513,8 @@ typing-inspection==0.4.4 ; python_full_version == '3.12.*' and implementation_na
     --hash=sha256:bbcfee771e71261a36615e5c4a5e8f9b73135afb3df3c45831c7c0fc4b0663f1
 tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d9ef0cf8d8c5f0a53470cc1169e023ad6a8a291cb8e1a5c84f3df3a1c4c70926
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ca9da4f6ca5ed1078ebd061dde870edc5e3e03c6d8e24f3e92a0d80bac2e88d9
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:869402a011adaed2d78d08b7a7b314ac8c70cbe011f8d060ef37d04be8cfd157
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -453,9 +531,11 @@ watchfiles==1.2.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:e0339a8c37d1b97a1ec206cd99c4b82dd0b1bee5a03017a8a34c84253ee79242
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:eeabefcdcd901abaf518f3988694af1a66dee29ecf63742e1077ee79f40532b6
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c3a530d8f90f281a40e60949e05b5795e0db679a0f8747241dd39ad0ef27601d
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8a5417956ac5a5e33f29f68525c6b22d655786d32c77a974090cdccffcdf4526
-websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:57c7d53a6be8a23d06552118f85eb04d4a7293df6c16817e41e3f845aa2c401b
 websockets==17.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f116adc758cc74bb5c47f3c62470f677eadfa11846cedc8e9c1aafad31e53373

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -71,6 +71,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/argon2_cffi_bindings-25.1.0-1-cp312-abi3-linux_x86_64.whl", upload-time = 2026-08-15T12:27:59Z, size = 88228, hashes = { sha256 = "4161ed2757def3b4923beba006f82493ece15900119a993e014e04048784269b" } }]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 70409, hashes = { sha256 = "ee5c9a6d206547ea0fd2086a55504aeef9b2e11962277d0bf5f010309f47e9a3" } }]
+
+[[packages]]
 name = "ast-serialize"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -89,6 +95,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/asttokens-3.0.2-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 29413, hashes = { sha256 = "ca4520ea7a874796fc8627d1a3b44b32c8b7661735a44b52e73a2c224df7d7f6" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 10055, hashes = { sha256 = "1b42c7e9cb96060faf4a5c879fd4e44bc6f3fabda6fb5dd638324330a868e989" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -99,6 +111,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 47527, hashes = { sha256 = "10975975ed9b1e8741aeceeae6f9d64f51df560ac5c0cd3297e74147b948655c" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 10198501, hashes = { sha256 = "49d903d13c404e2de727709733f295a77f61660fb8c35b303f6a4f482c6d7035" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -171,6 +189,12 @@ name = "click"
 version = "8.4.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 120859, hashes = { sha256 = "3706183f30a8d73eefcbd8cdf71d36c333aed206b087d7a02998d9b0655a4d51" } }]
+
+[[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 13200, hashes = { sha256 = "875dff328231c0a7e7ca38b22018c8116e9ea94144753081f444e3ed45bb8783" } }]
 
 [[packages]]
 name = "cloudpickle"
@@ -269,9 +293,15 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/docker-7.2.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 150397, hashes = { sha256 = "5a5a1445a21611e0dbce3bbb5dd5e88475e8b94b6ff6c11a4c8f3a472178dc33" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 24250, hashes = { sha256 = "e30292d160f7435654ad3d0238dec21a081ac51c3f38b8f2626a39a00d49175a" } }]
+
+[[packages]]
 name = "durationpy"
 version = "0.10"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/durationpy-0.10-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 5635, hashes = { sha256 = "3d8381d7b51204661cfd5adf2d6d15f0062c6c1008e9e2044a7f15dc2efae0dd" } }]
 
 [[packages]]
@@ -329,6 +359,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/fonttools-4.63.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 1166224, hashes = { sha256 = "e1f61230cb61c92bdf281ce20c60a71d78eb5962033921e31b26b76f783dc42a" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 5291, hashes = { sha256 = "269f79952da891c129457defa26977163ee9f9eb1ed3d3e7ed7d16ab39dcc20f" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -355,7 +391,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "google-api-core"
 version = "2.34.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 182294, hashes = { sha256 = "8e4df772c66becdc49e364d528393d2461cb40d71f98adb0917a544dc9daea23" } }]
 
 [[packages]]
@@ -365,9 +401,33 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_auth-2.56.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 260807, hashes = { sha256 = "b2816991ea9f32c72df04324ad1663b3a5a0c5c068fceb8a6a01c12d18b05294" } }]
 
 [[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T16:54:15Z, size = 32811, hashes = { sha256 = "90547e6d27939bc56fdae458b35a508ec36b868c0aa9c548be1d1988bc8f17ff" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 343299, hashes = { sha256 = "9eca513a3d0e4af5d7d4c2ae845ae4a08681cb6581cc7d8d347591bdde5ce834" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 15530, hashes = { sha256 = "52fe7115ec85f30545bf974db9521fe2e0d15dac16c935cc79a4fc62abbafa7d" } }]
+
+[[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T16:54:15Z, size = 83370, hashes = { sha256 = "f8dd30133a89307b04d861ff3bcca60606acb1328b570a2f6b441886585e2f06" } }]
+
+[[packages]]
 name = "googleapis-common-protos"
 version = "1.75.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/googleapis_common_protos-1.75.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 302479, hashes = { sha256 = "c863217e8061a385cb798121d9f1249f0ad397c11511805a260fe096029464c2" } }]
 
 [[packages]]
@@ -413,10 +473,22 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/h11-0.16.0-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 39144, hashes = { sha256 = "e481ac9aefe4a935351ee32b96fcca637222b7f5e48384bd52b838cd5f8af24b" } }]
 
 [[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/httpcore-1.0.9-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 80437, hashes = { sha256 = "082036e28a6d861254e132836874c52102488aa67de4400e3f4db02cf42522d1" } }]
+
+[[packages]]
 name = "httptools"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/httptools-0.8.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 514722, hashes = { sha256 = "7942ab61641871103eb228e9d220556df9e140093efd2755526012553d4f3c98" } }]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/httpx-0.28.1-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 75163, hashes = { sha256 = "5d7138bea54ef31da9db5abd95b585f1a2812a98293dd2ff3634cd75d14fb41d" } }]
 
 [[packages]]
 name = "huey"
@@ -473,6 +545,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/ipywidgets-8.1.2-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 141123, hashes = { sha256 = "64be0e8a800f90b1ab2d356342c2d6aadd9cede8e8dab385614cc53360f7603c" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 13135, hashes = { sha256 = "81519bd3cda71507afa100e36e918d3cc5f0a2f1f0d54f8ab6e18c4aecf06180" } }]
+
+[[packages]]
 name = "itsdangerous"
 version = "2.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -503,6 +581,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/joblib-1.5.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 310690, hashes = { sha256 = "713e822a83cc588a62150403f15a34aa1e9a7b6dd1144a658910515abdd731cf" } }]
 
 [[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 38187, hashes = { sha256 = "d99630fef264966c9e1761550a0ae3b537064151a9f8a2a3b548560457a3e578" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 9359, hashes = { sha256 = "ff9ed8cbe1f40fe316b1c1ab6bf7cf87ccabc6a022c944582b7c400f325376ee" } }]
+
+[[packages]]
 name = "jsonschema"
 version = "4.26.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -513,6 +603,12 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 20296, hashes = { sha256 = "6cb9666251bcde94d436986b9fa7ed70195446be6eebba32680779d32184310c" } }]
+
+[[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 917003, hashes = { sha256 = "0dff35581c6a4768fbdb87e5a303af9cb25c535aaa11540c4b39d9ccba5e53c0" } }]
 
 [[packages]]
 name = "jupyter-client"
@@ -527,10 +623,46 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 30715, hashes = { sha256 = "5d366ffd69eaad79f3e3b7f58f32d2323f31cbba2ec48f2a8fd5029e9955e924" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 21225, hashes = { sha256 = "5dfa1698cf538cd1e2938c5b67a6b9f493e9176595552f452fdcf292322f1658" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 79188, hashes = { sha256 = "aee61b425d2f881fedfa9e74b5848aadd6aff299babfbc099c70c9f03aa8c533" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:14:06Z, size = 395768, hashes = { sha256 = "18ec103d82dfb02ca5999274cf6f3edbd829fe29ed69483c0f7547c93b797787" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 15515, hashes = { sha256 = "bf309d5b2c8d7d3eb0e9bec9770472a9ac8faa3a79d42f5f0c2f333fa90eb424" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 12454274, hashes = { sha256 = "117dd2f50e68fe7dce2822528776707263e704a82b0d3ae3dea5796611e22674" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 17963, hashes = { sha256 = "e252c24c3b5645842eb9b20db35666a53b26c753f21af9da99c1c3af0267ef7a" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 61571, hashes = { sha256 = "d09c831d4672f8229ffe3a63155dcfc645f8138464902f5d7880d80810134982" } }]
 
 [[packages]]
 name = "jupyterlab-widgets"
@@ -543,6 +675,30 @@ name = "kafka-python-ng"
 version = "2.2.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kafka_python_ng-2.2.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 234706, hashes = { sha256 = "028b202b1298051c6ca771d3042f2b04e97ba19e5143d4bf2e7a7249b42300ba" } }]
+
+[[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 479782, hashes = { sha256 = "c190196f31ca1f0bc9fa6f2e346e437ce72b5bd6d599546f59f98f641bf96c59" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 29466, hashes = { sha256 = "5649dcecf8ec7137b7698bf7ee0095ceca7de87b03e9bc7ce634c78b389566d6" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 11707, hashes = { sha256 = "e3a9611956f8b9d5ec9875c0e32adf3a685dd8732cebfa17f2a503b595e9f4c1" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 130414, hashes = { sha256 = "903e9a9852d599a666a6c8b7da7ba74834c08d6914a105607fd1d46f7630d6f1" } }]
 
 [[packages]]
 name = "kiwisolver"
@@ -559,8 +715,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "kubernetes"
 version = "36.0.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 4619741, hashes = { sha256 = "4e23a8e68bc6d3e4bf7aab8d3840bb7cea244107d2496551c5eb5fbca9018c04" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 114761, hashes = { sha256 = "aa6fe9b26b947a05e846f6a12bdf1d0e2ea036d26ff0ec5aad2201ab5d7f2d1e" } }]
 
 [[packages]]
 name = "librt"
@@ -737,6 +899,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/networkx-3.6.1-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 2070146, hashes = { sha256 = "ccfd56d2553cf0797cd25fec22365f038d6918904becd1cde74e5a4ead72e237" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 5548930, hashes = { sha256 = "4898612847f29cdb6d9562421f7dd21ad0a731a13161cf0f04557f7c97152746" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 14999, hashes = { sha256 = "807ab07e2114489d90bbbd714759286920df7096ed42ef24aa027c4f43071ab7" } }]
+
+[[packages]]
 name = "numpy"
 version = "2.5.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -745,8 +919,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 161705, hashes = { sha256 = "85911787c86f5316402be0c046e4f8bc63eb276e43a89c678de724fd9bb919f1" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T01:18:10Z, size = 377925, hashes = { sha256 = "b81fe384fd3cd12112b5ac319da4689b65ca9c26c805a809d79778a54e742e2e" } }]
 
 [[packages]]
 name = "onnx"
@@ -818,7 +998,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandocfilters"
@@ -919,7 +1102,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "proto-plus"
 version = "1.28.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/proto_plus-1.28.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 52495, hashes = { sha256 = "03ccc3478943fa426138d02f6d9544d01fcd0c3b861e8fadbcb1cb1378c6f5a8" } }]
 
 [[packages]]
@@ -1061,6 +1244,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/python_dotenv-1.2.3-1-py3-none-any.whl", upload-time = 2026-08-20T01:04:36Z, size = 24505, hashes = { sha256 = "1119caaceafe3c3de340f1c81ff0bef768ac54cbe4e515c2bf13a107c428460c" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T00:51:31Z, size = 16753, hashes = { sha256 = "675fbb87e2962894b0312ac0c71a09869f5ada530a9df6f17e4876e10e8963a0" } }]
+
+[[packages]]
 name = "pytz"
 version = "2026.3.post1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1092,15 +1281,39 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "requests"
-version = "2.34.2"
+version = "2.33.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests-2.34.2-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 74726, hashes = { sha256 = "0170d9a4f1d63b2d17dc1765630ef4280c32edb64dfbf106429b1a9f6b3d8981" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests-2.33.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 66703, hashes = { sha256 = "d8747770242c156929970f27c048c1e5f562ceaee3e5720dd4a6967f456613e1" } }]
 
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 26050, hashes = { sha256 = "5747d7378989925f749b61baca7ca74291f58139a72c6a7d9da5cc3216c335ae" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 53485, hashes = { sha256 = "fbb6f2df6e9a54c7507da09a60b5de158a1da49529783524ed3f47abb0ed6ae3" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 5387, hashes = { sha256 = "94366cf35067f911c75bec56f790a912cf97b3baefdfd2d7da19c3e8e554673a" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 6205, hashes = { sha256 = "bb2e0ae3e7b060b72caad8e7194311086164637ed91a9c6916df5ee67073e7f5" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 9778, hashes = { sha256 = "367f0cc2b8c7a1f5ce74bc34d2c5c00d98bdfbb04ee37e1ce314e1df618d96ef" } }]
 
 [[packages]]
 name = "rich"
@@ -1131,6 +1344,12 @@ name = "scipy"
 version = "1.18.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/scipy-1.18.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 25301246, hashes = { sha256 = "2f1e38ec86a3a1e98f10b082cac234f3d4b26b7c47141d345aa0a10cda5605e5" } }]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 19285, hashes = { sha256 = "78f6a71068173712207c35296d0319c27afa8a0a4beb55aa0cf0644f1c1f5c43" } }]
 
 [[packages]]
 name = "setuptools"
@@ -1229,6 +1448,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/tensorboard_data_server-0.7.2-py3-none-any.whl", upload-time = 2026-08-15T01:27:43Z, size = 2356, hashes = { sha256 = "7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb" } }]
 
 [[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 15815, hashes = { sha256 = "157ecd9fc68d1025e2b7d989621abb570c544401d9ddcde255ade0b9066eef05" } }]
+
+[[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1292,7 +1517,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "triton"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 119953429, hashes = { sha256 = "bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 119953429, hashes = { sha256 = "bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-27T02:12:20Z, size = 119953509, hashes = { sha256 = "c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c" } },
+]
 
 [[packages]]
 name = "typeguard"
@@ -1317,6 +1545,12 @@ name = "tzdata"
 version = "2026.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 349808, hashes = { sha256 = "d9ef0cf8d8c5f0a53470cc1169e023ad6a8a291cb8e1a5c84f3df3a1c4c70926" } }]
+
+[[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 12896, hashes = { sha256 = "ca9da4f6ca5ed1078ebd061dde870edc5e3e03c6d8e24f3e92a0d80bac2e88d9" } }]
 
 [[packages]]
 name = "urllib3"
@@ -1367,6 +1601,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 324792, hashes = { sha256 = "eeabefcdcd901abaf518f3988694af1a66dee29ecf63742e1077ee79f40532b6" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 16606, hashes = { sha256 = "c3a530d8f90f281a40e60949e05b5795e0db679a0f8747241dd39ad0ef27601d" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1375,7 +1615,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 84341, hashes = { sha256 = "57c7d53a6be8a23d06552118f85eb04d4a7293df6c16817e41e3f845aa2c401b" } }]
 
 [[packages]]

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/requirements.rocm.txt
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/requirements.rocm.txt
@@ -21,6 +21,8 @@ argon2-cffi==25.1.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:0aa4852a4218d1719f97422214b85b01a4548cfa36f39d4bfd5542fc329b2d88
 argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4161ed2757def3b4923beba006f82493ece15900119a993e014e04048784269b
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ee5c9a6d206547ea0fd2086a55504aeef9b2e11962277d0bf5f010309f47e9a3
 ast-serialize==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3323d989785ac9b2e49becbeb3f1a309532b0e76074f5422dddf9b90c713a9ed
 astor==0.8.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -29,10 +31,14 @@ asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:ca4520ea7a874796fc8627d1a3b44b32c8b7661735a44b52e73a2c224df7d7f6
 astunparse==1.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:70fc71c5d46220d7013f172f64b6ddbb94aea75a448d08e93e935ade203fd782
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:1b42c7e9cb96060faf4a5c879fd4e44bc6f3fabda6fb5dd638324330a868e989
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:729c41aeef6209abb1a76f2d1b26ea09a6cd347debef6d9fbc8a509f434fff85
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:10975975ed9b1e8741aeceeae6f9d64f51df560ac5c0cd3297e74147b948655c
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:49d903d13c404e2de727709733f295a77f61660fb8c35b303f6a4f482c6d7035
 bcrypt==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:fc33be01668e12a02f2e0377e8dd6a5137fb481669f1c23a8f7370b6c054c147
 beautifulsoup4==4.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -57,6 +63,8 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:fd4ae4becfaa995378bf66e7a8f5558fb1d18a019dc7581ab91b812aa34a523b
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3706183f30a8d73eefcbd8cdf71d36c333aed206b087d7a02998d9b0655a4d51
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:875dff328231c0a7e7ca38b22018c8116e9ea94144753081f444e3ed45bb8783
 cloudpickle==3.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8ca7ce3c39b51c0ed1c1602f2da024399966d43991d3b14832d965620d7fab6e
 codeflare-sdk==0.38.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
@@ -89,7 +97,9 @@ dnspython==2.8.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:2d2f16c964ebf8943fb294cb53c4865e85c1a22f3a0d89588980f7d1e8b0bc21
 docker==7.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5a5a1445a21611e0dbce3bbb5dd5e88475e8b94b6ff6c11a4c8f3a472178dc33
-durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e30292d160f7435654ad3d0238dec21a081ac51c3f38b8f2626a39a00d49175a
+durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3d8381d7b51204661cfd5adf2d6d15f0062c6c1008e9e2044a7f15dc2efae0dd
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ef28e3b55915294e3a2cb625770754bfbefeec5c972a506c4a1aa19ad71312ea
@@ -111,6 +121,8 @@ flatbuffers==25.12.19 ; python_full_version == '3.12.*' and implementation_name 
     --hash=sha256:8de0951742ac92a1c30ef4d83c87929972a90ba2cc50833b6ee4259a69cb1a1a
 fonttools==4.63.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e1f61230cb61c92bdf281ce20c60a71d78eb5962033921e31b26b76f783dc42a
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:269f79952da891c129457defa26977163ee9f9eb1ed3d3e7ed7d16ab39dcc20f
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:71547ca469b6c231ae7df34476f2dd5224ac3205d0d41fba5a7cfec76b2bf57c
 fsspec==2026.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -121,13 +133,21 @@ gitdb==4.0.12 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:ce9cd07eaafcba526d03aebd325b726311bf148b2bd49eb20e398d1c8cd818e6
 gitpython==3.1.59 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4dba1c94c0a491994de3a7c104afc5d458a6e5c17a9bda388e214781f018c661
-google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e4df772c66becdc49e364d528393d2461cb40d71f98adb0917a544dc9daea23
 google-auth==2.56.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b2816991ea9f32c72df04324ad1663b3a5a0c5c068fceb8a6a01c12d18b05294
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:90547e6d27939bc56fdae458b35a508ec36b868c0aa9c548be1d1988bc8f17ff
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9eca513a3d0e4af5d7d4c2ae845ae4a08681cb6581cc7d8d347591bdde5ce834
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:52fe7115ec85f30545bf974db9521fe2e0d15dac16c935cc79a4fc62abbafa7d
 google-pasta==0.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e577bcacc533091604014f3dc91140ed803056f1abb525ae833972909e16e33b
-googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f8dd30133a89307b04d861ff3bcca60606acb1328b570a2f6b441886585e2f06
+googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c863217e8061a385cb798121d9f1249f0ad397c11511805a260fe096029464c2
 graphene==3.4.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9f859e5c0c10e49dd833b971e7a53ba49d4035d046eafb7bd7b399b09d90d913
@@ -145,8 +165,12 @@ h11==0.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
     --hash=sha256:e481ac9aefe4a935351ee32b96fcca637222b7f5e48384bd52b838cd5f8af24b
 h5py==3.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c0627b559795785e9cb0ad3943079b46a4e1987371be93961b527678b52db610
+httpcore==1.0.9 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:082036e28a6d861254e132836874c52102488aa67de4400e3f4db02cf42522d1
 httptools==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7942ab61641871103eb228e9d220556df9e140093efd2755526012553d4f3c98
+httpx==0.28.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5d7138bea54ef31da9db5abd95b585f1a2812a98293dd2ff3634cd75d14fb41d
 huey==3.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9fed18c61ba53fde549dfd34bce1d7e16ef276e66f6e2a6c35ac987e0285b7c5
 idna==3.18 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -165,6 +189,8 @@ ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementat
     --hash=sha256:321d3caba426531f67b938f0f5bc9c01733567e38ce583bfc8a0bb4e65872f09
 ipywidgets==8.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:64be0e8a800f90b1ab2d356342c2d6aadd9cede8e8dab385614cc53360f7603c
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:81519bd3cda71507afa100e36e918d3cc5f0a2f1f0d54f8ab6e18c4aecf06180
 itsdangerous==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5ebd7b919a261d510a697e29c795acd3654d3620a44127426e8d0ada3c023b44
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -175,28 +201,56 @@ jmespath==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:0762a3bfd6559779d81338573657955bf7153e908b786bb64c894d492610f82d
 joblib==1.5.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:713e822a83cc588a62150403f15a34aa1e9a7b6dd1144a658910515abdd731cf
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d99630fef264966c9e1761550a0ae3b537064151a9f8a2a3b548560457a3e578
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ff9ed8cbe1f40fe316b1c1ab6bf7cf87ccabc6a022c944582b7c400f325376ee
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:00681fb9164e36b953da202164b2e214945cacd2a3ff94e748d6f5cd94b4da5d
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6cb9666251bcde94d436986b9fa7ed70195446be6eebba32680779d32184310c
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:0dff35581c6a4768fbdb87e5a303af9cb25c535aaa11540c4b39d9ccba5e53c0
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f02ca8e58195c21ca643f2c59604f385ca8eba8f814a741f9319f9804bf47e70
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5d366ffd69eaad79f3e3b7f58f32d2323f31cbba2ec48f2a8fd5029e9955e924
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5dfa1698cf538cd1e2938c5b67a6b9f493e9176595552f452fdcf292322f1658
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:aee61b425d2f881fedfa9e74b5848aadd6aff299babfbc099c70c9f03aa8c533
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:18ec103d82dfb02ca5999274cf6f3edbd829fe29ed69483c0f7547c93b797787
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bf309d5b2c8d7d3eb0e9bec9770472a9ac8faa3a79d42f5f0c2f333fa90eb424
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:117dd2f50e68fe7dce2822528776707263e704a82b0d3ae3dea5796611e22674
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e252c24c3b5645842eb9b20db35666a53b26c753f21af9da99c1c3af0267ef7a
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d09c831d4672f8229ffe3a63155dcfc645f8138464902f5d7880d80810134982
 jupyterlab-widgets==3.0.16 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:2f2551f7b9e77fda7cef9c2dfbcdb89384b71ca6103e46c7c6a8b0a369cca045
 kafka-python-ng==2.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:028b202b1298051c6ca771d3042f2b04e97ba19e5143d4bf2e7a7249b42300ba
 keras==3.15.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9b65da2e1630768b86f947fa998f313315eee09640b0415e5d960d142adfcf93
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c190196f31ca1f0bc9fa6f2e346e437ce72b5bd6d599546f59f98f641bf96c59
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5649dcecf8ec7137b7698bf7ee0095ceca7de87b03e9bc7ce634c78b389566d6
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:e3a9611956f8b9d5ec9875c0e32adf3a685dd8732cebfa17f2a503b595e9f4c1
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:903e9a9852d599a666a6c8b7da7ba74834c08d6914a105607fd1d46f7630d6f1
 kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b2387e67540cd108b49cec537cecd2206f1dd6eb0e1839cf2199316cbfa10d1e
 kube-authkit==0.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:ae1724f8b23bd934ff1ccbf093e81cc8728373f51ed71f0cfc9878cf593dbe98
-kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4e23a8e68bc6d3e4bf7aab8d3840bb7cea244107d2496551c5eb5fbca9018c04
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:aa6fe9b26b947a05e846f6a12bdf1d0e2ea036d26ff0ec5aad2201ab5d7f2d1e
 libclang==18.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4ca8fcc58c062c1ef719e3666d4cb38f22e1543b35fa1bd4eb5d708d4047cd84
 librt==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
@@ -257,10 +311,16 @@ nest-asyncio2==1.7.2 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:b7509468fde4540006f4bfed9d97117e2bd5bab098d0f1b0b423ab607b93e4cf
 networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ccfd56d2553cf0797cd25fec22365f038d6918904becd1cde74e5a4ead72e237
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4898612847f29cdb6d9562421f7dd21ad0a731a13161cf0f04557f7c97152746
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:807ab07e2114489d90bbbd714759286920df7096ed42ef24aa027c4f43071ab7
 numpy==2.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9a30e094e70991e30b7342105b6c3a8cde23b004358ac92f0fe4654e98327843
-oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:85911787c86f5316402be0c046e4f8bc63eb276e43a89c678de724fd9bb919f1
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b81fe384fd3cd12112b5ac319da4689b65ca9c26c805a809d79778a54e742e2e
 onnx==1.22.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:930f864313343cbce034a47191717372a57e8da6de5e3a5b17baf05927676a79
 onnxconverter-common==1.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -288,7 +348,8 @@ optree==0.19.1 ; python_full_version == '3.12.*' and implementation_name == 'cpy
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b81a13ee5e71ca470cf7650a70ef61fbd72ea6970526ce49feef1494557df834
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -321,7 +382,7 @@ prompt-toolkit==3.0.53 ; python_full_version == '3.12.*' and implementation_name
     --hash=sha256:54b3eae5de96a48958f735b3679c5ae1f86ae592d5721a90d12aa6271fc89bf0
 propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ea045cc044fefa85445d843bfb166d98c603bd1ff67387ef043a2a102c4268fa
-proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:03ccc3478943fa426138d02f6d9544d01fcd0c3b861e8fadbcb1cb1378c6f5a8
 protobuf==6.31.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:15c7601022dd83a16fa25b84b7e267d69b1b20b60afd8321cd26e832c6dba1c0
@@ -369,6 +430,8 @@ python-discovery==1.5.2 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:f13ab5694577172a974cc1818e9e2e9aa097d93099fe9b5031e620aea0bbedf0
 python-dotenv==1.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1119caaceafe3c3de340f1c81ff0bef768ac54cbe4e515c2bf13a107c428460c
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:675fbb87e2962894b0312ac0c71a09869f5ada530a9df6f17e4876e10e8963a0
 pytz==2026.3.post1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:fc63086d3e3345d9181498328411bfc2a71b517045715cdb578f78d00fbe1760
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -379,10 +442,18 @@ ray==2.55.1 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
     --hash=sha256:2339e7e8a9079cfcac4faed47d2e637c6188caa7e2f81d58138daf81f16f8b1f
 referencing==0.37.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:60aec986b2ee0ad2093b55dfa1ab9bb04b75c7d25cf4ece320a7282aa5c76936
-requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:0170d9a4f1d63b2d17dc1765630ef4280c32edb64dfbf106429b1a9f6b3d8981
-requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+requests==2.33.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d8747770242c156929970f27c048c1e5f562ceaee3e5720dd4a6967f456613e1
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5747d7378989925f749b61baca7ca74291f58139a72c6a7d9da5cc3216c335ae
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:fbb6f2df6e9a54c7507da09a60b5de158a1da49529783524ed3f47abb0ed6ae3
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:94366cf35067f911c75bec56f790a912cf97b3baefdfd2d7da19c3e8e554673a
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bb2e0ae3e7b060b72caad8e7194311086164637ed91a9c6916df5ee67073e7f5
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:367f0cc2b8c7a1f5ce74bc34d2c5c00d98bdfbb04ee37e1ce314e1df618d96ef
 rich==14.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4d186b5042571765bf00dd57aff1b603fe4439a15f28ab7854d02aeea319bcf9
 rpds-py==2026.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -393,6 +464,8 @@ scikit-learn==1.9.0 ; python_full_version == '3.12.*' and implementation_name ==
     --hash=sha256:714c352a5354e3d718f46a9ec8d92cb25018964c0dbcc26579710fa031c148c2
 scipy==1.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2f1e38ec86a3a1e98f10b082cac234f3d4b26b7c47141d345aa0a10cda5605e5
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:78f6a71068173712207c35296d0319c27afa8a0a4beb55aa0cf0644f1c1f5c43
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5bfbca783a7269470cd847f0f71862dbd6008a09d2ea2a5dc6142e24575aef26
 six==1.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -427,6 +500,8 @@ tensorflow-rocm==2.20.0+redhat ; python_full_version == '3.12.*' and implementat
     --hash=sha256:0816a6422fcffcc5d44ec7079ae607c79c77cec2e656d30b8c54b0fae625b59c
 termcolor==3.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dffa682bab5105d4e0ab474440c14d49abf1ec3b7f7d9f08025052add89d195c
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:157ecd9fc68d1025e2b7d989621abb570c544401d9ddcde255ade0b9066eef05
 threadpoolctl==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d6fa366ebb859a065d722f5ba4cca0df47067a1c92891182b08550c9917d6075
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -449,6 +524,8 @@ typing-inspection==0.4.4 ; python_full_version == '3.12.*' and implementation_na
     --hash=sha256:bbcfee771e71261a36615e5c4a5e8f9b73135afb3df3c45831c7c0fc4b0663f1
 tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d9ef0cf8d8c5f0a53470cc1169e023ad6a8a291cb8e1a5c84f3df3a1c4c70926
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ca9da4f6ca5ed1078ebd061dde870edc5e3e03c6d8e24f3e92a0d80bac2e88d9
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:869402a011adaed2d78d08b7a7b314ac8c70cbe011f8d060ef37d04be8cfd157
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -465,9 +542,11 @@ watchfiles==1.2.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:e0339a8c37d1b97a1ec206cd99c4b82dd0b1bee5a03017a8a34c84253ee79242
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:eeabefcdcd901abaf518f3988694af1a66dee29ecf63742e1077ee79f40532b6
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c3a530d8f90f281a40e60949e05b5795e0db679a0f8747241dd39ad0ef27601d
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8a5417956ac5a5e33f29f68525c6b22d655786d32c77a974090cdccffcdf4526
-websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:57c7d53a6be8a23d06552118f85eb04d4a7293df6c16817e41e3f845aa2c401b
 websockets==17.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f116adc758cc74bb5c47f3c62470f677eadfa11846cedc8e9c1aafad31e53373

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -71,6 +71,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/argon2_cffi_bindings-25.1.0-1-cp312-abi3-linux_x86_64.whl", upload-time = 2026-08-15T12:27:59Z, size = 88228, hashes = { sha256 = "4161ed2757def3b4923beba006f82493ece15900119a993e014e04048784269b" } }]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 70409, hashes = { sha256 = "ee5c9a6d206547ea0fd2086a55504aeef9b2e11962277d0bf5f010309f47e9a3" } }]
+
+[[packages]]
 name = "ast-serialize"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -95,6 +101,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/astunparse-1.6.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 14535, hashes = { sha256 = "70fc71c5d46220d7013f172f64b6ddbb94aea75a448d08e93e935ade203fd782" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 10055, hashes = { sha256 = "1b42c7e9cb96060faf4a5c879fd4e44bc6f3fabda6fb5dd638324330a868e989" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -105,6 +117,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 47527, hashes = { sha256 = "10975975ed9b1e8741aeceeae6f9d64f51df560ac5c0cd3297e74147b948655c" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 10198501, hashes = { sha256 = "49d903d13c404e2de727709733f295a77f61660fb8c35b303f6a4f482c6d7035" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -177,6 +195,12 @@ name = "click"
 version = "8.4.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 120859, hashes = { sha256 = "3706183f30a8d73eefcbd8cdf71d36c333aed206b087d7a02998d9b0655a4d51" } }]
+
+[[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 13200, hashes = { sha256 = "875dff328231c0a7e7ca38b22018c8116e9ea94144753081f444e3ed45bb8783" } }]
 
 [[packages]]
 name = "cloudpickle"
@@ -275,9 +299,15 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/docker-7.2.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 150397, hashes = { sha256 = "5a5a1445a21611e0dbce3bbb5dd5e88475e8b94b6ff6c11a4c8f3a472178dc33" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 24250, hashes = { sha256 = "e30292d160f7435654ad3d0238dec21a081ac51c3f38b8f2626a39a00d49175a" } }]
+
+[[packages]]
 name = "durationpy"
 version = "0.10"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/durationpy-0.10-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 5635, hashes = { sha256 = "3d8381d7b51204661cfd5adf2d6d15f0062c6c1008e9e2044a7f15dc2efae0dd" } }]
 
 [[packages]]
@@ -341,6 +371,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/fonttools-4.63.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 1166224, hashes = { sha256 = "e1f61230cb61c92bdf281ce20c60a71d78eb5962033921e31b26b76f783dc42a" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 5291, hashes = { sha256 = "269f79952da891c129457defa26977163ee9f9eb1ed3d3e7ed7d16ab39dcc20f" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -373,7 +409,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "google-api-core"
 version = "2.34.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 182294, hashes = { sha256 = "8e4df772c66becdc49e364d528393d2461cb40d71f98adb0917a544dc9daea23" } }]
 
 [[packages]]
@@ -383,15 +419,39 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_auth-2.56.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 260807, hashes = { sha256 = "b2816991ea9f32c72df04324ad1663b3a5a0c5c068fceb8a6a01c12d18b05294" } }]
 
 [[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T16:54:15Z, size = 32811, hashes = { sha256 = "90547e6d27939bc56fdae458b35a508ec36b868c0aa9c548be1d1988bc8f17ff" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 343299, hashes = { sha256 = "9eca513a3d0e4af5d7d4c2ae845ae4a08681cb6581cc7d8d347591bdde5ce834" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 15530, hashes = { sha256 = "52fe7115ec85f30545bf974db9521fe2e0d15dac16c935cc79a4fc62abbafa7d" } }]
+
+[[packages]]
 name = "google-pasta"
 version = "0.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_pasta-0.2.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 55041, hashes = { sha256 = "e577bcacc533091604014f3dc91140ed803056f1abb525ae833972909e16e33b" } }]
 
 [[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T16:54:15Z, size = 83370, hashes = { sha256 = "f8dd30133a89307b04d861ff3bcca60606acb1328b570a2f6b441886585e2f06" } }]
+
+[[packages]]
 name = "googleapis-common-protos"
 version = "1.75.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/googleapis_common_protos-1.75.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 302479, hashes = { sha256 = "c863217e8061a385cb798121d9f1249f0ad397c11511805a260fe096029464c2" } }]
 
 [[packages]]
@@ -443,10 +503,22 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/h5py-3.16.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T13:19:54Z, size = 8273269, hashes = { sha256 = "c0627b559795785e9cb0ad3943079b46a4e1987371be93961b527678b52db610" } }]
 
 [[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/httpcore-1.0.9-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 80437, hashes = { sha256 = "082036e28a6d861254e132836874c52102488aa67de4400e3f4db02cf42522d1" } }]
+
+[[packages]]
 name = "httptools"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/httptools-0.8.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 514722, hashes = { sha256 = "7942ab61641871103eb228e9d220556df9e140093efd2755526012553d4f3c98" } }]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/httpx-0.28.1-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 75163, hashes = { sha256 = "5d7138bea54ef31da9db5abd95b585f1a2812a98293dd2ff3634cd75d14fb41d" } }]
 
 [[packages]]
 name = "huey"
@@ -503,6 +575,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/ipywidgets-8.1.2-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 141123, hashes = { sha256 = "64be0e8a800f90b1ab2d356342c2d6aadd9cede8e8dab385614cc53360f7603c" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 13135, hashes = { sha256 = "81519bd3cda71507afa100e36e918d3cc5f0a2f1f0d54f8ab6e18c4aecf06180" } }]
+
+[[packages]]
 name = "itsdangerous"
 version = "2.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -533,6 +611,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/joblib-1.5.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 310690, hashes = { sha256 = "713e822a83cc588a62150403f15a34aa1e9a7b6dd1144a658910515abdd731cf" } }]
 
 [[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 38187, hashes = { sha256 = "d99630fef264966c9e1761550a0ae3b537064151a9f8a2a3b548560457a3e578" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 9359, hashes = { sha256 = "ff9ed8cbe1f40fe316b1c1ab6bf7cf87ccabc6a022c944582b7c400f325376ee" } }]
+
+[[packages]]
 name = "jsonschema"
 version = "4.26.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -543,6 +633,12 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 20296, hashes = { sha256 = "6cb9666251bcde94d436986b9fa7ed70195446be6eebba32680779d32184310c" } }]
+
+[[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 917003, hashes = { sha256 = "0dff35581c6a4768fbdb87e5a303af9cb25c535aaa11540c4b39d9ccba5e53c0" } }]
 
 [[packages]]
 name = "jupyter-client"
@@ -557,10 +653,46 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 30715, hashes = { sha256 = "5d366ffd69eaad79f3e3b7f58f32d2323f31cbba2ec48f2a8fd5029e9955e924" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 21225, hashes = { sha256 = "5dfa1698cf538cd1e2938c5b67a6b9f493e9176595552f452fdcf292322f1658" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 79188, hashes = { sha256 = "aee61b425d2f881fedfa9e74b5848aadd6aff299babfbc099c70c9f03aa8c533" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:14:06Z, size = 395768, hashes = { sha256 = "18ec103d82dfb02ca5999274cf6f3edbd829fe29ed69483c0f7547c93b797787" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 15515, hashes = { sha256 = "bf309d5b2c8d7d3eb0e9bec9770472a9ac8faa3a79d42f5f0c2f333fa90eb424" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 12454274, hashes = { sha256 = "117dd2f50e68fe7dce2822528776707263e704a82b0d3ae3dea5796611e22674" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 17963, hashes = { sha256 = "e252c24c3b5645842eb9b20db35666a53b26c753f21af9da99c1c3af0267ef7a" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 61571, hashes = { sha256 = "d09c831d4672f8229ffe3a63155dcfc645f8138464902f5d7880d80810134982" } }]
 
 [[packages]]
 name = "jupyterlab-widgets"
@@ -581,6 +713,30 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/keras-3.15.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 2400212, hashes = { sha256 = "9b65da2e1630768b86f947fa998f313315eee09640b0415e5d960d142adfcf93" } }]
 
 [[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 479782, hashes = { sha256 = "c190196f31ca1f0bc9fa6f2e346e437ce72b5bd6d599546f59f98f641bf96c59" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 29466, hashes = { sha256 = "5649dcecf8ec7137b7698bf7ee0095ceca7de87b03e9bc7ce634c78b389566d6" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 11707, hashes = { sha256 = "e3a9611956f8b9d5ec9875c0e32adf3a685dd8732cebfa17f2a503b595e9f4c1" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 130414, hashes = { sha256 = "903e9a9852d599a666a6c8b7da7ba74834c08d6914a105607fd1d46f7630d6f1" } }]
+
+[[packages]]
 name = "kiwisolver"
 version = "1.5.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -595,8 +751,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "kubernetes"
 version = "36.0.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 4619741, hashes = { sha256 = "4e23a8e68bc6d3e4bf7aab8d3840bb7cea244107d2496551c5eb5fbca9018c04" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 114761, hashes = { sha256 = "aa6fe9b26b947a05e846f6a12bdf1d0e2ea036d26ff0ec5aad2201ab5d7f2d1e" } }]
 
 [[packages]]
 name = "libclang"
@@ -779,6 +941,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/networkx-3.6.1-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 2070146, hashes = { sha256 = "ccfd56d2553cf0797cd25fec22365f038d6918904becd1cde74e5a4ead72e237" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 5548930, hashes = { sha256 = "4898612847f29cdb6d9562421f7dd21ad0a731a13161cf0f04557f7c97152746" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 14999, hashes = { sha256 = "807ab07e2114489d90bbbd714759286920df7096ed42ef24aa027c4f43071ab7" } }]
+
+[[packages]]
 name = "numpy"
 version = "2.5.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -787,8 +961,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 161705, hashes = { sha256 = "85911787c86f5316402be0c046e4f8bc63eb276e43a89c678de724fd9bb919f1" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T01:18:10Z, size = 377925, hashes = { sha256 = "b81fe384fd3cd12112b5ac319da4689b65ca9c26c805a809d79778a54e742e2e" } }]
 
 [[packages]]
 name = "onnx"
@@ -872,7 +1052,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandocfilters"
@@ -973,7 +1156,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "proto-plus"
 version = "1.28.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/proto_plus-1.28.3-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 52495, hashes = { sha256 = "03ccc3478943fa426138d02f6d9544d01fcd0c3b861e8fadbcb1cb1378c6f5a8" } }]
 
 [[packages]]
@@ -1115,6 +1298,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/python_dotenv-1.2.3-1-py3-none-any.whl", upload-time = 2026-08-20T01:04:36Z, size = 24505, hashes = { sha256 = "1119caaceafe3c3de340f1c81ff0bef768ac54cbe4e515c2bf13a107c428460c" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T00:51:31Z, size = 16753, hashes = { sha256 = "675fbb87e2962894b0312ac0c71a09869f5ada530a9df6f17e4876e10e8963a0" } }]
+
+[[packages]]
 name = "pytz"
 version = "2026.3.post1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1146,15 +1335,39 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "requests"
-version = "2.34.2"
+version = "2.33.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests-2.34.2-1-py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 74726, hashes = { sha256 = "0170d9a4f1d63b2d17dc1765630ef4280c32edb64dfbf106429b1a9f6b3d8981" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests-2.33.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 66703, hashes = { sha256 = "d8747770242c156929970f27c048c1e5f562ceaee3e5720dd4a6967f456613e1" } }]
 
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 26050, hashes = { sha256 = "5747d7378989925f749b61baca7ca74291f58139a72c6a7d9da5cc3216c335ae" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T05:00:03Z, size = 53485, hashes = { sha256 = "fbb6f2df6e9a54c7507da09a60b5de158a1da49529783524ed3f47abb0ed6ae3" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 5387, hashes = { sha256 = "94366cf35067f911c75bec56f790a912cf97b3baefdfd2d7da19c3e8e554673a" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 6205, hashes = { sha256 = "bb2e0ae3e7b060b72caad8e7194311086164637ed91a9c6916df5ee67073e7f5" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 9778, hashes = { sha256 = "367f0cc2b8c7a1f5ce74bc34d2c5c00d98bdfbb04ee37e1ce314e1df618d96ef" } }]
 
 [[packages]]
 name = "rich"
@@ -1185,6 +1398,12 @@ name = "scipy"
 version = "1.18.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/scipy-1.18.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T05:00:03Z, size = 25301246, hashes = { sha256 = "2f1e38ec86a3a1e98f10b082cac234f3d4b26b7c47141d345aa0a10cda5605e5" } }]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 19285, hashes = { sha256 = "78f6a71068173712207c35296d0319c27afa8a0a4beb55aa0cf0644f1c1f5c43" } }]
 
 [[packages]]
 name = "setuptools"
@@ -1289,6 +1508,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/termcolor-3.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 9394, hashes = { sha256 = "dffa682bab5105d4e0ab474440c14d49abf1ec3b7f7d9f08025052add89d195c" } }]
 
 [[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 15815, hashes = { sha256 = "157ecd9fc68d1025e2b7d989621abb570c544401d9ddcde255ade0b9066eef05" } }]
+
+[[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1355,6 +1580,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 349808, hashes = { sha256 = "d9ef0cf8d8c5f0a53470cc1169e023ad6a8a291cb8e1a5c84f3df3a1c4c70926" } }]
 
 [[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 12896, hashes = { sha256 = "ca9da4f6ca5ed1078ebd061dde870edc5e3e03c6d8e24f3e92a0d80bac2e88d9" } }]
+
+[[packages]]
 name = "urllib3"
 version = "2.7.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1403,6 +1634,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 324792, hashes = { sha256 = "eeabefcdcd901abaf518f3988694af1a66dee29ecf63742e1077ee79f40532b6" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T12:27:59Z, size = 16606, hashes = { sha256 = "c3a530d8f90f281a40e60949e05b5795e0db679a0f8747241dd39ad0ef27601d" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1411,7 +1648,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-14T07:40:51Z, size = 84341, hashes = { sha256 = "57c7d53a6be8a23d06552118f85eb04d4a7293df6c16817e41e3f845aa2c401b" } }]
 
 [[packages]]

--- a/runtimes/tensorflow/ubi9-python-3.12/requirements.cuda.txt
+++ b/runtimes/tensorflow/ubi9-python-3.12/requirements.cuda.txt
@@ -23,6 +23,8 @@ argon2-cffi==25.1.0 ; python_full_version == '3.12.*' and implementation_name ==
 argon2-cffi-bindings==25.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d428b4db13f72ff0b8d9f250d85b90241bd91309f118990fb3499d64513d007a \
     --hash=sha256:ca84a0a4bc0555431b9eb8ec6b1bd19523de9425c078b3a6d5ca2f4beb4ea021
+arrow==1.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:43a5edda065059ea60be2091354c701b2bf12674fd96518e1396d06f19953629
 ast-serialize==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:93a5ce23dbe55faf790c099fb8a7eecb364dc8742d2a7308ce20a58a60d4ef53 \
     --hash=sha256:f4fa00641f6e5ea6bb0e37065d0ebf1cfbd4929a9e185ac44fdc4d5ae92fe6be
@@ -32,10 +34,14 @@ asttokens==3.0.2 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:f3cfcb010a31fe09e775c6ad1829fb534ecb08273deb060e4924784c95a40880
 astunparse==1.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:83190b8da8ef6ca568f0ec4a26f2e620d9c439c9a6da9bfabfafd454cb26c402
+async-lru==2.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:eb85e4c0ed3f441c632129a91aeb669b61904f2ed8c7b4decd08506791d96a9d
 attrs==26.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5e96e3ffd2e51604ef733b00a0be768ccfacd94c9419975be2c188bf7fe24d49
 autopep8==2.3.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ef34fe1076d16f5f37bf513c3ffb810a6905ff84df726c1ba1456591a618428b
+babel==2.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6f80fa28d5c515a8ee159230529023d6d982cf1101fcba6d2bd6738c05c7f738
 bcrypt==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:a4e05ae5ef6e8df19533d7aa36d707b550cf93dacfa1908c6578673a3727acbc \
     --hash=sha256:813a1e02f5c28d456677f0dbcdadeaecb390e1bbe3324348a5a703efda174c2f
@@ -62,6 +68,8 @@ charset-normalizer==3.5.1 ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:dfeed0d8d630d902523e9985f13fa419dc80a0269b6b2475353e8c819715a51f
 click==8.4.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:75c22a95afacd075d97dc01f135e12a7c6c99587539db2bfb0fcfce56aa0ffef
+click-option-group==0.5.7 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:6bb8d01f44feff277b97a2c488ad8f187fac105e3c8a679af2a551f0f9cdc29f
 cloudpickle==3.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8e0d103185d5eee277811cd19a652e061ac90c40edd25a61de1cd70430d3f113
 codeflare-sdk==0.38.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
@@ -97,7 +105,9 @@ dnspython==2.8.0 ; python_full_version == '3.12.*' and implementation_name == 'c
     --hash=sha256:fec6c14087f59b16dc97a39621a9c341a6d15e836a3e46f81323787ed794cd81
 docker==7.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e117a9f6c8111898acd83dc46315f78fb544ab46d6c57f22c0f5274634fd9827
-durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+docstring-parser==0.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3f57d74f733e217d998fcc4f1d247ef44c1ff71b46c7ce8a688263108de48b35
+durationpy==0.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1a56d40cb0fd75827df17dde82ead426c4e8e5c96972aca93798de15ec4b2add
 entrypoints==0.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:eec23a3ee2165cf62d811e87193787acc3cb2b9d8d9eeddabe7c1fbfd3c2f36a
@@ -119,6 +129,8 @@ flatbuffers==25.12.19 ; python_full_version == '3.12.*' and implementation_name 
     --hash=sha256:8e8bef5fa6f5061061e7f2a0cb3154988423cfa430f4d46a91d649b6b110b2b0
 fonttools==4.63.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f7d7b728504685009f17a3dd783a827bbb28880ff3236ff1c96ee1d54f3cb1f6
+fqdn==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9839695de0ccd904b7314286805784512bef1f8f63a9627160600e39064cf83d
 frozenlist==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4da5a0d77e08fb8d2b03d241aa0d18bbaab0c2ad0d9e3bb887194e664c1ef7b3 \
     --hash=sha256:4c09064ea7f2d88a4e4f14124742eeb98142e2df80473d8039397aae887ccb40
@@ -130,13 +142,21 @@ gitdb==4.0.12 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:1e0fd771d3b64d00483c31c9400796a54fdc47ddc3e0bf9872b8287e0a86eead
 gitpython==3.1.59 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d565c8f1609e2bd0eaf9793b813b85659bd859e768383e58a325f6e3158671b0
-google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-api-core==2.34.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:c80ae74c88d3bb5d03a3b0f5632c2e64526a7f432f0bb4e0d53be82e24f19c3e
 google-auth==2.56.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:10b1c803336c34383c22cc008970359dc04321aa602451252da55994c317ffd9
+google-cloud-core==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:052531c56e55fccf35a6eef2bd0178b11f7cf7ec75420dce7e7197d292081b92
+google-cloud-storage==3.13.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:24398209806b8e89af366afe0d2503b38f4a7a424260c35523b3f532ac104b46
+google-crc32c==1.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:17ab823b54879ca9f003c099bd9c120e5fc52d9bd9f243f95c41531f1c33aa55
 google-pasta==0.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5bd3131469f2afd8aab53377331a7f2a9921eca26d6749bf55cc0b246975f6b8
-googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+google-resumable-media==2.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:83e62b273e02f3f5f20fb2b5b9db51350cc16aa51c10cda8021da0c48137c0cd
+googleapis-common-protos==1.75.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1fa8a9faf0dbf029aa4af673b53d2aed7ac1f627de08c57f0a3ff88ac4d230f3
 graphene==3.4.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ff8ee16bd1aa9fd08d2e2b8fecbadcc37b4ff4c71df2f4a8a3dabe4ba381377a
@@ -157,9 +177,13 @@ h11==0.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
 h5py==3.14.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:41995e2fbad3522b726f67df8420c9a06cd026b58267e97c9ce4c9dd8786b85a \
     --hash=sha256:46f098ebd22fa06c0861f5a721d1d78a2ca40d9ac1938131f92756739965e027
+httpcore==1.0.9 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7697e85f4db06dc7623fc6803f4924dd1581262509865eb44e4a614af901ad4c
 httptools==0.8.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9da5e75fa062ac1d3cb0b2e23a831c15a38bc8baf1ef3f40db83e65a79f70aac \
     --hash=sha256:73bd20346c82b054ccd2453e5fab5ea923bfd583afd874dbf26c6a754303bdd9
+httpx==0.28.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:b1c5ac7db28662ed7e0300516e7dc1b5fa48dda3cd89b94cfd99fce1a8ddd04c
 huey==3.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0c65ac58f86c09440a097f737b68aaa53382c9e9e1694c45f7e0d61ea69a9a14
 idna==3.18 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -178,6 +202,8 @@ ipython-pygments-lexers==1.1.1 ; python_full_version == '3.12.*' and implementat
     --hash=sha256:b590297884c66c7bed56ab87d41a93536bb078c59a257cff94187393cf050472
 ipywidgets==8.1.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:92081d41f8fa2cd46721fe5118490f9593c9a66498615cf6bcbe15dd204a6cbe
+isoduration==20.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:41e1ec7ca11a72f086f83c30b33a245825b7b6bc3b13ed23294e8705fd90749f
 itsdangerous==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4af5886dd1ddceb797a54ee678cfa11efafa238e8855fa25be7505c5dcdefeb2
 jedi==0.20.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -188,29 +214,57 @@ jmespath==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:b5d92b09f51645fd5e5cd483a9b17095f20af45c1551539b2cfa24b70ce79569
 joblib==1.5.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:ee757e508f682997fd33e262c61d6769534e31ceed5399fa683948c746e7066f
+json5==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c0b7399e3de7893520d7b970a32a80621e0821b8ae5a1b9a67fdd159335beb67
+jsonpointer==3.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:30e3bd268c6a1cf64305d426abaf884b9e2a7ae8634202d93c2c93a4c05821f4
 jsonschema==4.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:38e9bf0d52dee97b79f404cce5d3aee2e53a59878247e0374daeacd2c2a6dcc2
 jsonschema-specifications==2025.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1cc3fdeeb3d9528d7291cbe86b75c8d76adc18d6e6433eeb5dc0f2dbc15aceac
+jupyter-builder==1.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:f84df03b2b44b5f80fa6e0f09f617540ce80910e93889449b7ff2f1affe24e90
 jupyter-client==8.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:13e64c3c4036a0622b7d8104ad64486c0b5be135fe3b55ea728d1881dba1f17d
 jupyter-core==5.9.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7ace5d4fbead52867051ff4d1b3c60902604cefd72f92a06a6983ce8ad4ca287
+jupyter-events==0.12.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:29ed7e2820c1837ed548d6ebdbe7b539d88dcbce8b10a5563ca1e96c1b1e4494
+jupyter-lsp==2.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:26faf55195a481ea64a0d04434a0f292b2f1fdddc2b5bc70aad09fd9349e5bf7
+jupyter-server==2.21.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c3784c78bc5397cb0d0e5dfaf8922d23b7512629c5eb010ebae6e70bd56e2b39
+jupyter-server-terminals==0.5.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ce85923c6609c41d0c4b6d4f9b95ef4a2559cdf976b1226e57b3615d76633a06
+jupyterlab==4.5.10 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:57b05aa5ddb641df1579dfe02dd7980886ab2e667ce4e52bd9937efd5d583830
 jupyterlab-pygments==0.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a8fbe77b1d5725c89c39f74a4d45c7f4bebe927fc02d9f61a1abd3dda4fb0873
+jupyterlab-server==2.28.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:bde983e08f6578559dd8695208ba9ed3a348b596d920b0594e432d8dad693751
 jupyterlab-widgets==3.0.16 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:d8b2d9561b4fcde0a998f75f090e2b56963a53c1f7681e49bad4ea7beeddec2d
 kafka-python-ng==2.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:71786baee047d973cbee3f902d392605952e6fa309c60d08b14d46f8120f6ae0
 keras==3.15.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f6dd13772ad0e87202b1e816523c3b8fbb0288a0c3606587cfac85aa09771d77
+kfp==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:7420b5313ba65c18aa4caf0e71f3994dc85bb2d79e11491863e1fade69b759c2
+kfp-kubernetes==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2e5cfda852fe8a1494b6362c662528e42ca2605ac25cd09c298e09e155204d8a
+kfp-pipeline-spec==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:4e3b23f58358ce5b9f9ac043fc3e7b40f6218a0bba738d3de3ba06642becaff0
+kfp-server-api==2.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ac0f6a5dbaa9a150212fe657d9d229d1f183f9332cd0799c0fe680ccd1df8f11
 kiwisolver==1.5.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:bfa76a131bd3703b2fce72fa2502ded73c2e8b10b29799b80c88eb99d2ddd1f8 \
     --hash=sha256:98b1d8b8d0b07c9bfa161ce7711d5ef09ca15e45607c3c304342180097218156
 kube-authkit==0.4.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
     --hash=sha256:256d85ca51f47bd510139e5c8ab7da136162e62d18b5b75c9490172fed8d4629
-kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+kubernetes==36.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:22bfb67c7728a5557306a99a206c7b5ee82ae6a1e32f3ce8cdebd2119758a587
+lark==1.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:046ee5e0cd45582fb2bc39fe46cb9f10716e5d8da1f14293c6430f952e9fc483
 libclang==18.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:39b2bcf6751d83df728ef33fbddc28a9157754207553b265ffaa145709fed3aa
 librt==0.15.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_python_implementation != 'PyPy' and sys_platform == 'linux' \
@@ -279,11 +333,17 @@ nest-asyncio2==1.7.2 ; python_full_version == '3.12.*' and implementation_name =
     --hash=sha256:643d7f0b7db422f8bc23b06fbfaf0483c6e0121ecb66e3a9d8d88437ea9bf17e
 networkx==3.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9d8090bdf3c018314e3807e048322a64e3161a05f9e9b1b7d06ec85ca65006cf
+notebook==7.6.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:ea8e8bd68913c42ef8d6863936424999c9c4d0cb50e3b5d41614a2651e5addf6
+notebook-shim==0.2.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:07f0cbc23fc8c78a7ed62e1269cf441ec9c9e3ce711a283fb45bb8b9b0316d9b
 numpy==2.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f472d7dba39b147e1222814912f2a9cf3624795a5e572582b3480a3d9121b771 \
     --hash=sha256:d7b7199052974d44395f68c99b2b25a88d0acf09333cd121bf86e1651a7d1c03
-oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+oauthlib==3.3.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3f1e5648119bb8ab9d8917558b3efa6ab5448b15b9907a12aaacf3273b9f1938
+odh-kale==2.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:894bca84222cae1fb55bbc9a964e48761b98a591b6dd8b95af18f9f572bc910b
 onnx==1.22.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:836d49ad1f168b87862ab2bbd060f0f894ab6fa3235080709be6c8feaa7de153 \
     --hash=sha256:4afea5d98f0f4e558c1b8c857ea441eb994aaeec574b06c63421f8ad0c3c9aba
@@ -314,7 +374,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:4ff10c33baae07c17d38d7bf83d734762ae7e42000bb5957eaa2a7ecaa79cfaa
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2 \
-    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0
+    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0 \
+    --hash=sha256:610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99 \
+    --hash=sha256:e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a293260e58a82f52644c3a189227ec3f445b5149480eef442b3de894b9173d78
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -349,7 +411,7 @@ prompt-toolkit==3.0.53 ; python_full_version == '3.12.*' and implementation_name
 propcache==0.5.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:2e1dcb127228ec5c2d73ec447c84992aa20db6b917496db5aeed91778ef5279e \
     --hash=sha256:a75d7fb3793ba2d76c61d57ecaf05a402d02dce26ea05f9d55732418a622a7e3
-proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+proto-plus==1.28.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b4dc76f48169cec285087340940136264a53c5960137289ac33e14ad13e2c55e
 protobuf==6.31.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e6913ffc9520e41863464df0cb2b2c89974fc34222248071ffce77598eff6a72 \
@@ -405,6 +467,8 @@ python-discovery==1.5.2 ; python_full_version == '3.12.*' and implementation_nam
     --hash=sha256:47cc249478d223f7aedea10fbfa097a087b02ffa54a33f3069c084f9bb9ebadf
 python-dotenv==1.2.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:3187699396fc627608a79c4c7346ee47e5d72e072d1350a92a1bf0cd74f8e36a
+python-json-logger==4.2.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9722ab7ea2bf437a582daf37fd7dff0d558c00da3f105d2317f22875b5969bc1
 pytz==2026.3.post1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:4b66fdd9166f3df061f44e84701bfb1e21e4d6d03879639a0e762175c98849f9
 pyyaml==6.0.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -418,10 +482,18 @@ ray==2.55.1 ; python_full_version == '3.12.*' and implementation_name == 'cpytho
     --hash=sha256:4ff2fc6fc1477b1a5808289f90cfcf2ad73ab7eab7d420edd3e73f4961e6a5b1
 referencing==0.37.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:dd26a1a54233d0a61402d0e8a09f0f4079087922fb31e4b215d83a864997b07d
-requests==2.34.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:a29c5b0502f5d144d0ad91c136df6497ab82cd7861bda7b3436fe0e66cdef426
-requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+requests==2.33.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:c2c2e99d4cb4a8b677ffed7e2bf5711ba888b8a5b672149125c5e8c7eaf89ed9
+requests-oauthlib==2.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:44abe38b57c15fc67d311b139c31ffe15aa320d5219354795b4ef1b12016c0ba
+requests-toolbelt==1.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:138d67a426d08d9b317790ce872f49731930c406b7a3b66f0929491a57ccd3de
+rfc3339-validator==0.1.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:3171a62483e82eaa12df371371b6f3965793415e2b2118fbda005cfb6c98d008
+rfc3986-validator==0.1.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:d6f6bf80fa85bc2f1d47d93f62b32f5306d518976a5d19fd6c4131d453a8f8da
+rfc3987-syntax==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:93f541d2d28149a7a8d78705c16e1eae51d4d6f093fe4b855b22f6b63c6f7445
 rich==14.3.4 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:69e3def63ddf78f0e212bf8ce88cbd2b92146fe68e9ada7582e06c9282ad9d15
 rpds-py==2026.6.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -435,6 +507,8 @@ scikit-learn==1.9.0 ; python_full_version == '3.12.*' and implementation_name ==
 scipy==1.18.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5f4355117553d9be7f554f253cd240864c3002765fe4ea3b891a3d2413412a80 \
     --hash=sha256:7c6e2b8afa2f9e0834b5d5432cdb0bc06b52dd0fad81e359c1e90df9428150df
+send2trash==2.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:9bc06afefd38c4ed1d45c33c038832519e475d85be90d9131321c287e4b61161
 setuptools==84.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:8da90a8b235473f85581beea8f7c388a68dd565a8c70ae76ec860ad6d3bb495a
 six==1.17.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -471,6 +545,8 @@ tensorflow==2.21.0+redhat ; python_full_version == '3.12.*' and implementation_n
     --hash=sha256:1a9a2a33e47b740fbb4ca3f8194e57ceb4c462a995062362258c5ed55faf4022
 termcolor==3.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:f722efc690a9688b31ac88f7d4672014254607f3e3211c7f4be7bfe152d5cc35
+terminado==0.18.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:09fd29b39b2faca10e975722a670a85ecda25da764173d9bfc213d4aee6807ca
 threadpoolctl==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:6be43615d32ba6ae579b1b12adcc0b7cc0cedca3401d63e375937b29220bfa84
 tinycss2==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -494,6 +570,8 @@ typing-inspection==0.4.4 ; python_full_version == '3.12.*' and implementation_na
     --hash=sha256:4ac1bf81b1a5c81db44e7bcaa93bd3e855d9e80336078be1ea3fb71baa3dc50f
 tzdata==2026.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:538b6e5341e07f26baaf23ff6ec9a1a84a2f1752884909b3a0c7d1ae63271719
+uri-template==1.3.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:87d0dc58bec837afdbffddfa595e95c76e4a66f84d29cbbf60485a0234649b86
 urllib3==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:22c05ba20811924a0028c48d5f0c32a8bfc7c455671da9d6320d2795f262ec4f
 uv==0.12.5 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
@@ -513,9 +591,11 @@ watchfiles==1.2.0 ; python_full_version == '3.12.*' and implementation_name == '
     --hash=sha256:427e93f71b3f10713f1b65d6bdc18f3085f9b8d48c3b0777d941f09d92638e5a
 wcwidth==0.8.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:61062682e72afd871ee7ce5f6de2f4a7bae2726f1780a140314bd36471e6697e
+webcolors==25.10.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:5290b96f45464c9afba21255f70a6764d7f02ce996043606d4ad73c767c52f7c
 webencodings==0.6.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0a67a572ad6844cc10c6cafb38b4c0db736a2038e0db8f662d3aaa3bf989ad4d
-websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \
+websocket-client==1.9.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:47153ee286214566b5c3532ed3c92e92a9daa8ee963d3c8d4bc79e5899d042e7
 websockets==17.0.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:53f3d00a7fd562d984454ad8cbdcc8ed178514b0ac69945b6e3ea1a4f6e6a7be \

--- a/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -77,6 +77,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "arrow"
+version = "1.4.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/arrow-1.4.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 70410, hashes = { sha256 = "43a5edda065059ea60be2091354c701b2bf12674fd96518e1396d06f19953629" } }]
+
+[[packages]]
 name = "ast-serialize"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -104,6 +110,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/astunparse-1.6.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 14534, hashes = { sha256 = "83190b8da8ef6ca568f0ec4a26f2e620d9c439c9a6da9bfabfafd454cb26c402" } }]
 
 [[packages]]
+name = "async-lru"
+version = "2.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/async_lru-2.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 10054, hashes = { sha256 = "eb85e4c0ed3f441c632129a91aeb669b61904f2ed8c7b4decd08506791d96a9d" } }]
+
+[[packages]]
 name = "attrs"
 version = "26.1.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -114,6 +126,12 @@ name = "autopep8"
 version = "2.3.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/autopep8-2.3.2-1-py2.py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 47527, hashes = { sha256 = "ef34fe1076d16f5f37bf513c3ffb810a6905ff84df726c1ba1456591a618428b" } }]
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/babel-2.18.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 10198503, hashes = { sha256 = "6f80fa28d5c515a8ee159230529023d6d982cf1101fcba6d2bd6738c05c7f738" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -192,6 +210,12 @@ name = "click"
 version = "8.4.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/click-8.4.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 120858, hashes = { sha256 = "75c22a95afacd075d97dc01f135e12a7c6c99587539db2bfb0fcfce56aa0ffef" } }]
+
+[[packages]]
+name = "click-option-group"
+version = "0.5.7"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/click_option_group-0.5.7-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 13201, hashes = { sha256 = "6bb8d01f44feff277b97a2c488ad8f187fac105e3c8a679af2a551f0f9cdc29f" } }]
 
 [[packages]]
 name = "cloudpickle"
@@ -299,9 +323,15 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/docker-7.2.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 150401, hashes = { sha256 = "e117a9f6c8111898acd83dc46315f78fb544ab46d6c57f22c0f5274634fd9827" } }]
 
 [[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/docstring_parser-0.18.0-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 24248, hashes = { sha256 = "3f57d74f733e217d998fcc4f1d247ef44c1ff71b46c7ce8a688263108de48b35" } }]
+
+[[packages]]
 name = "durationpy"
 version = "0.10"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/durationpy-0.10-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 5633, hashes = { sha256 = "1a56d40cb0fd75827df17dde82ead426c4e8e5c96972aca93798de15ec4b2add" } }]
 
 [[packages]]
@@ -365,6 +395,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/fonttools-4.63.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 1166224, hashes = { sha256 = "f7d7b728504685009f17a3dd783a827bbb28880ff3236ff1c96ee1d54f3cb1f6" } }]
 
 [[packages]]
+name = "fqdn"
+version = "1.5.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/fqdn-1.5.1-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 5291, hashes = { sha256 = "9839695de0ccd904b7314286805784512bef1f8f63a9627160600e39064cf83d" } }]
+
+[[packages]]
 name = "frozenlist"
 version = "1.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -400,7 +436,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "google-api-core"
 version = "2.34.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_api_core-2.34.0-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 182294, hashes = { sha256 = "c80ae74c88d3bb5d03a3b0f5632c2e64526a7f432f0bb4e0d53be82e24f19c3e" } }]
 
 [[packages]]
@@ -410,15 +446,39 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_auth-2.56.3-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 260806, hashes = { sha256 = "10b1c803336c34383c22cc008970359dc04321aa602451252da55994c317ffd9" } }]
 
 [[packages]]
+name = "google-cloud-core"
+version = "2.7.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_cloud_core-2.7.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:07:53Z, size = 32812, hashes = { sha256 = "052531c56e55fccf35a6eef2bd0178b11f7cf7ec75420dce7e7197d292081b92" } }]
+
+[[packages]]
+name = "google-cloud-storage"
+version = "3.13.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_cloud_storage-3.13.1-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 343298, hashes = { sha256 = "24398209806b8e89af366afe0d2503b38f4a7a424260c35523b3f532ac104b46" } }]
+
+[[packages]]
+name = "google-crc32c"
+version = "1.8.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_crc32c-1.8.0-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 15530, hashes = { sha256 = "17ab823b54879ca9f003c099bd9c120e5fc52d9bd9f243f95c41531f1c33aa55" } }]
+
+[[packages]]
 name = "google-pasta"
 version = "0.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_pasta-0.2.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 55041, hashes = { sha256 = "5bd3131469f2afd8aab53377331a7f2a9921eca26d6749bf55cc0b246975f6b8" } }]
 
 [[packages]]
+name = "google-resumable-media"
+version = "2.10.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/google_resumable_media-2.10.2-1-py3-none-any.whl", upload-time = 2026-08-31T17:07:53Z, size = 83370, hashes = { sha256 = "83e62b273e02f3f5f20fb2b5b9db51350cc16aa51c10cda8021da0c48137c0cd" } }]
+
+[[packages]]
 name = "googleapis-common-protos"
 version = "1.75.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/googleapis_common_protos-1.75.1-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 302478, hashes = { sha256 = "1fa8a9faf0dbf029aa4af673b53d2aed7ac1f627de08c57f0a3ff88ac4d230f3" } }]
 
 [[packages]]
@@ -479,6 +539,12 @@ wheels = [
 ]
 
 [[packages]]
+name = "httpcore"
+version = "1.0.9"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/httpcore-1.0.9-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 80437, hashes = { sha256 = "7697e85f4db06dc7623fc6803f4924dd1581262509865eb44e4a614af901ad4c" } }]
+
+[[packages]]
 name = "httptools"
 version = "0.8.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -486,6 +552,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/httptools-0.8.0-1-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T01:08:46Z, size = 506288, hashes = { sha256 = "9da5e75fa062ac1d3cb0b2e23a831c15a38bc8baf1ef3f40db83e65a79f70aac" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/httptools-0.8.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:12:18Z, size = 514721, hashes = { sha256 = "73bd20346c82b054ccd2453e5fab5ea923bfd583afd874dbf26c6a754303bdd9" } },
 ]
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/httpx-0.28.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 75165, hashes = { sha256 = "b1c5ac7db28662ed7e0300516e7dc1b5fa48dda3cd89b94cfd99fce1a8ddd04c" } }]
 
 [[packages]]
 name = "huey"
@@ -542,6 +614,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/ipywidgets-8.1.2-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 141125, hashes = { sha256 = "92081d41f8fa2cd46721fe5118490f9593c9a66498615cf6bcbe15dd204a6cbe" } }]
 
 [[packages]]
+name = "isoduration"
+version = "20.11.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/isoduration-20.11.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 13135, hashes = { sha256 = "41e1ec7ca11a72f086f83c30b33a245825b7b6bc3b13ed23294e8705fd90749f" } }]
+
+[[packages]]
 name = "itsdangerous"
 version = "2.2.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -572,6 +650,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/joblib-1.5.3-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 310690, hashes = { sha256 = "ee757e508f682997fd33e262c61d6769534e31ceed5399fa683948c746e7066f" } }]
 
 [[packages]]
+name = "json5"
+version = "0.15.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/json5-0.15.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 38186, hashes = { sha256 = "c0b7399e3de7893520d7b970a32a80621e0821b8ae5a1b9a67fdd159335beb67" } }]
+
+[[packages]]
+name = "jsonpointer"
+version = "3.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jsonpointer-3.1.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 9357, hashes = { sha256 = "30e3bd268c6a1cf64305d426abaf884b9e2a7ae8634202d93c2c93a4c05821f4" } }]
+
+[[packages]]
 name = "jsonschema"
 version = "4.26.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -582,6 +672,12 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jsonschema_specifications-2025.9.1-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 20294, hashes = { sha256 = "1cc3fdeeb3d9528d7291cbe86b75c8d76adc18d6e6433eeb5dc0f2dbc15aceac" } }]
+
+[[packages]]
+name = "jupyter-builder"
+version = "1.2.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyter_builder-1.2.2-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 917004, hashes = { sha256 = "f84df03b2b44b5f80fa6e0f09f617540ce80910e93889449b7ff2f1affe24e90" } }]
 
 [[packages]]
 name = "jupyter-client"
@@ -596,10 +692,46 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyter_core-5.9.1-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 30712, hashes = { sha256 = "7ace5d4fbead52867051ff4d1b3c60902604cefd72f92a06a6983ce8ad4ca287" } }]
 
 [[packages]]
+name = "jupyter-events"
+version = "0.12.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyter_events-0.12.1-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 21225, hashes = { sha256 = "29ed7e2820c1837ed548d6ebdbe7b539d88dcbce8b10a5563ca1e96c1b1e4494" } }]
+
+[[packages]]
+name = "jupyter-lsp"
+version = "2.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyter_lsp-2.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 79186, hashes = { sha256 = "26faf55195a481ea64a0d04434a0f292b2f1fdddc2b5bc70aad09fd9349e5bf7" } }]
+
+[[packages]]
+name = "jupyter-server"
+version = "2.21.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyter_server-2.21.0-1-py3-none-any.whl", upload-time = 2026-08-31T17:07:53Z, size = 395767, hashes = { sha256 = "c3784c78bc5397cb0d0e5dfaf8922d23b7512629c5eb010ebae6e70bd56e2b39" } }]
+
+[[packages]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyter_server_terminals-0.5.4-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 15515, hashes = { sha256 = "ce85923c6609c41d0c4b6d4f9b95ef4a2559cdf976b1226e57b3615d76633a06" } }]
+
+[[packages]]
+name = "jupyterlab"
+version = "4.5.10"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyterlab-4.5.10-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 12454274, hashes = { sha256 = "57b05aa5ddb641df1579dfe02dd7980886ab2e667ce4e52bd9937efd5d583830" } }]
+
+[[packages]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyterlab_pygments-0.3.0-2-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 17964, hashes = { sha256 = "a8fbe77b1d5725c89c39f74a4d45c7f4bebe927fc02d9f61a1abd3dda4fb0873" } }]
+
+[[packages]]
+name = "jupyterlab-server"
+version = "2.28.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/jupyterlab_server-2.28.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 61570, hashes = { sha256 = "bde983e08f6578559dd8695208ba9ed3a348b596d920b0594e432d8dad693751" } }]
 
 [[packages]]
 name = "jupyterlab-widgets"
@@ -620,6 +752,30 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/keras-3.15.1-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 2400211, hashes = { sha256 = "f6dd13772ad0e87202b1e816523c3b8fbb0288a0c3606587cfac85aa09771d77" } }]
 
 [[packages]]
+name = "kfp"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/kfp-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 479782, hashes = { sha256 = "7420b5313ba65c18aa4caf0e71f3994dc85bb2d79e11491863e1fade69b759c2" } }]
+
+[[packages]]
+name = "kfp-kubernetes"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/kfp_kubernetes-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 29466, hashes = { sha256 = "2e5cfda852fe8a1494b6362c662528e42ca2605ac25cd09c298e09e155204d8a" } }]
+
+[[packages]]
+name = "kfp-pipeline-spec"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/kfp_pipeline_spec-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 11705, hashes = { sha256 = "4e3b23f58358ce5b9f9ac043fc3e7b40f6218a0bba738d3de3ba06642becaff0" } }]
+
+[[packages]]
+name = "kfp-server-api"
+version = "2.17.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/kfp_server_api-2.17.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 130413, hashes = { sha256 = "ac0f6a5dbaa9a150212fe657d9d229d1f183f9332cd0799c0fe680ccd1df8f11" } }]
+
+[[packages]]
 name = "kiwisolver"
 version = "1.5.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -637,8 +793,14 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "kubernetes"
 version = "36.0.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/kubernetes-36.0.3-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 4619743, hashes = { sha256 = "22bfb67c7728a5557306a99a206c7b5ee82ae6a1e32f3ce8cdebd2119758a587" } }]
+
+[[packages]]
+name = "lark"
+version = "1.3.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/lark-1.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 114760, hashes = { sha256 = "046ee5e0cd45582fb2bc39fe46cb9f10716e5d8da1f14293c6430f952e9fc483" } }]
 
 [[packages]]
 name = "libclang"
@@ -845,6 +1007,18 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/networkx-3.6.1-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 2070143, hashes = { sha256 = "9d8090bdf3c018314e3807e048322a64e3161a05f9e9b1b7d06ec85ca65006cf" } }]
 
 [[packages]]
+name = "notebook"
+version = "7.6.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/notebook-7.6.2-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 5548930, hashes = { sha256 = "ea8e8bd68913c42ef8d6863936424999c9c4d0cb50e3b5d41614a2651e5addf6" } }]
+
+[[packages]]
+name = "notebook-shim"
+version = "0.2.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/notebook_shim-0.2.4-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 15001, hashes = { sha256 = "07f0cbc23fc8c78a7ed62e1269cf441ec9c9e3ce711a283fb45bb8b9b0316d9b" } }]
+
+[[packages]]
 name = "numpy"
 version = "2.5.2"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -856,8 +1030,14 @@ wheels = [
 [[packages]]
 name = "oauthlib"
 version = "3.3.1"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/oauthlib-3.3.1-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 161705, hashes = { sha256 = "3f1e5648119bb8ab9d8917558b3efa6ab5448b15b9907a12aaacf3273b9f1938" } }]
+
+[[packages]]
+name = "odh-kale"
+version = "2.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/odh_kale-2.2.0-1-py3-none-any.whl", upload-time = 2026-08-18T01:19:50Z, size = 377925, hashes = { sha256 = "894bca84222cae1fb55bbc9a964e48761b98a591b6dd8b95af18f9f572bc910b" } }]
 
 [[packages]]
 name = "onnx"
@@ -950,6 +1130,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-15T05:36:58Z, size = 12065020, hashes = { sha256 = "1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T05:23:21Z, size = 12761081, hashes = { sha256 = "0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:54:15Z, size = 12053826, hashes = { sha256 = "610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:49:38Z, size = 12742529, hashes = { sha256 = "e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698" } },
 ]
 
 [[packages]]
@@ -1057,7 +1239,7 @@ wheels = [
 [[packages]]
 name = "proto-plus"
 version = "1.28.3"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/proto_plus-1.28.3-1-py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 52499, hashes = { sha256 = "b4dc76f48169cec285087340940136264a53c5960137289ac33e14ad13e2c55e" } }]
 
 [[packages]]
@@ -1223,6 +1405,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/python_dotenv-1.2.3-1-py3-none-any.whl", upload-time = 2026-08-20T01:02:05Z, size = 24504, hashes = { sha256 = "3187699396fc627608a79c4c7346ee47e5d72e072d1350a92a1bf0cd74f8e36a" } }]
 
 [[packages]]
+name = "python-json-logger"
+version = "4.2.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/python_json_logger-4.2.0-1-py3-none-any.whl", upload-time = 2026-08-19T01:25:12Z, size = 16753, hashes = { sha256 = "9722ab7ea2bf437a582daf37fd7dff0d558c00da3f105d2317f22875b5969bc1" } }]
+
+[[packages]]
 name = "pytz"
 version = "2026.3.post1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1263,15 +1451,39 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "requests"
-version = "2.34.2"
+version = "2.33.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/requests-2.34.2-1-py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 74725, hashes = { sha256 = "a29c5b0502f5d144d0ad91c136df6497ab82cd7861bda7b3436fe0e66cdef426" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/requests-2.33.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 66702, hashes = { sha256 = "c2c2e99d4cb4a8b677ffed7e2bf5711ba888b8a5b672149125c5e8c7eaf89ed9" } }]
 
 [[packages]]
 name = "requests-oauthlib"
 version = "2.0.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/requests_oauthlib-2.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-15T01:24:27Z, size = 26049, hashes = { sha256 = "44abe38b57c15fc67d311b139c31ffe15aa320d5219354795b4ef1b12016c0ba" } }]
+
+[[packages]]
+name = "requests-toolbelt"
+version = "1.0.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/requests_toolbelt-1.0.0-1-py2.py3-none-any.whl", upload-time = 2026-08-14T00:12:18Z, size = 53486, hashes = { sha256 = "138d67a426d08d9b317790ce872f49731930c406b7a3b66f0929491a57ccd3de" } }]
+
+[[packages]]
+name = "rfc3339-validator"
+version = "0.1.4"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/rfc3339_validator-0.1.4-1-py2.py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 5387, hashes = { sha256 = "3171a62483e82eaa12df371371b6f3965793415e2b2118fbda005cfb6c98d008" } }]
+
+[[packages]]
+name = "rfc3986-validator"
+version = "0.1.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/rfc3986_validator-0.1.1-1-py2.py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 6207, hashes = { sha256 = "d6f6bf80fa85bc2f1d47d93f62b32f5306d518976a5d19fd6c4131d453a8f8da" } }]
+
+[[packages]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/rfc3987_syntax-1.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 9776, hashes = { sha256 = "93f541d2d28149a7a8d78705c16e1eae51d4d6f093fe4b855b22f6b63c6f7445" } }]
 
 [[packages]]
 name = "rich"
@@ -1311,6 +1523,12 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/scipy-1.18.0-1-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T01:08:46Z, size = 23993809, hashes = { sha256 = "5f4355117553d9be7f554f253cd240864c3002765fe4ea3b891a3d2413412a80" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/scipy-1.18.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T00:12:18Z, size = 25301244, hashes = { sha256 = "7c6e2b8afa2f9e0834b5d5432cdb0bc06b52dd0fad81e359c1e90df9428150df" } },
 ]
+
+[[packages]]
+name = "send2trash"
+version = "2.1.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/send2trash-2.1.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 19286, hashes = { sha256 = "9bc06afefd38c4ed1d45c33c038832519e475d85be90d9131321c287e4b61161" } }]
 
 [[packages]]
 name = "setuptools"
@@ -1421,6 +1639,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/termcolor-3.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 9395, hashes = { sha256 = "f722efc690a9688b31ac88f7d4672014254607f3e3211c7f4be7bfe152d5cc35" } }]
 
 [[packages]]
+name = "terminado"
+version = "0.18.1"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/terminado-0.18.1-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 15816, hashes = { sha256 = "09fd29b39b2faca10e975722a670a85ecda25da764173d9bfc213d4aee6807ca" } }]
+
+[[packages]]
 name = "threadpoolctl"
 version = "3.6.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1490,6 +1714,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/tzdata-2026.3-1-py2.py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 349807, hashes = { sha256 = "538b6e5341e07f26baaf23ff6ec9a1a84a2f1752884909b3a0c7d1ae63271719" } }]
 
 [[packages]]
+name = "uri-template"
+version = "1.3.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/uri_template-1.3.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 12896, hashes = { sha256 = "87d0dc58bec837afdbffddfa595e95c76e4a66f84d29cbbf60485a0234649b86" } }]
+
+[[packages]]
 name = "urllib3"
 version = "2.7.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1547,6 +1777,12 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/wcwidth-0.8.2-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 324792, hashes = { sha256 = "61062682e72afd871ee7ce5f6de2f4a7bae2726f1780a140314bd36471e6697e" } }]
 
 [[packages]]
+name = "webcolors"
+version = "25.10.0"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/webcolors-25.10.0-1-py3-none-any.whl", upload-time = 2026-08-15T14:32:18Z, size = 16606, hashes = { sha256 = "5290b96f45464c9afba21255f70a6764d7f02ce996043606d4ad73c767c52f7c" } }]
+
+[[packages]]
 name = "webencodings"
 version = "0.6.1"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
@@ -1555,7 +1791,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 [[packages]]
 name = "websocket-client"
 version = "1.9.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/websocket_client-1.9.0-1-py3-none-any.whl", upload-time = 2026-08-15T05:23:21Z, size = 84343, hashes = { sha256 = "47153ee286214566b5c3532ed3c92e92a9daa8ee963d3c8d4bc79e5899d042e7" } }]
 
 [[packages]]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-89794

https://redhat-internal.slack.com/archives/C05TTTYG599/p1788270662445349

## Description
Modifying the runtime image dependencies to include Kale. After testing Kale on disconnected environment, we found that Kale is not included. 

Currently this is not a problem because the user can select which runtime image it uses for the pipeline and we are not integrated with the list of runtime images as Elyra is. However, in next versions Kale will have support to list of images and it will list the runtime images, so we must make it sure that the base image will work in disconnected environments.

The initial implementation was inspired on Elyra runtime image implementation, however, Kale needs itself as dependency for the runtime image, while Elyra only needs a few other packages.

## How Has This Been Tested?
TBD

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Python runtime support with additional notebook, JupyterLab, Kubeflow, Google Cloud, and validation packages.
  * Broadened compatibility for several runtime dependencies across Linux architectures, including ppc64le and s390x.
  * Added support for refreshed platform-specific pandas and Triton package builds.

* **Updates**
  * Updated AnyIO to version 4.15.0.
  * Updated runtime dependency pins and package integrity checks across CPU, CUDA, and ROCm environments.
  * Consolidated Kale runtime dependencies around the Kale package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->