### PR TITLE
GHA: Renew lock files

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/fb70b498fbf0e9d5e12f97241a1a9233010445b6b305f8b490b56f7a05904564-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8815
-    checksum: sha256:fb70b498fbf0e9d5e12f97241a1a9233010445b6b305f8b490b56f7a05904564
+    checksum: sha256:2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -9699,10 +9699,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/5504263ebdbf6edcafec236717df5bf66abc15fa8a0f21179de6373e9ed4b397-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 8729
-    checksum: sha256:5504263ebdbf6edcafec236717df5bf66abc15fa8a0f21179de6373e9ed4b397
+    checksum: sha256:01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -14534,10 +14534,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/93a832004e66bbc05f6c809c54b96039bfa7f110729f2860b6b4af3a762f45d5-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8470
-    checksum: sha256:93a832004e66bbc05f6c809c54b96039bfa7f110729f2860b6b4af3a762f45d5
+    checksum: sha256:0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -19418,10 +19418,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/f03641709c4d53633f3ec361229c91b3d0034a183a8f21622f51fb2c05b99f25-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8371
-    checksum: sha256:f03641709c4d53633f3ec361229c91b3d0034a183a8f21622f51fb2c05b99f25
+    checksum: sha256:65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860

--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -795,13 +795,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2879929
-    checksum: sha256:62e7fb8318b2c8d630c67139f09325dbc2bed069ff0b80c0b279396aa85ed1f1
+    size: 2882381
+    checksum: sha256:c99d6e379176e2617942bbb1b429f58377a74930af88ed24e9d85f3d53d75fb0
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -4822,10 +4822,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/0d72f7ae5fc5bfeb3d645f6d2571614ae474bd7f0a5c95914c70bcc6893aef7e-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65896
-    checksum: sha256:0d72f7ae5fc5bfeb3d645f6d2571614ae474bd7f0a5c95914c70bcc6893aef7e
+    checksum: sha256:98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -5633,13 +5633,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2903733
-    checksum: sha256:aabe7d848f91d233740825606a5773e8b5c85fb97a5caae0ac53434afc161788
+    size: 2906129
+    checksum: sha256:dd1c1221252a44f184e44ab4a4bbe82743e4970169cfc3405f44d4a7d0f54232
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -9681,10 +9681,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/f492a36b506693c58be862dd0b0d6c3f1fa5829f91d434cc9b315a63af88f267-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65556
-    checksum: sha256:f492a36b506693c58be862dd0b0d6c3f1fa5829f91d434cc9b315a63af88f267
+    checksum: sha256:998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -10520,13 +10520,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2909877
-    checksum: sha256:e0f15f18c9c6e2c8451b4ef0b722d9a979a4bf5dc419c75273da560e4da8c89f
+    size: 2912377
+    checksum: sha256:0b7f6e5b57c4a4a459fd36b9e930959958bb5a18b2bdac21f46b53b5c2950b47
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -14512,10 +14512,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/6bb9729465e8c8348c399bcfd062bfcfd596e341ec146db0fb1f1b57a895d2c8-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 63883
-    checksum: sha256:6bb9729465e8c8348c399bcfd062bfcfd596e341ec146db0fb1f1b57a895d2c8
+    checksum: sha256:97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -15330,13 +15330,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2919193
-    checksum: sha256:73240f2b54765a2e2cd551a836d927acc78fa4f882a7d3a924e65c8177e7e97a
+    size: 2921665
+    checksum: sha256:a33898add57c43e68cc37c0cfb99d8b96cbc0be46b47e58d69b2e9738b9ad998
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -19378,7 +19378,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/6acf7613ae48392b4da7246244f43ad7d25b4c084dee3b7342534113ca19d000-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 68111
-    checksum: sha256:6acf7613ae48392b4da7246244f43ad7d25b4c084dee3b7342534113ca19d000
+    checksum: sha256:8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/fb70b498fbf0e9d5e12f97241a1a9233010445b6b305f8b490b56f7a05904564-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8815
-    checksum: sha256:fb70b498fbf0e9d5e12f97241a1a9233010445b6b305f8b490b56f7a05904564
+    checksum: sha256:2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -9699,10 +9699,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/5504263ebdbf6edcafec236717df5bf66abc15fa8a0f21179de6373e9ed4b397-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 8729
-    checksum: sha256:5504263ebdbf6edcafec236717df5bf66abc15fa8a0f21179de6373e9ed4b397
+    checksum: sha256:01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -14534,10 +14534,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/93a832004e66bbc05f6c809c54b96039bfa7f110729f2860b6b4af3a762f45d5-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8470
-    checksum: sha256:93a832004e66bbc05f6c809c54b96039bfa7f110729f2860b6b4af3a762f45d5
+    checksum: sha256:0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -19418,10 +19418,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/f03641709c4d53633f3ec361229c91b3d0034a183a8f21622f51fb2c05b99f25-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8371
-    checksum: sha256:f03641709c4d53633f3ec361229c91b3d0034a183a8f21622f51fb2c05b99f25
+    checksum: sha256:65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -851,13 +851,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2879929
-    checksum: sha256:62e7fb8318b2c8d630c67139f09325dbc2bed069ff0b80c0b279396aa85ed1f1
+    size: 2882381
+    checksum: sha256:c99d6e379176e2617942bbb1b429f58377a74930af88ed24e9d85f3d53d75fb0
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -4899,10 +4899,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/0d72f7ae5fc5bfeb3d645f6d2571614ae474bd7f0a5c95914c70bcc6893aef7e-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65896
-    checksum: sha256:0d72f7ae5fc5bfeb3d645f6d2571614ae474bd7f0a5c95914c70bcc6893aef7e
+    checksum: sha256:98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -5766,13 +5766,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2903733
-    checksum: sha256:aabe7d848f91d233740825606a5773e8b5c85fb97a5caae0ac53434afc161788
+    size: 2906129
+    checksum: sha256:dd1c1221252a44f184e44ab4a4bbe82743e4970169cfc3405f44d4a7d0f54232
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -9835,10 +9835,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/f492a36b506693c58be862dd0b0d6c3f1fa5829f91d434cc9b315a63af88f267-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65556
-    checksum: sha256:f492a36b506693c58be862dd0b0d6c3f1fa5829f91d434cc9b315a63af88f267
+    checksum: sha256:998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -10730,13 +10730,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2909877
-    checksum: sha256:e0f15f18c9c6e2c8451b4ef0b722d9a979a4bf5dc419c75273da560e4da8c89f
+    size: 2912377
+    checksum: sha256:0b7f6e5b57c4a4a459fd36b9e930959958bb5a18b2bdac21f46b53b5c2950b47
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -14743,10 +14743,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/6bb9729465e8c8348c399bcfd062bfcfd596e341ec146db0fb1f1b57a895d2c8-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 63883
-    checksum: sha256:6bb9729465e8c8348c399bcfd062bfcfd596e341ec146db0fb1f1b57a895d2c8
+    checksum: sha256:97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -15617,13 +15617,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2919193
-    checksum: sha256:73240f2b54765a2e2cd551a836d927acc78fa4f882a7d3a924e65c8177e7e97a
+    size: 2921665
+    checksum: sha256:a33898add57c43e68cc37c0cfb99d8b96cbc0be46b47e58d69b2e9738b9ad998
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -19686,7 +19686,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/6acf7613ae48392b4da7246244f43ad7d25b4c084dee3b7342534113ca19d000-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 68111
-    checksum: sha256:6acf7613ae48392b4da7246244f43ad7d25b4c084dee3b7342534113ca19d000
+    checksum: sha256:8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c

--- a/jupyter/baseline/ubi9-python-3.12/pylock.toml
+++ b/jupyter/baseline/ubi9-python-3.12/pylock.toml
@@ -388,11 +388,11 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/44/56/30c91c61b8f70d4
 
 [[packages]]
 name = "google-auth"
-version = "2.57.1"
+version = "2.58.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/53/3a/d3982b28d267880b5641f9a32c55d8062a9d2bad2d28d0274285391c89c2/google_auth-2.57.1.tar.gz", upload-time = 2026-09-04T00:50:27Z, size = 372426, hashes = { sha256 = "eb47b230fc6707eed4aee1c9cef55ec05bc1785eecba74ff8b572d531e921b1e" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/3b/27/0f7247b8002a1404fdb5412aeb15fb0fe70288eb8f88a5873d1c0d8262cf/google_auth-2.57.1-py3-none-any.whl", upload-time = 2026-09-04T00:50:21Z, size = 259974, hashes = { sha256 = "ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/ca/f398a483ce5aad18ca2f735646e45ccee2439bd94a41a4ad0cfa646bd495/google_auth-2.58.0.tar.gz", upload-time = 2026-09-09T20:49:38Z, size = 380018, hashes = { sha256 = "55e30cf15e737de92c5323d78cda8a83fcd57e7ffbaf900c4600039fd60a80fd" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/59/13/477d90d09591b3938b45c4e11f4d8a51291682112cb5efcac961e815d562/google_auth-2.58.0-py3-none-any.whl", upload-time = 2026-09-09T20:49:33Z, size = 262404, hashes = { sha256 = "8a9c4645bb4c8e91668fb1934b95ae6a8687084232753639220ba9bf04a1610d" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -815,16 +815,16 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953
 
 [[packages]]
 name = "multidict"
-version = "6.7.1"
+version = "6.8.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", upload-time = 2026-01-26T02:46:45Z, size = 102010, hashes = { sha256 = "ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d" } }
+sdist = { url = "https://files.pythonhosted.org/packages/14/95/989c1b5ca17b72128661530cd6e351a0a83cda9a4d6c036e9ed976c18931/multidict-6.8.0.tar.gz", upload-time = 2026-09-09T13:57:57Z, size = 122412, hashes = { sha256 = "5cd4637ce76312ba1e05eb9c5193fec231f64fee0944e135fa1e951242355b37" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-01-26T02:43:57Z, size = 258883, hashes = { sha256 = "eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75" } },
-    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-01-26T02:44:03Z, size = 256322, hashes = { sha256 = "bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961" } },
-    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-01-26T02:44:04Z, size = 253955, hashes = { sha256 = "3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582" } },
-    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-01-26T02:44:12Z, size = 251377, hashes = { sha256 = "fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba" } },
-    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", upload-time = 2026-01-26T02:46:44Z, size = 12319, hashes = { sha256 = "55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56" } },
+    { url = "https://files.pythonhosted.org/packages/db/47/736080fec911ed9f2dd57ccab5a8145e4f17c4987de0bfc27bee20e4d170/multidict-6.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-09-09T13:53:55Z, size = 283771, hashes = { sha256 = "90c10b22860dbd09982d0b8993b66231a861bea2993d4a817ff35273f6ea285a" } },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/4544cc02e45bbfac4d8788b05379bb360021fd8c53fa74b0f624126ac188/multidict-6.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-09-09T13:54:01Z, size = 287410, hashes = { sha256 = "003a3bddb32915c3f67096ea41d24e53edf710edb65a1f5d0c70ab40b0e4d20b" } },
+    { url = "https://files.pythonhosted.org/packages/25/3e/73fae10e15fc4d711975337caff7e494c87de5d0189afe3518b21b945326/multidict-6.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-09-09T13:54:04Z, size = 277831, hashes = { sha256 = "e9dc7b4ff6ef184504b49ef9a4113d49a646653b2ce89f5f48c1f57cdf6ba081" } },
+    { url = "https://files.pythonhosted.org/packages/08/7e/7b7cd611fd94bf2f6bd16244c50495867ba394d5baaf8e6e487d39494ab3/multidict-6.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-09-09T13:54:15Z, size = 281653, hashes = { sha256 = "ad474c11d851b6fc97cb625e4822bc0cbd567fc07dc2602e28faec5a36b42bbb" } },
+    { url = "https://files.pythonhosted.org/packages/b1/ee/be4e1a4b7a2b27f4fb6936510d4bebcb41b0562c946930ad26916e069cf9/multidict-6.8.0-py3-none-any.whl", upload-time = 2026-09-09T13:57:56Z, size = 16297, hashes = { sha256 = "75daa15ca16d6285eb2e104b2f05ee6f8d9836c68da3ce5c85f615a0450eed0e" } },
 ]
 
 [[packages]]

--- a/jupyter/baseline/ubi9-python-3.12/requirements.cpu.txt
+++ b/jupyter/baseline/ubi9-python-3.12/requirements.cpu.txt
@@ -119,8 +119,8 @@ gitpython==3.1.62 ; (implementation_name == 'cpython' and platform_machine == 'a
     --hash=sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e
 google-api-core==2.36.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:e4d0b179260727ea5c42222426d9199285214dbef7bf48f8b16600c7f9a78944
-google-auth==2.57.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
-    --hash=sha256:ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9
+google-auth==2.58.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:8a9c4645bb4c8e91668fb1934b95ae6a8687084232753639220ba9bf04a1610d
 google-cloud-core==2.7.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:c18a250904cfdda021eb3ae8b8238c9f9ca272a4cbbfb5cba946b3fe3022eed1
 google-cloud-storage==3.14.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -229,12 +229,12 @@ minio==7.2.20 ; (implementation_name == 'cpython' and platform_machine == 'aarch
     --hash=sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e
 mistune==3.3.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a
-multidict==6.7.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
-    --hash=sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75 \
-    --hash=sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961 \
-    --hash=sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582 \
-    --hash=sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba \
-    --hash=sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56
+multidict==6.8.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:90c10b22860dbd09982d0b8993b66231a861bea2993d4a817ff35273f6ea285a \
+    --hash=sha256:003a3bddb32915c3f67096ea41d24e53edf710edb65a1f5d0c70ab40b0e4d20b \
+    --hash=sha256:e9dc7b4ff6ef184504b49ef9a4113d49a646653b2ce89f5f48c1f57cdf6ba081 \
+    --hash=sha256:ad474c11d851b6fc97cb625e4822bc0cbd567fc07dc2602e28faec5a36b42bbb \
+    --hash=sha256:75daa15ca16d6285eb2e104b2f05ee6f8d9836c68da3ce5c85f615a0450eed0e
 mypy-extensions==1.1.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505
 narwhals==2.26.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.rocm.txt
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.rocm.txt
@@ -558,21 +558,19 @@ tomlkit==0.15.1 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:eeff0d1269e4154afe53c09cc7cd494c245be6df79b3f963881b3bad025add53
 toolz==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:31e87f366f6aa621db2f64b19f4da23d3f3fe93eaf5c883b45bae84a5bdf2203
-torch==2.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:6de9eadfa0fd3f530089c05c690072ab6bb09235076b6549e08b308200aec339 \
-    --hash=sha256:72624586bebc7a07bf05f707feeb0afdf026beae10eb015d907b71d266be76d9
-torchvision==0.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:6bac92554be11e46e9d03ad29e84c11ee7e0ace846493545a59d8af20e86770a \
-    --hash=sha256:56d0af27b9dc5569e340cb80e631943a1dd461a47a9befbc946ea78dc58978ec
+torch==2.12.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:eef81648820f8ecdf78c0cfb01d8248010006d46f1b99d17192dd2a316af156d
+torchvision==0.27.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:74290c2114e0205ce2e398ca3296fc8e17aff7472d2a7b02e617fe4318acc877
 tornado==6.5.8 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7640a618891771afceb24880c07b6b543246232a13b74ab3ff051f2739eb4717
 tqdm==4.70.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:25d0006553f41bf79eebd264e90056cd4dfd4fe67f8113396119a924f4ed89bc
 traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d522f22796a09555cfc57c6529951e7f369481ae7ab53f95da559a918032110d
-triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc \
-    --hash=sha256:c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c
+triton==3.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2f8d810e83307d25cb07c6a244ae283bd8b0f4df4a0bacff51eff98755dfde30 \
+    --hash=sha256:2560291eece96bda30d9e30c9c407fd146e7e815ee96a76c15aa3b0699eb06ae
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9301f862d28e9220bbe54557d13cf05fcd86d0914b1dcff530892ae533320d17
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1683,21 +1683,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "torch"
-version = "2.11.0"
+version = "2.12.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torch-2.11.0-6-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 596493473, hashes = { sha256 = "6de9eadfa0fd3f530089c05c690072ab6bb09235076b6549e08b308200aec339" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torch-2.11.0-7-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 596492843, hashes = { sha256 = "72624586bebc7a07bf05f707feeb0afdf026beae10eb015d907b71d266be76d9" } },
-]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torch-2.12.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-09T04:58:58Z, size = 556959261, hashes = { sha256 = "eef81648820f8ecdf78c0cfb01d8248010006d46f1b99d17192dd2a316af156d" } }]
 
 [[packages]]
 name = "torchvision"
-version = "0.26.0"
+version = "0.27.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torchvision-0.26.0-2-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 1456655, hashes = { sha256 = "6bac92554be11e46e9d03ad29e84c11ee7e0ace846493545a59d8af20e86770a" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torchvision-0.26.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 1456677, hashes = { sha256 = "56d0af27b9dc5569e340cb80e631943a1dd461a47a9befbc946ea78dc58978ec" } },
-]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torchvision-0.27.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-09T04:58:58Z, size = 1308238, hashes = { sha256 = "74290c2114e0205ce2e398ca3296fc8e17aff7472d2a7b02e617fe4318acc877" } }]
 
 [[packages]]
 name = "tornado"
@@ -1719,11 +1713,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "triton"
-version = "3.6.0"
+version = "3.7.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 119953429, hashes = { sha256 = "bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 119953509, hashes = { sha256 = "c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.7.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 127498585, hashes = { sha256 = "2f8d810e83307d25cb07c6a244ae283bd8b0f4df4a0bacff51eff98755dfde30" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.7.0-5-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 127498671, hashes = { sha256 = "2560291eece96bda30d9e30c9c407fd146e7e815ee96a76c15aa3b0699eb06ae" } },
 ]
 
 [[packages]]

--- a/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/odh/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -23,13 +23,13 @@ spec:
           [
             {"name": "ROCm", "version": "7.14"},
             {"name": "Python", "version": "v3.12"},
-            {"name": "ROCm-PyTorch", "version": "2.11"}
+            {"name": "ROCm-PyTorch", "version": "2.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab", "version": "4.5"},
-            {"name": "ROCm-PyTorch", "version": "2.11"},
+            {"name": "ROCm-PyTorch", "version": "2.12"},
             {"name": "Tensorboard", "version": "2.20"},
             {"name": "Boto3", "version": "1.43"},
             {"name": "Kafka-Python-ng", "version": "2.2"},

--- a/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/jupyter-rocm-pytorch-notebook-imagestream.yaml
@@ -23,13 +23,13 @@ spec:
           [
             {"name": "ROCm", "version": "7.14"},
             {"name": "Python", "version": "v3.12"},
-            {"name": "ROCm-PyTorch", "version": "2.11"}
+            {"name": "ROCm-PyTorch", "version": "2.12"}
           ]
         # language=json
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "JupyterLab", "version": "4.5"},
-            {"name": "ROCm-PyTorch", "version": "2.11"},
+            {"name": "ROCm-PyTorch", "version": "2.12"},
             {"name": "Tensorboard", "version": "2.20"},
             {"name": "Boto3", "version": "1.43"},
             {"name": "Kafka-Python-ng", "version": "2.2"},

--- a/prefetch-input/odh/rpms.lock.yaml
+++ b/prefetch-input/odh/rpms.lock.yaml
@@ -1880,6 +1880,13 @@ arches:
     name: tzdata-java
     evr: 2026c-1.el9_8
     sourcerpm: tzdata-2026c-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/u/unixODBC-2.3.12-2.el9_8.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 492227
+    checksum: sha256:7ebd83fb02e2cba64cba8a92f6c558aa7b84087aa85e5822d4849dfb481ca4d7
+    name: unixODBC
+    evr: 2.3.12-2.el9_8
+    sourcerpm: unixODBC-2.3.12-2.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/u/upower-0.99.13-2.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 174823
@@ -2923,6 +2930,13 @@ arches:
     name: pybind11-devel
     evr: 1:2.10.4-2.el9
     sourcerpm: pybind11-2.10.4-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/codeready-builder/os/Packages/u/unixODBC-devel-2.3.12-2.el9_8.aarch64.rpm
+    repoid: codeready-builder-for-ubi-9-aarch64-rpms
+    size: 57405
+    checksum: sha256:100f0901f280e7e5c2da3d0d5021d12036115b66fdec1898904305bf5a4d798d
+    name: unixODBC-devel
+    evr: 2.3.12-2.el9_8
+    sourcerpm: unixODBC-2.3.12-2.el9_8.src.rpm
   - url: https://dl.fedoraproject.org/pub/epel/9/Everything/aarch64/Packages/p/pandoc-2.14.0.3-17.el9.aarch64.rpm
     repoid: epel
     size: 27890272
@@ -5345,13 +5359,6 @@ arches:
     name: texlive-zref
     evr: 9:20200406-26.el9
     sourcerpm: texlive-20200406-26.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/unixODBC-2.3.12-2.el9.aarch64.rpm
-    repoid: appstream
-    size: 484527
-    checksum: sha256:38e755db400ee49fea525f18660cc22ba97840c8510739705066775f2bffdfad
-    name: unixODBC
-    evr: 2.3.12-2.el9
-    sourcerpm: unixODBC-2.3.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/wireplumber-0.5.12-1.el9.aarch64.rpm
     repoid: appstream
     size: 123589
@@ -6003,13 +6010,6 @@ arches:
     name: zlib
     evr: 1.2.11-41.el9
     sourcerpm: zlib-1.2.11-41.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/CRB/aarch64/os/Packages/unixODBC-devel-2.3.12-2.el9.aarch64.rpm
-    repoid: crb
-    size: 50178
-    checksum: sha256:7a9ec0c4694c7ec11ebfdd8d735cfbd8c50272adcff25a59b0c0a94946251cc7
-    name: unixODBC-devel
-    evr: 2.3.12-2.el9
-    sourcerpm: unixODBC-2.3.12-2.el9.src.rpm
   source: []
   module_metadata: []
 - arch: ppc64le
@@ -7890,6 +7890,13 @@ arches:
     name: tzdata-java
     evr: 2026c-1.el9_8
     sourcerpm: tzdata-2026c-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/u/unixODBC-2.3.12-2.el9_8.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 515801
+    checksum: sha256:3353963a511ebc89646fb940692524ea08b57f2cdd32c4347875ff874f5d7856
+    name: unixODBC
+    evr: 2.3.12-2.el9_8
+    sourcerpm: unixODBC-2.3.12-2.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/u/upower-0.99.13-2.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 185286
@@ -8933,6 +8940,13 @@ arches:
     name: pybind11-devel
     evr: 1:2.10.4-2.el9
     sourcerpm: pybind11-2.10.4-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/codeready-builder/os/Packages/u/unixODBC-devel-2.3.12-2.el9_8.ppc64le.rpm
+    repoid: codeready-builder-for-ubi-9-ppc64le-rpms
+    size: 57442
+    checksum: sha256:bde6204cbdbf08c77ed02c15b23dae5de1a714c96b11fc01586165e9e5fd6d41
+    name: unixODBC-devel
+    evr: 2.3.12-2.el9_8
+    sourcerpm: unixODBC-2.3.12-2.el9_8.src.rpm
   - url: https://dl.fedoraproject.org/pub/epel/9/Everything/ppc64le/Packages/i/iptables-legacy-1.8.10-11.1.el9.ppc64le.rpm
     repoid: epel
     size: 53770
@@ -11355,13 +11369,6 @@ arches:
     name: texlive-zref
     evr: 9:20200406-26.el9
     sourcerpm: texlive-20200406-26.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/unixODBC-2.3.12-2.el9.ppc64le.rpm
-    repoid: appstream
-    size: 508470
-    checksum: sha256:b5ad5fabd028ede8eededdaf987a739a73d0fdc57f48693d79458a484620a1e8
-    name: unixODBC
-    evr: 2.3.12-2.el9
-    sourcerpm: unixODBC-2.3.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/Packages/wireplumber-0.5.12-1.el9.ppc64le.rpm
     repoid: appstream
     size: 125781
@@ -12013,13 +12020,6 @@ arches:
     name: zlib
     evr: 1.2.11-41.el9
     sourcerpm: zlib-1.2.11-41.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/CRB/ppc64le/os/Packages/unixODBC-devel-2.3.12-2.el9.ppc64le.rpm
-    repoid: crb
-    size: 50205
-    checksum: sha256:de127ef07955e54239862d166e560eca16ffc6cfe1990bcf3f9c845f8528e27b
-    name: unixODBC-devel
-    evr: 2.3.12-2.el9
-    sourcerpm: unixODBC-2.3.12-2.el9.src.rpm
   source: []
   module_metadata: []
 - arch: s390x
@@ -13914,6 +13914,13 @@ arches:
     name: tzdata-java
     evr: 2026c-1.el9_8
     sourcerpm: tzdata-2026c-1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/u/unixODBC-2.3.12-2.el9_8.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 489915
+    checksum: sha256:00f4a3e0e58b7012a2e2322f6567fc1a743a7ec2d56099c7fecf7ee2ebc702e5
+    name: unixODBC
+    evr: 2.3.12-2.el9_8
+    sourcerpm: unixODBC-2.3.12-2.el9_8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/u/upower-0.99.13-2.el9.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 145323
@@ -14936,6 +14943,13 @@ arches:
     name: pybind11-devel
     evr: 1:2.10.4-2.el9
     sourcerpm: pybind11-2.10.4-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/codeready-builder/os/Packages/u/unixODBC-devel-2.3.12-2.el9_8.s390x.rpm
+    repoid: codeready-builder-for-ubi-9-s390x-rpms
+    size: 58680
+    checksum: sha256:355ac00bdcff38556d11d138dfbfd5644c77672d27e4c68ef70ae7f7d28d25b3
+    name: unixODBC-devel
+    evr: 2.3.12-2.el9_8
+    sourcerpm: unixODBC-2.3.12-2.el9_8.src.rpm
   - url: https://dl.fedoraproject.org/pub/epel/9/Everything/s390x/Packages/i/iptables-legacy-1.8.10-11.1.el9.s390x.rpm
     repoid: epel
     size: 49418
@@ -17372,13 +17386,6 @@ arches:
     name: texlive-zref
     evr: 9:20200406-26.el9
     sourcerpm: texlive-20200406-26.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/unixODBC-2.3.12-2.el9.s390x.rpm
-    repoid: appstream
-    size: 482679
-    checksum: sha256:8416e8f52617fc3843e4c2595e9fa554191d220e4bb01fcff6f1781871e2d9a2
-    name: unixODBC
-    evr: 2.3.12-2.el9
-    sourcerpm: unixODBC-2.3.12-2.el9.src.rpm
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/wireplumber-0.5.12-1.el9.s390x.rpm
     repoid: appstream
     size: 122862
@@ -18009,13 +18016,6 @@ arches:
     name: zlib
     evr: 1.2.11-41.el9
     sourcerpm: zlib-1.2.11-41.el9.src.rpm
-  - url: https://mirror.stream.centos.org/9-stream/CRB/s390x/os/Packages/unixODBC-devel-2.3.12-2.el9.s390x.rpm
-    repoid: crb
-    size: 51434
-    checksum: sha256:789bb8e35d6ea608abe9e3ea184caed8abdbf9e32759ba22b04c9f1d632ceea2
-    name: unixODBC-devel
-    evr: 2.3.12-2.el9
-    sourcerpm: unixODBC-2.3.12-2.el9.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64

--- a/prefetch-input/rhds/rpms.lock.yaml
+++ b/prefetch-input/rhds/rpms.lock.yaml
@@ -557,13 +557,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2879929
-    checksum: sha256:62e7fb8318b2c8d630c67139f09325dbc2bed069ff0b80c0b279396aa85ed1f1
+    size: 2882381
+    checksum: sha256:c99d6e379176e2617942bbb1b429f58377a74930af88ed24e9d85f3d53d75fb0
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -6581,13 +6581,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2903733
-    checksum: sha256:aabe7d848f91d233740825606a5773e8b5c85fb97a5caae0ac53434afc161788
+    size: 2906129
+    checksum: sha256:dd1c1221252a44f184e44ab4a4bbe82743e4970169cfc3405f44d4a7d0f54232
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -12647,13 +12647,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2909877
-    checksum: sha256:e0f15f18c9c6e2c8451b4ef0b722d9a979a4bf5dc419c75273da560e4da8c89f
+    size: 2912377
+    checksum: sha256:0b7f6e5b57c4a4a459fd36b9e930959958bb5a18b2bdac21f46b53b5c2950b47
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098
@@ -18650,13 +18650,13 @@ arches:
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.45.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.46.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 2919193
-    checksum: sha256:73240f2b54765a2e2cd551a836d927acc78fa4f882a7d3a924e65c8177e7e97a
+    size: 2921665
+    checksum: sha256:a33898add57c43e68cc37c0cfb99d8b96cbc0be46b47e58d69b2e9738b9ad998
     name: kernel-headers
-    evr: 5.14.0-687.45.1.el9_8
-    sourcerpm: kernel-5.14.0-687.45.1.el9_8.src.rpm
+    evr: 5.14.0-687.46.1.el9_8
+    sourcerpm: kernel-5.14.0-687.46.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-14.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 14098

--- a/runtimes/baseline/ubi9-python-3.12/pylock.toml
+++ b/runtimes/baseline/ubi9-python-3.12/pylock.toml
@@ -313,11 +313,11 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/44/56/30c91c61b8f70d4
 
 [[packages]]
 name = "google-auth"
-version = "2.57.1"
+version = "2.58.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/53/3a/d3982b28d267880b5641f9a32c55d8062a9d2bad2d28d0274285391c89c2/google_auth-2.57.1.tar.gz", upload-time = 2026-09-04T00:50:27Z, size = 372426, hashes = { sha256 = "eb47b230fc6707eed4aee1c9cef55ec05bc1785eecba74ff8b572d531e921b1e" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/3b/27/0f7247b8002a1404fdb5412aeb15fb0fe70288eb8f88a5873d1c0d8262cf/google_auth-2.57.1-py3-none-any.whl", upload-time = 2026-09-04T00:50:21Z, size = 259974, hashes = { sha256 = "ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/ca/f398a483ce5aad18ca2f735646e45ccee2439bd94a41a4ad0cfa646bd495/google_auth-2.58.0.tar.gz", upload-time = 2026-09-09T20:49:38Z, size = 380018, hashes = { sha256 = "55e30cf15e737de92c5323d78cda8a83fcd57e7ffbaf900c4600039fd60a80fd" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/59/13/477d90d09591b3938b45c4e11f4d8a51291682112cb5efcac961e815d562/google_auth-2.58.0-py3-none-any.whl", upload-time = 2026-09-09T20:49:33Z, size = 262404, hashes = { sha256 = "8a9c4645bb4c8e91668fb1934b95ae6a8687084232753639220ba9bf04a1610d" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -656,16 +656,16 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953
 
 [[packages]]
 name = "multidict"
-version = "6.7.1"
+version = "6.8.0"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", upload-time = 2026-01-26T02:46:45Z, size = 102010, hashes = { sha256 = "ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d" } }
+sdist = { url = "https://files.pythonhosted.org/packages/14/95/989c1b5ca17b72128661530cd6e351a0a83cda9a4d6c036e9ed976c18931/multidict-6.8.0.tar.gz", upload-time = 2026-09-09T13:57:57Z, size = 122412, hashes = { sha256 = "5cd4637ce76312ba1e05eb9c5193fec231f64fee0944e135fa1e951242355b37" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-01-26T02:43:57Z, size = 258883, hashes = { sha256 = "eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75" } },
-    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-01-26T02:44:03Z, size = 256322, hashes = { sha256 = "bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961" } },
-    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-01-26T02:44:04Z, size = 253955, hashes = { sha256 = "3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582" } },
-    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-01-26T02:44:12Z, size = 251377, hashes = { sha256 = "fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba" } },
-    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", upload-time = 2026-01-26T02:46:44Z, size = 12319, hashes = { sha256 = "55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56" } },
+    { url = "https://files.pythonhosted.org/packages/db/47/736080fec911ed9f2dd57ccab5a8145e4f17c4987de0bfc27bee20e4d170/multidict-6.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-09-09T13:53:55Z, size = 283771, hashes = { sha256 = "90c10b22860dbd09982d0b8993b66231a861bea2993d4a817ff35273f6ea285a" } },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/4544cc02e45bbfac4d8788b05379bb360021fd8c53fa74b0f624126ac188/multidict-6.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-09-09T13:54:01Z, size = 287410, hashes = { sha256 = "003a3bddb32915c3f67096ea41d24e53edf710edb65a1f5d0c70ab40b0e4d20b" } },
+    { url = "https://files.pythonhosted.org/packages/25/3e/73fae10e15fc4d711975337caff7e494c87de5d0189afe3518b21b945326/multidict-6.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-09-09T13:54:04Z, size = 277831, hashes = { sha256 = "e9dc7b4ff6ef184504b49ef9a4113d49a646653b2ce89f5f48c1f57cdf6ba081" } },
+    { url = "https://files.pythonhosted.org/packages/08/7e/7b7cd611fd94bf2f6bd16244c50495867ba394d5baaf8e6e487d39494ab3/multidict-6.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-09-09T13:54:15Z, size = 281653, hashes = { sha256 = "ad474c11d851b6fc97cb625e4822bc0cbd567fc07dc2602e28faec5a36b42bbb" } },
+    { url = "https://files.pythonhosted.org/packages/b1/ee/be4e1a4b7a2b27f4fb6936510d4bebcb41b0562c946930ad26916e069cf9/multidict-6.8.0-py3-none-any.whl", upload-time = 2026-09-09T13:57:56Z, size = 16297, hashes = { sha256 = "75daa15ca16d6285eb2e104b2f05ee6f8d9836c68da3ce5c85f615a0450eed0e" } },
 ]
 
 [[packages]]

--- a/runtimes/baseline/ubi9-python-3.12/requirements.cpu.txt
+++ b/runtimes/baseline/ubi9-python-3.12/requirements.cpu.txt
@@ -100,8 +100,8 @@ frozenlist==1.8.0 ; (implementation_name == 'cpython' and platform_machine == 'a
     --hash=sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d
 google-api-core==2.36.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:e4d0b179260727ea5c42222426d9199285214dbef7bf48f8b16600c7f9a78944
-google-auth==2.57.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
-    --hash=sha256:ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9
+google-auth==2.58.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:8a9c4645bb4c8e91668fb1934b95ae6a8687084232753639220ba9bf04a1610d
 google-cloud-core==2.7.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:c18a250904cfdda021eb3ae8b8238c9f9ca272a4cbbfb5cba946b3fe3022eed1
 google-cloud-storage==3.14.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
@@ -188,12 +188,12 @@ minio==7.2.20 ; (implementation_name == 'cpython' and platform_machine == 'aarch
     --hash=sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e
 mistune==3.3.4 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a
-multidict==6.7.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
-    --hash=sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75 \
-    --hash=sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961 \
-    --hash=sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582 \
-    --hash=sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba \
-    --hash=sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56
+multidict==6.8.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
+    --hash=sha256:90c10b22860dbd09982d0b8993b66231a861bea2993d4a817ff35273f6ea285a \
+    --hash=sha256:003a3bddb32915c3f67096ea41d24e53edf710edb65a1f5d0c70ab40b0e4d20b \
+    --hash=sha256:e9dc7b4ff6ef184504b49ef9a4113d49a646653b2ce89f5f48c1f57cdf6ba081 \
+    --hash=sha256:ad474c11d851b6fc97cb625e4822bc0cbd567fc07dc2602e28faec5a36b42bbb \
+    --hash=sha256:75daa15ca16d6285eb2e104b2f05ee6f8d9836c68da3ce5c85f615a0450eed0e
 nbclient==0.11.0 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895
 nbconvert==7.17.1 ; (implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux') \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.rocm.txt
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.rocm.txt
@@ -490,21 +490,19 @@ toml==0.10.2 ; python_full_version == '3.12.*' and implementation_name == 'cpyth
     --hash=sha256:445f21924b39ee2b22768d4cbc240c958a2a8e30eb476b6660b805a9ef8fb3d5
 toolz==1.1.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:31e87f366f6aa621db2f64b19f4da23d3f3fe93eaf5c883b45bae84a5bdf2203
-torch==2.11.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:6de9eadfa0fd3f530089c05c690072ab6bb09235076b6549e08b308200aec339 \
-    --hash=sha256:72624586bebc7a07bf05f707feeb0afdf026beae10eb015d907b71d266be76d9
-torchvision==0.26.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:6bac92554be11e46e9d03ad29e84c11ee7e0ace846493545a59d8af20e86770a \
-    --hash=sha256:56d0af27b9dc5569e340cb80e631943a1dd461a47a9befbc946ea78dc58978ec
+torch==2.12.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:eef81648820f8ecdf78c0cfb01d8248010006d46f1b99d17192dd2a316af156d
+torchvision==0.27.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:74290c2114e0205ce2e398ca3296fc8e17aff7472d2a7b02e617fe4318acc877
 tornado==6.5.8 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7640a618891771afceb24880c07b6b543246232a13b74ab3ff051f2739eb4717
 tqdm==4.70.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:25d0006553f41bf79eebd264e90056cd4dfd4fe67f8113396119a924f4ed89bc
 traitlets==5.16.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:d522f22796a09555cfc57c6529951e7f369481ae7ab53f95da559a918032110d
-triton==3.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc \
-    --hash=sha256:c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c
+triton==3.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
+    --hash=sha256:2f8d810e83307d25cb07c6a244ae283bd8b0f4df4a0bacff51eff98755dfde30 \
+    --hash=sha256:2560291eece96bda30d9e30c9c407fd146e7e815ee96a76c15aa3b0699eb06ae
 typeguard==4.6.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:9301f862d28e9220bbe54557d13cf05fcd86d0914b1dcff530892ae533320d17
 typing-extensions==4.16.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1479,21 +1479,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "torch"
-version = "2.11.0"
+version = "2.12.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torch-2.11.0-6-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 596493473, hashes = { sha256 = "6de9eadfa0fd3f530089c05c690072ab6bb09235076b6549e08b308200aec339" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torch-2.11.0-7-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 596492843, hashes = { sha256 = "72624586bebc7a07bf05f707feeb0afdf026beae10eb015d907b71d266be76d9" } },
-]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torch-2.12.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-09T04:58:58Z, size = 556959261, hashes = { sha256 = "eef81648820f8ecdf78c0cfb01d8248010006d46f1b99d17192dd2a316af156d" } }]
 
 [[packages]]
 name = "torchvision"
-version = "0.26.0"
+version = "0.27.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torchvision-0.26.0-2-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 1456655, hashes = { sha256 = "6bac92554be11e46e9d03ad29e84c11ee7e0ace846493545a59d8af20e86770a" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torchvision-0.26.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 1456677, hashes = { sha256 = "56d0af27b9dc5569e340cb80e631943a1dd461a47a9befbc946ea78dc58978ec" } },
-]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/torchvision-0.27.0-1-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-09T04:58:58Z, size = 1308238, hashes = { sha256 = "74290c2114e0205ce2e398ca3296fc8e17aff7472d2a7b02e617fe4318acc877" } }]
 
 [[packages]]
 name = "tornado"
@@ -1515,11 +1509,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "triton"
-version = "3.6.0"
+version = "3.7.0"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.6.0-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 119953429, hashes = { sha256 = "bec93d1406724ccdf70207e198b6dc91091de5ec53b6384a86f0d311d7896ccc" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.6.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 119953509, hashes = { sha256 = "c7333666cc776e6fe0087e8762af79afc53d28de51b078350cf907a2acdae60c" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.7.0-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 127498585, hashes = { sha256 = "2f8d810e83307d25cb07c6a244ae283bd8b0f4df4a0bacff51eff98755dfde30" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA2/rocm7.14-ubi9-test/triton-3.7.0-5-cp312-cp312-linux_x86_64.whl", upload-time = 2026-09-01T13:40:01Z, size = 127498671, hashes = { sha256 = "2560291eece96bda30d9e30c9c407fd146e7e815ee96a76c15aa3b0699eb06ae" } },
 ]
 
 [[packages]]


### PR DESCRIPTION
Automated lock file renewal in a single PR with separate commits:

1. Pylock lock files
2. Manifest annotations and generated Dockerfiles
3. ODH `rpms.lock.yaml` regeneration
4. RHDS `rpms.lock.yaml` regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
  - Updated `google-auth` and `multidict` in Python 3.12 environments.
  - Upgraded ROCm PyTorch components: PyTorch 2.12, TorchVision 0.27, and Triton 3.7.
  - Updated ROCm PyTorch notebook metadata to reflect the 2.12 stack.

- **Platform Updates**
  - Refreshed UBI 9 repository metadata across supported architectures.
  - Updated Linux kernel headers to version 5.14.0-687.46.1.
  - Switched selected UnixODBC packages to UBI-hosted sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->