### PR TITLE
RHAIENG-3915: ci(.github/workflows): move permissions to job level

### DIFF
--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -13,10 +13,6 @@
 # see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets
 # and https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 
-permissions:
-  contents: read
-  packages: read
-
 concurrency:
   group: ${{ format('build-notebooks-pr-aipcc-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
@@ -116,6 +112,9 @@ jobs:
         shell: bash
 
   build:
+    permissions:
+      contents: read
+      packages: read
     name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["authorize", "gen"]
     strategy:

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -13,10 +13,6 @@
 # see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets
 # and https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 
-permissions:
-  contents: read
-  packages: read
-
 concurrency:
   group: ${{ format('build-notebooks-pr-rhel-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
@@ -114,6 +110,9 @@ jobs:
         shell: bash
 
   build:
+    permissions:
+      contents: read
+      packages: read
     name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["authorize", "gen"]
     strategy:

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -21,10 +21,6 @@
   "schedule":
     - "cron": "0 2 * * *"
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   gen:
     name: Generate job matrix
@@ -62,6 +58,9 @@ jobs:
         shell: bash
 
   build:
+    permissions:
+      contents: read
+      packages: write
     name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["gen"]
     strategy:
@@ -78,6 +77,9 @@ jobs:
     secrets: inherit
 
   build-aipcc:
+    permissions:
+      contents: read
+      packages: write
     name: "${{ matrix.target }} · ${{ matrix.platform }}"
     needs: ["gen"]
     strategy:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,11 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   check-generated-code:
+    permissions:
+      contents: read
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -249,6 +248,8 @@ jobs:
           fail_ci_if_error: false
 
   code-static-analysis:
+    permissions:
+      contents: read
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -311,6 +312,8 @@ jobs:
 
   # https://github.com/pre-commit/action
   prek:
+    permissions:
+      contents: read
     name: "prek"
     runs-on: ubuntu-26.04
     timeout-minutes: 10

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,7 +1,5 @@
 ---
 name: Create release
-permissions:
-  contents: write
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
@@ -40,6 +38,8 @@ env:
 
 jobs:
   release:
+    permissions:
+      contents: write
     name: Create opendatahub-io/notebooks release
     runs-on: ubuntu-26.04
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,11 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   generate-releasenotes:
+    permissions:
+      contents: read
     name: Generate list of images for release notes
     runs-on: ubuntu-26.04
     steps:

--- a/.github/workflows/lock-renewal.yaml
+++ b/.github/workflows/lock-renewal.yaml
@@ -4,6 +4,8 @@
 # Opens one PR with up to four commits (one per step).
 name: Full Lock Files Renewal Action
 
+permissions: {}  # default-deny: unscoped jobs get only metadata:read
+
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 1 * * 3"  # Weekly lockfile update (Wednesday 1am UTC)

--- a/.github/workflows/lock-renewal.yaml
+++ b/.github/workflows/lock-renewal.yaml
@@ -4,8 +4,6 @@
 # Opens one PR with up to four commits (one per step).
 name: Full Lock Files Renewal Action
 
-permissions: {}  # least-privilege: grant per-job below
-
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 1 * * 3"  # Weekly lockfile update (Wednesday 1am UTC)

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -20,11 +20,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   validation-of-params-env:
+    permissions:
+      contents: read
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -3,6 +3,8 @@
 # Scheduled runs moved to lock-renewal.yaml; this workflow remains for manual fallback.
 name: Lock Files Renewal Action (Pip)
 
+permissions: {}  # default-deny: unscoped jobs get only metadata:read
+
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:  # for manual trigger workflow from GH Web UI
     inputs:

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -3,8 +3,6 @@
 # Scheduled runs moved to lock-renewal.yaml; this workflow remains for manual fallback.
 name: Lock Files Renewal Action (Pip)
 
-permissions: {}  # least-privilege: grant per-job below
-
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:  # for manual trigger workflow from GH Web UI
     inputs:

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -5,12 +5,13 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - 'main'
 
-permissions:
-  pull-requests: read
 env:
   QUAY_IMAGE_REPO: ${{ secrets.QUAY_IMAGE_REPO }}
 jobs:
   delete-pr-quay-image:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-26.04
     steps:
       - name: Git checkout

--- a/.github/workflows/purge-ghcr.yaml
+++ b/.github/workflows/purge-ghcr.yaml
@@ -11,11 +11,10 @@ name: "Purge old ghcr.io test images periodically"
   schedule:
     - cron: "0 5 * * *"  # at 05:00 every day
 
-permissions:
-  packages: write
-
 jobs:
   clean:
+    permissions:
+      packages: write
     runs-on: ubuntu-26.04
     name: Delete old test images
     steps:

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -3,6 +3,8 @@
 # validate with make test, and open a PR with the resulting changes.
 name: Release Kickoff Action
 
+permissions: {}  # default-deny: unscoped jobs get only metadata:read
+
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-kickoff.yaml
+++ b/.github/workflows/release-kickoff.yaml
@@ -3,8 +3,6 @@
 # validate with make test, and open a PR with the resulting changes.
 name: Release Kickoff Action
 
-permissions: {}
-
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -20,6 +20,8 @@
 # quay.io / registry.redhat.io resolve (docker datasource + hostRules).
 name: Renovate (self-hosted)
 
+permissions: {}  # default-deny: unscoped jobs get only metadata:read
+
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:

--- a/.github/workflows/renovate-self-hosted.yaml
+++ b/.github/workflows/renovate-self-hosted.yaml
@@ -20,8 +20,6 @@
 # quay.io / registry.redhat.io resolve (docker datasource + hostRules).
 name: Renovate (self-hosted)
 
-permissions: {}  # least-privilege; Renovate uses RENOVATE_TOKEN
-
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:

--- a/.github/workflows/rpms-lock-renewal.yaml
+++ b/.github/workflows/rpms-lock-renewal.yaml
@@ -3,8 +3,6 @@
 # Scheduled runs moved to lock-renewal.yaml; this workflow remains for manual fallback.
 name: RPM Lock Files Renewal Action
 
-permissions: {}  # least-privilege: grant per-job below
-
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:

--- a/.github/workflows/rpms-lock-renewal.yaml
+++ b/.github/workflows/rpms-lock-renewal.yaml
@@ -3,6 +3,8 @@
 # Scheduled runs moved to lock-renewal.yaml; this workflow remains for manual fallback.
 name: RPM Lock Files Renewal Action
 
+permissions: {}  # default-deny: unscoped jobs get only metadata:read
+
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:

--- a/.github/workflows/semgrep-tls.yml
+++ b/.github/workflows/semgrep-tls.yml
@@ -4,11 +4,10 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main, master, dev, odh, incubating, stable, stable-2.x]
 
-permissions:
-  contents: read
-
 jobs:
   semgrep-tls:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: semgrep/semgrep@sha256:525beaba156b9bd3f9847d6ec0eb8f308e11f407e0c0b2da641e7c8dd99c97d6  # 1.168.0

--- a/.github/workflows/stale-prs.yaml
+++ b/.github/workflows/stale-prs.yaml
@@ -4,11 +4,11 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
-permissions:
-  issues: write
-  pull-requests: write
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0

--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -1,10 +1,6 @@
 ---
 name: Test Build Notebooks Template
 
-permissions:
-  contents: read
-  packages: write
-
 "on":
   push:
     branches: [main, stable, 'rhoai-*']
@@ -29,6 +25,9 @@ concurrency:
 
 jobs:
   test-template-minimal:
+    permissions:
+      contents: read
+      packages: write
     name: Test Template with Minimal Notebook
     uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
     with:

--- a/.github/workflows/test-capture-kernel-logs.yaml
+++ b/.github/workflows/test-capture-kernel-logs.yaml
@@ -17,11 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   test-capture:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -18,10 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-  packages: read
-
 env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
@@ -31,6 +27,9 @@ env:
 
 jobs:
   find-images:
+    permissions:
+      contents: read
+      packages: read
     name: Find test images
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-26.04
@@ -96,6 +95,9 @@ jobs:
               f.write(f"matrix={json.dumps(matrix)}\n")
 
   container-tests:
+    permissions:
+      contents: read
+      packages: read
     name: "${{ matrix.name }}"
     needs: find-images
     runs-on: ubuntu-26.04
@@ -178,6 +180,9 @@ jobs:
           log-prefix: ${{ matrix.name }}
 
   openshift-container-tests:
+    permissions:
+      contents: read
+      packages: read
     name: "openshift: ${{ matrix.name }}"
     needs: find-images
     runs-on: ubuntu-26.04

--- a/.github/workflows/test-setup-uv.yaml
+++ b/.github/workflows/test-setup-uv.yaml
@@ -21,11 +21,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   test-setup-uv:
+    permissions:
+      contents: read
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/tls-lint.yml
+++ b/.github/workflows/tls-lint.yml
@@ -4,12 +4,11 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main, master, dev, odh, incubating, stable, stable-2.x]
 
-permissions:
-  contents: read
-  security-events: write
-
 jobs:
   tls-lint:
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -4,8 +4,6 @@
 # Fast static checks also run via make test / pytest-tests.
 name: Validate Renovate config
 
-permissions: {}
-
 on:  # yamllint disable-line rule:truthy
   pull_request:
     paths:

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -4,6 +4,8 @@
 # Fast static checks also run via make test / pytest-tests.
 name: Validate Renovate config
 
+permissions: {}  # default-deny: unscoped jobs get only metadata:read
+
 on:  # yamllint disable-line rule:truthy
   pull_request:
     paths:


### PR DESCRIPTION
## Summary

Implements [RHAIENG-3915](https://redhat.atlassian.net/browse/RHAIENG-3915): move GitHub Actions `permissions` declarations from **workflow-level** to **job-level** so each job only receives the scopes it actually needs (principle of least privilege).

A job with no job-level `permissions` inherits the workflow-level block; for scopes that are moved to the job level, the workflow-level entry is removed so the job no longer inherits a broader default.

## Scope

22 workflows declared a workflow-level `permissions:` block; all are converted to job-level scopes. The other workflows in `.github/workflows/` never declared one (they inherit repo defaults) and are left unchanged — scoping those is a separate least-privilege follow-up.

## Notable per-job scopes

| Workflow / job | Job-level permissions | Why |
|---|---|---|
| `build-notebooks-pr-aipcc` / `build-notebooks-pr-rhel` → `build` | `contents: read`, `packages: read` | TEMPLATE caller; PR builds do **not** push images (`PUSH_IMAGES=no`, no cache write). |
| `build-notebooks-push` → `build` / `build-aipcc` | `contents: read`, `packages: write` | TEMPLATE callers; push/schedule builds publish images. |
| `test-build-notebooks-template` → `test-template-minimal` | `contents: read`, `packages: write` | TEMPLATE caller; publishes on push events. |
| `test-containers` (3 jobs) | `contents: read`, `packages: read` | Pull test images from ghcr.io. |
| `code-quality` → `check-generated-code` / `code-static-analysis` / `prek` | `contents: read` | Checkout + local analysis only (`pytest-tests` / `go-tests` / `action-pin-check` were already job-scoped). |
| `pr-merge-image-delete` → `delete-pr-quay-image` | `contents: read`, `pull-requests: read` | `actions/checkout` requires `contents: read`, which the prior workflow-level block (`pull-requests: read` only) did **not** grant — latent gap fixed here. |
| `purge-ghcr` → `clean` | `packages: write` | Deletes ghcr.io images via GITHUB_TOKEN. |
| `stale-prs` → `stale` | `issues: write`, `pull-requests: write` | Labels/closes issues & PRs. |
| `tls-lint` → `tls-lint` | `contents: read`, `security-events: write` | Checkout + SARIF upload. |
| `create-release` / `docs` / `params-env` / `semgrep-tls` / `test-capture-kernel-logs` / `test-setup-uv` | `contents: read` (release: `write`) | Single-job workflows; scope matches prior workflow-level. |

## Workflow-level `permissions: {}` kept as a default-deny backstop

Six workflows already had a workflow-level `permissions: {}` with **every** job explicitly job-scoped (`lock-renewal`, `piplock-renewal`, `release-kickoff`, `renovate-self-hosted`, `rpms-lock-renewal`, `validate-renovate-config`). Those `permissions: {}` lines are **kept**, not dropped.

Rationale: when a `permissions` key is present at any level, every unspecified scope is forced to `none` (only `metadata: read` is implicit). A workflow-level `permissions: {}` therefore makes any job *without* explicit job-level permissions fail closed to `metadata:read` — instead of falling back to the repository default workflow permissions (broader, e.g. `contents: read`). It's a fail-closed default: a future job added without a permissions block errors loudly if it needs more, rather than silently inheriting broader repo defaults. Current behavior is unchanged (job-level overrides workflow-level).

## Intentionally unchanged

- **`build-notebooks-TEMPLATE.yaml`** — a reusable (callee) workflow whose token permissions are driven by the **calling job's** `permissions`. Its `build` job must not declare a fixed scope: a fixed `packages: read` would break push builds, and `packages: write` would force every PR caller to grant write. The callers now carry the correct, context-appropriate scopes.
- **`build-notebooks-pr.yaml`** / **`insta-merge.yaml`** — already job-scoped (no workflow-level block); nothing to move.

## Verification

- `actionlint .github/workflows/*.yaml .github/workflows/*.yml` — pass
- `yamllint --strict --config-file ./ci/yamllint-config.yaml` (changed files) — pass
- `pinact run --check --verify` — pass (no `uses:` lines changed)

Behavior is preserved: each job's new job-level scope equals what it previously inherited from the workflow level (except the `pr-merge-image-delete` `contents: read` addition required by `actions/checkout`).

## References

- Parent audit: [RHAIENG-3913](https://redhat.atlassian.net/browse/RHAIENG-3913)
- Related: PR #3169 ([RHAIENG-3914](https://redhat.atlassian.net/browse/RHAIENG-3914)) introduced the per-job `authorize` gate


[RHAIENG-3915]: https://redhat.atlassian.net/browse/RHAIENG-3915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-3913]: https://redhat.atlassian.net/browse/RHAIENG-3913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Scoped repository, package, issue, pull request, and security-event permissions to the specific CI jobs that require them.
  * Reduced workflow-wide permission grants, limiting access and write capabilities to relevant tasks.
  * Added default-deny permission settings for workflows with explicitly defined job access.
  * Removed redundant top-level permission declarations where job-level permissions already provide the required access.

* **Maintenance**
  * Existing workflow triggers, jobs, and operational behavior remain unchanged while permission boundaries are tightened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->