### PR TITLE
fix(tests): resolve triton plugins libtriton.so in ELF link check

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -65,8 +65,14 @@ class TestBaseImage:
 
                         count_scanned += 1
 
+                        # Drop empty entries (e.g. from an unset LD_LIBRARY_PATH): an
+                        # empty path element makes the dynamic loader search the current
+                        # working directory, which could shadow a library under test.
+                        configured_paths = [
+                            entry for entry in os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep) if entry
+                        ]
                         extra_paths = [
-                            os.environ.get("LD_LIBRARY_PATH", ""),
+                            *configured_paths,
                             # $ORIGIN
                             os.path.dirname(dlib),
                             # torchvision needs libtorch_cpu.so, libc10_cuda.so from torch

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -65,15 +65,21 @@ class TestBaseImage:
 
                         count_scanned += 1
 
-                        ld_library_path = os.path.pathsep.join(
-                            (
-                                os.environ.get("LD_LIBRARY_PATH", ""),
-                                # $ORIGIN
-                                os.path.dirname(dlib),
-                                # torchvision needs libtorch_cpu.so, libc10_cuda.so from torch
-                                "/opt/app-root/lib/python3.12/site-packages/torch/lib/",
-                            )
-                        )
+                        extra_paths = [
+                            os.environ.get("LD_LIBRARY_PATH", ""),
+                            # $ORIGIN
+                            os.path.dirname(dlib),
+                            # torchvision needs libtorch_cpu.so, libc10_cuda.so from torch
+                            "/opt/app-root/lib/python3.12/site-packages/torch/lib/",
+                        ]
+                        # triton plugins (site-packages/triton/plugins/*.so) link against
+                        # libtriton.so, which the triton package bundles in
+                        # site-packages/triton/_C/ and triton pre-loads via dlopen before
+                        # loading the plugins; ldd run in isolation cannot see it.
+                        dlib_dir = os.path.dirname(dlib)
+                        if os.path.basename(dlib_dir) == "plugins":
+                            extra_paths.append(os.path.join(os.path.dirname(dlib_dir), "_C"))
+                        ld_library_path = os.path.pathsep.join(extra_paths)
                         output = subprocess.check_output(
                             ["ldd", dlib],
                             # search the $ORIGIN, essentially; most python libs expect this


### PR DESCRIPTION
## Summary

`TestBaseImage::test_elf_files_can_link_runtime_libs` fails on the ROCm pytorch images (workbench and pipeline runtime) with:

```
dlib='.../site-packages/triton/plugins/libMLIRDialectPlugin.so' has unsatisfied dependencies deps='libtriton.so => not found'
```

This is a test false positive, not a runtime breakage. The triton 3.7.0 wheel (AIPCC) ships its plugins under `triton/plugins/`, and those `.so` files link against `libtriton.so`, which the same wheel bundles at `triton/_C/libtriton.so`. At runtime triton dlopens its own `libtriton.so` (absolute path) before loading the plugins, so the process always has the soname `libtriton.so` loaded and the plugins resolve fine — the plugin `DT_RUNPATH` entries (`$ORIGIN/../lib`, `/usr/lib64/llvm-triton-<hash>/lib`, build-machine paths) are never the mechanism used in the image. `ldd` run in isolation (as the test does) cannot see the pre-loaded library, so it reports `not found`.

The failure is independent of the base image tag: it reproduces on `main` with the previous `rocm-7.14-el9.8` base (triggered by the lock renewal that moved ROCm pytorch images to triton 3.7.0).

## Change

Extend the test's `LD_LIBRARY_PATH` (the same mechanism already used for torchvision's `libtorch_cpu.so` / `libc10_cuda.so` coming from `torch/lib`): when the scanned file lives in a `.../triton/plugins` directory, also add the sibling `.../triton/_C` directory. The test stays strict — if the wheel ever stops bundling `libtriton.so`, the check fails again.

## Verification

- Reproduced the exact CI failure locally: extracted the triton 3.7.0 wheel into a `site-packages` layout and ran the old scan logic in an amd64 container → the 3 plugin `.so` files fail with `libtriton.so => not found`; the new logic → 0 unsatisfied dependencies.
- `ruff check` / `ruff format --check` pass.

Fixes the `test_elf_files_can_link_runtime_libs` failures seen in the ROCm pytorch checks on PR #4572 and on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved ELF dependency validation by filtering empty library-path entries.
  * Preserved configured library paths and existing Torch, library-origin, and Triton plugin locations during dependency checks.
  * Increased reliability of shared-library dependency verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->