### PR TITLE
fix(scripts/buildinputs): enumerate tracked Dockerfiles in parse test

### DIFF
--- a/scripts/buildinputs/buildinputs_test.go
+++ b/scripts/buildinputs/buildinputs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -10,26 +11,30 @@ import (
 	"testing"
 )
 
+// globDockerfiles lists the Dockerfiles tracked by git under dir.
+// It uses git ls-files rather than walking the tree so that untracked
+// build artifacts (e.g. an in-tree Go module cache or nested worktrees)
+// do not contribute third-party Dockerfiles to the parse check.
 func globDockerfiles(dir string) ([]string, error) {
+	//nolint:gosec // G204: dir is the repo root derived from this test file's own location (runtime.Caller); command and flags are fixed
+	out, err := exec.Command("git", "-C", dir, "ls-files", "-z").Output()
+	if err != nil {
+		return nil, err
+	}
 	files := make([]string, 0)
-	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if f.IsDir() {
-			return nil
+	for _, path := range strings.Split(string(out), "\x00") {
+		if path == "" {
+			continue
 		}
 		base := filepath.Base(path)
 		if base == "Dockerfile.json" {
-			return nil
+			continue
 		}
 		if base == "Dockerfile" || strings.HasPrefix(base, "Dockerfile.") {
-			files = append(files, path)
+			files = append(files, filepath.Join(dir, path))
 		}
-		return nil
-	})
-
-	return files, err
+	}
+	return files, nil
 }
 
 // TestParseAllDockerfiles checks there are no panics when processing all Dockerfiles we have


### PR DESCRIPTION
**Failure**

TestParseAllDockerfiles (Go, scripts/buildinputs) panicked during the unit test run:

```
panic: dockerfile parse error on line 4: unknown instruction: **/.DS_Store
```

**Root cause**

The test collected Dockerfile / Dockerfile.* files by walking the *entire* project tree rather than the files the repo tracks, so any untracked artifact directory left in the checkout got scanned too:

- an in-tree Go module cache (e.g. GOPATH set to a directory inside the repo by a local test run)
- nested worktrees checked out under the main checkout

Those directories contain third-party Dockerfile* files - for example a vendored Dockerfile.dockerignore (a dockerignore file, not a Dockerfile) whose 4th line is the glob **/.DS_Store - which the BuildKit parser rejects as an unknown instruction, panicking the whole test binary.

The failure is environment-dependent (it depends on what untracked content sits in the checkout); clean CI checkouts are unaffected, which is why it only surfaced in local runs.

**Fix**

Enumerate the Dockerfiles with git ls-files instead of filepath.Walk, so only project-tracked files are parsed. A clean checkout resolves to exactly the same set of project Dockerfiles as before; untracked content can no longer contribute third-party files to the parse check.

**Verification**

- go test -C scripts/buildinputs -cover ./... (the Makefile test-unit Go step): passes, including with an in-tree module cache present in the worktree
- gofmt, go vet, golangci-lint run (gosec/staticcheck/errcheck/govet/ineffassign): clean
- go build: OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dockerfile discovery now reliably identifies tracked Dockerfiles while excluding `Dockerfile.json` and empty paths.
  * Errors encountered while retrieving tracked files are now reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->