### PR TITLE
NO-JIRA: chore(.agents/skills): add konflux-logs and konflux-analyze skills

### DIFF
--- a/.agents/skills/konflux-analyze/SKILL.md
+++ b/.agents/skills/konflux-analyze/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: konflux-analyze
+description: Investigate Konflux pipeline failures on a GitHub PR — fetch the PR check runs, identify failed Konflux checks, extract PipelineRun names and cluster info, query KubeArchive (with Tekton Results fallback) for each failed PipelineRun and TaskRun, categorize failure modes, and report a verdict (infrastructure issue vs PR-related failure). Use when asked to analyze why a PR's Konflux checks failed or to triage multiple failing pipeline runs on a PR; do not use to inspect a single named PipelineRun by URL or name (use the konflux-logs skill).
+---
+
+# Konflux PR Failure Analysis
+
+Investigate Konflux pipeline failures on a GitHub PR. The user provides a PR
+number or URL for the opendatahub-io/notebooks repo (or another repo), e.g.
+`3569` or `https://github.com/opendatahub-io/notebooks/pull/3569`.
+
+## Steps
+
+### 1. Fetch PR check runs
+
+Get all checks for the PR (GitHub MCP `pull_request_read` with method
+`get_check_runs`, or `gh pr checks <number> --repo <repo>`). Identify the
+failed checks — look for checks whose name contains "Konflux" or
+"Red Hat Konflux" with `conclusion: "failure"`.
+
+If there are no Konflux failures, report that and stop.
+
+### 2. Extract PipelineRun names and cluster info
+
+From each failed check's `detailsUrl`, extract:
+
+- **Cluster**: from the URL domain (e.g., `stone-prd-rh01` or `stone-prod-p02`)
+- **Namespace**: from the URL path (e.g., `open-data-hub-tenant` or `rhoai-tenant`)
+- **PipelineRun name**: from the URL path (the last path segment)
+
+Use this mapping for clusters and namespaces:
+
+| Component (upstream / downstream)            | Cluster         | Namespace              |
+| -------------------------------------------- | --------------- | ---------------------- |
+| ODH notebooks (opendatahub-io)               | stone-prd-rh01  | `open-data-hub-tenant` |
+| RHOAI notebooks (red-hat-data-services)      | stone-prod-p02  | `rhoai-tenant`         |
+
+### 3. Verify cluster access
+
+Check that the user has a valid `oc` context for the target cluster:
+
+```bash
+KONFLUX_CTX="$(oc config get-contexts -o name | grep <cluster-name> | head -1)"
+oc whoami --context="$KONFLUX_CTX"
+```
+
+If the token is expired, run `oc login --web` directly (don't just tell the
+user to do it):
+
+```bash
+oc login --web --server=https://api.<cluster-domain>:6443 --context="$KONFLUX_CTX"
+```
+
+### 4. Query KubeArchive for each failed PipelineRun
+
+For each failed PipelineRun, query the KubeArchive API for:
+
+**a) PipelineRun status:**
+
+```bash
+TOKEN="$(oc whoami -t --context="$KONFLUX_CTX")"
+KA_HOST="https://kubearchive-api-server-product-kubearchive.apps.<cluster-domain>"
+
+curl -s --max-time 30 -H "Authorization: Bearer $TOKEN" \
+  "$KA_HOST/apis/tekton.dev/v1/namespaces/$NS/pipelineruns/$PIPELINERUN" | \
+  jq '{name: .metadata.name, status: .status.conditions}'
+```
+
+**b) TaskRun statuses (non-succeeded only):**
+
+```bash
+curl -s --max-time 30 -H "Authorization: Bearer $TOKEN" \
+  "$KA_HOST/apis/tekton.dev/v1/namespaces/$NS/taskruns?labelSelector=tekton.dev/pipelineRun=$PIPELINERUN&limit=50" | \
+  jq '[.items[] | {task: .metadata.labels["tekton.dev/pipelineTask"], status: .status.conditions[0].reason, message: .status.conditions[0].message}] | map(select(.status != "Succeeded"))'
+```
+
+Run queries for independent PipelineRuns in parallel (multiple shell calls
+in one message) to save time.
+
+### 5. Categorize failure modes
+
+For each failed TaskRun, classify the failure:
+
+- **PodCreationFailed** with "resource quota evaluation timed out" →
+  cluster resource quota pressure (infrastructure issue)
+- **PodCreationFailed** with "exceeded quota" → namespace quota limit
+  reached (infrastructure issue)
+- **TaskRunCancelled** with "PipelineRun ... has timed out" → secondary
+  failure from pipeline timeout
+- **Failed** with step error → actual task failure (may be PR-related)
+- **TaskRunImagePullFailed** → image registry issue
+
+### 6. Report findings
+
+Produce a summary with:
+
+- A clear verdict: infrastructure issue vs. PR-related failure
+- A per-pipeline table showing: pipeline name, timeout duration, failed
+  task(s), failure mode
+- Key observations (e.g., "all build-images tasks succeeded", "resource
+  quota pressure on cluster")
+- Recommendation (re-trigger, fix code, etc.)
+
+## KubeArchive host mapping
+
+| Cluster        | KubeArchive Host                                                                                          |
+| -------------- | --------------------------------------------------------------------------------------------------------- |
+| stone-prd-rh01 | `kubearchive-api-server-product-kubearchive.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com`                 |
+| stone-prod-p02 | `kubearchive-api-server-product-kubearchive.apps.stone-prod-p02.hjvn.p1.openshiftapps.com`                 |
+| kflux-prd-rh02 | `kubearchive-api-server-product-kubearchive.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com`                 |
+| kflux-prd-rh03 | `kubearchive-api-server-product-kubearchive.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com`                 |
+
+## Tekton Results fallback
+
+If KubeArchive returns empty results, fall back to Tekton Results:
+
+| Cluster        | Tekton Results Host                                                                    |
+| -------------- | -------------------------------------------------------------------------------------- |
+| stone-prd-rh01 | `tekton-results-tekton-results.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com`           |
+| stone-prod-p02 | `tekton-results-tekton-results.apps.stone-prod-p02.hjvn.p1.openshiftapps.com`           |
+
+```bash
+HOST="tekton-results-tekton-results.apps.<cluster-domain>"
+curl -s --max-time 60 -H "Authorization: Bearer $TOKEN" \
+  "https://${HOST}/apis/results.tekton.dev/v1alpha2/parents/${NS}/results/-/records?filter=data.metadata.name==%22${PIPELINERUN}%22&page_size=5&fields=records.name"
+```

--- a/.agents/skills/konflux-logs/SKILL.md
+++ b/.agents/skills/konflux-logs/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: konflux-logs
+description: Check the status, task breakdown, and build logs of a specific Konflux PipelineRun by Konflux UI URL or PipelineRun name — parse the URL (cluster, namespace, name), verify oc access, query the live cluster or fall back to KubeArchive, drill into TaskRun/step-level details and pod logs, and cross-reference GitHub PR checks. Use when asked to check, debug, or fetch logs for one specific Konflux pipeline run; do not use to find which checks failed on a PR (use the konflux-analyze skill).
+---
+
+# Konflux PipelineRun Logs
+
+Check the status and logs of a specific Konflux PipelineRun. The user
+provides a Konflux UI URL or a bare PipelineRun name.
+
+Examples:
+
+- `https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-release/pipelineruns/odh-workbench-jupyter-universal-cpu-py312-ubi9-on-pull-reqnwj8d`
+- `odh-workbench-jupyter-universal-cpu-py312-ubi9-on-pull-reqnwj8d`
+
+## Steps
+
+### 1. Parse the input
+
+Extract from the URL (or ask the user if only a bare name is given):
+
+- **Cluster domain**: e.g. `stone-prd-rh01.pg1f.p1.openshiftapps.com`
+- **Namespace**: e.g. `open-data-hub-tenant`
+- **PipelineRun name**: the last path segment (strip trailing `/`)
+
+If only a name is provided without a URL, infer based on naming conventions:
+
+- Names containing `on-pull-req` or `on-push` with `odh-` prefix and namespace
+  `open-data-hub-tenant` → cluster `stone-prd-rh01`
+- Names with `-v2-25`, `-v3-3`, `-v3-4`, `-v3-5` suffixes in `rhoai-tenant`
+  → cluster `stone-prod-p02`
+- Ask the user if ambiguous
+
+### 2. Verify cluster access
+
+```bash
+oc whoami --context "$(oc config get-contexts -o name | grep <cluster-short-name> | head -1)" 2>&1
+```
+
+If the token is expired, run `oc login --web` directly (don't just tell the
+user to do it):
+
+```bash
+oc login --web https://api.<cluster-domain>:6443
+```
+
+This opens a browser for SSO. Wait for it to complete (use a 120s timeout).
+
+### 3. Try the live cluster first
+
+```bash
+oc get pipelinerun $PIPELINERUN -n $NAMESPACE -o json
+```
+
+If it returns `NotFound`, the PipelineRun was garbage-collected — fall
+through to step 4.
+
+If found, parse and display:
+
+- Overall status (Succeeded/Failed/Running) and message
+- List of child task references with their names
+- Then jump to step 5
+
+### 4. Fall back to KubeArchive
+
+KubeArchive hosts by cluster:
+
+| Cluster        | KubeArchive Host                                                                                          |
+| -------------- | --------------------------------------------------------------------------------------------------------- |
+| stone-prd-rh01 | `kubearchive-api-server-product-kubearchive.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com`                 |
+| stone-prod-p02 | `kubearchive-api-server-product-kubearchive.apps.stone-prod-p02.hjvn.p1.openshiftapps.com`                 |
+
+```bash
+TOKEN=$(oc whoami -t)
+KA_HOST="https://kubearchive-api-server-product-kubearchive.apps.<cluster-domain>"
+curl -sS --max-time 15 -H "Authorization: Bearer $TOKEN" \
+  "$KA_HOST/apis/tekton.dev/v1/namespaces/$NS/pipelineruns/$PIPELINERUN"
+```
+
+Parse the same fields as step 3. KubeArchive returns the full PipelineRun
+object including status.
+
+### 5. Get task-level details
+
+From the PipelineRun's `.status.childReferences[]`, identify which tasks ran
+and their names. Then for each task (prioritize `prefetch-dependencies` and
+`build-images` as the most common failure points):
+
+**If on the live cluster:**
+
+```bash
+oc get taskrun $TASKRUN_NAME -n $NAMESPACE -o json
+```
+
+**If via KubeArchive:**
+
+```bash
+curl -sS --max-time 15 -H "Authorization: Bearer $TOKEN" \
+  "$KA_HOST/apis/tekton.dev/v1/namespaces/$NS/taskruns/$TASKRUN_NAME"
+```
+
+For each TaskRun, extract:
+
+- `.status.conditions[0]` → Succeeded/Failed/Running and reason
+- `.status.steps[]` → per-step exit codes and status
+- `.status.podName` → needed for log retrieval
+
+Focus on failed tasks first. Run queries for independent tasks in parallel.
+
+### 6. Get build logs from failed steps
+
+Once you know the pod name and which step failed, fetch logs:
+
+**Live cluster:**
+
+```bash
+oc logs $POD_NAME -n $NAMESPACE -c step-build 2>&1 | tail -80
+```
+
+**KubeArchive:**
+
+```bash
+curl -sS --max-time 15 -H "Authorization: Bearer $TOKEN" \
+  "$KA_HOST/api/v1/namespaces/$NS/pods/$POD_NAME/log?container=step-build" | tail -80
+```
+
+Common step container names: `step-build`, `step-prefetch-dependencies`,
+`step-push`.
+
+Show the last ~80 lines which usually contain the error. If the error
+references an earlier issue (e.g., a dependency chain), fetch more lines to
+capture the full context.
+
+### 7. Cross-reference with GitHub
+
+If this is a PR pipeline run (name contains `on-pull-req`), identify the
+associated PR:
+
+- The component name is the prefix before `-on-pull-req...` (e.g.,
+  `odh-workbench-jupyter-universal-cpu-py312-ubi9`)
+- Search recent PRs on the relevant repo for matching Konflux checks
+
+```bash
+gh pr list --repo opendatahub-io/notebooks --state all --limit 10 \
+  --json number,title,headRefName,state
+```
+
+Then get the full checks status for the matching PR:
+
+```bash
+gh pr checks $PR_NUMBER --repo $REPO
+```
+
+This provides broader context: did GHA builds also fail? Are there other
+Konflux components failing?
+
+### 8. Report findings
+
+Produce a summary with:
+
+- **Status**: Succeeded / Failed / Running (with duration if available)
+- **Task breakdown**: which tasks passed/failed/are running
+- **Root cause** (for failures): the actual error from the build logs
+- **Failure classification**:
+  - `calver`/`setuptools`/dependency missing → prefetch lockfile incomplete
+  - `Could not find a version that satisfies` → hermetic build missing a
+    transitive dep
+  - `resource quota` / `PodCreationFailed` → infrastructure issue
+  - `exit status 1` in buildah → Dockerfile build error
+  - Step test failures → post-build test issue
+- **GitHub cross-reference**: if GHA builds passed/failed and why
+- **Recommendation**: what to fix or whether to re-trigger
+
+## Cluster access notes
+
+- Tokens are cluster-specific — a token from prd-rh01 won't work on prod-p02
+- Tokens expire frequently; if you get 401, re-run `oc login --web`
+- For `open-data-hub-tenant` on prd-rh01: this is ODH upstream, the
+  authoritative Konflux for opendatahub-io repos
+- For `rhoai-tenant` on prod-p02: this is RHOAI downstream, authoritative
+  for red-hat-data-services repos
+- `rhoai-tenant` on prd-rh01: legacy duplicate — safe to ignore for merge
+  decisions (but still valid for log inspection)


### PR DESCRIPTION
Closes #4405 (re-scoped).

## Why the scope changed

The issue asked for a `.cursor/commands -> ../.claude/commands` symlink,
premise being that Konflux helpers "already live" as Claude Code slash
commands. Re-verification against `origin/main` showed `.claude/commands/`
**has never been committed** — the `konflux-logs.md` / `konflux-analyze.md`
files only existed as local, untracked, git-excluded files. A symlink PR
would have shipped a dangling link.

Meanwhile, the repo has since standardized on vendor-neutral Agent Skills
(#4404, PR #4533, merged: `.agents/skills/` is the SoT with
`.cursor/skills` / `.claude/skills` symlinks; and the `jira-conventions` /
`test-conventions` rule→skill migration in #4534). Per that convention,
commands become skills instead of per-tool shims — so this PR adds the two
Konflux helpers as Agent Skills under `.agents/skills/`.

## What changed

Two new skills (content ported from the local command files, no duplication
of skill bodies anywhere else):

- `.agents/skills/konflux-logs/SKILL.md` — status/task breakdown/build logs
  for a single Konflux PipelineRun by Konflux UI URL or name (live cluster
  first, KubeArchive fallback, GitHub cross-reference)
- `.agents/skills/konflux-analyze/SKILL.md` — Konflux failure triage across
  a PR's failed checks (KubeArchive + Tekton Results fallback, failure-mode
  categorization, infra-vs-PR verdict)

Deltas from the original command files:

- `$ARGUMENTS` placeholders removed — skills take input contextually
- Frontmatter follows the repo's existing skill convention: `name` matching
  the directory + long trigger-style `description` ("Use when …; do not use
  … (use the other skill)"), **no** `disable-model-invocation`
- Token-expiry handling made consistent (both skills: run
  `oc login --web` directly instead of telling the user)
- Cross-referenced `docs/konflux.md` where relevant stays in the doc, not
  duplicated here

Discovery: `.cursor/skills` and `.claude/skills` are already symlinks to
`.agents/skills/` (from #4404), so Cursor/Claude pick the skills up with no
extra shims. No `.cursor/commands` symlink is added (the premise it was
built for no longer applies).

## Verification

- `markdownlint-cli2` (repo config: MD040 fenced-code-language, MD014
  commands-show-output) on both files: **0 issues**.
- Frontmatter validated: `name` matches the skill directory for both;
  `description` present; `disable-model-invocation` absent.
- `git diff origin/main --stat`: exactly 2 new files, 309 insertions — no
  other paths touched.
- Re-verified the issue's original audit claims against `origin/main`:
  `git ls-tree origin/main .claude/commands` → empty; no commit in any ref
  ever added `konflux-*` command files (the only `konflux-*` files in
  history are build infra: `Dockerfile.konflux.*`, `.tekton/*`, `ci/*`,
  `docs/konflux.md`).

## CI

No prior CI run exists for this new branch. The previous (re-scoped-away)
branch's `workflow_dispatch` run
[33123024348](https://github.com/opendatahub-io/notebooks/actions/runs/33123024348)
on commit `abf73b4bf` failed only in unrelated container image build jobs
(`jupyter-baseline`, `codeserver-baseline` odh/rhoai, `cuda-jupyter-tensorflow`
arm64); all non-image-build jobs passed. This change is two documentation
skill files only (no Dockerfiles, no dependencies).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for diagnosing failed Konflux checks on GitHub pull requests.
  * Added guidance for inspecting Konflux PipelineRuns, including task details, step results, pod logs, and related pull request checks.
  * Added fallback procedures for retrieving PipelineRun information when primary records are unavailable.
  * Added failure classification and reporting guidance to help distinguish infrastructure issues from pull-request-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->