### PR TITLE
NO-JIRA: fix(baseline): run uv bootstrap as app user in baseline Dockerfiles

### DIFF
--- a/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -153,10 +153,16 @@ COPY ${BASELINE_SOURCE_CODE}/requirements.${PYLOCK_FLAVOR}.txt ./requirements.tx
 COPY --chown=1001:0 ${BASELINE_SOURCE_CODE}/setup-elyra.sh ${BASELINE_SOURCE_CODE}/setup-kale.sh ${BASELINE_SOURCE_CODE}/utils ./utils/
 COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
-# The raw RHEL Python base does not bootstrap uv the way AIPCC notebook bases
-# do. Install uv from the hermeto/cachi2 pip cache (offline) before the main
+# Install uv from the hermeto/cachi2 pip cache (offline) before the main
 # package install. Online `pip install uv` would break hermetic Konflux builds.
-# UV_VERSION is derived from this image's requirements.cpu.txt by scripts/dockerfile_fragments.py.
+# UV_VERSION is derived from this image's requirements.cpu.txt by
+# scripts/dockerfile_fragments.py.
+#
+# Runs as USER 1001:0: files under /opt/app-root must stay 1001:0-owned,
+# because ensure-openshift-site-packages.sh (USER 1001:0) cannot chmod
+# root-owned files (EPERM).
+USER 1001:0
+
 ### BEGIN UV version
 ARG UV_VERSION=0.12.5
 
@@ -164,8 +170,6 @@ ARG UV_VERSION=0.12.5
 RUN python3 -m pip install --no-cache-dir --no-index \
     --find-links /cachi2/output/deps/pip \
     "uv==${UV_VERSION}"
-
-USER 1001:0
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail

--- a/runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -106,10 +106,16 @@ COPY --chown=1001:0 ${BASELINE_SOURCE_CODE}/utils ./utils/
 COPY --chown=1001:0 prefetch-input/elyra-v4.3.1/elyra/kfp/bootstrapper.py /opt/app-root/bin/utils/bootstrapper.py
 COPY --chown=1001:0 --chmod=0755 base-images/utils/ensure-openshift-site-packages.sh /usr/local/bin/ensure-openshift-site-packages.sh
 
-# The raw RHEL Python base does not bootstrap uv the way AIPCC notebook bases
-# do. Install uv from the hermeto/cachi2 pip cache (offline) before the main
+# Install uv from the hermeto/cachi2 pip cache (offline) before the main
 # package install. Online `pip install uv` would break hermetic Konflux builds.
-# UV_VERSION is derived from this image's requirements.cpu.txt by scripts/dockerfile_fragments.py.
+# UV_VERSION is derived from this image's requirements.cpu.txt by
+# scripts/dockerfile_fragments.py.
+#
+# Runs as USER 1001:0: files under /opt/app-root must stay 1001:0-owned,
+# because ensure-openshift-site-packages.sh (USER 1001:0) cannot chmod
+# root-owned files (EPERM).
+USER 1001:0
+
 ### BEGIN UV version
 ARG UV_VERSION=0.12.5
 
@@ -117,8 +123,6 @@ ARG UV_VERSION=0.12.5
 RUN python3 -m pip install --no-cache-dir --no-index \
     --find-links /cachi2/output/deps/pip \
     "uv==${UV_VERSION}"
-
-USER 1001:0
 
 ENV ELYRA_INSTALL_PACKAGES="false"
 


### PR DESCRIPTION
## Summary

Moves `USER 1001:0` above the pinned `uv` bootstrap install in `jupyter/baseline` and `runtimes/baseline` so the bootstrap runs as the app user instead of root.

## Why

Since the base image digest bump in #4539 (Sep 9), `odh-base-image-cpu-py312-c9s` ships `uv 0.12.7` in site-packages. The Dockerfile bootstrap (`pip install "uv==${UV_VERSION}"`, pin 0.12.5) then runs **as root** (it sits above the `USER 1001:0` switch, inheriting the dnf step's `USER 0`) and rewrites the package as root-owned [mode-0644](https://redhat.atlassian.net/browse/mode-0644) files. The subsequent `uv pip install` treats the pinned `uv` as already satisfied, and `ensure-openshift-site-packages.sh` (running as UID 1001) fails with `chmod: Operation not permitted` on the root-owned `uv` files, breaking the build:

- Failing PR job (uv-0.12.10): https://github.com/opendatahub-io/notebooks/actions/runs/34706649948/job/103587836457?pr=4578#step:19:388
- Failing main push build (uv-0.12.5): https://github.com/opendatahub-io/notebooks/actions/runs/34700222996/job/103570574651

Running the bootstrap as 1001:0 keeps everything under `/opt/app-root` owned by 1001:0 (matching the original Sep 1 hermetic layout, where the bootstrap lived inside the app-user install heredoc) and makes the root-vs-pin version mismatch harmless: pip rewrites the files as 1001, which the ensure sweep can chmod.

## Verification

- `gmake jupyter-baseline-ubi9-python-3.12` and `gmake runtime-baseline-ubi9-python-3.12` (PUSH_IMAGES=no) build green, with zero un-chmoddable files in site-packages.
- CI builds both images on this PR.

Extracted from the commit stack of #4567 (sdist toolchain work) so the main breakage can be unblocked independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container setup so offline Python tooling installation uses the intended application-user permissions.
  * Ensured installed files under the application directory have appropriate ownership, supporting smoother runtime use.

* **Documentation**
  * Added clearer guidance about installation requirements and offline setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->