### PR TITLE
fix(scripts): filter --upgrade from pylock header comments

### DIFF
--- a/scripts/pylocks_generator.py
+++ b/scripts/pylocks_generator.py
@@ -538,8 +538,9 @@ def parse_exclude_newer_from_lockfile(path: Path) -> str | None:
 def compile_command_for_lock_header(cmd: list[str]) -> str:
     """Build the ``uv pip compile`` command string stored in pylock header comments.
 
-    Omits the uv binary path (uses ``uv``), ``--exclude-newer``, ``--quiet``, and
-    ``--custom-compile-command`` so committed lockfiles do not embed cutoff timestamps.
+    Omits the uv binary path (uses ``uv``), ``--exclude-newer``, ``--upgrade``,
+    ``--quiet``, and ``--custom-compile-command`` so committed lockfiles do not
+    embed cutoff timestamps or one-off upgrade flags.
     """
     parts: list[str] = []
     skip_next = False
@@ -555,7 +556,7 @@ def compile_command_for_lock_header(cmd: list[str]) -> str:
         if arg in ("--exclude-newer", "--custom-compile-command"):
             skip_next = True
             continue
-        if arg == "--quiet":
+        if arg in ("--quiet", "--upgrade"):
             continue
         parts.append(arg)
     return " ".join(parts)


### PR DESCRIPTION
## Summary

The pylock header comment filter in `compile_command_for_lock_header()` already stripped the per-run `--exclude-newer` cutoff timestamp (and `--quiet` / `--custom-compile-command`) from the committed lockfile headers, but not the `--upgrade` flag. When lockfiles are regenerated with `FORCE_LOCKFILES_UPGRADE=1`, the header comment recorded in the pylock TOML embedded the one-off `--upgrade` flag.

This change adds `--upgrade` to the filtered arguments so committed pylock headers only contain the reproducible command.

## Verification

- `ruff check` / `ruff format --check` pass.
- Sanity-checked `compile_command_for_lock_header()` with a representative `uv pip compile` argv (with `--upgrade`, `--exclude-newer=`, `--quiet`, `--custom-compile-command=`) — all four are omitted from the rendered header, and the spaced `--exclude-newer <ts>` form is still handled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lockfile header commands no longer include the `--upgrade` option, keeping generated command instructions consistent with the recorded lock state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->