### PR TITLE
GHA: Update RHDS rpms.lock.yaml lock files

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -4822,10 +4822,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/098c69a9ac950c5e5ff5b8dd7701b684ac18eababc16faf47914b1f730333470-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/eda0ce0eca050a9a6a5488fae0acd0e0e73c53d04f88d32ac08c3b7d068aa559-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65847
-    checksum: sha256:098c69a9ac950c5e5ff5b8dd7701b684ac18eababc16faf47914b1f730333470
+    checksum: sha256:eda0ce0eca050a9a6a5488fae0acd0e0e73c53d04f88d32ac08c3b7d068aa559
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -9681,10 +9681,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/56eeb3f5077cb3a5056c0e0d1625d45ba806d6d36b6032c7addb9c7c79d81918-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/94564851694c81427f5764d800b0e6251033bd5743aa689c0bcb57aeda568b2c-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65337
-    checksum: sha256:56eeb3f5077cb3a5056c0e0d1625d45ba806d6d36b6032c7addb9c7c79d81918
+    checksum: sha256:94564851694c81427f5764d800b0e6251033bd5743aa689c0bcb57aeda568b2c
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -14512,10 +14512,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/eef17cf6312d457edb060099c9a7b6062e5facbe47b9d9154786984ca266b2f1-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/e145297305a3b598404a7cf721b1b80f8c1de24210deb401835418aabeb9de2f-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 63806
-    checksum: sha256:eef17cf6312d457edb060099c9a7b6062e5facbe47b9d9154786984ca266b2f1
+    checksum: sha256:e145297305a3b598404a7cf721b1b80f8c1de24210deb401835418aabeb9de2f
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -19378,7 +19378,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/195e2dab181f172fb94f20099bcbb1b6d7aee4793465c59a9565297ddd9ec0f5-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/b6b385fc1f94ae5c1bf449654a2039063004ec626ae7da9793bf41c7cf4b81e7-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 68051
-    checksum: sha256:195e2dab181f172fb94f20099bcbb1b6d7aee4793465c59a9565297ddd9ec0f5
+    checksum: sha256:b6b385fc1f94ae5c1bf449654a2039063004ec626ae7da9793bf41c7cf4b81e7

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -4899,10 +4899,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/098c69a9ac950c5e5ff5b8dd7701b684ac18eababc16faf47914b1f730333470-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/eda0ce0eca050a9a6a5488fae0acd0e0e73c53d04f88d32ac08c3b7d068aa559-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65847
-    checksum: sha256:098c69a9ac950c5e5ff5b8dd7701b684ac18eababc16faf47914b1f730333470
+    checksum: sha256:eda0ce0eca050a9a6a5488fae0acd0e0e73c53d04f88d32ac08c3b7d068aa559
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -9835,10 +9835,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/56eeb3f5077cb3a5056c0e0d1625d45ba806d6d36b6032c7addb9c7c79d81918-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/94564851694c81427f5764d800b0e6251033bd5743aa689c0bcb57aeda568b2c-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65337
-    checksum: sha256:56eeb3f5077cb3a5056c0e0d1625d45ba806d6d36b6032c7addb9c7c79d81918
+    checksum: sha256:94564851694c81427f5764d800b0e6251033bd5743aa689c0bcb57aeda568b2c
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -14743,10 +14743,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/eef17cf6312d457edb060099c9a7b6062e5facbe47b9d9154786984ca266b2f1-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/e145297305a3b598404a7cf721b1b80f8c1de24210deb401835418aabeb9de2f-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 63806
-    checksum: sha256:eef17cf6312d457edb060099c9a7b6062e5facbe47b9d9154786984ca266b2f1
+    checksum: sha256:e145297305a3b598404a7cf721b1b80f8c1de24210deb401835418aabeb9de2f
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -19686,7 +19686,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/195e2dab181f172fb94f20099bcbb1b6d7aee4793465c59a9565297ddd9ec0f5-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/b6b385fc1f94ae5c1bf449654a2039063004ec626ae7da9793bf41c7cf4b81e7-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 68051
-    checksum: sha256:195e2dab181f172fb94f20099bcbb1b6d7aee4793465c59a9565297ddd9ec0f5
+    checksum: sha256:b6b385fc1f94ae5c1bf449654a2039063004ec626ae7da9793bf41c7cf4b81e7


### PR DESCRIPTION
Automated regeneration of `rpms.lock.yaml` from `rpms.in.yaml` for the **RHDS** variant.

Updated paths:
- `prefetch-input/rhds/rpms.lock.yaml`
- `codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml`
- `codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml`