### PR TITLE
GHA: Renew lock files

### DIFF
--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/b966aa1638dbbb5ca74c37f368b6cec0a3db4075bc672cb1758ab92aed1ca575-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8815
-    checksum: sha256:2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496
+    checksum: sha256:b966aa1638dbbb5ca74c37f368b6cec0a3db4075bc672cb1758ab92aed1ca575
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -9699,10 +9699,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/23e4c0e2a672611f3c8195c118365e30d52ce55d075b11dd30bea224335d74f1-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 8729
-    checksum: sha256:01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23
+    checksum: sha256:23e4c0e2a672611f3c8195c118365e30d52ce55d075b11dd30bea224335d74f1
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -14534,10 +14534,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/39c455a2c18e80dca6ab495093d84b2020e3665f6e1a1a97278c4bccc9c5c5d3-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8470
-    checksum: sha256:0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0
+    checksum: sha256:39c455a2c18e80dca6ab495093d84b2020e3665f6e1a1a97278c4bccc9c5c5d3
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -19418,10 +19418,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/1a1de5428df1ee84974753430c6c5004d3cf95d72bfde8bd4acdca5ae59439db-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8371
-    checksum: sha256:65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632
+    checksum: sha256:1a1de5428df1ee84974753430c6c5004d3cf95d72bfde8bd4acdca5ae59439db
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860

--- a/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver-baseline/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -18,13 +18,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.aarch64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54160127
-    checksum: sha256:51e8a599b800c1f8d1758030557aa28cf65e335d00b555e50b2f048ad0393444
+    size: 54115507
+    checksum: sha256:814ad26801c6c0bdafc0d65c64c0741391cfb44cc563f4ae0161d3cd7b606217
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/annobin-12.98-2.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1120755
@@ -732,13 +732,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4529173
-    checksum: sha256:c5347668e520e0194b6702d60a1d2cafac4ad6aaf8bae14dc6130ab56d25e572
+    size: 4530293
+    checksum: sha256:46fcb6f34490f575b318518eff43154b93f47278dd85b824a045f5997a92e1c8
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 571094
@@ -3476,20 +3476,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1177900
-    checksum: sha256:ee2de9f5fbc5e83bad920a353c45d3446997aa0e4023436528b2d6f817bd6f50
+    size: 1175876
+    checksum: sha256:22827aedd764c1ab706086965859e7f8fef0d719ac0b3d8735f6b8e53b0a13e9
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2114764
-    checksum: sha256:cd79ca65bba152b9ccadcb9780ec78e3d06ce538b693078fd14459d038ab5c0c
+    size: 2115646
+    checksum: sha256:b449955249a6d2da7369522a5ac2759919d36633e129ba88924057814906d5f5
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/cpio-2.13-16.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 284454
@@ -4687,13 +4687,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 94569
@@ -4822,10 +4822,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/4b4dabe1115020567587d6d9b90e705bce17d0a597aabe97e8de877ebe30886d-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65896
-    checksum: sha256:98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc
+    checksum: sha256:4b4dabe1115020567587d6d9b90e705bce17d0a597aabe97e8de877ebe30886d
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -4842,13 +4842,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.ppc64le.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 51128429
-    checksum: sha256:ac85191b03d4889030e6e26e7d51b0fefc8a0b243bcc86a5e7fa6ca0ed7e7e84
+    size: 51106987
+    checksum: sha256:f16a825fc74afbda18ab5988674e865ff100a6fbf446dd2969368ea0131dfe2b
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/annobin-12.98-2.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1126819
@@ -5570,13 +5570,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4569759
-    checksum: sha256:a736acf30d416a2c25da06b9a23dc4310ae524f2406ac35cccd2e22c80acfdce
+    size: 4578701
+    checksum: sha256:14eb3e2046580a216550728d58c75ee4e984c21dddbd66125a233504748837fb
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 574899
@@ -8321,20 +8321,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-8.32-41.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1259870
-    checksum: sha256:d9fc3be701da7abe502bc5f9d07f93e13088de2e78cf0de8bcf5fb8c0fc7e737
+    size: 1262204
+    checksum: sha256:195fa8b9b1eee88c69323de32c1fadc6dd9af2dfe7df10a2a04ee796b5248767
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.ppc64le.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2115089
-    checksum: sha256:a242aae86238374731d5d52f23962a6af31b5ed51ce5cffaeee62e05046ed2ce
+    size: 2113363
+    checksum: sha256:a9006eb589f6f6dfd468ae1f2c8d3ea9874b86238f462b21f75a12a5c298f7b1
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/cpio-2.13-16.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 292586
@@ -9546,13 +9546,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 120233
@@ -9681,10 +9681,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/b96d0c2d56b6a3702716c4ee2af0037b1a1778166d8e16925190b1185febd262-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65556
-    checksum: sha256:998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87
+    checksum: sha256:b96d0c2d56b6a3702716c4ee2af0037b1a1778166d8e16925190b1185febd262
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -9701,13 +9701,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.s390x.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 53235751
-    checksum: sha256:4db0881f22ab8b470ed49749e9ec27b7272bf6b993e12cf5106082efac395194
+    size: 53015009
+    checksum: sha256:a5995487cebd8c6b453f68bcd38f33f09a6124b51d6c1a97f2ca82c8c494f875
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/annobin-12.98-2.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1120442
@@ -10436,13 +10436,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4759397
-    checksum: sha256:3ded7b647cc34b8723a763597e4658d1a641bc4ee116838a10ba55d42c9f0b26
+    size: 4764172
+    checksum: sha256:c83b117153a1a130c218f82d378e7f02c412927ba37a681974d66048d15576d7
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 570340
@@ -13208,20 +13208,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-8.32-41.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1206429
-    checksum: sha256:ca42d8e48fa5056805089051e473d693c1eeb2b05b0f47ecc00f6a3a4c10496f
+    size: 1206694
+    checksum: sha256:a86313c10c9310922710ae321145017bc1046a600ad35c528691164fcaba512b
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.s390x.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2112471
-    checksum: sha256:3eb7d326a40de65cee2458c471b6b8f8a16218452a6d2194c6b6f2eb1c344bb9
+    size: 2117124
+    checksum: sha256:b0f8b8a7b42cb74b9397afb79c98f6614bd2da8331e51081a3d9b7d60623b5d5
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/cpio-2.13-16.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 284105
@@ -14377,13 +14377,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 96039
@@ -14512,10 +14512,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/4a3f6e412c19d338ed8faf3a45113a857a928a277ab8f9455fc5fef7b1b1e939-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 63883
-    checksum: sha256:97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095
+    checksum: sha256:4a3f6e412c19d338ed8faf3a45113a857a928a277ab8f9455fc5fef7b1b1e939
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -14532,13 +14532,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.x86_64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54962756
-    checksum: sha256:f54ee03ff8005b69bc15955e5ceb8b648cedd122fa39b391c33c44adde1bf291
+    size: 54905233
+    checksum: sha256:69a11c0159a951add980be403e13f587f523bf82ced7e1279238ccbbd575a323
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/annobin-12.98-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1121890
@@ -15260,13 +15260,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 5023104
-    checksum: sha256:b2b3eac45360ea20a81a4a72b2bc19790846fc182e8684a0ae034642fab7677c
+    size: 5019312
+    checksum: sha256:35df42ac8b1c7231a0a54f67188c652cc270739f7387b61cfa286b73cd6b6d30
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 571607
@@ -18011,20 +18011,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1220715
-    checksum: sha256:e53f0f831246c73ab03ae395054d261ae392faa1229e6c691c08d2321a824b75
+    size: 1222083
+    checksum: sha256:374257c4cd69107333a7f524dd99579f3ea3ab842b66168eade0a3475fb6eea1
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2116611
-    checksum: sha256:1d4010cdc4f0fb7a4be68bf1bf0f0cda84a11d7337bd15d8368ab0ff90ca0db4
+    size: 2113503
+    checksum: sha256:41f69eb8b2087feaa98d0228fb933b6fe8af20a4bf371cfef51e11cbd1f84b4e
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/cpio-2.13-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 286157
@@ -19243,13 +19243,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 96649
@@ -19378,7 +19378,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/dcf933ff03a4b07bda6aff3a8fd0f62a05100e1b41b3282018b38c7636d9bcc4-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 68111
-    checksum: sha256:8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c
+    checksum: sha256:dcf933ff03a4b07bda6aff3a8fd0f62a05100e1b41b3282018b38c7636d9bcc4

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -4836,10 +4836,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/repodata/b966aa1638dbbb5ca74c37f368b6cec0a3db4075bc672cb1758ab92aed1ca575-modules.yaml.gz
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8815
-    checksum: sha256:2ccbc017036d595ab599d91e2be10e1bbd011990190a06d913148485c77f6496
+    checksum: sha256:b966aa1638dbbb5ca74c37f368b6cec0a3db4075bc672cb1758ab92aed1ca575
   - url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/repodata/34ca4edf97306440fe749058f09d43512fcdf8ea384ab2de21bc22b4294769c2-modules.yaml.xz
     repoid: appstream
     size: 16912
@@ -9699,10 +9699,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/repodata/23e4c0e2a672611f3c8195c118365e30d52ce55d075b11dd30bea224335d74f1-modules.yaml.gz
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 8729
-    checksum: sha256:01cdf4b2df0be76a33caed874e47fbfd8a9945d0831e16b6c1d15fe13bbffb23
+    checksum: sha256:23e4c0e2a672611f3c8195c118365e30d52ce55d075b11dd30bea224335d74f1
   - url: https://mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/repodata/fc97d63cf2c2d2586d77558eef50f286a2dcc95232147423e1745312f811cb01-modules.yaml.xz
     repoid: appstream
     size: 16916
@@ -14534,10 +14534,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/repodata/39c455a2c18e80dca6ab495093d84b2020e3665f6e1a1a97278c4bccc9c5c5d3-modules.yaml.gz
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8470
-    checksum: sha256:0950129de3d88bf746a55adf1e60ff0b68eed79efc9c6b75cc779feaa5dc25c0
+    checksum: sha256:39c455a2c18e80dca6ab495093d84b2020e3665f6e1a1a97278c4bccc9c5c5d3
   - url: https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/repodata/d7fbdcf63e9f0588a177a227913b142e0a6694f61ff343b66291f3ef7cecc140-modules.yaml.xz
     repoid: appstream
     size: 16824
@@ -19418,10 +19418,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/1a1de5428df1ee84974753430c6c5004d3cf95d72bfde8bd4acdca5ae59439db-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8371
-    checksum: sha256:65c888eb22647d434baab31c63e19a83ada1d9d56f2e96011d37cbe439011632
+    checksum: sha256:1a1de5428df1ee84974753430c6c5004d3cf95d72bfde8bd4acdca5ae59439db
   - url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/0e1bbac09e7f76898c5a9c9dfa23589933a8fbcf9e4700b31046b704624b2697-modules.yaml.xz
     repoid: appstream
     size: 16860

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -18,13 +18,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.aarch64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54160127
-    checksum: sha256:51e8a599b800c1f8d1758030557aa28cf65e335d00b555e50b2f048ad0393444
+    size: 54115507
+    checksum: sha256:814ad26801c6c0bdafc0d65c64c0741391cfb44cc563f4ae0161d3cd7b606217
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/annobin-12.98-2.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1120755
@@ -39,27 +39,27 @@ arches:
     name: apr
     evr: 1.7.0-12.el9_3
     sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/apr-util-1.6.1-23.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/apr-util-1.6.1-23.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 100645
-    checksum: sha256:7a4c6d9667176da5d9f7d471be8e98a7ba4f1235357ebf5c43ede7d6bcd3ad51
+    size: 104447
+    checksum: sha256:b4c94d506b7b13a740c2d3a43e6327b6f7f51f5e11e45c547a3af87e519999e3
     name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.aarch64.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 14452
-    checksum: sha256:099574e9b736916e44070e851691172b380b00bf82ec8023c7f1624a9fb76347
+    size: 18671
+    checksum: sha256:5f156c039be2fd167b11b5df639b62b9831590d775a134a1a3fc8de87bec781d
     name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.aarch64.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 16614
-    checksum: sha256:ffffa1f27c75146b511e0e9f17991641e9b71abe3114e1ddc423bec452e18b10
+    size: 20817
+    checksum: sha256:ef8c953e60430b1cf73a5bd43726f3ec09f7a7fc5dac767c7938e47de19f75bf
     name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 697155
@@ -760,13 +760,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4529173
-    checksum: sha256:c5347668e520e0194b6702d60a1d2cafac4ad6aaf8bae14dc6130ab56d25e572
+    size: 4530293
+    checksum: sha256:46fcb6f34490f575b318518eff43154b93f47278dd85b824a045f5997a92e1c8
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 571094
@@ -3546,20 +3546,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1177900
-    checksum: sha256:ee2de9f5fbc5e83bad920a353c45d3446997aa0e4023436528b2d6f817bd6f50
+    size: 1175876
+    checksum: sha256:22827aedd764c1ab706086965859e7f8fef0d719ac0b3d8735f6b8e53b0a13e9
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2114764
-    checksum: sha256:cd79ca65bba152b9ccadcb9780ec78e3d06ce538b693078fd14459d038ab5c0c
+    size: 2115646
+    checksum: sha256:b449955249a6d2da7369522a5ac2759919d36633e129ba88924057814906d5f5
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/cpio-2.13-16.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 284454
@@ -4764,13 +4764,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 94569
@@ -4899,10 +4899,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/repodata/4b4dabe1115020567587d6d9b90e705bce17d0a597aabe97e8de877ebe30886d-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65896
-    checksum: sha256:98df51e859bed4a8989f407c0a009e86b98081cad7f54797bde51b9f956a26dc
+    checksum: sha256:4b4dabe1115020567587d6d9b90e705bce17d0a597aabe97e8de877ebe30886d
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.ppc64le.rpm
@@ -4919,13 +4919,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.ppc64le.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 51128429
-    checksum: sha256:ac85191b03d4889030e6e26e7d51b0fefc8a0b243bcc86a5e7fa6ca0ed7e7e84
+    size: 51106987
+    checksum: sha256:f16a825fc74afbda18ab5988674e865ff100a6fbf446dd2969368ea0131dfe2b
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/annobin-12.98-2.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1126819
@@ -4940,27 +4940,27 @@ arches:
     name: apr
     evr: 1.7.0-12.el9_3
     sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/apr-util-1.6.1-23.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/apr-util-1.6.1-23.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 111855
-    checksum: sha256:5cb74aa5533426565635ba94dd07923b799f179e77b8fd0612dd61c32ae8509b
+    size: 115557
+    checksum: sha256:8bdce71bdb8b163c942236aff3467d542276feafd46a4cb79b0d708b4aa11188
     name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.ppc64le.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 14844
-    checksum: sha256:da540d1d08706e41d7bbb6cca14d781b993d3dfb98d4c2056e8ff8babc404fa4
+    size: 18990
+    checksum: sha256:e1d5118a5e7cbf5c821b346a1e295e11c0c32ff3c4a011e0ea9aba5a9ed2a914
     name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.ppc64le.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 17128
-    checksum: sha256:b475b23df9afee4b66de967750473754890a83b919ef1b9a88270c0e10d1c9a3
+    size: 21275
+    checksum: sha256:adf51f28bef2a5b4a20cb4fe4c5cf5b17bbbaca224329c0f12fa9952f15b13dc
     name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 697155
@@ -5675,13 +5675,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4569759
-    checksum: sha256:a736acf30d416a2c25da06b9a23dc4310ae524f2406ac35cccd2e22c80acfdce
+    size: 4578701
+    checksum: sha256:14eb3e2046580a216550728d58c75ee4e984c21dddbd66125a233504748837fb
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 574899
@@ -8468,20 +8468,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-8.32-41.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1259870
-    checksum: sha256:d9fc3be701da7abe502bc5f9d07f93e13088de2e78cf0de8bcf5fb8c0fc7e737
+    size: 1262204
+    checksum: sha256:195fa8b9b1eee88c69323de32c1fadc6dd9af2dfe7df10a2a04ee796b5248767
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.ppc64le.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2115089
-    checksum: sha256:a242aae86238374731d5d52f23962a6af31b5ed51ce5cffaeee62e05046ed2ce
+    size: 2113363
+    checksum: sha256:a9006eb589f6f6dfd468ae1f2c8d3ea9874b86238f462b21f75a12a5c298f7b1
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/cpio-2.13-16.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 292586
@@ -9700,13 +9700,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 120233
@@ -9835,10 +9835,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/repodata/b96d0c2d56b6a3702716c4ee2af0037b1a1778166d8e16925190b1185febd262-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 65556
-    checksum: sha256:998c9526bd3b8b9f664e158dd49f1534d138605ec22ea44d857474dadd2d3c87
+    checksum: sha256:b96d0c2d56b6a3702716c4ee2af0037b1a1778166d8e16925190b1185febd262
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.s390x.rpm
@@ -9855,13 +9855,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.s390x.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 53235751
-    checksum: sha256:4db0881f22ab8b470ed49749e9ec27b7272bf6b993e12cf5106082efac395194
+    size: 53015009
+    checksum: sha256:a5995487cebd8c6b453f68bcd38f33f09a6124b51d6c1a97f2ca82c8c494f875
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/annobin-12.98-2.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1120442
@@ -9876,27 +9876,27 @@ arches:
     name: apr
     evr: 1.7.0-12.el9_3
     sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/apr-util-1.6.1-23.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/apr-util-1.6.1-23.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 100444
-    checksum: sha256:5f2db1555556b4054c575b93ed50ede89bb677128bd38059f8cafcf914561615
+    size: 104223
+    checksum: sha256:ef30ed34a60dd2eca071f0adcd96cb7ba862d5de7900d1b3b72e1b957abfdf84
     name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.s390x.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 14220
-    checksum: sha256:49cf4df0a36f62fc0cb5b212a9a73f31686ae313467be09e46c18faabfd51d82
+    size: 18382
+    checksum: sha256:880fc5a8b1c9394ebfe051a903049052090931ff065108bc6d8ceda403ddd022
     name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.s390x.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 16802
-    checksum: sha256:87813c421e55511fedd494c6e33fbc32463f0482a95dd48a32a799d360769cc6
+    size: 20985
+    checksum: sha256:2b3ea9aa461d67fa0148f8dbc540f4f8d0043bd03086ab586d4132eec638b424
     name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 697155
@@ -10618,13 +10618,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4759397
-    checksum: sha256:3ded7b647cc34b8723a763597e4658d1a641bc4ee116838a10ba55d42c9f0b26
+    size: 4764172
+    checksum: sha256:c83b117153a1a130c218f82d378e7f02c412927ba37a681974d66048d15576d7
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 570340
@@ -13432,20 +13432,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-8.32-41.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1206429
-    checksum: sha256:ca42d8e48fa5056805089051e473d693c1eeb2b05b0f47ecc00f6a3a4c10496f
+    size: 1206694
+    checksum: sha256:a86313c10c9310922710ae321145017bc1046a600ad35c528691164fcaba512b
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.s390x.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2112471
-    checksum: sha256:3eb7d326a40de65cee2458c471b6b8f8a16218452a6d2194c6b6f2eb1c344bb9
+    size: 2117124
+    checksum: sha256:b0f8b8a7b42cb74b9397afb79c98f6614bd2da8331e51081a3d9b7d60623b5d5
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/cpio-2.13-16.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 284105
@@ -14608,13 +14608,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 96039
@@ -14743,10 +14743,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/repodata/4a3f6e412c19d338ed8faf3a45113a857a928a277ab8f9455fc5fef7b1b1e939-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 63883
-    checksum: sha256:97a20bba483b6f7899745e9f35d8031bf8a87dc91e9ae0dd5cb100a4b08f3095
+    checksum: sha256:4a3f6e412c19d338ed8faf3a45113a857a928a277ab8f9455fc5fef7b1b1e939
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/l/libsndfile-1.2.2-6.el9ai.x86_64.rpm
@@ -14763,13 +14763,13 @@ arches:
     name: ninja-build
     evr: 1.11.1-9.el9ai
     sourcerpm: ninja-build-1.11.1-9.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.x86_64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54962756
-    checksum: sha256:f54ee03ff8005b69bc15955e5ceb8b648cedd122fa39b391c33c44adde1bf291
+    size: 54905233
+    checksum: sha256:69a11c0159a951add980be403e13f587f523bf82ced7e1279238ccbbd575a323
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/annobin-12.98-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 1121890
@@ -14784,27 +14784,27 @@ arches:
     name: apr
     evr: 1.7.0-12.el9_3
     sourcerpm: apr-1.7.0-12.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/apr-util-1.6.1-23.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/apr-util-1.6.1-23.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 99555
-    checksum: sha256:fdafa0c878091c68d7e4ff66bdffa2d3a39904351128b55caafc896175651718
+    size: 103077
+    checksum: sha256:883147c3c2fdc0f53ea41d9b79a23c33263b20b3cc8d644c7894e348fb502977
     name: apr-util
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9.x86_64.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/apr-util-bdb-1.6.1-23.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 14447
-    checksum: sha256:d996f1e3b3375cd48b9910f31965e0e8c0df99b553dcac8c4368ac6ed5177623
+    size: 18606
+    checksum: sha256:f425baa0a827f052a01fa3539a17d8314fe1eb43e8d2006cd14bacc72ba28b94
     name: apr-util-bdb
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9.x86_64.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/apr-util-openssl-1.6.1-23.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 16990
-    checksum: sha256:6bb1406bff8e1232134161c6cbfc4dd07a36c2fd7a2b3a95fba8d842bf76fe2e
+    size: 21140
+    checksum: sha256:4b210b595528c750ff1f58ac99e7ebb3dc197052e652779a61fdafd6d9755e61
     name: apr-util-openssl
-    evr: 1.6.1-23.el9
-    sourcerpm: apr-util-1.6.1-23.el9.src.rpm
+    evr: 1.6.1-23.el9_8.1
+    sourcerpm: apr-util-1.6.1-23.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/autoconf-2.69-41.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 697155
@@ -15519,13 +15519,13 @@ arches:
     name: git-core-doc
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 5023104
-    checksum: sha256:b2b3eac45360ea20a81a4a72b2bc19790846fc182e8684a0ae034642fab7677c
+    size: 5019312
+    checksum: sha256:35df42ac8b1c7231a0a54f67188c652cc270739f7387b61cfa286b73cd6b6d30
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/glib2-devel-2.68.4-19.el9_8.10.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 571607
@@ -18312,20 +18312,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1220715
-    checksum: sha256:e53f0f831246c73ab03ae395054d261ae392faa1229e6c691c08d2321a824b75
+    size: 1222083
+    checksum: sha256:374257c4cd69107333a7f524dd99579f3ea3ab842b66168eade0a3475fb6eea1
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2116611
-    checksum: sha256:1d4010cdc4f0fb7a4be68bf1bf0f0cda84a11d7337bd15d8368ab0ff90ca0db4
+    size: 2113503
+    checksum: sha256:41f69eb8b2087feaa98d0228fb933b6fe8af20a4bf371cfef51e11cbd1f84b4e
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/cpio-2.13-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 286157
@@ -19551,13 +19551,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 96649
@@ -19686,7 +19686,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/repodata/dcf933ff03a4b07bda6aff3a8fd0f62a05100e1b41b3282018b38c7636d9bcc4-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 68111
-    checksum: sha256:8c599a4515e1d54d4cab4d5160e1290ec31b62231bfad8643c45879df5ae251c
+    checksum: sha256:dcf933ff03a4b07bda6aff3a8fd0f62a05100e1b41b3282018b38c7636d9bcc4

--- a/prefetch-input/rhds/rpms.lock.yaml
+++ b/prefetch-input/rhds/rpms.lock.yaml
@@ -18,13 +18,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.aarch64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54160127
-    checksum: sha256:51e8a599b800c1f8d1758030557aa28cf65e335d00b555e50b2f048ad0393444
+    size: 54115507
+    checksum: sha256:814ad26801c6c0bdafc0d65c64c0741391cfb44cc563f4ae0161d3cd7b606217
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 377278
@@ -438,13 +438,13 @@ arches:
     name: git-core
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4529173
-    checksum: sha256:c5347668e520e0194b6702d60a1d2cafac4ad6aaf8bae14dc6130ab56d25e572
+    size: 4530293
+    checksum: sha256:46fcb6f34490f575b318518eff43154b93f47278dd85b824a045f5997a92e1c8
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os/Packages/g/glibc-devel-2.34-275.el9_8.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 576947
@@ -4638,20 +4638,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1177900
-    checksum: sha256:ee2de9f5fbc5e83bad920a353c45d3446997aa0e4023436528b2d6f817bd6f50
+    size: 1175876
+    checksum: sha256:22827aedd764c1ab706086965859e7f8fef0d719ac0b3d8735f6b8e53b0a13e9
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2114764
-    checksum: sha256:cd79ca65bba152b9ccadcb9780ec78e3d06ce538b693078fd14459d038ab5c0c
+    size: 2115646
+    checksum: sha256:b449955249a6d2da7369522a5ac2759919d36633e129ba88924057814906d5f5
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/c/cpio-2.13-16.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 284454
@@ -5926,13 +5926,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/Packages/w/which-2.21-30.el9_6.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 41522
@@ -6042,13 +6042,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.ppc64le.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 51128429
-    checksum: sha256:ac85191b03d4889030e6e26e7d51b0fefc8a0b243bcc86a5e7fa6ca0ed7e7e84
+    size: 51106987
+    checksum: sha256:f16a825fc74afbda18ab5988674e865ff100a6fbf446dd2969368ea0131dfe2b
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 377278
@@ -6462,13 +6462,13 @@ arches:
     name: git-core
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4569759
-    checksum: sha256:a736acf30d416a2c25da06b9a23dc4310ae524f2406ac35cccd2e22c80acfdce
+    size: 4578701
+    checksum: sha256:14eb3e2046580a216550728d58c75ee4e984c21dddbd66125a233504748837fb
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-275.el9_8.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 587995
@@ -10662,20 +10662,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-8.32-41.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1259870
-    checksum: sha256:d9fc3be701da7abe502bc5f9d07f93e13088de2e78cf0de8bcf5fb8c0fc7e737
+    size: 1262204
+    checksum: sha256:195fa8b9b1eee88c69323de32c1fadc6dd9af2dfe7df10a2a04ee796b5248767
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.ppc64le.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2115089
-    checksum: sha256:a242aae86238374731d5d52f23962a6af31b5ed51ce5cffaeee62e05046ed2ce
+    size: 2113363
+    checksum: sha256:a9006eb589f6f6dfd468ae1f2c8d3ea9874b86238f462b21f75a12a5c298f7b1
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/c/cpio-2.13-16.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 292586
@@ -11964,13 +11964,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/ppc64le/baseos/os/Packages/w/which-2.21-30.el9_6.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 43161
@@ -12080,13 +12080,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.s390x.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 53235751
-    checksum: sha256:4db0881f22ab8b470ed49749e9ec27b7272bf6b993e12cf5106082efac395194
+    size: 53015009
+    checksum: sha256:a5995487cebd8c6b453f68bcd38f33f09a6124b51d6c1a97f2ca82c8c494f875
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 377278
@@ -12507,13 +12507,13 @@ arches:
     name: git-core
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4759397
-    checksum: sha256:3ded7b647cc34b8723a763597e4658d1a641bc4ee116838a10ba55d42c9f0b26
+    size: 4764172
+    checksum: sha256:c83b117153a1a130c218f82d378e7f02c412927ba37a681974d66048d15576d7
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/appstream/os/Packages/g/glibc-devel-2.34-275.el9_8.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 54280
@@ -16728,20 +16728,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-8.32-41.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1206429
-    checksum: sha256:ca42d8e48fa5056805089051e473d693c1eeb2b05b0f47ecc00f6a3a4c10496f
+    size: 1206694
+    checksum: sha256:a86313c10c9310922710ae321145017bc1046a600ad35c528691164fcaba512b
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.s390x.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2112471
-    checksum: sha256:3eb7d326a40de65cee2458c471b6b8f8a16218452a6d2194c6b6f2eb1c344bb9
+    size: 2117124
+    checksum: sha256:b0f8b8a7b42cb74b9397afb79c98f6614bd2da8331e51081a3d9b7d60623b5d5
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/c/cpio-2.13-16.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 284105
@@ -17988,13 +17988,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/s390x/baseos/os/Packages/w/which-2.21-30.el9_6.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 42656
@@ -18104,13 +18104,13 @@ arches:
     name: texlive-tcolorbox
     evr: 20200406-1.el9ai
     sourcerpm: texlive-tcolorbox-20200406-1.el9ai.src.rpm
-  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.x86_64.rpm
     repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
-    size: 54962756
-    checksum: sha256:f54ee03ff8005b69bc15955e5ceb8b648cedd122fa39b391c33c44adde1bf291
+    size: 54905233
+    checksum: sha256:69a11c0159a951add980be403e13f587f523bf82ced7e1279238ccbbd575a323
     name: openshift-clients
-    evr: 4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9
-    sourcerpm: openshift-clients-4.16.0-202608111505.p2.g6f88b58.assembly.stream.el9.src.rpm
+    evr: 4.16.0-202608211840.p2.g33afbae.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202608211840.p2.g33afbae.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 377278
@@ -18524,13 +18524,13 @@ arches:
     name: git-core
     evr: 2.52.0-1.el9
     sourcerpm: git-2.52.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/git-lfs-3.7.1-4.el9_8.3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 5023104
-    checksum: sha256:b2b3eac45360ea20a81a4a72b2bc19790846fc182e8684a0ae034642fab7677c
+    size: 5019312
+    checksum: sha256:35df42ac8b1c7231a0a54f67188c652cc270739f7387b61cfa286b73cd6b6d30
     name: git-lfs
-    evr: 3.7.1-4.el9_8.2
-    sourcerpm: git-lfs-3.7.1-4.el9_8.2.src.rpm
+    evr: 3.7.1-4.el9_8.3
+    sourcerpm: git-lfs-3.7.1-4.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os/Packages/g/glibc-devel-2.34-275.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 46499
@@ -22717,20 +22717,20 @@ arches:
     name: ca-certificates
     evr: 2025.2.80_v9.0.305-91.el9
     sourcerpm: ca-certificates-2025.2.80_v9.0.305-91.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1220715
-    checksum: sha256:e53f0f831246c73ab03ae395054d261ae392faa1229e6c691c08d2321a824b75
+    size: 1222083
+    checksum: sha256:374257c4cd69107333a7f524dd99579f3ea3ab842b66168eade0a3475fb6eea1
     name: coreutils
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 2116611
-    checksum: sha256:1d4010cdc4f0fb7a4be68bf1bf0f0cda84a11d7337bd15d8368ab0ff90ca0db4
+    size: 2113503
+    checksum: sha256:41f69eb8b2087feaa98d0228fb933b6fe8af20a4bf371cfef51e11cbd1f84b4e
     name: coreutils-common
-    evr: 8.32-41.el9_8
-    sourcerpm: coreutils-8.32-41.el9_8.src.rpm
+    evr: 8.32-41.el9_8.1
+    sourcerpm: coreutils-8.32-41.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/c/cpio-2.13-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 286157
@@ -24012,13 +24012,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-25.el9
     sourcerpm: util-linux-2.37.4-25.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.13.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.21.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 22931
-    checksum: sha256:7758bbb54a85bb53aecdbb9c740c4981b2b42cac6df9580414838c6bdbab8dbd
+    size: 24156
+    checksum: sha256:4362190912229b1a670e20a7e46d1f20fb2d1d30e80ec22342bba1318784f742
     name: vim-filesystem
-    evr: 2:8.2.2637-26.el9_8.13
-    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
+    evr: 2:8.2.2637-26.el9_8.21
+    sourcerpm: vim-8.2.2637-26.el9_8.21.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os/Packages/w/which-2.21-30.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 42038


### PR DESCRIPTION
Automated lock file renewal in a single PR with separate commits:

1. Pylock lock files
2. Manifest annotations and generated Dockerfiles
3. ODH `rpms.lock.yaml` regeneration
4. RHDS `rpms.lock.yaml` regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed bundled RPM packages and repository metadata across supported CPU architectures.
  * Updated OpenShift clients, Git LFS, Coreutils, Vim filesystem, and APR utility packages to newer builds.
  * Refreshed package checksums, sizes, versions, and download metadata to ensure installations use the updated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->