### PR TITLE
RHAIENG-6407: feat(manifests): add notebook-tier metadata to ImageStreams

### DIFF
--- a/manifests/odh/base/code-server-notebook-imagestream.yaml
+++ b/manifests/odh/base/code-server-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
     opendatahub.io/notebook-image-order: "22"
+    opendatahub.io/notebook-tier: "secure"
   name: code-server-notebook
 spec:
   lookupPolicy:

--- a/manifests/odh/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-datascience-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries available in all notebooks"
     opendatahub.io/notebook-image-order: "10"
+    opendatahub.io/notebook-tier: "secure"
   name: jupyter-datascience-notebook
 spec:
   lookupPolicy:

--- a/manifests/odh/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "6"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-minimal-gpu-notebook
 spec:

--- a/manifests/odh/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-minimal-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "4"
+    opendatahub.io/notebook-tier: "secure"
   name: jupyter-minimal-notebook
 spec:
   lookupPolicy:

--- a/manifests/odh/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch LLM Compressor | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch LLM Compressor libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "13"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-llmcompressor
 spec:

--- a/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "12"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-notebook
 spec:

--- a/manifests/odh/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "8"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-minimal
 spec:

--- a/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "15"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-pytorch
 spec:

--- a/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized TensorFlow notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "19"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-tensorflow
 spec:

--- a/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "17"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-tensorflow-notebook
 spec:

--- a/manifests/odh/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
     opendatahub.io/notebook-image-order: "20"
+    opendatahub.io/notebook-tier: "secure"
   name: jupyter-trustyai-notebook
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-datascience-imagestream.yaml
+++ b/manifests/odh/base/runtime-datascience-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-datascience
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-minimal-imagestream.yaml
+++ b/manifests/odh/base/runtime-minimal-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-minimal
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/odh/base/runtime-pytorch-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-pytorch
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/odh/base/runtime-pytorch-llmcompressor-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-pytorch-llmcompressor
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/odh/base/runtime-rocm-pytorch-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-rocm-pytorch
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/odh/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-rocm-tensorflow
 spec:
   lookupPolicy:

--- a/manifests/odh/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/odh/base/runtime-tensorflow-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-tensorflow
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Code Server | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "code-server workbench allows users to code, build, and collaborate on projects directly from web."
     opendatahub.io/notebook-image-order: "22"
+    opendatahub.io/notebook-tier: "secure"
   name: code-server-notebook
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-datascience-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Data Science | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
     opendatahub.io/notebook-image-order: "10"
+    opendatahub.io/notebook-tier: "secure"
   name: s2i-generic-data-science-notebook
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "6"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: minimal-gpu
 spec:

--- a/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-minimal-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "4"
+    opendatahub.io/notebook-tier: "secure"
   name: s2i-minimal-notebook
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-llmcompressor-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch LLM Compressor | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch LLM Compressor libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "13"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-llmcompressor
 spec:

--- a/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "12"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: pytorch
 spec:

--- a/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-minimal-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | Minimal | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "8"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-minimal
 spec:

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | PyTorch | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized PyTorch notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "15"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-pytorch
 spec:

--- a/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | ROCm | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized TensorFlow notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "19"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-tensorflow
 spec:

--- a/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TensorFlow | CUDA | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "17"
+    opendatahub.io/notebook-tier: "secure"
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: tensorflow
 spec:

--- a/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -9,6 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Jupyter | TrustyAI | CPU | Python 3.12"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
     opendatahub.io/notebook-image-order: "19"
+    opendatahub.io/notebook-tier: "secure"
   name: odh-trustyai-notebook
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-datascience-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-datascience-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | Datascience | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Datascience runtime image for Elyra, enabling pipeline execution from Workbenches with a set of advanced AI/ML data science libraries, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-datascience
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-minimal-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-minimal-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | Minimal | CPU | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "Minimal runtime image for Elyra, enabling pipeline execution from Workbenches with minimal dependency set to start experimenting with, for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-minimal
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-pytorch
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-pytorch-llmcompressor-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-pytorch-llmcompressor-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch LLM Compressor | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-pytorch-llmcompressor
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-rocm-pytorch-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | PyTorch | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized PyTorch runtime image for Elyra, enabling pipeline execution from Workbenches with PyTorch libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-rocm-pytorch
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | TensorFlow | ROCm | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "ROCm optimized TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-rocm-tensorflow
 spec:
   lookupPolicy:

--- a/manifests/rhoai/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/rhoai/base/runtime-tensorflow-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/runtime-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/runtimes"
     opendatahub.io/runtime-image-name: "Runtime | TensorFlow | CUDA | Python 3.12 | Latest"
     opendatahub.io/runtime-image-desc: "TensorFlow runtime image for Elyra, enabling pipeline execution from Workbenches with TensorFlow libraries and dependencies, supporting different runtimes for various pipeline nodes."
+    opendatahub.io/notebook-tier: "secure"
   name: runtime-tensorflow
 spec:
   lookupPolicy:


### PR DESCRIPTION
## Summary

Add `opendatahub.io/notebook-tier` annotation to all 36 ImageStream manifests (both ODH and RHOAI), enabling downstream components to identify and propagate tier information.

## Changes

- Added `opendatahub.io/notebook-tier: "secure"` annotation to:
  - 18 ODH ImageStreams (jupyter + runtime)
  - 18 RHOAI ImageStreams (jupyter + runtime)

## Tier Values

| Tier | Description | Package Source |
|------|-------------|----------------|
| `secure` | Red Hat vetted packages | AIPCC/rh_index |
| `community` | Public packages | PyPI |

All current production images use AIPCC, hence marked as `secure`.

## Purpose

This enables:
- Kubeflow Notebook Controllers to consume tier metadata
- Proper labeling and enforcement at runtime
- User visibility of tier information
- Future differentiation for community images

## Testing

- [x] Pre-commit hooks passed
- [x] Verified annotation format matches existing patterns

Resolves: [RHAIENG-6407](https://redhat.atlassian.net/browse/RHAIENG-6407)

Made with [Cursor](https://cursor.com)

[RHAIENG-6407]: https://redhat.atlassian.net/browse/RHAIENG-6407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notebook and runtime images are now classified as **secure-tier** images.
  - This classification is applied consistently across supported CPU, GPU, ROCm, PyTorch, TensorFlow, Data Science, minimal, TrustyAI, and code-server images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->