### PR TITLE
NO-JIRA: scripts: dedupe skopeo tag-selection helper

### DIFF
--- a/scripts/update-commit-latest-env.py
+++ b/scripts/update-commit-latest-env.py
@@ -322,6 +322,8 @@ async def find_latest_tag_by_skopeo_created(
     image: str,
     pattern: re.Pattern,
     semaphore: asyncio.Semaphore,
+    *,
+    log_failure: bool = True,
 ) -> str | None:
     """Return the most recently created tag on *image* matching *pattern*."""
     tags = await skopeo_list_tags(image, semaphore)
@@ -332,7 +334,7 @@ async def find_latest_tag_by_skopeo_created(
 
     log.info("found candidate tags via skopeo", image=image, count=len(matching))
     inspected = await asyncio.gather(
-        *[skopeo_inspect_config(f"{image}:{tag}", semaphore, log_failure=False) for tag in matching]
+        *[skopeo_inspect_config(f"{image}:{tag}", semaphore, log_failure=log_failure) for tag in matching]
     )
 
     best_tag: str | None = None
@@ -362,7 +364,9 @@ async def find_latest_odh_main_tag(image_base: str, semaphore: asyncio.Semaphore
         return tag
 
     log.info("discovering latest ODH main-<sha> tag via skopeo", image=image_base)
-    return await find_latest_tag_by_skopeo_created(image_base, ODH_TAG_PATTERN, semaphore)
+    # The fallback already logged why it is being used; keep per-tag inspect
+    # failures quiet so a dead image does not flood the log.
+    return await find_latest_tag_by_skopeo_created(image_base, ODH_TAG_PATTERN, semaphore, log_failure=False)
 
 
 async def resolve_odh_vcs_ref(
@@ -396,41 +400,10 @@ async def resolve_odh_vcs_ref(
     return vcs_ref_from_odh_main_tag(tag)
 
 
-async def find_latest_rhoai_tag_by_created(
-    image: str,
-    semaphore: asyncio.Semaphore,
-) -> str | None:
+async def find_latest_rhoai_tag_by_created(image: str, semaphore: asyncio.Semaphore) -> str | None:
     """Return the most recently created ``rhoai-X.Y`` tag on *image*."""
-    tags = await skopeo_list_tags(image, semaphore)
-    matching = [tag for tag in tags if RHOAI_TAG_PATTERN.match(tag)]
-    if not matching:
-        log.error(
-            "no rhoai-X.Y tags match pattern",
-            image=image,
-            pattern=RHOAI_TAG_PATTERN.pattern,
-            sample=tags[:10],
-        )
-        return None
-
-    log.info("found RHOAI candidate tags", image=image, count=len(matching))
-    inspected = await asyncio.gather(*[skopeo_inspect_config(f"{image}:{tag}", semaphore) for tag in matching])
-
-    best_tag: str | None = None
-    best_created = ""
-    for tag, (_, cfg) in zip(matching, inspected, strict=True):
-        if cfg is None:
-            continue
-        created = cfg.get("created", "")
-        if created > best_created:
-            best_created = created
-            best_tag = tag
-
-    if best_tag is None:
-        log.error("could not inspect any RHOAI candidate tags", image=image)
-        return None
-
-    log.info("selected latest RHOAI tag", image=image, tag=best_tag, created=best_created)
-    return best_tag
+    # log_failure=True (the default) matches the pre-merge RHOAI behavior.
+    return await find_latest_tag_by_skopeo_created(image, RHOAI_TAG_PATTERN, semaphore, log_failure=True)
 
 
 async def collect_odh_entries(

--- a/tests/unit/scripts/test_update_commit_latest_env.py
+++ b/tests/unit/scripts/test_update_commit_latest_env.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "update-commit-latest-env.py"
+_SPEC = importlib.util.spec_from_file_location("update_commit_latest_env", _MODULE_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+update_env = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(update_env)
+
+
+def test_find_latest_tag_selects_newest_matching_tag_and_forwards_logging(monkeypatch: MonkeyPatch) -> None:
+    tags = ["not-a-main-tag", f"main-{'a' * 40}", f"main-{'b' * 40}"]
+    inspected: list[tuple[str, bool]] = []
+
+    def inspect_config(
+        image_url: str,
+        semaphore: asyncio.Semaphore,
+        *,
+        log_failure: bool,
+    ) -> tuple[str, dict[str, str]]:
+        inspected.append((image_url, log_failure))
+        created = "2026-01-02T00:00:00Z" if image_url.endswith("a" * 40) else "2026-01-03T00:00:00Z"
+        return image_url, {"created": created}
+
+    monkeypatch.setattr(update_env, "skopeo_list_tags", AsyncMock(return_value=tags))
+    monkeypatch.setattr(update_env, "skopeo_inspect_config", AsyncMock(side_effect=inspect_config))
+
+    result = asyncio.run(
+        update_env.find_latest_tag_by_skopeo_created(
+            "quay.io/example/image", update_env.ODH_TAG_PATTERN, asyncio.Semaphore(1), log_failure=False
+        )
+    )
+
+    assert result == f"main-{'b' * 40}"
+    assert inspected == [
+        (f"quay.io/example/image:main-{'a' * 40}", False),
+        (f"quay.io/example/image:main-{'b' * 40}", False),
+    ]
+
+
+def test_find_latest_tag_returns_none_without_matching_tags(monkeypatch: MonkeyPatch) -> None:
+    inspect_config = AsyncMock()
+
+    monkeypatch.setattr(update_env, "skopeo_list_tags", AsyncMock(return_value=["rhoai-3.6", "latest"]))
+    monkeypatch.setattr(update_env, "skopeo_inspect_config", inspect_config)
+
+    result = asyncio.run(
+        update_env.find_latest_tag_by_skopeo_created(
+            "quay.io/example/image", update_env.ODH_TAG_PATTERN, asyncio.Semaphore(1)
+        )
+    )
+
+    assert result is None
+    inspect_config.assert_not_awaited()
+
+
+def test_find_latest_tag_returns_none_when_all_inspects_fail(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        update_env,
+        "skopeo_list_tags",
+        AsyncMock(return_value=[f"main-{'a' * 40}", f"main-{'b' * 40}"]),
+    )
+    monkeypatch.setattr(update_env, "skopeo_inspect_config", AsyncMock(return_value=("unused", None)))
+
+    result = asyncio.run(
+        update_env.find_latest_tag_by_skopeo_created(
+            "quay.io/example/image", update_env.ODH_TAG_PATTERN, asyncio.Semaphore(1)
+        )
+    )
+
+    assert result is None
+
+
+def test_find_latest_rhoai_tag_enables_failure_logging_explicitly(monkeypatch: MonkeyPatch) -> None:
+    semaphore = asyncio.Semaphore(1)
+    helper = AsyncMock(return_value="rhoai-3.6")
+
+    monkeypatch.setattr(update_env, "find_latest_tag_by_skopeo_created", helper)
+
+    result = asyncio.run(update_env.find_latest_rhoai_tag_by_created("quay.io/example/image", semaphore))
+
+    assert result == "rhoai-3.6"
+    helper.assert_awaited_once_with("quay.io/example/image", update_env.RHOAI_TAG_PATTERN, semaphore, log_failure=True)
+
+
+def test_find_latest_odh_main_tag_disables_failure_logging_on_fallback(monkeypatch: MonkeyPatch) -> None:
+    semaphore = asyncio.Semaphore(1)
+    helper = AsyncMock(return_value=f"main-{'a' * 40}")
+
+    monkeypatch.setattr(update_env, "quay_list_matching_tags", AsyncMock(return_value=[]))
+    monkeypatch.setattr(update_env, "find_latest_tag_by_skopeo_created", helper)
+
+    result = asyncio.run(update_env.find_latest_odh_main_tag("quay.io/example/image", semaphore))
+
+    assert result == f"main-{'a' * 40}"
+    helper.assert_awaited_once_with("quay.io/example/image", update_env.ODH_TAG_PATTERN, semaphore, log_failure=False)


### PR DESCRIPTION
Closes #4237

## Changes

- `find_latest_tag_by_skopeo_created` gains a keyword-only `log_failure: bool = True` parameter, threaded into its `skopeo_inspect_config` calls (previously hardcoded to `False`).
- The ODH caller (`find_latest_odh_main_tag` fallback) passes `log_failure=False` explicitly, preserving its quiet-fallback behavior.
- `find_latest_rhoai_tag_by_created` becomes a thin delegate to the shared helper using `RHOAI_TAG_PATTERN` with `log_failure=True`, matching its pre-merge behavior.
- Adds `tests/unit/scripts/test_update_commit_latest_env.py` (ported from #4474, adapted to the keyword-only signature and repo import conventions): newest-`created` tag selection with `log_failure` forwarding, no-match and all-inspects-fail cases, and explicit coverage of both call sites.

Net: −36/+9 lines in `scripts/update-commit-latest-env.py` — one algorithm instead of two copies.

## Verification

- Re-verified against `origin/main` (`48c199bfe`) that both helpers are still present and duplicated exactly as the issue describes (L321 / L399); the only main-side change to the file since this branch's original base is a docstring-only edit (#4449).
- `uv run pytest tests/unit/scripts` → 343 passed (5 new tests).
- `uvx prek run --files scripts/update-commit-latest-env.py tests/unit/scripts/test_update_commit_latest_env.py` → all hooks pass (ruff check, ruff format, pyright).

## CI

Prior run on the pre-rebase commit `d942fd7a9` (same core fix, no tests yet):
https://github.com/opendatahub-io/notebooks/actions/runs/33031810356 — 60 of 61 jobs green; the single failure is the unrelated `codeserver-ubi9-python-3.12 · linux/amd64 / rhoai` image-build job (same cross-arch pattern seen on #4028/#4030). No prior CI exists for the tests added here; this push re-triggers the workflow.

## Relationship to #4474

[#4474](https://github.com/opendatahub-io/notebooks/pull/4474) (Mr-Neutr0n) contained the same core fix plus a 145-line test file. This PR supersedes it: it keeps the same core fix (with a keyword-only parameter and explanatory comments) and ports the test file, adapted to the keyword-only signature, `TYPE_CHECKING` import convention, and with the parametrized `skopeo_inspect_config` exception-handler tests dropped (see below). Suggestion: close #4474 in favor of this PR.

## Deliberately not included

PR #4474's second commit made `skopeo_inspect_config`'s four exception handlers (timeout, JSON parse, unexpected error, missing binary) honor `log_failure`. That is a behavioral change to a third shared function beyond #4237's scope ("merge the two near-identical tag-selection helpers"), so it is excluded here. If desired, it can be tracked as a follow-up issue.

<details><summary>Implementation comparison</summary>

Two implementations existed for this issue:

**A — branch `issue-4237-merge-tag-helpers` (this PR):** 1 commit, −36/+9, matches the issue's suggested fix exactly. Keyword-only `log_failure: bool = True`; ODH fallback passes `log_failure=False` with a comment explaining why it stays quiet; RHOAI helper becomes a 3-line delegate. No tests (added here, ported from B).

**B — PR #4474 (fork, 2 commits):** commit 1 is the same core fix (positional parameter); commit 2 additionally makes `skopeo_inspect_config` exception handlers honor `log_failure` (out of scope); adds the 145-line unit test file (kept, adapted). Fork PR blocked on maintainer approval — no CI signal.

Combination: A's fix + B's tests, minus B's out-of-scope commit 2.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment tag discovery when individual tag inspections fail.
  - Preserved error reporting for RHOAI tag discovery while allowing ODH fallback discovery to continue quietly past inspection errors.
  - Consolidated tag-selection behavior for more consistent results.

- **Tests**
  - Added coverage for selecting the newest matching tag, inspection failures, missing matches, logging behavior, and RHOAI/ODH fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->