### PR TITLE
NO-JIRA: ci(.tekton/): remove obsolete sbom-syft-generate step override

### DIFF
--- a/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -66,14 +66,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cpu-py312-c9s-push.yaml
@@ -61,14 +61,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-pull-request.yaml
@@ -67,14 +67,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-12-9-py312-c9s-push.yaml
@@ -59,14 +59,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-pull-request.yaml
@@ -67,14 +67,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-cuda-13-0-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-cuda-13-0-py312-c9s-push.yaml
@@ -59,14 +59,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-pull-request.yaml
@@ -66,14 +66,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
+++ b/.tekton/odh-base-image-rocm-7-14-py312-c9s-push.yaml
@@ -58,14 +58,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -81,14 +81,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -87,14 +87,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -74,14 +74,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -81,14 +81,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -87,14 +87,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -75,14 +75,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -77,14 +77,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -77,14 +77,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -80,14 +80,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -76,14 +76,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -85,14 +85,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-ci-push.yaml
@@ -71,14 +71,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -76,14 +76,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -71,14 +71,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-ci-push.yaml
@@ -227,14 +227,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-pull-request.yaml
@@ -230,14 +230,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -231,14 +231,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-ci-push.yaml
@@ -76,14 +76,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -77,14 +77,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-ci-push.yaml
@@ -70,14 +70,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -87,14 +87,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -89,14 +89,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-ci-push.yaml
@@ -70,14 +70,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -85,14 +85,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -89,14 +89,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-ci-push.yaml
@@ -71,14 +71,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -84,14 +84,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -80,14 +80,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-ci-push.yaml
@@ -74,14 +74,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -91,14 +91,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -94,14 +94,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-ci-push.yaml
@@ -72,14 +72,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -83,14 +83,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -68,14 +68,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-ci-push.yaml
@@ -73,14 +73,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -90,14 +90,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -77,14 +77,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-ci-push.yaml
@@ -81,14 +81,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -90,14 +90,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: clair-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -68,14 +68,6 @@ spec:
             limits:
               cpu: '4'
               memory: 8Gi
-        - name: sbom-syft-generate
-          computeResources:
-            requests:
-              cpu: '4'
-              memory: 8Gi
-            limits:
-              cpu: '4'
-              memory: 8Gi
         - name: build
           computeResources:
             requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ci-push.yaml
@@ -82,14 +82,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -80,14 +80,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -75,14 +75,6 @@ spec:
             limits:
               cpu: '4'
               memory: 8Gi
-        - name: sbom-syft-generate
-          computeResources:
-            requests:
-              cpu: '4'
-              memory: 8Gi
-            limits:
-              cpu: '4'
-              memory: 8Gi
         - name: build
           computeResources:
             requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-ci-push.yaml
@@ -85,14 +85,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -122,14 +122,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: rpms-signature-scan
     computeResources:
       requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -108,14 +108,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
## Summary

Removes the obsolete `sbom-syft-generate` step override from the `build-images`
`stepSpecs` in the ODH Konflux PipelineRuns.

Buildah task v0.11.0 removed the `sbom-syft-generate` step (SBOM generation now runs
inside the `build` step). A `stepSpecs` entry referencing a removed step fails pipeline
validation with:

    [User error] invalid StepOverride: No Step named sbom-syft-generate

The `prepare-sboms` and `build` overrides are retained (both steps still exist).
62 `.tekton/` PipelineRun files changed (8 lines removed each).

## Related

- konflux-central already fixed for the push-pipeline source: PR #3382 (main), #3381 (RHOAI-3.4).
- Migration guidance: buildah 0.11.0 removed `sbom-syft-generate`; SBOM generation moved into the build step.

## Testing

- All 62 modified files still parse as valid YAML.
- No `sbom-syft-generate` references remain in `.tekton/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed resource allocations for the software bill of materials generation step across image-build and workbench build pipelines.
  - Existing build-step resource settings and other pipeline configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->