### PR TITLE
GHA: Update ODH rpms.lock.yaml lock files

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/941ef90259e7e00d9a98af75da49bd34d4d3b9ddb366540d1490a662126fcc8b-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/c59b38149b490c5b395495c1f8d6eb25c72e0cb763f057c62e942ebdc61f6c3e-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8830
-    checksum: sha256:941ef90259e7e00d9a98af75da49bd34d4d3b9ddb366540d1490a662126fcc8b
+    checksum: sha256:c59b38149b490c5b395495c1f8d6eb25c72e0cb763f057c62e942ebdc61f6c3e
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -9699,10 +9699,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/8a4e0daa6f091f7a237a21b5b8f69bc506d86187b941c2fcbe46e4fa2b9bb3e6-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/3468707a48df6e449949b68741e5826d437729c0188fcabae2782caef7cef879-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 8755
-    checksum: sha256:8a4e0daa6f091f7a237a21b5b8f69bc506d86187b941c2fcbe46e4fa2b9bb3e6
+    checksum: sha256:3468707a48df6e449949b68741e5826d437729c0188fcabae2782caef7cef879
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -14534,10 +14534,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/deb281dc356692bf11c4ee34cd90984ee887e0061b00a6e297dd012d14784809-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/fdff6fb2922aed89c1f40ba91929e5ed0149c8aed45550329f049be6a5057498-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8464
-    checksum: sha256:deb281dc356692bf11c4ee34cd90984ee887e0061b00a6e297dd012d14784809
+    checksum: sha256:fdff6fb2922aed89c1f40ba91929e5ed0149c8aed45550329f049be6a5057498
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -19418,10 +19418,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/f42598d9509bdf2a9da9f340a52cb611c95c5994a72d9c926d334edc2318ec30-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/d81884380238dcdd13b7bdfcb7fdbf1743d058cc7e9f5c0a51c9f46db489d66e-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8478
-    checksum: sha256:f42598d9509bdf2a9da9f340a52cb611c95c5994a72d9c926d334edc2318ec30
+    checksum: sha256:d81884380238dcdd13b7bdfcb7fdbf1743d058cc7e9f5c0a51c9f46db489d66e
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/941ef90259e7e00d9a98af75da49bd34d4d3b9ddb366540d1490a662126fcc8b-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/c59b38149b490c5b395495c1f8d6eb25c72e0cb763f057c62e942ebdc61f6c3e-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8830
-    checksum: sha256:941ef90259e7e00d9a98af75da49bd34d4d3b9ddb366540d1490a662126fcc8b
+    checksum: sha256:c59b38149b490c5b395495c1f8d6eb25c72e0cb763f057c62e942ebdc61f6c3e
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -9699,10 +9699,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/8a4e0daa6f091f7a237a21b5b8f69bc506d86187b941c2fcbe46e4fa2b9bb3e6-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/3468707a48df6e449949b68741e5826d437729c0188fcabae2782caef7cef879-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 8755
-    checksum: sha256:8a4e0daa6f091f7a237a21b5b8f69bc506d86187b941c2fcbe46e4fa2b9bb3e6
+    checksum: sha256:3468707a48df6e449949b68741e5826d437729c0188fcabae2782caef7cef879
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -14534,10 +14534,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/deb281dc356692bf11c4ee34cd90984ee887e0061b00a6e297dd012d14784809-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/fdff6fb2922aed89c1f40ba91929e5ed0149c8aed45550329f049be6a5057498-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8464
-    checksum: sha256:deb281dc356692bf11c4ee34cd90984ee887e0061b00a6e297dd012d14784809
+    checksum: sha256:fdff6fb2922aed89c1f40ba91929e5ed0149c8aed45550329f049be6a5057498
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -19418,10 +19418,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/f42598d9509bdf2a9da9f340a52cb611c95c5994a72d9c926d334edc2318ec30-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/d81884380238dcdd13b7bdfcb7fdbf1743d058cc7e9f5c0a51c9f46db489d66e-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8478
-    checksum: sha256:f42598d9509bdf2a9da9f340a52cb611c95c5994a72d9c926d334edc2318ec30
+    checksum: sha256:d81884380238dcdd13b7bdfcb7fdbf1743d058cc7e9f5c0a51c9f46db489d66e
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860


### PR DESCRIPTION
Automated regeneration of `rpms.lock.yaml` from `rpms.in.yaml` for the **ODH** variant.

Updated paths:
- `prefetch-input/odh/rpms.lock.yaml`
- `codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml`
- `codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refreshed UBI 9 AppStream repository metadata references and integrity checks for Python 3.12 environments.
  - Updated metadata across aarch64, ppc64le, s390x, and x86_64 platforms.
  - Repository identifiers and metadata sizes remain unchanged, preserving existing platform coverage and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->