### PR TITLE
RHOAIENG-84389: fix: enable PQC crypto policy in baseline and midstream base images

### DIFF
--- a/base-images/README.md
+++ b/base-images/README.md
@@ -23,6 +23,21 @@ Tag bumps for `quay.io/centos/centos` are blocked by `allowedVersions` in
 [`.github/renovate.json5`](../.github/renovate.json5); digest refreshes within
 `stream9` remain allowed.
 
+## PQC crypto policy
+
+Post-quantum crypto is required for OCP 5.0 (RHOAI 3.6+, tracked in
+RHOAIENG-84389). Every Dockerfile in `base-images/` runs
+`update-crypto-policies --set DEFAULT:PQ` as root — C9S carries the RHEL 9.8 PQ
+profile, and RHEL 10 will enable PQ by default. ODH workbench/runtime images
+inherit the policy from these bases.
+
+The same policy line is required in any image Dockerfile whose base does not
+already ship PQC: AIPCC bases have carried it since `3.6.0-ea.2`, while the
+RHOAI baseline images set it explicitly on top of
+`registry.redhat.io/rhel9/python-312` (not PQC by default on EL9). The coverage
+is enforced by `test_dockerfiles_pqc_crypto_policy_coverage` in
+[`tests/test_main.py`](../tests/test_main.py).
+
 ## Layout
 
 | Directory | Purpose |

--- a/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
+++ b/base-images/cpu/c9s-python-3.12/Dockerfile.cpu
@@ -86,6 +86,10 @@ set -Eeuxo pipefail
 fix-permissions ${APP_ROOT} -P
 EOF
 
+# PQC (OCP 5.0): enable the post-quantum crypto policy profile (C9S carries
+# the RHEL 9.8 PQ profile; RHEL 10 enables PQ by default).
+RUN update-crypto-policies --set DEFAULT:PQ
+
 RUN rpm-file-permissions
 
 # Restore user workspace

--- a/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/12.9/c9s-python-3.12/Dockerfile.cuda
@@ -39,6 +39,10 @@ set -Eeuxo pipefail
 fix-permissions ${APP_ROOT} -P
 EOF
 
+# PQC (OCP 5.0): enable the post-quantum crypto policy profile (C9S carries
+# the RHEL 9.8 PQ profile; RHEL 10 enables PQ by default).
+RUN update-crypto-policies --set DEFAULT:PQ
+
 USER 1001
 WORKDIR /opt/app-root/bin
 

--- a/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
+++ b/base-images/cuda/13.0/c9s-python-3.12/Dockerfile.cuda
@@ -50,6 +50,10 @@ set -Eeuxo pipefail
 fix-permissions ${APP_ROOT} -P
 EOF
 
+# PQC (OCP 5.0): enable the post-quantum crypto policy profile (C9S carries
+# the RHEL 9.8 PQ profile; RHEL 10 enables PQ by default).
+RUN update-crypto-policies --set DEFAULT:PQ
+
 USER 1001
 WORKDIR /opt/app-root/bin
 

--- a/base-images/rocm/7.14/c9s-python-3.12/Dockerfile.rocm
+++ b/base-images/rocm/7.14/c9s-python-3.12/Dockerfile.rocm
@@ -39,6 +39,10 @@ set -Eeuxo pipefail
 fix-permissions ${APP_ROOT} -P
 EOF
 
+# PQC (OCP 5.0): enable the post-quantum crypto policy profile (C9S carries
+# the RHEL 9.8 PQ profile; RHEL 10 enables PQ by default).
+RUN update-crypto-policies --set DEFAULT:PQ
+
 USER 1001
 WORKDIR /opt/app-root/bin
 

--- a/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver-baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -146,6 +146,10 @@ USER 0
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+# PQC (OCP 5.0): the rhel9/python-312 base does not enable post-quantum
+# crypto by default (only RHEL 10 does); set the system policy explicitly.
+RUN update-crypto-policies --set DEFAULT:PQ
+
 # [HERMETIC] Enable nodejs:22 module stream (see rpm-base comment).
 RUN dnf module enable nodejs:22 -y
 

--- a/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -32,6 +32,10 @@ ARG RHEL_VERSION=9.8
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+# PQC (OCP 5.0): the rhel9/python-312 base does not enable post-quantum
+# crypto by default (only RHEL 10 does); set the system policy explicitly.
+RUN update-crypto-policies --set DEFAULT:PQ
+
 ### BEGIN PyPI pip and uv index
 ENV PIP_INDEX_URL=https://pypi.org/simple
 ENV UV_INDEX_URL=https://pypi.org/simple

--- a/runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -31,6 +31,10 @@ ARG RHEL_VERSION=9.8
 RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-CentOS-Official || true
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
+# PQC (OCP 5.0): the rhel9/python-312 base does not enable post-quantum
+# crypto by default (only RHEL 10 does); set the system policy explicitly.
+RUN update-crypto-policies --set DEFAULT:PQ
+
 ### BEGIN PyPI pip and uv index
 ENV PIP_INDEX_URL=https://pypi.org/simple
 ENV UV_INDEX_URL=https://pypi.org/simple

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -179,6 +179,62 @@ def test_dockerfiles_unintended_subscription_manager_pattern():
                 )
 
 
+# PQC (OCP 5.0): every shipped image must enable post-quantum crypto. AIPCC
+# bases carry `update-crypto-policies --set DEFAULT:PQ` since 3.6-EA2, so
+# images FROM them inherit PQC; in-repo C9S bases under base-images/ set it
+# themselves (checked below). Any other base (e.g.
+# registry.redhat.io/rhel9/python-312) requires the explicit policy line.
+PQC_POLICY_RUN_RE = re.compile(r"update-crypto-policies\s+--set\s+DEFAULT:PQ")
+PQC_ENABLED_BASE_PREFIXES = (
+    "quay.io/aipcc/base-images/",
+    "quay.io/opendatahub/odh-base-image",  # built in-repo by base-images/
+)
+
+
+def _dockerfile_for_build_args_conf(conf: pathlib.Path) -> pathlib.Path | None:
+    """Map a build-args conf (cpu.conf / konflux.cuda.conf / ...) to its Dockerfile, if present."""
+    variant = conf.name.removesuffix(".conf")
+    dockerfile = conf.parent.parent / f"Dockerfile.{variant}"
+    return dockerfile if dockerfile.is_file() else None
+
+
+def test_dockerfiles_pqc_crypto_policy_coverage() -> None:
+    """Every shipped image must enable the post-quantum crypto policy (OCP 5.0 PQC mandate).
+
+    See RHOAIENG-84389. The policy must be set while running as root in a stage
+    of the final image (non-root `update-crypto-policies` fails with
+    "You must be root to run update-crypto-policies").
+    """
+    # In-repo C9S base images must set the policy themselves; images that
+    # FROM them (ODH workbenches/runtimes) inherit it.
+    for dockerfile in sorted(PROJECT_ROOT.glob("base-images/**/Dockerfile*")):
+        if not dockerfile.is_file():
+            continue
+        assert PQC_POLICY_RUN_RE.search(dockerfile.read_text()), (
+            f"{dockerfile.relative_to(PROJECT_ROOT)}: C9S base image must enable the post-quantum "
+            "crypto policy: add `RUN update-crypto-policies --set DEFAULT:PQ` while running as root."
+        )
+
+    for conf in sorted(PROJECT_ROOT.glob("**/build-args/*.conf")):
+        base_image = next(
+            (line.split("=", 1)[1].strip() for line in conf.read_text().splitlines() if line.startswith("BASE_IMAGE=")),
+            None,
+        )
+        if base_image is None:
+            continue
+        # repository without tag/digest
+        repository = base_image.split(":", 1)[0]
+        if repository.startswith(PQC_ENABLED_BASE_PREFIXES):
+            continue
+        dockerfile = _dockerfile_for_build_args_conf(conf)
+        if dockerfile is None:
+            continue
+        assert PQC_POLICY_RUN_RE.search(dockerfile.read_text()), (
+            f"{conf.relative_to(PROJECT_ROOT)}: base image {base_image} is not known to ship PQC, but "
+            f"{dockerfile.relative_to(PROJECT_ROOT)} does not run `update-crypto-policies --set DEFAULT:PQ`."
+        )
+
+
 @pytest.mark.parametrize("manifests_directory", [manifests.MANIFESTS_ODH_DIR, manifests.MANIFESTS_RHOAI_DIR])
 def test_image_pyprojects(subtests: pytest.Subtests, manifests_directory: pathlib.Path):
     for file in PROJECT_ROOT.glob("**/pyproject.toml"):


### PR DESCRIPTION
## Description

Enable the post-quantum crypto policy (`update-crypto-policies --set DEFAULT:PQ`) on every image this repo ships — required for OCP 5.0 (RHOAI 3.6+), tracked in [RHOAIENG-84389](https://redhat.atlassian.net/browse/RHOAIENG-84389).

- **RHOAI baseline images** (`jupyter/baseline`, `codeserver-baseline`, `runtimes/baseline`) build on `registry.redhat.io/rhel9/python-312`, which does not enable PQC by default (only RHEL 10 does). The policy line runs in the root section of the `cpu-base` stage.
- **ODH midstream base images** (`base-images/`) now set the policy as root; ODH workbench/runtime images inherit it from these bases. C9S carries the RHEL 9.8 PQ profile.
- **Static guard** (`test_dockerfiles_pqc_crypto_policy_coverage` in `tests/test_main.py`): every `base-images/` Dockerfile must set the policy, and any image whose base is not known to ship PQC (AIPCC bases carry it since `3.6.0-ea.2`, in-repo C9S bases set it themselves) must set it explicitly. Catches a non-PQC base being adopted without the policy line.

All other RHOAI images already inherit PQC from their AIPCC `3.6.0-ea.2` bases.

## How Has This Been Tested?

- `make test-unit`: **629 passed** (incl. the new guard, negative-tested on both branches: removing a policy line fails the test, restoring it passes).
- Verified `DEFAULT:PQ` sets and persists (`/etc/crypto-policies/config` + `--show`) **as root** on:
  - `registry.redhat.io/rhel9/python-312:9.8-1788919789` (exact baseline base tag),
  - `quay.io/centos/centos:stream9` and the published `odh-base-image-cpu-py312-c9s` (C9S, `crypto-policies-20260714`),
  - `quay.io/sclorg/python-312-c9s@sha256:bad808b5…` — the exact base the midstream CUDA/ROCm images build on (their GPU layers do not touch crypto-policies),
  - a full local build of `base-images/cpu` — the built image reports `DEFAULT:PQ`.
- Note: the baseline base runs as UID 1001 by default; the line must stay in a `USER 0` section (non-root fails with "You must be root to run update-crypto-policies").

Self checklist:
- [x] Ran `make test-unit` (629 passed) + a full local build of the ODH c9s CPU base with policy verification; the container-test parts of `make test` run in CI
- [x] Changes made in `odh/notebooks`; the three `Dockerfile.konflux.cpu` edits flow to `rhds/notebooks` via the normal sync

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages (3 commits: baseline fix / base-images fix / test guard)
- [x] Testing instructions have been added in the PR body
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-84389]: https://redhat.atlassian.net/browse/RHOAIENG-84389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled the `DEFAULT:PQ` post-quantum cryptographic policy across supported CPU, CUDA, ROCm, code-server, Jupyter, and runtime base images.
  - Updated supported CentOS Stream 9 and RHEL 9 images to provide post-quantum cryptography by default.

- **Tests**
  - Added automated coverage checks to verify that shipped images apply the required post-quantum cryptographic policy.

- **Documentation**
  - Documented the policy requirement, supported image coverage, and validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->