### PR TITLE
RHAIENG-7444: fix(lock-renewal): cap speculators<0.8 and retry transient index 5xx

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -17,7 +17,10 @@ dependencies = [
     # llmcompressor packages
     # see https://redhat-internal.slack.com/archives/C0961HQ858Q/p1757007056725559?thread_ts=1756924127.136609&cid=C0961HQ858Q
     "odh-notebooks-meta-llmcompressor-deps",
-    "speculators",
+    # speculators 0.8.0 ships a vendored hs-connectors path dependency that
+    # 'uv pip compile' cannot resolve (URL deps must be direct requirements).
+    # Cap below 0.8 until speculators ships a lock-friendly 0.8.x release.
+    "speculators<0.8",
     "lm-eval",
 
     # Datascience and useful extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dev = [
     "pyjson5",
     "ruamel-yaml",
     "structlog",
+    # Lock-file retry resilience: scripts/pylocks_generator.py uses stamina
+    # (a higher-level retry API) over tenacity to retry transient RH-index failures.
+    "tenacity",
+    "stamina",
     #
     "testcontainers",
     "docker",

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -11,7 +11,10 @@ dependencies = [
 
     # llmcompressor packages
     "odh-notebooks-meta-llmcompressor-deps",
-    "speculators",
+    # speculators 0.8.0 ships a vendored hs-connectors path dependency that
+    # 'uv pip compile' cannot resolve (URL deps must be direct requirements).
+    # Cap below 0.8 until speculators ships a lock-friendly 0.8.x release.
+    "speculators<0.8",
     "lm-eval",
 
     # Datascience and useful extensions

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -78,7 +78,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 import tomllib
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -90,6 +89,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import packaging.requirements
 import packaging.utils
+import stamina
 import typer
 
 from scripts.index_url_resolver import IndexResolutionError, ResolvedIndexConfig, resolve_index_config
@@ -115,9 +115,12 @@ UV_MIN_VERSION = (0, 4, 0)
 # index briefly returning 5xx on a wheel metadata fetch). uv retries a few times
 # internally, but a sustained blip defeats that; without this a single flaky index
 # fails the entire lock renewal. Deterministic errors (e.g. resolution failures)
-# are never retried.
+# are never retried. Implemented with stamina (a thin retry API over tenacity),
+# which adds exponential backoff plus jitter to avoid thundering-herd retries.
 LOCK_RETRY_MAX_ATTEMPTS = 4
 LOCK_RETRY_BACKOFF_BASE_SECONDS = 10
+LOCK_RETRY_BACKOFF_MAX_SECONDS = 40
+LOCK_RETRY_BACKOFF_JITTER_SECONDS = 5
 
 NO_EMIT_PACKAGES = (
     "odh-notebooks-meta-db-connectors-deps",
@@ -918,6 +921,18 @@ def _is_transient_lock_error(stderr: str) -> bool:
     return any(marker in low for marker in _TRANSIENT_LOCK_ERROR_MARKERS)
 
 
+class TransientLockError(Exception):
+    """A transient uv pip compile failure (e.g. a 5xx from the index) worth retrying.
+
+    Carries the stderr of the failing attempt so the last failure can be surfaced
+    in the log once stamina exhausts its retry budget.
+    """
+
+    def __init__(self, message: str, stderr: str = "") -> None:
+        super().__init__(message)
+        self.stderr = stderr
+
+
 def run_public_index_lock(
     project_dir: Path,
     index_flags: list[str],
@@ -1094,9 +1109,8 @@ def run_lock(
 
     compile_env = {k: v for k, v in os.environ.items() if k not in ("UV_EXTRA_INDEX_URL", "PIP_EXTRA_INDEX_URL")}
 
-    result: subprocess.CompletedProcess[str] | None = None
-    timed_out = False
-    for attempt in range(1, LOCK_RETRY_MAX_ATTEMPTS + 1):
+    def _compile_once() -> subprocess.CompletedProcess[str]:
+        """Run one uv pip compile; raise TransientLockError on a transient failure."""
         try:
             result = subprocess.run(
                 cmd,
@@ -1107,39 +1121,33 @@ def run_lock(
                 timeout=600,
                 env=compile_env,
             )
-            timed_out = False
-        except subprocess.TimeoutExpired:
-            log.warning(f"Timed out generating {desc} in {project_dir} (attempt {attempt}/{LOCK_RETRY_MAX_ATTEMPTS})")
-            result = None
-            timed_out = True
+        except subprocess.TimeoutExpired as exc:
+            log.warning(f"Timed out generating {desc} in {project_dir}")
+            raise TransientLockError("uv pip compile timed out") from exc
 
-        if result is not None and result.returncode == 0:
-            break
+        # A deterministic failure (resolution error, missing package) is returned
+        # as-is so stamina does not retry it; only transient index errors raise.
+        if result.returncode != 0 and _is_transient_lock_error(result.stderr or ""):
+            log.warning(f"Transient index error generating {desc} in {project_dir}; stamina will retry")
+            raise TransientLockError("transient uv pip compile failure", stderr=result.stderr or "")
+        return result
 
-        # Failed (non-zero exit or timeout). Retry only transient index errors.
-        transient = timed_out or _is_transient_lock_error(result.stderr if result is not None else "")
-        if not transient:
-            break
-        if attempt < LOCK_RETRY_MAX_ATTEMPTS:
-            delay = LOCK_RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
-            log.warning(
-                f"Transient index error generating {desc} in {project_dir} "
-                f"(attempt {attempt}/{LOCK_RETRY_MAX_ATTEMPTS}); retrying in {delay}s."
-            )
-            time.sleep(delay)
+    retried_compile = stamina.retry(
+        on=TransientLockError,
+        attempts=LOCK_RETRY_MAX_ATTEMPTS,
+        timeout=None,
+        wait_initial=LOCK_RETRY_BACKOFF_BASE_SECONDS,
+        wait_max=LOCK_RETRY_BACKOFF_MAX_SECONDS,
+        wait_jitter=LOCK_RETRY_BACKOFF_JITTER_SECONDS,
+        wait_exp_base=2,
+    )(_compile_once)
 
-    if result is None or result.returncode != 0:
-        if result is not None:
-            if result.stdout:
-                log.print(result.stdout)
-            if result.stderr:
-                log.print(result.stderr)
-        if timed_out:
-            log.warning(
-                f"Failed to generate {desc} in {project_dir} (timed out after {LOCK_RETRY_MAX_ATTEMPTS} attempts)"
-            )
-        else:
-            log.warning(f"Failed to generate {desc} in {project_dir}")
+    try:
+        result = retried_compile()
+    except TransientLockError as exc:
+        if exc.stderr:
+            log.print(exc.stderr)
+        log.warning(f"Failed to generate {desc} in {project_dir} (exhausted {LOCK_RETRY_MAX_ATTEMPTS} attempts)")
         (project_dir / output).unlink(missing_ok=True)
         return False
 
@@ -1147,6 +1155,11 @@ def run_lock(
         log.print(result.stdout)
     if result.stderr:
         log.print(result.stderr)
+    if result.returncode != 0:
+        log.warning(f"Failed to generate {desc} in {project_dir}")
+        (project_dir / output).unlink(missing_ok=True)
+        return False
+
     log.ok(f"{desc} generated successfully.")
     return True
 

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -78,6 +78,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import tomllib
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -109,6 +110,14 @@ GLOBAL_LOCK_INPUTS: tuple[Path, ...] = (
     Path("scripts/index_url_resolver.py"),
 )
 UV_MIN_VERSION = (0, 4, 0)
+
+# Bounded retry for transient index failures in `uv pip compile` (e.g. an RH EA
+# index briefly returning 5xx on a wheel metadata fetch). uv retries a few times
+# internally, but a sustained blip defeats that; without this a single flaky index
+# fails the entire lock renewal. Deterministic errors (e.g. resolution failures)
+# are never retried.
+LOCK_RETRY_MAX_ATTEMPTS = 4
+LOCK_RETRY_BACKOFF_BASE_SECONDS = 10
 
 NO_EMIT_PACKAGES = (
     "odh-notebooks-meta-db-connectors-deps",
@@ -874,6 +883,41 @@ def _run_subprocess(
     return result
 
 
+# Substrings of a `uv pip compile` error that indicate a transient
+# network/server failure (index server temporarily unavailable), not a missing
+# package. A 503/502/504, a 429 rate limit, a connection reset, or a timeout all
+# mean "try again", whereas a 404/absent package is a resolution error.
+_TRANSIENT_LOCK_ERROR_MARKERS = (
+    "request failed after",
+    "http status server error",
+    "http status client error (429)",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "connection error",
+    "timed out",
+    "temporary failure in name resolution",
+    "dns error",
+)
+# Substrings that indicate a deterministic failure: retrying is wasted work.
+_DETERMINISTIC_LOCK_ERROR_MARKERS = (
+    "failed to resolve",
+    "resolution error",
+    "no solution found",
+)
+
+
+def _is_transient_lock_error(stderr: str) -> bool:
+    """Return True when a uv pip compile failure looks transient (retryable)."""
+    low = (stderr or "").lower()
+    if any(marker in low for marker in _DETERMINISTIC_LOCK_ERROR_MARKERS):
+        return False
+    return any(marker in low for marker in _TRANSIENT_LOCK_ERROR_MARKERS)
+
+
 def run_public_index_lock(
     project_dir: Path,
     index_flags: list[str],
@@ -1050,18 +1094,52 @@ def run_lock(
 
     compile_env = {k: v for k, v in os.environ.items() if k not in ("UV_EXTRA_INDEX_URL", "PIP_EXTRA_INDEX_URL")}
 
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=project_dir,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=600,
-            env=compile_env,
-        )
-    except subprocess.TimeoutExpired:
-        log.warning(f"Timed out generating {desc} in {project_dir}")
+    result: subprocess.CompletedProcess[str] | None = None
+    timed_out = False
+    for attempt in range(1, LOCK_RETRY_MAX_ATTEMPTS + 1):
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=600,
+                env=compile_env,
+            )
+            timed_out = False
+        except subprocess.TimeoutExpired:
+            log.warning(f"Timed out generating {desc} in {project_dir} (attempt {attempt}/{LOCK_RETRY_MAX_ATTEMPTS})")
+            result = None
+            timed_out = True
+
+        if result is not None and result.returncode == 0:
+            break
+
+        # Failed (non-zero exit or timeout). Retry only transient index errors.
+        transient = timed_out or _is_transient_lock_error(result.stderr if result is not None else "")
+        if not transient:
+            break
+        if attempt < LOCK_RETRY_MAX_ATTEMPTS:
+            delay = LOCK_RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+            log.warning(
+                f"Transient index error generating {desc} in {project_dir} "
+                f"(attempt {attempt}/{LOCK_RETRY_MAX_ATTEMPTS}); retrying in {delay}s."
+            )
+            time.sleep(delay)
+
+    if result is None or result.returncode != 0:
+        if result is not None:
+            if result.stdout:
+                log.print(result.stdout)
+            if result.stderr:
+                log.print(result.stderr)
+        if timed_out:
+            log.warning(
+                f"Failed to generate {desc} in {project_dir} (timed out after {LOCK_RETRY_MAX_ATTEMPTS} attempts)"
+            )
+        else:
+            log.warning(f"Failed to generate {desc} in {project_dir}")
         (project_dir / output).unlink(missing_ok=True)
         return False
 
@@ -1069,12 +1147,6 @@ def run_lock(
         log.print(result.stdout)
     if result.stderr:
         log.print(result.stderr)
-
-    if result.returncode != 0:
-        log.warning(f"Failed to generate {desc} in {project_dir}")
-        (project_dir / output).unlink(missing_ok=True)
-        return False
-
     log.ok(f"{desc} generated successfully.")
     return True
 

--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -893,7 +893,7 @@ def _run_subprocess(
 _TRANSIENT_LOCK_ERROR_MARKERS = (
     "request failed after",
     "http status server error",
-    "http status client error (429)",
+    "http status client error (429",
     "service unavailable",
     "bad gateway",
     "gateway timeout",
@@ -914,11 +914,19 @@ _DETERMINISTIC_LOCK_ERROR_MARKERS = (
 
 
 def _is_transient_lock_error(stderr: str) -> bool:
-    """Return True when a uv pip compile failure looks transient (retryable)."""
+    """Return True when a uv pip compile failure looks transient (retryable).
+
+    Transient markers take precedence over the deterministic ones: uv can emit a
+    resolution failure such as "no solution found" *because* a transient index
+    error like "request failed after N retries" interrupted the resolve, and that
+    combined output is still worth retrying.
+    """
     low = (stderr or "").lower()
+    if any(marker in low for marker in _TRANSIENT_LOCK_ERROR_MARKERS):
+        return True
     if any(marker in low for marker in _DETERMINISTIC_LOCK_ERROR_MARKERS):
         return False
-    return any(marker in low for marker in _TRANSIENT_LOCK_ERROR_MARKERS)
+    return False
 
 
 class TransientLockError(Exception):

--- a/tests/unit/scripts/test_pylocks_generator.py
+++ b/tests/unit/scripts/test_pylocks_generator.py
@@ -380,6 +380,129 @@ def test_run_lock_logs_index_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert any("Lock INDEX_URL: https://example.invalid/simple/?format=json" in line for line in log._lines)
 
 
+class TestIsTransientLockError:
+    """`_is_transient_lock_error()` - transient-vs-deterministic classification."""
+
+    def test_503_server_error_is_transient(self) -> None:
+        stderr = "error: Request failed after 3 retries\nCaused by: HTTP status server error (503 Service Unavailable)"
+        assert pg._is_transient_lock_error(stderr) is True
+
+    def test_429_with_reason_phrase_is_transient(self) -> None:
+        # uv 0.12.0 emits the reason phrase before the closing paren, so the
+        # marker must match the "(429" prefix, not the full "(429)" token.
+        assert pg._is_transient_lock_error("error: HTTP status client error (429 Too Many Requests)") is True
+
+    def test_deterministic_resolution_is_not_transient(self) -> None:
+        assert pg._is_transient_lock_error("error: No solution found when resolving dependencies") is False
+
+    def test_speculators_url_dep_is_not_transient(self) -> None:
+        # The speculators 0.8.0 hs-connectors failure has no transient marker.
+        stderr = "Failed to resolve dependencies for speculators (v0.8.0)\nPackage hs-connectors was included as a URL dependency"
+        assert pg._is_transient_lock_error(stderr) is False
+
+    def test_combined_transient_and_resolution_is_transient(self) -> None:
+        # A transient index error that interrupts resolve emits both a resolution
+        # and a transient marker; the transient one must win so it is retried.
+        stderr = "error: No solution found\nCaused by: Request failed after 3 retries (HTTP status server error 503)"
+        assert pg._is_transient_lock_error(stderr) is True
+
+    def test_empty_is_not_transient(self) -> None:
+        assert pg._is_transient_lock_error("") is False
+
+
+def _run_lock_with_fake_subprocess(
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    outcomes: list[tuple[int, str]],
+) -> tuple[bool, int]:
+    """Run pg.run_lock with a scripted fake subprocess.run.
+
+    Returns (success, attempt_count). `outcomes` is a list of (returncode, stderr)
+    per attempt; the last entry is reused for any further attempts. stamina's
+    backoff sleep is neutralized so the test runs instantly.
+    """
+    project_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        idx = min(calls["n"], len(outcomes) - 1)
+        rc, err = outcomes[idx]
+        calls["n"] += 1
+        return pg.subprocess.CompletedProcess(args=cmd, returncode=rc, stdout="", stderr=err)
+
+    monkeypatch.setattr(pg.subprocess, "run", fake_run)
+    success = pg.run_lock(
+        project_dir,
+        "cpu",
+        ["--default-index=https://example.invalid/simple/?format=json"],
+        pg.IndexMode.rh_index,
+        "3.12",
+        False,
+        False,
+        "2026-05-18T00:00:00Z",
+        pg.LogBuffer(),
+    )
+    return success, calls["n"]
+
+
+def test_run_lock_retries_combined_transient_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A combined (resolution + transient) error is retried for all attempts."""
+    combined = "error: No solution found\nCaused by: Request failed after 3 retries (HTTP status server error 503)"
+    success, calls = _run_lock_with_fake_subprocess(tmp_path / "p", monkeypatch, [(1, combined)] * 8)
+    assert success is False
+    assert calls == pg.LOCK_RETRY_MAX_ATTEMPTS
+
+
+def test_run_lock_succeeds_after_transient_retries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two transient 503s then a success resolves before the budget is exhausted."""
+    success, calls = _run_lock_with_fake_subprocess(
+        tmp_path / "p",
+        monkeypatch,
+        [(1, "HTTP status server error (503 Service Unavailable)"), (1, "HTTP status server error (503)"), (0, "")],
+    )
+    assert success is True
+    assert calls == 3
+
+
+def test_run_lock_does_not_retry_deterministic_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pure resolution error (no transient marker) fails fast on the first attempt."""
+    success, calls = _run_lock_with_fake_subprocess(
+        tmp_path / "p",
+        monkeypatch,
+        [(1, "error: No solution found when resolving dependencies")],
+    )
+    assert success is False
+    assert calls == 1
+
+
+def test_run_lock_times_out_and_exhausts_retries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persistent subprocess timeout is transient: retried until the budget is exhausted."""
+    project_dir = tmp_path / "p"
+    project_dir.mkdir()
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        raise pg.subprocess.TimeoutExpired(cmd=cmd, timeout=600)
+
+    monkeypatch.setattr(pg.subprocess, "run", fake_run)
+    success = pg.run_lock(
+        project_dir,
+        "cpu",
+        ["--default-index=https://example.invalid/simple/?format=json"],
+        pg.IndexMode.rh_index,
+        "3.12",
+        False,
+        False,
+        "2026-05-18T00:00:00Z",
+        pg.LogBuffer(),
+    )
+    assert success is False
+    assert calls["n"] == pg.LOCK_RETRY_MAX_ATTEMPTS
+
+
 def test_generate_requirements_txt_falls_back_to_pylock_header_when_index_resolution_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/uv.lock
+++ b/uv.lock
@@ -1276,7 +1276,9 @@ dev = [
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "ruff" },
+    { name = "stamina" },
     { name = "structlog" },
+    { name = "tenacity" },
     { name = "testcontainers" },
     { name = "typer" },
 ]
@@ -1310,7 +1312,9 @@ dev = [
     { name = "rich", specifier = ">=15.0.0" },
     { name = "ruamel-yaml" },
     { name = "ruff" },
+    { name = "stamina" },
     { name = "structlog" },
+    { name = "tenacity" },
     { name = "testcontainers" },
     { name = "typer" },
 ]


### PR DESCRIPTION
Closes the failure in the **Full Lock Files Renewal** workflow — [run 34446363025](https://github.com/opendatahub-io/notebooks/actions/runs/34446363025).

https://redhat.atlassian.net/browse/RHAIENG-7444

## Problem

The `renew-lock-files` job failed at the **`Commit pylock updates`** step (`make refresh-lock-files`). Two independent causes across **5** image dirs:

### 1. `speculators` 0.8.0 — unresolvable URL dependency (deterministic)
`speculators` was declared **unpinned** in the two `pytorch+llmcompressor` projects. The renewal re-runs `uv pip compile` (a *fresh* resolve — it does **not** read the existing lock), so it picked up the newly released `speculators==0.8.0`, which ships a vendored `hs-connectors` **path** dependency that `uv` cannot resolve:

> ```
> × Failed to resolve dependencies for `speculators` (v0.8.0)
>   ╰─▶ Package `hs-connectors` was included as a URL dependency.
>       URL dependencies must be expressed as direct requirements
>       or constraints.
> ```

Affected: `jupyter/pytorch+llmcompressor` (CUDA), `runtimes/pytorch+llmcompressor` (CUDA). The committed lock was on the working `0.7.0.1`.

### 2. `503 Service Unavailable` from the RH EA index (transient infra)
Three CUDA/ROCM locks failed on transient `503` responses while fetching wheel metadata (e.g. `python_json_logger-4.2.0`, `fonttools-4.64.0`) from the RH EA index. `uv`'s internal 3× retry was insufficient for the sustained blip, so each `uv pip compile` failed and took its whole flavor down with it.

Affected: `jupyter/minimal` (CUDA), `jupyter/pytorch` (CUDA), `jupyter/rocm/pytorch` (ROCM).

## Changes

**Two commits:**
1. `aec100418` — cap `speculators<0.8` and add a transient-index retry to `run_lock`.
2. `cfc827a08` — replace that hand-rolled retry with **stamina** (over tenacity).

- **Cap `speculators<0.8`** in the two `pytorch+llmcompressor` `pyproject.toml` files, until speculators ships a lock-friendly 0.8.x. (Verified: excludes 0.8.0/0.8.1, allows 0.7.0.1/0.7.5 → resolves back to the known-good 0.7.x already in the lock.)
- **Retry transient index failures with stamina/tenacity.** Added `tenacity` + `stamina` to the top-level `dev` dependency group (and `uv.lock`). `run_lock` now wraps a single `uv pip compile` in `stamina.retry(on=TransientLockError, attempts=4, timeout=None, wait_initial=10, wait_max=40, wait_jitter=5, wait_exp_base=2)`. `run_lock` raises `TransientLockError` (carrying stderr) for transient failures (5xx / timeout) that stamina retries with exponential backoff + jitter; deterministic failures (resolution errors) are returned as-is and **never** retried.

## Verification

- `ruff check` / `ruff format --check` — clean
- `python3.14 -m py_compile` — OK
- `uv lock --check` — lock in sync
- `pytest tests/unit/scripts/test_pylocks_generator.py` — **57/57 pass** (incl. `test_run_lock_logs_index_url`)
- `pytest tests/test_main.py` — 23/24 pass; the 1 failure (`test_make_disable_pushing`, a `gmake --just-print` target check) is **pre-existing** (fails on the base commit too — confirmed via `git stash` — unrelated to this change)
- Retry behavior (via stamina): transient→success = 3 calls / 2 backoffs · deterministic → fail-fast = 1 call / 0 backoffs · transient-exhausted = 4 calls / 3 backoffs (10/20/40s + jitter)

## Session trajectory
<details>
<summary>Exact trajectory of this session</summary>

1. **Identify the run.** Fetched the run via the GitHub API → `Full Lock Files Renewal` (`.github/workflows/lock-renewal.yaml`), `workflow_dispatch`, branch `main`, base SHA `380dcdb49`, `run_attempt: 4`, conclusion `failure`.
2. **Locate the failing job/step.** Jobs endpoint → single job `renew-lock-files`; failing step **`Commit pylock updates`** (all later steps `skipped`).
3. **Pull the job log** (`gh api …/jobs/<id>/logs`, 1138 lines; ANSI-stripped) and grep for errors → **two failure classes**:
   - `× Failed to resolve dependencies for speculators (v0.8.0)` (hs-connectors URL dep) — 2 dirs
   - `HTTP status server error (503 Service Unavailable)` on a wheel-metadata fetch — 3 dirs
   The generator summary listed exactly 5 failed dirs and exited 1 (`make: *** [Makefile:445: refresh-lock-files] Error 1`).
4. **Trace `speculators`.** `grep` → `speculators` is unpinned in both `pytorch+llmcompressor` `pyproject.toml` files; the committed `requirements.cuda.txt` had `speculators==0.7.0.1`. The meta-deps package `odh-notebooks-meta-llmcompressor-deps` does not constrain it, so the unpinned dep is what lets the renewal float to the broken 0.8.0.
5. **Read the pipeline.** `lock-renewal.yaml`: the failing step runs `make refresh-lock-files INDEX_MODE=…` under `set -euo pipefail`; the Makefile target runs `uv run scripts/pylocks_generator.py "$INDEX_MODE"`. In `pylocks_generator.py`: `run_lock` ran `uv pip compile` **once** per flavor with no retry; `process_directory` marks a dir failed if **any** flavor fails; `main` exits 1 if **any** dir failed — a 1:1 mapping to the 5 failed dirs.
6. **Create the worktree** from the run's base (`380dcdb49` == `origin/main` tip) as `notebooks-worktrees/fix-lock-renewal-speculators-503` on branch `fix/lock-renewal-speculators-503` (first attempt at a sibling path was blocked by the workspace sandbox; recreated under the workspace).
7. **Apply the fixes (commit `aec100418`).** Pin `speculators<0.8` (with a comment) in both `pyproject.toml`; add a bounded per-flavor retry to `run_lock` that retries only transient index errors and never deterministic resolution failures.
8. **Verify commit 1.** `ruff` clean, `python3.14 -m py_compile` OK, 57/57 generator unit tests, and a throwaway harness confirmed the retry counts + that the speculators/hs-connectors message is classified non-transient. Pushed and opened this PR.
9. **Refactor the retry to stamina (commit `cfc827a08`), on request.** Added `tenacity` + `stamina` to the top-level `dev` group, ran `uv lock` (only `+stamina`/`+tenacity` in `uv.lock`), and inspected the real stamina 26.1.0 API (`retry(on=, attempts=, timeout=, wait_initial=, wait_max=, wait_jitter=, wait_exp_base=)`). Replaced the hand-rolled loop: `run_lock` raises `TransientLockError` (carrying stderr) for transient failures and wraps the single `uv pip compile` in `stamina.retry(on=TransientLockError, attempts=4, timeout=None, wait_initial=10, wait_max=40, wait_jitter=5, wait_exp_base=2)`; deterministic failures are returned as-is (not retried). `timeout=None` because each `uv pip compile` has its own 600s cap (stamina's default 45s total budget would cut off too early).
10. **Verify commit 2.** `ruff check`/`format` clean, `python3.14 -m py_compile` OK, `uv lock --check` in sync, 57/57 generator unit tests, and a stamina sanity harness confirmed transient→success (3 calls / 2 backoffs), deterministic→fail-fast (1 call / 0 backoffs), transient-exhausted (4 calls / 3 backoffs of 10/20/40s + jitter). `pytest tests/test_main.py` 23/24 — the single failure (`test_make_disable_pushing`) confirmed **pre-existing** via `git stash` on the clean tree.
</details>

---
_Note for reviewers: the transient `503` failures ride out typical EA-index blips thanks to the stamina retry; a **prolonged** index outage would still fail and is an infra escalation to the RH index maintainers rather than a code fix._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when generating dependency lock files by retrying temporary registry failures with bounded backoff.
  - Preserved immediate failure behavior for non-recoverable dependency errors.
  - Improved error reporting after repeated failures and removed incomplete lock files.

- **Compatibility**
  - Restricted the affected `speculators` package to versions below 0.8 to avoid incompatible dependency resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->